### PR TITLE
Dont expose testing api

### DIFF
--- a/src/riak.erl
+++ b/src/riak.erl
@@ -32,7 +32,9 @@
          join/1]).
 -export([code_hash/0]).
 
+-ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-endif.
 
 
 %% @spec stop() -> ok

--- a/src/riak_kv_cache_backend.erl
+++ b/src/riak_kv_cache_backend.erl
@@ -43,8 +43,9 @@
 
 -define(PRINT(Var), error_logger:info_msg("DEBUG: ~p:~p - ~p: ~p~n", [?MODULE, ?LINE, ??Var, Var])).
 
-
+-ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-endif.
 
 -define (DEFAULT_TTL,     timer:minutes(10)).
 -define (DEFAULT_MAX_TTL, timer:hours(1)).

--- a/src/riak_kv_mapreduce.erl
+++ b/src/riak_kv_mapreduce.erl
@@ -45,7 +45,9 @@
          reduce_sum/2,
          reduce_plist_sum/2]).
 
+%-ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+%-endif.
 
 %%
 %% Map Phases

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -24,7 +24,9 @@
 -behavior(riak_kv_backend).
 -export([start/2, stop/1,get/2,put/3,list/1,list_bucket/2,delete/2,is_empty/1,drop/1,fold/3]).
 -export([callback/3]).
+-ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-endif.
 
 -record (state, {backends, default_backend}).
 

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -23,7 +23,9 @@
 %% @doc coordination of Riak PUT requests
 
 -module(riak_kv_put_fsm).
+%-ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+%-endif.
 -include_lib("riak_kv_vnode.hrl").
 -behaviour(gen_fsm).
 -define(DEFAULT_OPTS, [{returnbody, false}]).

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -23,7 +23,9 @@
 %% @doc container for Riak data and metadata
 
 -module(riak_object).
+-ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-endif.
 -include("riak_kv_wm_raw.hrl").
 
 -type key() :: binary().


### PR DESCRIPTION
Hello.

If you're including "eunit/include/eunit.hrl", then you're defining TEST automatically. This leads to explicit including of test functions into final *.beam files. So I just guarded this include by necessary ifdefs to avoid accidental exposing testing API to the byte-compiler.

This is a minor issue (doesn't really affect the runtime).
