### PR TITLE
Timeout listing keys if "tokenize" filter used and key has fewer than _n_ tokens

### DIFF
--- a/src/riak_kv_mapred_filters.erl
+++ b/src/riak_kv_mapred_filters.erl
@@ -79,7 +79,14 @@ to_lower(_) ->
 tokenize(Args) ->
     Seps = riak_kv_mapred_filters:to_string(lists:nth(1, Args)),
     TokenNum = lists:nth(2, Args),
-    fun(V) -> list_to_binary(lists:nth(TokenNum, string:tokens(to_string(V), Seps))) end.
+    fun(V) ->
+	    Tokens = string:tokens(to_string(V), Seps),
+	    case length(Tokens) < TokenNum of
+		true -> [];
+		false ->
+		    list_to_binary(lists:nth(TokenNum, Tokens))
+	    end
+    end.
 
 urldecode(_) ->
     fun(V) -> {_, V1} = hd(mochiweb_util:parse_qs("x=" ++ to_string(V))), V1 end.
@@ -350,6 +357,10 @@ to_lower_test() ->
 tokenize_test() ->
     F = compose([{riak_kv_mapred_filters, tokenize, ["-", 3]}]),
     F("12-20-2010") =:= "2010".
+
+tokenize_too_few_tokens_test() ->
+    F = compose([{riak_kv_mapred_filters, tokenize, ["-", 4]}]),
+    F("12-20-2010") =:= [].
 
 % filters
 

--- a/src/riak_kv_mapred_filters.erl
+++ b/src/riak_kv_mapred_filters.erl
@@ -80,12 +80,12 @@ tokenize(Args) ->
     Seps = riak_kv_mapred_filters:to_string(lists:nth(1, Args)),
     TokenNum = lists:nth(2, Args),
     fun(V) ->
-	    Tokens = string:tokens(to_string(V), Seps),
-	    case length(Tokens) < TokenNum of
-		true -> [];
-		false ->
-		    list_to_binary(lists:nth(TokenNum, Tokens))
-	    end
+            Tokens = string:tokens(to_string(V), Seps),
+            case length(Tokens) < TokenNum of
+                true -> [];
+                false ->
+                    list_to_binary(lists:nth(TokenNum, Tokens))
+            end
     end.
 
 urldecode(_) ->

--- a/src/riak_kv_mapred_filters.erl
+++ b/src/riak_kv_mapred_filters.erl
@@ -80,12 +80,12 @@ tokenize(Args) ->
     Seps = riak_kv_mapred_filters:to_string(lists:nth(1, Args)),
     TokenNum = lists:nth(2, Args),
     fun(V) ->
-            Tokens = string:tokens(to_string(V), Seps),
-            case length(Tokens) < TokenNum of
-                true -> [];
-                false ->
-                    list_to_binary(lists:nth(TokenNum, Tokens))
-            end
+        Tokens = string:tokens(to_string(V), Seps),
+        case length(Tokens) < TokenNum of
+            true -> [];
+            false ->
+                list_to_binary(lists:nth(TokenNum, Tokens))
+        end
     end.
 
 urldecode(_) ->


### PR DESCRIPTION
Choice was either
1. return the key untransformed
2. do not return the key

I went with 2
