### PR TITLE
Bz932 no transfers active

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -102,12 +102,20 @@ transfers([]) ->
         [] -> ok;
         _  -> io:format("Nodes ~p are currently down.\n", [DownNodes])
     end,
-    F = fun({waiting_to_handoff, Node, Count}, _) ->
-                io:format("~p waiting to handoff ~p partitions\n", [Node, Count]);
-           ({stopped, Node, Count}, _) ->
-                io:format("~p does not have ~p primary partitions running\n", [Node, Count])
+    F = fun({waiting_to_handoff, Node, Count}, Acc) ->
+                io:format("~p waiting to handoff ~p partitions\n", [Node, Count]),
+                Acc + 1;
+           ({stopped, Node, Count}, Acc) ->
+                io:format("~p does not have ~p primary partitions running\n", [Node, Count]),
+                Acc + 1
         end,
-    lists:foldl(F, ok, Pending).
+    case lists:foldl(F, 0, Pending) of
+        0 ->
+            io:format("No transfers active\n"),
+            ok;
+        _ ->
+            error
+    end.
 
 
 format_stats([], Acc) ->


### PR DESCRIPTION
Reviewer: Dizzy ('cept that he's really busy this week) or anyone else (preferably).

I added the missing message as well as changed the return value so that
the exit status of "riak-admin transfers" will be non-zero when the # of pending
transfers is non-zero.

NOTE: this needs to go to both riak_kv-0.14 and master branches.
