### PR TITLE
R unsatisfied but object found

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -216,6 +216,7 @@ mapred_dynamic_inputs_stream(FSMPid, InputDef, Timeout) ->
 %%       {error, notfound} |
 %%       {error, timeout} |
 %%       {error, {n_val_violation, N::integer()}} |
+%%       {error, {r_val_unsatisfied, R::integer(), Replies::integer()}} |
 %%       {error, Err :: term()}
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as the default
 %%      R-value for the nodes have responded with a value or error.
@@ -227,6 +228,7 @@ get(Bucket, Key) -> get(Bucket, Key, default, ?DEFAULT_TIMEOUT).
 %%       {error, notfound} |
 %%       {error, timeout} |
 %%       {error, {n_val_violation, N::integer()}} |
+%%       {error, {r_val_unsatisfied, R::integer(), Replies::integer()}} |
 %%       {error, Err :: term()}
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as R
 %%      nodes have responded with a value or error.
@@ -239,6 +241,7 @@ get(Bucket, Key, R) -> get(Bucket, Key, R, ?DEFAULT_TIMEOUT).
 %%       {error, notfound} |
 %%       {error, timeout} |
 %%       {error, {n_val_violation, N::integer()}} |
+%%       {error, {r_val_unsatisfied, R::integer(), Replies::integer()}} |
 %%       {error, Err :: term()}
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as R
 %%      nodes have responded with a value or error, or TimeoutMillisecs passes.

--- a/src/riak_kv_wm_raw.erl
+++ b/src/riak_kv_wm_raw.erl
@@ -345,43 +345,38 @@ malformed_request(RD, Ctx) ->
             case DocCtx#ctx.doc of
                 {error, notfound} ->
                     {{halt, 404},
-                     wrq:set_resp_header("X-Riak-Error", io_lib:format("~p~n", [DocCtx#ctx.doc]),
                      wrq:set_resp_header("Content-Type", "text/plain",
                                          wrq:append_to_response_body(
                                            io_lib:format("not found~n",[]),
-                                           ResRD))),
+                                           ResRD)),
                      DocCtx};
                 {error, {r_val_unsatisfied, Requested, Given}} ->
                     {{halt, 503},
-                     wrq:set_resp_header("X-Riak-Error", io_lib:format("~p~n", [DocCtx#ctx.doc]),
                      wrq:set_resp_header("Content-Type", "text/plain",
                                          wrq:append_to_response_body(
                                            io_lib:format("R-value unsatisfied (got ~p of ~p)~n",[Given,Requested]),
-                                           ResRD))),
+                                           ResRD)),
                      DocCtx};
                 {error, timeout} ->
                     {{halt, 503},
-                     wrq:set_resp_header("X-Riak-Error", io_lib:format("~p~n", [DocCtx#ctx.doc]),
                      wrq:set_resp_header("Content-Type", "text/plain",
                                       wrq:append_to_response_body(
                                         io_lib:format("request timed out~n",[]),
-                                        ResRD))),
+                                        ResRD)),
                      DocCtx};
                 {error, {n_val_violation, _}} ->
                     {{halt, 400},
-                     wrq:set_resp_header("X-Riak-Error", io_lib:format("~p~n", [DocCtx#ctx.doc]),
                      wrq:set_resp_header("Content-Type", "text/plain",
                                   wrq:append_to_response_body(
                                     io_lib:format("R-value unsatisfiable~n",[]),
-                                    ResRD))),
+                                    ResRD)),
                      DocCtx};
                 {error, Err} ->
                     {{halt, 500},
-                     wrq:set_resp_header("X-Riak-Error", io_lib:format("~p~n", [DocCtx#ctx.doc]),
                      wrq:set_resp_header("Content-Type", "text/plain",
                                   wrq:append_to_response_body(
                                     io_lib:format("Error:~n~p~n",[Err]),
-                                    ResRD))),
+                                    ResRD)),
                      DocCtx};
                 _ ->
                     {false, ResRD, DocCtx}
@@ -650,19 +645,18 @@ resource_exists(RD, Ctx0) ->
                      RD, DocCtx#ctx{vtag=Vtag}}
             end;
         {error,_} ->
