### PR TITLE
Fix lru leak

### DIFF
--- a/src/riak_kv_lru.erl
+++ b/src/riak_kv_lru.erl
@@ -52,7 +52,8 @@ new(Size) ->
     CacheName = pid_to_list(self()) ++ "_cache",
     Idx = ets:new(list_to_atom(IdxName), [ordered_set, private]),
     BucketIdx = ets:new(list_to_atom(BucketIdxName), [bag, private]),
-    Cache = ets:new(list_to_atom(CacheName), [private, {keypos, 2}]),
+    Cache = ets:new(list_to_atom(CacheName), [private,
+					      {keypos, #kv_lru_entry.key}]),
     #kv_lru{max_size=Size, age_idx=Idx, bucket_idx=BucketIdx, cache=Cache}.
 
 put(#kv_lru{max_size=0}, _BKey, _Key, _Value) ->


### PR DESCRIPTION
Hi,

This patch set fixes a (memory) leak in the LRU cache which I saw when running some Erlang Map/Reduce queries through the riakc_pb_socket interface. The commit message describes the problem and the one-line fix that plugs the leak in question.

Test case also provided.
