### PR TITLE
Bz882 cluster info

### DIFF
--- a/ebin/riak_kv.app
+++ b/ebin/riak_kv.app
@@ -14,6 +14,7 @@
              riak_kv_backend,
              riak_kv_bitcask_backend,
              riak_kv_cache_backend,
+             riak_kv_cinfo,
              riak_kv_console,
              riak_kv_delete,
              riak_kv_dets_backend,

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -70,6 +70,10 @@ start(_Type, _StartArgs) ->
             ok
     end,
 
+    %% Register our cluster_info app callback modules, with catch if
+    %% the app is missing or packaging is broken.
+    catch cluster_info:register_app(riak_kv_cinfo),
+
     %% Spin up supervisor
     case riak_kv_sup:start_link() of
         {ok, Pid} ->

--- a/src/riak_kv_cinfo.erl
+++ b/src/riak_kv_cinfo.erl
@@ -1,0 +1,54 @@
+%% -------------------------------------------------------------------
+%%
+%% Riak: A lightweight, decentralized key-value store.
+%%
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_kv_cinfo).
+-export([cluster_info_init/0, cluster_info_generator_funs/0]).
+
+%% @spec () -> term()
+%% @doc Required callback function for cluster_info: initialization.
+%%
+%% This function doesn't have to do anything.
+
+cluster_info_init() ->
+    ok.
+
+%% @spec () -> list({string(), fun()})
+%% @doc Required callback function for cluster_info: return list of
+%%      {NameForReport, FunOfArity_1} tuples to generate ASCII/UTF-8
+%%      formatted reports.
+
+cluster_info_generator_funs() ->
+    [
+     {"Riak KV status", fun status/1},
+     {"Riak KV ringready", fun ringready/1},
+     {"Riak KV transfers", fun transfers/1}
+    ].
+
+status(CPid) -> % CPid is the data collector's pid.
+    cluster_info:format(CPid, "~p\n", [riak_kv_console:status(quiet)]).
+
+ringready(CPid) ->
+    cluster_info:format(CPid, "~p\n", [riak_kv_console:ringready(quiet)]).
+
+transfers(CPid) ->
+    cluster_info:format(CPid, "~p\n", [riak_kv_console:transfers(quiet)]).
+


### PR DESCRIPTION
Reviewer: anyone interested

I've rearranged some of the functions in riak_kv_console.erl to do
double-duty in the name of reusing useful code: spit stuff out "verbose"ly
when riak_kv_console:Foo([]) is called (old-style) and avoid io:format()
calls when riak_kv_console:Foo(quiet) is called (new-style).
