### PR TITLE
Bug 964 - riak_kv_mapred_term doesn't understand key-filters (Protobuffs) 

### DIFF
--- a/src/riak_kv_mapred_term.erl
+++ b/src/riak_kv_mapred_term.erl
@@ -58,6 +58,7 @@ parse_request(BinReq) ->
 %% Return ok if inputs are valid, {error, Reason} if not
 %% @type mapred_inputs() = [bucket_key()]
 %%                        |bucket()
+%%                        |{bucket(), list()}
 %%                        |{modfun, atom(), atom(), list()}
 valid_inputs(Bucket) when is_binary(Bucket) ->    
     ok;
@@ -66,8 +67,10 @@ valid_inputs(Targets) when is_list(Targets) ->
 valid_inputs({modfun, Module, Function, _Options})
   when is_atom(Module), is_atom(Function) ->
     ok;
+valid_inputs({Bucket, Filters}) when is_binary(Bucket), is_list(Filters) ->
+    ok;
 valid_inputs(Invalid) ->
-    {error, {"Inputs must be a binary bucket, a list of target tuples, or a modfun tuple:", Invalid}}.
+    {error, {"Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of target tuples, or a modfun tuple:", Invalid}}.
 
 %% @type bucket_key() = {binary(), binary()}
 %%                     |{{binary(), binary()}, term()}


### PR DESCRIPTION
Fixes bug where JSON format understands key filters but Erlang-terms format does not.
