### PR TITLE
Support o_sync sync_strategy in Bitcask backend

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -251,6 +251,8 @@ maybe_schedule_sync(Ref) when is_reference(Ref) ->
             %%                   {?MODULE, {sync, SyncIntervalMs}});
         {ok, none} ->
             ok;
+        {ok, o_sync} ->
+            ok;
         BadStrategy ->
             error_logger:info_msg("Ignoring invalid bitcask sync strategy: ~p\n",
                                   [BadStrategy]),


### PR DESCRIPTION
Bitcask supports the o_sync sync_strategy in its application config, but riak_kv_bitcask_backend does not recognize it. This tiny patch fixes that.