-            RD2 = wrq:set_resp_header("X-Riak-Error", io_lib:format("~p~n", [DocCtx#ctx.doc]), RD),
             case DocCtx#ctx.doc of
                 {error, notfound} ->
-                    {false, RD2, DocCtx};
+                    {false, RD, DocCtx};
                 {error, {r_val_unsatisfied, Requested, Given}} ->
                     Msg = io_lib:format("R-value unsatisfied (got ~p of ~p)~n", [Given,Requested]),
-                    {{halt, 503}, wrq:append_to_response_body(Msg, RD2), DocCtx};
+                    {{halt, 503}, wrq:append_to_response_body(Msg, RD), DocCtx};
                 {error, timeout} ->
                     {{halt, 503}, RD, DocCtx};
                 {error, {n_val_violation, N}} ->
                     Msg = io_lib:format("Specified r/w/dw values invalid for bucket"
                                         " n value of ~p~n", [N]),
-                    {{halt, 400}, wrq:append_to_response_body(Msg, RD2), DocCtx}
+                    {{halt, 400}, wrq:append_to_response_body(Msg, RD), DocCtx}
             end
     end.
 

--- a/src/riak_kv_wm_raw.erl
+++ b/src/riak_kv_wm_raw.erl
@@ -345,38 +345,43 @@ malformed_request(RD, Ctx) ->
             case DocCtx#ctx.doc of
                 {error, notfound} ->
                     {{halt, 404},
+                     wrq:set_resp_header("X-Riak-Error", io_lib:format("~p~n", [DocCtx#ctx.doc]),
                      wrq:set_resp_header("Content-Type", "text/plain",
                                          wrq:append_to_response_body(
                                            io_lib:format("not found~n",[]),
-                                           ResRD)),
+                                           ResRD))),
                      DocCtx};
                 {error, {r_val_unsatisfied, Requested, Given}} ->
                     {{halt, 503},
+                     wrq:set_resp_header("X-Riak-Error", io_lib:format("~p~n", [DocCtx#ctx.doc]),
                      wrq:set_resp_header("Content-Type", "text/plain",
                                          wrq:append_to_response_body(
                                            io_lib:format("R-value unsatisfied (got ~p of ~p)~n",[Given,Requested]),
-                                           ResRD)),
+                                           ResRD))),
                      DocCtx};
                 {error, timeout} ->
                     {{halt, 503},
+                     wrq:set_resp_header("X-Riak-Error", io_lib:format("~p~n", [DocCtx#ctx.doc]),
                      wrq:set_resp_header("Content-Type", "text/plain",
                                       wrq:append_to_response_body(
                                         io_lib:format("request timed out~n",[]),
-                                        ResRD)),
+                                        ResRD))),
                      DocCtx};
                 {error, {n_val_violation, _}} ->
                     {{halt, 400},
+                     wrq:set_resp_header("X-Riak-Error", io_lib:format("~p~n", [DocCtx#ctx.doc]),
                      wrq:set_resp_header("Content-Type", "text/plain",
                                   wrq:append_to_response_body(
                                     io_lib:format("R-value unsatisfiable~n",[]),
-                                    ResRD)),
+                                    ResRD))),
                      DocCtx};
                 {error, Err} ->
                     {{halt, 500},
+                     wrq:set_resp_header("X-Riak-Error", io_lib:format("~p~n", [DocCtx#ctx.doc]),
                      wrq:set_resp_header("Content-Type", "text/plain",
                                   wrq:append_to_response_body(
                                     io_lib:format("Error:~n~p~n",[Err]),
-                                    ResRD)),
+                                    ResRD))),
                      DocCtx};
                 _ ->
                     {false, ResRD, DocCtx}
@@ -644,17 +649,21 @@ resource_exists(RD, Ctx0) ->
                                MDs),
                      RD, DocCtx#ctx{vtag=Vtag}}
             end;
-        {error, notfound} ->
-            {false, RD, DocCtx};
-        {error, {r_val_unsatisfied, Requested, Given}} ->
-            Msg = io_lib:format("R-value unsatisfied (got ~p of ~p)~n", [Given,Requested]),
-            {{halt, 503}, wrq:append_to_response_body(Msg, RD), DocCtx};
-        {error, timeout} ->
-            {{halt, 503}, RD, DocCtx};
-        {error, {n_val_violation, N}} ->
-            Msg = io_lib:format("Specified r/w/dw values invalid for bucket"
-                                " n value of ~p~n", [N]),
-            {{halt, 400}, wrq:append_to_response_body(Msg, RD), DocCtx}
+        {error,_} ->
+            RD2 = wrq:set_resp_header("X-Riak-Error", io_lib:format("~p~n", [DocCtx#ctx.doc]), RD),
+            case DocCtx#ctx.doc of
+                {error, notfound} ->
+                    {false, RD2, DocCtx};
+                {error, {r_val_unsatisfied, Requested, Given}} ->
+                    Msg = io_lib:format("R-value unsatisfied (got ~p of ~p)~n", [Given,Requested]),
+                    {{halt, 503}, wrq:append_to_response_body(Msg, RD2), DocCtx};
+                {error, timeout} ->
+                    {{halt, 503}, RD, DocCtx};
+                {error, {n_val_violation, N}} ->
+                    Msg = io_lib:format("Specified r/w/dw values invalid for bucket"
+                                        " n value of ~p~n", [N]),
+                    {{halt, 400}, wrq:append_to_response_body(Msg, RD2), DocCtx}
+            end
     end.
 
 %% @spec produce_toplevel_body(reqdata(), context()) -> {binary(), reqdata(), context()}


### PR DESCRIPTION
Here's a proposed fix for the problem we have.

Let riak_client:get optionally return `{r_value_unsatisfied, R, P}`, where P is the number of ok replies, and R is the requested R value.

This changes the riak_kv_get_fsm logic in the cases where it receives 
`{error,  _}` to 
- not reply {error, notfound} unless the error is the Nth reply
- reply {r_value_unsatisfied, R, P} iff 0 < P < R and all errors
  from vnodes were notfound's, i.e. it is likely that a read-repair
  is imminent which will fix the issue.

So, effectively this lets us differentiate between two cases that currently reply `{error, notfound}`:
- the object is really not there (either it was deleted or never there)
- the object is available in _less than r vnodes_, but it is in there somewhere.

When the webmachine front receives a {r_value_unsatisfied, R, P}, it will issue an {halt, 503}.

So, this slows down the failure cases somewhat: it is slower to see the difference between a 404 "really-nothing-there" and a 503 "we have something, but the ?r=R request parameter was not satisfied.

For our usage cases, we really need to be able to make this distinction.
