### PR TITLE
Bz939 phase backpressure

### DIFF
--- a/src/riak_kv_js_manager.erl
+++ b/src/riak_kv_js_manager.erl
@@ -72,7 +72,7 @@ blocking_dispatch(Name, JSCall, Tries) ->
     blocking_dispatch(Name, JSCall, Tries, Tries).
 
 reserve_vm(Name) ->
-    gen_server:call(Name, reserve_vm).
+    gen_server:call(Name, reserve_vm, infinity).
 
 reserve_batch_vm(Name, Tries) ->
     reserve_batch_vm(Name, Tries, Tries).


### PR DESCRIPTION
This change causes the map phase to batch up outputs before sending them to any downstream phases. The idea here is to reduce the chattiness of a MapReduce job and increase the amount of work done per message.
