### PR TITLE
Purify KV FSMs

### DIFF
--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -77,7 +77,7 @@ execute(timeout, StateData0=#state{timeout=Timeout, r=R0, req_id=ReqId,
                                    bucket_props=BucketProps,
                                    up_nodes=UpNodes,
                                    ring=Ring}) ->
-    TRef = erlang:send_after(Timeout, self(), timeout),
+    TRef = schedule_timeout(Timeout),
     DocIdx = riak_core_util:chash_key({Bucket, Key}),
     Req = #riak_kv_get_req_v1{
       bkey = BKey,
@@ -281,6 +281,11 @@ terminate(Reason, _StateName, _State) ->
 
 %% @private
 code_change(_OldVsn, StateName, State, _Extra) -> {ok, StateName, State}.
+
+schedule_timeout(infinity) ->
+    undefined;
+schedule_timeout(Timeout) ->
+    erlang:send_after(Timeout, self(), timeout).
 
 client_reply(Reply, #state{client = Client, req_id = ReqId}) ->
     Client ! {ReqId, Reply}.

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -104,7 +104,7 @@ prepare(timeout, StateData=#state{bkey=BKey={Bucket,_Key}}) ->
     DocIdx = riak_core_util:chash_key(BKey),
     N = proplists:get_value(n_val,BucketProps),
     UpNodes = riak_core_node_watcher:nodes(riak_kv),
-    Preflist2 = riak_core_apl:get_apl2(DocIdx, N, Ring, UpNodes),
+    Preflist2 = riak_core_apl:get_apl_ann(DocIdx, N, Ring, UpNodes),
     {next_state, execute, StateData#state{starttime=riak_core_util:moment(),
                                           n = N,
                                           bucket_props=BucketProps,

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -363,6 +363,7 @@ setup() ->
 
     %% Have tracer on hand to grab any traces we want
     riak_core_tracer:start_link(),
+    riak_core_tracer:reset(),
     riak_core_tracer:filter([{riak_kv_vnode, readrepair}],
                    fun({trace, _Pid, call,
                         {riak_kv_vnode, readrepair, 
@@ -428,6 +429,7 @@ happy_path_case() ->
     %% Check readrepair issued to third node
     ExpRRPrefList = lists:sublist(Preflist, 3, 1),
     riak_kv_test_util:wait_for_pid(_FsmPid2),
+    riak_core_tracer:stop_collect(),
     ?assertEqual([{0, {rr, ExpRRPrefList, Obj1, ReqId3}}],
                  riak_core_tracer:results()).
 

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -23,6 +23,10 @@
 -module(riak_kv_get_fsm).
 -behaviour(gen_fsm).
 -include_lib("riak_kv_vnode.hrl").
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-export([test/7, test_link/7]).
+-endif.
 -export([start/6]).
 -export([init/1, handle_event/3, handle_sync_event/4,
          handle_info/3, terminate/3, code_change/4]).
@@ -44,7 +48,7 @@
                 num_fail = 0,
                 final_obj :: undefined | {ok, riak_object:riak_object()} |
                              tombstone | {error, notfound},
-                timeout :: pos_integer(),
+                timeout :: infinity | pos_integer(),
                 tref    :: reference(),
                 bkey :: {riak_object:bucket(), riak_object:key()},
                 bucket_props,
@@ -54,14 +58,47 @@
 start(ReqId,Bucket,Key,R,Timeout,From) ->
     gen_fsm:start(?MODULE, [ReqId,Bucket,Key,R,Timeout,From], []).
 
+-ifdef(TEST).
+%% Create a get FSM for testing.  StateProps must include
+%% starttime - start time in gregorian seconds
+%% n - N-value for request (is grabbed from bucket props in prepare)
+%% bucket_props - bucket properties
+%% preflist2 - [{{Idx,Node},primary|fallback}] preference list
+%% 
+test(ReqId,Bucket,Key,R,Timeout,From,StateProps) ->
+    gen_fsm:start(?MODULE, {test, [ReqId,Bucket,Key,R,Timeout,From], StateProps}, []).
+
+%% As test, but linked to the caller
+test_link(ReqId,Bucket,Key,R,Timeout,From,StateProps) ->
+    gen_fsm:start_link(?MODULE, {test, [ReqId,Bucket,Key,R,Timeout,From], StateProps}, []).
+-endif.
+
 %% @private
 init([ReqId,Bucket,Key,R,Timeout,Client]) ->
-    StateData = #state{client=Client,r=R, timeout=Timeout,
-                req_id=ReqId, bkey={Bucket,Key}},
-    {ok,prepare,StateData,0};
-
-prepare(timeout, StateData=#state{bkey=BKey={Bucket,_Key}}) ->
     StartNow = now(),
+    StateData = #state{client=Client,r=R, timeout=Timeout,
+                       req_id=ReqId, bkey={Bucket,Key},
+                       startnow=StartNow},
+    {ok,prepare,StateData,0};
+init({test, Args, StateProps}) ->
+    %% Call normal init
+    {ok, prepare, StateData, 0} = init(Args),
+
+    %% Then tweak the state record with entries provided by StateProps
+    Fields = record_info(fields, state),
+    FieldPos = lists:zip(Fields, lists:seq(2, length(Fields)+1)),
+    F = fun({Field, Value}, State0) ->
+                Pos = proplists:get_value(Field, FieldPos),
+                setelement(Pos, State0, Value)
+        end,
+    TestStateData = lists:foldl(F, StateData, StateProps),
+
+    %% Enter into the execute state, skipping any code that relies on the
+    %% state of the rest of the system
+    {ok, execute, TestStateData, 0}.
+
+%% @private
+prepare(timeout, StateData=#state{bkey=BKey={Bucket,_Key}}) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     BucketProps = riak_core_bucket:get_bucket(Bucket, Ring),
     DocIdx = riak_core_util:chash_key(BKey),
@@ -71,8 +108,7 @@ prepare(timeout, StateData=#state{bkey=BKey={Bucket,_Key}}) ->
     {next_state, execute, StateData#state{starttime=riak_core_util:moment(),
                                           n = N,
                                           bucket_props=BucketProps,
-                                          preflist2 = Preflist2,
-                                          startnow=StartNow}, 0}.
+                                          preflist2 = Preflist2}, 0}.
 
 %% @private
 execute(timeout, StateData0=#state{timeout=Timeout, n=N, r=R0, req_id=ReqId,
@@ -139,7 +175,8 @@ really_finalize(StateData=#state{allowmult = AllowMult,
                                  bkey=BKey,
                                  req_id=ReqId,
                                  replied_notfound=NotFound,
-                                 starttime=StartTime}) ->
+                                 starttime=StartTime,
+                                 bucket_props=BucketProps}) ->
     Final = case FinalObj of
                 undefined -> %% Recompute if extra read repairs have arrived
                     merge(RepliedR,AllowMult);
@@ -151,7 +188,7 @@ really_finalize(StateData=#state{allowmult = AllowMult,
             maybe_finalize_delete(StateData);
         {ok,_} ->
             maybe_do_read_repair(Sent,Final,RepliedR,NotFound,BKey,
-                                 ReqId,StartTime);
+                                 ReqId,StartTime,BucketProps);
         _ -> nop
     end,
     {stop,normal,StateData}.
@@ -176,7 +213,7 @@ maybe_finalize_delete(_StateData=#state{replied_notfound=NotFound,n=N,
         _ -> nop
     end.
 
-maybe_do_read_repair(Sent,Final,RepliedR,NotFound,BKey,ReqId,StartTime) ->
+maybe_do_read_repair(Sent,Final,RepliedR,NotFound,BKey,ReqId,StartTime,BucketProps) ->
     Targets = ancestor_indices(Final, RepliedR) ++ NotFound,
     {ok, FinalRObj} = Final,
     case Targets of
@@ -185,7 +222,8 @@ maybe_do_read_repair(Sent,Final,RepliedR,NotFound,BKey,ReqId,StartTime) ->
             RepairPreflist = [{Idx, Node} || {{Idx,Node},_Type} <- Sent, 
                                             lists:member(Idx, Targets)],
             riak_kv_vnode:readrepair(RepairPreflist, BKey, FinalRObj, ReqId, 
-                                     StartTime, [{returnbody, false}]),
+                                     StartTime, [{returnbody, false},
+                                                 {bucket_props, BucketProps}]),
             riak_kv_stat:update(read_repairs)
     end.
 
@@ -299,3 +337,140 @@ ancestor_indices({ok, Final},AnnoObjects) ->
 update_stats(#state{startnow=StartNow}) ->
     EndNow = now(),
     riak_kv_stat:update({get_fsm_time, timer:now_diff(EndNow, StartNow)}).    
+
+
+-ifdef(TEST).
+-define(expect_msg(Exp,Timeout), 
+        ?assertEqual(Exp, receive Exp -> Exp after Timeout -> timeout end)).
+
+get_fsm_test_() ->
+    {spawn, [{ setup,
+               fun setup/0,
+               fun cleanup/1,
+               [
+                fun happy_path_case/0,
+                fun n_val_violation_case/0
+               ]
+             }]}.
+
+setup() ->
+    %% Set infinity timeout for the vnode inactivity timer so it does not
+    %% try to handoff.
+    application:load(riak_core),
+    application:set_env(riak_core, vnode_inactivity_timeout, infinity),
+    application:load(riak_kv),
+    application:set_env(riak_kv, storage_backend, riak_kv_ets_backend),
+
+    %% Have tracer on hand to grab any traces we want
+    riak_core_tracer:start_link(),
+    riak_core_tracer:filter([{riak_kv_vnode, readrepair}],
+                   fun({trace, _Pid, call,
+                        {riak_kv_vnode, readrepair, 
+                         [Preflist, _BKey, Obj, ReqId, _StartTime, _Options]}}) ->
+                           [{rr, Preflist, Obj, ReqId}]
+                   end),
+    ok.
+
+cleanup(_) ->
+    application:unload(riak_kv),
+    application:unload(riak_core),
+    dbg:stop_clear().
+
+happy_path_case() ->
+    riak_core_tracer:collect(5000),
+    
+    %% Start 3 vnodes
+    Indices = [1, 2, 3],
+    Preflist2 = [begin 
+                     {ok, Pid} = riak_kv_vnode:test_vnode(Idx),
+                     {{Idx, Pid}, primary}
+                 end || Idx <- Indices],
+    Preflist = [IdxPid || {IdxPid,_Type} <- Preflist2],
+
+    %% Decide on some parameters
+    Bucket = <<"mybucket">>,
+    Key = <<"mykey">>,
+    Nval = 3,
+    BucketProps = bucket_props(Bucket, Nval),
+
+    %% Start the FSM to issue a get and  check notfound
+
+    ReqId1 = 112381838, % erlang:phash2(erlang:now()).
+    R = 2,
+    Timeout = 1000,
+    {ok, _FsmPid1} = test_link(ReqId1, Bucket, Key, R, Timeout, self(),
+                               [{starttime, 63465712389},
+                               {n, Nval},
+                               {bucket_props, BucketProps},
+                               {preflist2, Preflist2}]),
+    ?assertEqual({error, notfound}, wait_for_reqid(ReqId1, Timeout + 1000)),
+   
+    %% Update the first two vnodes with a value
+    ReqId2 = 49906465,
+    Value = <<"value">>,
+    Obj1 = riak_object:new(Bucket, Key, Value),
+    riak_kv_vnode:put(lists:sublist(Preflist, 2), {Bucket, Key}, Obj1, ReqId2,
+                      63465715958, [{bucket_props, BucketProps}], {raw, ReqId2, self()}),
+    ?expect_msg({ReqId2, {w, 1, ReqId2}}, Timeout + 1000),
+    ?expect_msg({ReqId2, {w, 2, ReqId2}}, Timeout + 1000),
+    ?expect_msg({ReqId2, {dw, 1, ReqId2}}, Timeout + 1000),
+    ?expect_msg({ReqId2, {dw, 2, ReqId2}}, Timeout + 1000),
+                     
+    %% Issue a get, check value returned.
+    ReqId3 = 30031523,
+    {ok, _FsmPid2} = test_link(ReqId3, Bucket, Key, R, Timeout, self(),
+                              [{starttime, 63465712389},
+                               {n, Nval},
+                               {bucket_props, BucketProps},
+                               {preflist2, Preflist2}]),
+    ?assertEqual({ok, Obj1}, wait_for_reqid(ReqId3, Timeout + 1000)),
+
+    %% Check readrepair issued to third node
+    ExpRRPrefList = lists:sublist(Preflist, 3, 1),
+    riak_kv_test_util:wait_for_pid(_FsmPid2),
+    ?assertEqual([{0, {rr, ExpRRPrefList, Obj1, ReqId3}}],
+                 riak_core_tracer:results()).
+
+
+n_val_violation_case() ->
+    ReqId1 = 13210434, % erlang:phash2(erlang:now()).
+    Bucket = <<"mybucket">>,
+    Key = <<"badnvalkey">>,
+    Nval = 3,
+    R = 5,
+    Timeout = 1000,
+    BucketProps = bucket_props(Bucket, Nval),
+    {ok, _FsmPid1} = test_link(ReqId1, Bucket, Key, R, Timeout, self(),
+                               [{starttime, 63465712389},
+                               {n, Nval},
+                               {bucket_props, BucketProps}]),
+    ?assertEqual({error, {n_val_violation, 3}}, wait_for_reqid(ReqId1, Timeout + 1000)).
+ 
+    
+wait_for_reqid(ReqId, Timeout) ->
+    receive
+        {ReqId, Msg} -> Msg
+    after Timeout ->
+            {error, req_timeout}
+    end.
+
+bucket_props(Bucket, Nval) -> % riak_core_bucket:get_bucket(Bucket).
+    [{name, Bucket},
+     {allow_mult,false},
+     {big_vclock,50},
+     {chash_keyfun,{riak_core_util,chash_std_keyfun}},
+     {dw,quorum},
+     {last_write_wins,false},
+     {linkfun,{modfun,riak_kv_wm_link_walker,mapreduce_linkfun}},
+     {n_val,Nval},
+     {old_vclock,86400},
+     {postcommit,[]},
+     {precommit,[]},
+     {r,quorum},
+     {rw,quorum},
+     {small_vclock,10},
+     {w,quorum},
+     {young_vclock,20}].
+ 
+
+-endif.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -87,10 +87,10 @@ get(Preflist, BKey, ReqId) ->
                       req_id=ReqId},
     %% Assuming this function is called from a FSM process
     %% so self() == FSM pid
-    riak_core_vnode_master:sync_spawn_command(Preflist,
-                                              Req,
-                                              {fsm, ReqId, self()},
-                                              riak_kv_vnode_master).
+    riak_core_vnode_master:command(Preflist,
+                                   Req,
+                                   {fsm, undefined, self()},
+                                   riak_kv_vnode_master).
 
 mget(Preflist, BKeys, ReqId) ->
     Req = ?KV_MGET_REQ{bkeys=BKeys,

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -101,10 +101,10 @@ mget(Preflist, BKeys, ReqId) ->
                                    riak_kv_vnode_master).
 
 del(Preflist, BKey, ReqId) ->
-    riak_core_vnode_master:sync_command(Preflist,
-                                        ?KV_DELETE_REQ{bkey=BKey,
-                                                       req_id=ReqId},
-                                        riak_kv_vnode_master).
+    riak_core_vnode_master:command(Preflist,
+                                   ?KV_DELETE_REQ{bkey=BKey,
+                                                  req_id=ReqId},
+                                   riak_kv_vnode_master).
 
 %% Issue a put for the object to the preflist, expecting a reply
 %% to an FSM.

--- a/test/get_fsm_qc.erl
+++ b/test/get_fsm_qc.erl
@@ -465,7 +465,7 @@ eqc_test_() ->
     {timeout, 200, ?_test(
         begin
             start_mock_servers(),
-            ?assert(test(300))
+            ?assert(test(50))
         end)
     }}.
 

--- a/test/get_fsm_qc.erl
+++ b/test/get_fsm_qc.erl
@@ -11,6 +11,8 @@
 -define(DEFAULT_BUCKET_PROPS,
         [{allow_mult, false},
          {chash_keyfun, {riak_core_util, chash_std_keyfun}}]).
+-define(QC_OUT(P),
+        eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).
 
 %% Generators
 
@@ -324,7 +326,7 @@ test() ->
     test(100).
 
 test(N) ->
-    quickcheck(numtests(N, prop_basic_get())).
+    quickcheck(numtests(N, ?QC_OUT(prop_basic_get()))).
 
 do_repair(_Heads, notfound) ->
     true;
@@ -460,10 +462,10 @@ wait_for_pid(Pid) ->
     
 eqc_test_() ->
     {spawn,
-    {timeout, 20, ?_test(
+    {timeout, 200, ?_test(
         begin
             start_mock_servers(),
-            ?assert(test(30))
+            ?assert(test(300))
         end)
     }}.
 

--- a/test/get_fsm_qc_vnode_master.erl
+++ b/test/get_fsm_qc_vnode_master.erl
@@ -70,9 +70,10 @@ handle_call(get_history, _From, State) ->
 handle_call(get_repair_history, _From, State) -> %
     {reply, lists:reverse(State#state.repair_history), State};
 
-handle_call(?VNODE_REQ{index=Idx, request=?KV_DELETE_REQ{}=Msg},
+handle_call(Req=?VNODE_REQ{request=?KV_DELETE_REQ{}},
             _From, State) ->
-    {reply, ok, State#state{repair_history=[{Idx,Msg}|State#state.repair_history]}};
+    {noreply, NewState} = handle_cast(Req, State),
+    {reply, ok, NewState};
 handle_call(_Request, _From, State) ->
     Reply = ok,
     {reply, Reply, State}.
@@ -96,7 +97,9 @@ handle_cast(?VNODE_REQ{index=Idx,
     {noreply, State1};
 handle_cast(?VNODE_REQ{index=Idx,
                        request=?KV_PUT_REQ{}=Msg}, State) ->
-    {noreply, State#state{repair_history=[{Idx,Msg}|State#state.repair_history]}};    
+    {noreply, State#state{repair_history=[{Idx,Msg}|State#state.repair_history]}};
+handle_cast(?VNODE_REQ{index=Idx, request=?KV_DELETE_REQ{}=Msg}, State) ->
+    {noreply, State#state{repair_history=[{Idx,Msg}|State#state.repair_history]}};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 


### PR DESCRIPTION
 I've spent some time refactoring the get FSM today in preparation for changes and thought I'd share progress to see if we think this is a viable approach.  I've created branches in riak_core and riak_kv called jdm-purify-fsms and have pushed my latest and greatest including some code I forgot to commit end of Wednesday.

Here's the broad strokes of what I've done:
- split the initialized state into prepare and execute.  Any side effects are isolated to the prepare function.
- added an alternate start function that takes a proplist to fudge the state and drops into the execute state.
- refactored the vnode response handling into a single function
- refactored the reply-to-client decision into a function
- replaced the preference list code with the riak_core_vnode_master based commands and added an alternate variant of the preflist code that provides the vnode type of primary/fallback (needed for deletes, but will be vital for adding RP-responses-from-primaries condition).
- taught the vnode_master commands to recognize Pids in the preference list and send messages there directly instead of going through a vnode master.
- taught riak_kv_vnode:put to accept bucket properties in options so it didn't try and get the ring while in 'pure' mode
- made read repair supply bucket properties.
- cleaned up the strange spawning/individual sync deletes - I don't believe they provide any additional protection against races.  We need to add conditional matching on the vclock soon anyway.

The refactored code still passes all the original quickcheck tests and I've added a couple of examples of how it can be used in 'pure' mode without any other parts of the system spun up.

./rebar eunit app=riak_kv suite=riak_kv_get_fsm if you'd like to see it run.

riak_kv_put_fsm is causing problems with running the whole test suite, I'll clean that up when I refactor the put FSM.

Also requires pull request https://github.com/basho/riak_core/pull/19 for riak_core.

Looking for comments on
- if this seems like a good approach
- reasons why any of the changes are bad or breaks something
- if the delete change is acceptable
- if the readrepair change is acceptable, and if we think it is ok in production or if it needs to be conditional for testing.  It will mean more data sent per read repair.
