### PR TITLE
Bz962 cluster info usage unclear

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -124,10 +124,7 @@ cluster_info([OutFile|Rest]) ->
             cluster_info:dump_all_connected(OutFile);
         Nodes ->
             cluster_info:dump_nodes(Nodes, OutFile)
-    end;
-cluster_info(_) ->
-    io:format("Usage: output-file ['local'|node_name ['local'|node_name] [...]]\n"),
-    error.
+    end.
 
 format_stats([], Acc) ->
     lists:reverse(Acc);


### PR DESCRIPTION
This change needs to be in sync with the pull requests from the same feature branches for riak and riak_ee since it moves the cluster_info argument check to riak-admin.
