### PR TITLE
Fix for Issue 937 regarding riak_client:filter_keys

### DIFF
--- a/src/riak_kv_keylister.erl
+++ b/src/riak_kv_keylister.erl
@@ -117,6 +117,9 @@ build_filter('_') ->
     {'_', []};
 build_filter(Bucket) when is_binary(Bucket) ->
     {Bucket, []};
+build_filter({filter, Bucket, Fun}) when is_function(Fun) ->
+    %% this is the representation used by riak_client:filter_keys
+    {Bucket, Fun};
 build_filter({Bucket, Filters}) ->
     FilterFun = riak_kv_mapred_filters:compose(Filters),
     {Bucket, FilterFun}.


### PR DESCRIPTION
riak_client:filter_keys produces a different "filter" format than other functions.  This patch fixes the issue in the same manner that bucket-listing was fixed: by adding a function clause to the filter builder to handle the alternate format.
