### PR TITLE
Bz933 missing key map

### DIFF
--- a/src/riak_kv_map_phase.erl
+++ b/src/riak_kv_map_phase.erl
@@ -98,7 +98,7 @@ handle_info({'DOWN', Ref, process, Pid, _Reason}, #state{mapper_data=MapperData,
                                 MapperData1 = lists:keydelete(Id, 1, lists:keydelete(Pid, 1, MapperData ++ FsmKeys)),
                                 {no_output, maybe_done(State#state{mapper_data=MapperData1, fsms=NewFSMs})}
                             catch
-                                _C:Error ->
+                                _:Error ->
                                     {stop, {error, {no_candidate_nodes, Error, erlang:get_stacktrace(), MapperData}}, State}
                             end
                     end;

--- a/src/riak_kv_mapred_planner.erl
+++ b/src/riak_kv_mapred_planner.erl
@@ -40,7 +40,7 @@ build_claim_list(InputData) ->
     claim_keys(PartList0, [], Keys).
 
 claim_keys([], [], _) ->
-    exit(self(), exhausted_preflist);
+    exit(exhausted_preflist);
 claim_keys(_, ClaimList, []) ->
     ClaimList;
 claim_keys([H|T], ClaimList, Keys) ->

--- a/src/riak_kv_mapreduce.erl
+++ b/src/riak_kv_mapreduce.erl
@@ -78,6 +78,21 @@ map_object_value(Acc) ->
 
 %% @spec map_object_value(riak_object:riak_object(), term(), term()) -> [term()]
 %% @doc map phase function for map_object_value/1
+%%      If the RiakObject is the tuple {error, notfound}, the
+%%      behavior of this function is defined by the Action argument.
+%%      Values for Action are:
+%%        <<"filter_notfound">> : produce no output (literally [])
+%%        <<"include_notfound">> : produce the not-found as the result
+%%                                 (literally [{error, notfound}])
+%%        <<"include_keydata">> : produce the keydata as the result
+%%                                (literally [KD])
+%%        {struct,[{<<"sub">>,term()}]} : produce term() as the result
+%%                                        (literally term())
+%%      The last form has a strange stucture, in order to allow
+%%      its specification over the HTTP interface
+%%      (as JSON like ..."arg":{"sub":1234}...).
+map_object_value({error, notfound}=NF, KD, Action) ->
+    notfound_map_action(NF, KD, Action);
 map_object_value(RiakObject, _, _) ->
     [riak_object:get_value(RiakObject)].
 
@@ -95,8 +110,19 @@ map_object_value_list(Acc) ->
 %% @spec map_object_value_list(riak_object:riak_object(), term(), term()) ->
 %%                            [term()]
 %% @doc map phase function for map_object_value_list/1
+%%      See map_object_value/3 for a description of the behavior of
+%%      this function with the RiakObject is {error, notfound}.
+map_object_value_list({error, notfound}=NF, KD, Action) ->
+    notfound_map_action(NF, KD, Action);
 map_object_value_list(RiakObject, _, _) ->
     riak_object:get_value(RiakObject).
+
+%% implementation of the notfound behavior for
+%% map_object_value and map_object_value_list
+notfound_map_action(_NF, _KD, <<"filter_notfound">>)    -> [];
+notfound_map_action(NF, _KD, <<"include_notfound">>)    -> [NF];
+notfound_map_action(_NF, KD, <<"include_keydata">>)     -> [KD]; 
+notfound_map_action(_NF, _KD, {struct,[{<<"sub">>,V}]}) -> V.
 
 %%
 %% Reduce Phases

--- a/src/riak_kv_mapreduce.erl
+++ b/src/riak_kv_mapreduce.erl
@@ -214,6 +214,8 @@ not_found_filter(Values) ->
               is_datum(Value)].
 is_datum({not_found, _}) ->
     false;
+is_datum({not_found, _, _}) ->
+    false;
 is_datum(_) ->
     true.
 

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -378,7 +378,7 @@ do_mget({fsm, Sender}, BKeys, ReqId, State=#state{idx=Idx, mod=Mod, modstate=Mod
                     {ok, Obj} ->
                         gen_fsm:send_event(Sender, {r, Obj, Idx, ReqId});
                     _ ->
-                        gen_fsm:send_event(Sender, {r, R, Idx, ReqId})
+                        gen_fsm:send_event(Sender, {r, {R, BKey}, Idx, ReqId})
                 end,
                 riak_kv_stat:update(vnode_get) end,
     [F(BKey) || BKey <- BKeys],


### PR DESCRIPTION
These patches prevent map/reduce jobs from failing (with 'exhausted_preflist' errors) when non-existent bucket/keys are sent to map phases.  They restore the 0.13.0 behavior of evaluating Erlang map functions with the {error, notfound} tuple, and of substituting a "not_found" result in lieu of evaluating Javascript map functions.
