### PR TITLE
Bz325 mapred builtins min max

### DIFF
--- a/priv/mapred_builtins.js
+++ b/priv/mapred_builtins.js
@@ -72,12 +72,20 @@ var Riak = function() {
         return [0];
       }},
     reduceMin: function(values, arg) {
-      values.sort();
-      return [values[0]];
+      if(values.length == 0)
+        return [];
+      else
+        return [values.reduce(function(prev,next){ 
+          return (prev < next) ? prev : next; 
+        })];
     },
     reduceMax: function(values, arg) {
-      values.sort().reverse();
-      return [values[0]];
+      if(values.length == 0)
+        return [];
+      else
+        return [values.reduce(function(prev,next){ 
+          return (prev > next) ? prev : next; 
+        })];
     },
     reduceSort: function(value, arg) {
       try {

--- a/priv/mapred_builtins.js
+++ b/priv/mapred_builtins.js
@@ -42,27 +42,27 @@ var Riak = function() {
       else {
         return data;
       }},
-     mapValuesJson: function(value, keyData, arg) {
+    mapValuesJson: function(value, keyData, arg) {
       if (value["not_found"]) {
         return [value];
       }
       var newValues = Riak.mapValues(value, keyData, arg);
       return newValues.map(function(nv) { return JSON.parse(nv); });
     },
-     mapByFields: function(value, keyData, fields) {
-         if(!value.not_found) {
-             var object = Riak.mapValuesJson(value)[0];
-             for(field in fields) {
-                 if(object[field] != fields[field]) {
-                     return [];
-                 }
-             }
-             return [object];
-         } 
-         else {
-             return [];
-         }
-     },
+    mapByFields: function(value, keyData, fields) {
+      if(!value.not_found) {
+        var object = Riak.mapValuesJson(value)[0];
+        for(field in fields) {
+          if(object[field] != fields[field]) {
+            return [];
+          }
+        }
+        return [object];
+      }
+      else {
+        return [];
+      }
+    },
     reduceSum: function(values, arg) {
       values = Riak.filterNotFound(values);
       if (values.length > 0) {


### PR DESCRIPTION
Fixes Riak.reduceMin and Riak.reduceMax. Also reformats some uneven indentation.

Javascript's sort() function sorts lexically and thus will not sort numbers correctly without a comparator function. Reduce/fold is the proper way to find a minimum or maximum.
