### PR TITLE
Specify Erlang map reduce functions as strings

### DIFF
--- a/ebin/riak_kv.app
+++ b/ebin/riak_kv.app
@@ -83,6 +83,15 @@
          {stats_urlpath, "stats"},
 
          %% Secondary code paths
-         {add_paths, []}
+         {add_paths, []},
+
+         %% Allow Erlang MapReduce functions to be specified as
+         %% strings.
+         %%
+         %% !!!WARNING!!!
+         %% This will allow arbitrary Erlang code to be submitted
+         %% through the REST and Protocol Buffers interfaces. This
+         %% should only be used for development purposes.
+         {allow_strfun, false}
         ]}
  ]}.

--- a/src/riak_kv_mapred_json.erl
+++ b/src/riak_kv_mapred_json.erl
@@ -378,6 +378,8 @@ erl_phase_error(StepDef) ->
                             "\"query\":[{\"map\":{\"language\":\"javascript\","
                             "\"source\":\"function(obj) { return obj; }\", \"keep\": false}}]}">>).
 
+-define(ERLANG_STRFUN_JOB, <<"{\"inputs\": [[\"foo\", \"bar\"]], \"query\":[{\"map\":{\"language\":\"erlang\","
+                               "\"source\":\"fun(_, _, _) -> [] end.\"}}]}">>).
 
 discrete_test() ->
     {ok, _Inputs, _Query, _Timeout} = riak_kv_mapred_json:parse_request(?DISCRETE_ERLANG_JOB),
@@ -389,5 +391,8 @@ bucket_test() ->
 
 key_select_test() ->
     {ok, _Inputs, _Query, _Timeout} = riak_kv_mapred_json:parse_request(?KEY_SELECTION_JOB).
+
+strfun_test() ->
+    {ok, _Inputs, _Query, _Timeout} = riak_kv_mapred_json:parse_request(?ERLANG_STRFUN_JOB).
 
 -endif.

--- a/src/riak_kv_mapred_query.erl
+++ b/src/riak_kv_mapred_query.erl
@@ -45,6 +45,9 @@
 %%         Mod:Fun(Object,KeyData,Arg)</li>
 %%<li>  {qfun, Fun} : Fun is an actual fun ->
 %%         Fun(Object,KeyData,Arg)</li>
+%%<li>  {strfun, Fun} : Fun is a string (list or binary)
+%%         containing the definition of an anonymous
+%%         Erlang function.</li>
 %%</ul>
 %% @type mapred_queryterm() =
 %%         {map, mapred_funterm(), Arg :: term(),
@@ -55,7 +58,8 @@
 %%          Accumulate :: boolean()}
 %% @type mapred_funterm() =
 %%         {modfun, Module :: atom(), Function :: atom()}|
-%%         {qfun, function()}
+%%         {qfun, function()}|
+%%         {strfun, list() | binary()}
 %% @type mapred_result() = [term()]
 
 -module(riak_kv_mapred_query).
@@ -87,11 +91,24 @@ check_query_syntax([QTerm={QTermType, QueryFun, Misc, Acc}|Rest], Accum) when is
                                {phase_mod(T), phase_behavior(T, QueryFun, Acc), [{erlang, QTerm}]};
                            {qfun, Fun} when is_function(Fun) ->
                                {phase_mod(T), phase_behavior(T, QueryFun, Acc), [{erlang, QTerm}]};
+                           {strfun, FunStr} when is_binary(FunStr); is_list(FunStr) ->
+                               Fun = define_anon_erl(FunStr),
+                               {phase_mod(T), phase_behavior(T, QueryFun, Acc),
+                                [{erlang, {T, {qfun, Fun}, Misc, Acc}}]};
+                           {strfun, {Bucket, Key}} when is_binary(Bucket), is_binary(Key) ->
+                               case fetch_src(Bucket, Key) of
+                                   {ok, FunStr} ->
+                                       Fun = define_anon_erl(FunStr),
+                                       {phase_mod(T), phase_behavior(T, QueryFun, Acc),
+                                        [{erlang, {T, {qfun, Fun}, Misc, Acc}}]};
+                                   _ ->
+                                       {bad_qterm, QTerm}
+                               end;
                            {jsanon, JS} when is_binary(JS) ->
                                {phase_mod(T), phase_behavior(T, QueryFun, Acc), [{javascript, QTerm}]};
                            {jsanon, {Bucket, Key}} when is_binary(Bucket),
                                                         is_binary(Key) ->
-                               case fetch_js(Bucket, Key) of
+                               case fetch_src(Bucket, Key) of
                                    {ok, JS} ->
                                        {phase_mod(T), phase_behavior(T, QueryFun, Acc), [{javascript,
                                                                                           {T, {jsanon, JS}, Misc, Acc}}]};
@@ -135,7 +152,7 @@ phase_behavior(reduce, _QueryFun, Accumulate) ->
             Behaviors0
     end.
 
-fetch_js(Bucket, Key) ->
+fetch_src(Bucket, Key) ->
     {ok, Client} = riak:local_client(),
     case Client:get(Bucket, Key, 1) of
         {ok, Obj} ->
@@ -143,3 +160,22 @@ fetch_js(Bucket, Key) ->
         _ ->
             {error, bad_fetch}
     end.
+
+define_anon_erl(FunStr) when is_binary(FunStr) ->
+    define_anon_erl(binary_to_list(FunStr));
+define_anon_erl(FunStr) when is_list(FunStr) ->
+    {ok, Tokens, _} = erl_scan:string(FunStr),
+    {ok, [Form]} = erl_parse:parse_exprs(Tokens),
+    {value, Fun, _} = erl_eval:expr(Form, erl_eval:new_bindings()),
+    Fun.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+strfun_test() ->
+    Query = [{map, {strfun, "fun(_,_,_) -> [] end."}, none, true}],
+    {ok, [{riak_kv_map_phase, [accumulate], [{erlang, {map, {qfun, Fun}, none, true}}]}]}
+        = check_query_syntax(Query),
+    ?assertEqual(true, erlang:is_function(Fun, 3)).
+
+-endif.


### PR DESCRIPTION
This commit allows users to specify Erlang map reduce functions as strings:
REST:
curl http://127.0.0.1:8098/mapred -XPOST -H 'content-type: application/json' -d '{"inputs":[["b","k1"],["b","k2"]], "query":[{"map":{"language":"erlang","source":"fun(_,_,_)-> [ok] end."}}]}'
["ok","ok"]

PBC:
(riak@127.0.0.1)3> {ok,Pid}=riakc_pb_socket:start_link ("127.0.0.1", 8087).
{ok,<0.12379.1>}
(riak@127.0.0.1)4> riakc_pb_socket:mapred(Pid, [{<<"b">>, <<"k1">>},{<<"b">>, <<"k2">>}], 
(riak@127.0.0.1)4>                        [{map, {strfun, "fun(_,_,_) -> [ok] end."}, none, true}]). 
{ok,[{0,[ok,ok]}]}
