### PR TITLE
Key count reduce function

### DIFF
--- a/src/riak_kv_mapreduce.erl
+++ b/src/riak_kv_mapreduce.erl
@@ -83,13 +83,13 @@ map_object_value(Acc) ->
 %%      If the RiakObject is the tuple {error, notfound}, the
 %%      behavior of this function is defined by the Action argument.
 %%      Values for Action are:
-%%        <<"filter_notfound">> : produce no output (literally [])
-%%        <<"include_notfound">> : produce the not-found as the result
-%%                                 (literally [{error, notfound}])
-%%        <<"include_keydata">> : produce the keydata as the result
-%%                                (literally [KD])
-%%        {struct,[{<<"sub">>,term()}]} : produce term() as the result
-%%                                        (literally term())
+%%        `<<"filter_notfound">>' : produce no output (literally [])
+%%        `<<"include_notfound">>' : produce the not-found as the result
+%%                                   (literally [{error, notfound}])
+%%        `<<"include_keydata">>' : produce the keydata as the result
+%%                                  (literally [KD])
+%%        `{struct,[{<<"sub">>,term()}]}' : produce term() as the result
+%%                                          (literally term())
 %%      The last form has a strange stucture, in order to allow
 %%      its specification over the HTTP interface
 %%      (as JSON like ..."arg":{"sub":1234}...).


### PR DESCRIPTION
The intention of this patch is to provide a suitable function for
counting the keys in a bucket via keylist+map/reduce.  Using this
function saves bandwidth over counting on the client side (with
?keys=stream, for example) because keys are never sent to the client.
Using this function saves I/O over a query including a map phase because
the values stored under the keys are never read from disk.

It still uses the regular list-keys process under the hood, but it at least abstracts the framework necessary for handling the streamed keylists.

See the commit message or edoc for example usage.
