### PR TITLE
Bz1007 inconsistent map phase behavior

### DIFF
--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -320,7 +320,7 @@ to_json({{error, notfound}, {Bucket, Key}}) ->
               {<<"vclock">>, <<"">>},
               {<<"values">>,
                [{struct,
-                 [{<<"data">>, {struct, [{<<"error">>, <<"notfound">>}]}}]
+                 [{<<"data">>, <<"{\"error\":\"notfound\"}">>}]
                 }]
               }]};
 to_json(Obj=#r_object{}) ->

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -314,6 +314,15 @@ set_contents(Object=#r_object{}, MVs) when is_list(MVs) ->
 
 %% @spec to_json(riak_object()) -> {struct, list(any())}
 %% @doc Converts a riak_object into its JSON equivalent
+to_json({{error, notfound}, {Bucket, Key}}) ->
+    {struct, [{<<"bucket">>, Bucket},
+              {<<"key">>, Key},    
+              {<<"vclock">>, <<"">>},
+              {<<"values">>,
+               [{struct,
+                 [{<<"data">>, {struct, [{<<"error">>, <<"notfound">>}]}}]
+                }]
+              }]};
 to_json(Obj=#r_object{}) ->
     {_,Vclock} = riak_kv_wm_raw:vclock_header(Obj),
     {struct, [{<<"bucket">>, riak_object:bucket(Obj)},


### PR DESCRIPTION
These changes along with the accompanying changes to erlang_js resolve the inconsistent handling of 'notfound' errors between erlang and javascript map functions. These changes adopt option number 2 that was outlined in the [bugzilla ticket](https://issues.basho.com/show_bug.cgi?id=1007): all 'notfound' errors are passed to the map functions and may be handled there. In the case the errors are not handled by the map functions, the error output returned from using erlang and javascript functions in HTTP MapReduce queries are consistent now. 

There is still more work to be done to cleanup and improve MapReduce error handling, but I found it to be out of scope of this ticket.
