### PR TITLE
Catch all errors and prevent them propogating back up to the user

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -43,9 +43,9 @@ join([NodeStr]) ->
         end
     catch
         Exception:Reason ->
-            log_to_riak_node("join failed ~p:~p~n", [Exception,
+            log_to_riak_node("Join failed ~p:~p~n", [Exception,
                     Reason]),
-            io:format("join failed, see log for details~n"),
+            io:format("Join failed, see log for details~n"),
             error
     end.
 
@@ -68,11 +68,11 @@ remove_node(Node) when is_atom(Node) ->
                         %% the result of subtracting the current node from the
                         %% cluster member list results in the empty list. When
                         %% that code gets refactored this can probably go away.
-                        io:format("leave failed, this node is the only member.~n");
+                        io:format("Leave failed, this node is the only member.~n");
                     _ ->
-                        log_to_riak_node("Error leaving cluster ~p~n",
+                        log_to_riak_node("Leave failed ~p~n",
                             [RPCReason]),
-                        io:format("leave failed, see log for details~n")
+                        io:format("Leave failed, see log for details~n")
                 end,
                 error;
             Res ->
@@ -80,9 +80,9 @@ remove_node(Node) when is_atom(Node) ->
         end
     catch
         Exception:Reason ->
-            log_to_riak_node("leave failed ~p:~p~n", [Exception,
+            log_to_riak_node("Leave failed ~p:~p~n", [Exception,
                     Reason]),
-            io:format("leave failed, see log for details~n"),
+            io:format("Leave failed, see log for details~n"),
             error
     end.
 
@@ -101,9 +101,9 @@ status([]) ->
         end
     catch
         Exception:Reason ->
-            log_to_riak_node("status failed ~p:~p~n", [Exception,
+            log_to_riak_node("Status failed ~p:~p~n", [Exception,
                     Reason]),
-            io:format("status failed, see log for details~n"),
+            io:format("Status failed, see log for details~n"),
             error
     end.
 
@@ -128,9 +128,9 @@ reip([OldNode, NewNode]) ->
             [element(2, riak_core_ring_manager:find_latest_ringfile())])
     catch
         Exception:Reason ->
-            log_to_riak_node("reip failed ~p:~p~n", [Exception,
+            log_to_riak_node("Reip failed ~p:~p~n", [Exception,
                     Reason]),
-            io:format("reip failed, see log for details~n"),
+            io:format("Reip failed, see log for details~n"),
             error
     end.
 
@@ -150,9 +150,9 @@ ringready([]) ->
         end
     catch
         Exception:Reason ->
-            log_to_riak_node("ringready failed ~p:~p~n", [Exception,
+            log_to_riak_node("Ringready failed ~p:~p~n", [Exception,
                     Reason]),
-            io:format("ringready failed, see log for details~n"),
+            io:format("Ringready failed, see log for details~n"),
             error
     end.
 
@@ -182,9 +182,9 @@ transfers([]) ->
         end
     catch
         Exception:Reason ->
-            log_to_riak_node("transfers failed ~p:~p~n", [Exception,
+            log_to_riak_node("Transfers failed ~p:~p~n", [Exception,
                     Reason]),
-            io:format("transfers failed, see log for details~n"),
+            io:format("Transfers failed, see log for details~n"),
             error
     end.
 
@@ -199,15 +199,15 @@ cluster_info([OutFile|Rest]) ->
         end
     catch
         error:{badmatch, {error, eacces}} ->
-            io:format("cluster_info failed, permission denied writing to ~p~n", [OutFile]);
+            io:format("Cluster_info failed, permission denied writing to ~p~n", [OutFile]);
         error:{badmatch, {error, enoent}} ->
-            io:format("cluster_info failed, no such directory ~p~n", [filename:dirname(OutFile)]);
+            io:format("Cluster_info failed, no such directory ~p~n", [filename:dirname(OutFile)]);
         error:{badmatch, {error, enotdir}} ->
-            io:format("cluster_info failed, not a directory ~p~n", [filename:dirname(OutFile)]);
+            io:format("Cluster_info failed, not a directory ~p~n", [filename:dirname(OutFile)]);
         Exception:Reason ->
-            log_to_riak_node("cluster_info failed ~p:~p~n",
+            log_to_riak_node("Cluster_info failed ~p:~p~n",
                 [Exception, Reason]),
-            io:format("cluster_info failed, see log for details~n"),
+            io:format("Cluster_info failed, see log for details~n"),
             error
     end.
 

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -28,21 +28,27 @@
          cluster_info/1]).
 
 join([NodeStr]) ->
-    case riak:join(NodeStr) of
-        ok ->
-            io:format("Sent join request to ~s\n", [NodeStr]),
-            ok;
-        {error, not_reachable} ->
-            io:format("Node ~s is not reachable!\n", [NodeStr]),
-            error;
-        {error, different_ring_sizes} ->
-            io:format("Failed: ~s has a different ring_creation_size~n",
-                      [NodeStr]),
+    try
+        case riak:join(NodeStr) of
+            ok ->
+                io:format("Sent join request to ~s\n", [NodeStr]),
+                ok;
+            {error, not_reachable} ->
+                io:format("Node ~s is not reachable!\n", [NodeStr]),
+                error;
+            {error, different_ring_sizes} ->
+                io:format("Failed: ~s has a different ring_creation_size~n",
+                    [NodeStr]),
+                error
+        end
+    catch
+        Exception:Reason ->
+            log_to_riak_node("join failed ~p:~p~n", [Exception,
+                    Reason]),
+            io:format("join failed, see log for details~n"),
             error
-    end;
-join(_) ->
-    io:format("Join requires a node to join with.\n"),
-    error.
+    end.
+
 
 leave([]) ->
     remove_node(node()).
@@ -51,51 +57,102 @@ remove([Node]) ->
     remove_node(list_to_atom(Node)).
 
 remove_node(Node) when is_atom(Node) ->
-    {ok, C} = riak:local_client(),
-    Res = C:remove_from_cluster(Node),
-    io:format("~p\n", [Res]).
+    try 
+        {ok, C} = riak:local_client(),
+        case C:remove_from_cluster(Node) of
+            {badrpc, RPCReason} ->
+                case RPCReason of
+                    {'EXIT', {badarg, [{erlang, hd, [[]]}|_]}} ->
+                        %% This is a workaround because
+                        %% riak_core_gossip:remove_from_cluster doesn't check if
+                        %% the result of subtracting the current node from the
+                        %% cluster member list results in the empty list. When
+                        %% that code gets refactored this can probably go away.
+                        io:format("leave failed, this node is the only member.~n");
+                    _ ->
+                        log_to_riak_node("Error leaving cluster ~p~n",
+                            [RPCReason]),
+                        io:format("leave failed, see log for details~n")
+                end,
+                error;
+            Res ->
+                io:format(" ~p\n", [Res])
+        end
+    catch
+        Exception:Reason ->
+            log_to_riak_node("leave failed ~p:~p~n", [Exception,
+                    Reason]),
+            io:format("leave failed, see log for details~n"),
+            error
+    end.
+
 
 -spec(status([]) -> ok).
 status([]) ->
-    case riak_kv_status:statistics() of
-        [] ->
-            io:format("riak_kv_stat is not enabled.\n", []);
-        Stats ->
-            StatString = format_stats(Stats,
-                                      ["-------------------------------------------\n",
-                                       io_lib:format("1-minute stats for ~p~n",[node()])]),
-            io:format("~s\n", [StatString])
+    try
+        case riak_kv_status:statistics() of
+            [] ->
+                io:format("riak_kv_stat is not enabled.\n", []);
+            Stats ->
+                StatString = format_stats(Stats,
+                    ["-------------------------------------------\n",
+                        io_lib:format("1-minute stats for ~p~n",[node()])]),
+                io:format("~s\n", [StatString])
+        end
+    catch
+        Exception:Reason ->
+            log_to_riak_node("status failed ~p:~p~n", [Exception,
+                    Reason]),
+            io:format("status failed, see log for details~n"),
+            error
     end.
 
+
 reip([OldNode, NewNode]) ->
-    %% reip is called when node is down (so riak_core_ring_manager is not running),
-    %% so it has to use the basic ring operations.
-    %%
-    %% Do *not* convert to use riak_core_ring_manager:ring_trans.
-    %%
-    application:load(riak_core),
-    RingStateDir = app_helper:get_env(riak_core, ring_state_dir),
-    {ok, RingFile} = riak_core_ring_manager:find_latest_ringfile(),
-    BackupFN = filename:join([RingStateDir, filename:basename(RingFile)++".BAK"]),
-    {ok, _} = file:copy(RingFile, BackupFN),
-    io:format("Backed up existing ring file to ~p~n", [BackupFN]),
-    Ring = riak_core_ring_manager:read_ringfile(RingFile),
-    NewRing = riak_core_ring:rename_node(Ring, OldNode, NewNode),
-    riak_core_ring_manager:do_write_ringfile(NewRing),
-    io:format("New ring file written to ~p~n", 
-              [element(2, riak_core_ring_manager:find_latest_ringfile())]).
+    try
+        %% reip is called when node is down (so riak_core_ring_manager is not running),
+        %% so it has to use the basic ring operations.
+        %%
+        %% Do *not* convert to use riak_core_ring_manager:ring_trans.
+        %%
+        application:load(riak_core),
+        RingStateDir = app_helper:get_env(riak_core, ring_state_dir),
+        {ok, RingFile} = riak_core_ring_manager:find_latest_ringfile(),
+        BackupFN = filename:join([RingStateDir, filename:basename(RingFile)++".BAK"]),
+        {ok, _} = file:copy(RingFile, BackupFN),
+        io:format("Backed up existing ring file to ~p~n", [BackupFN]),
+        Ring = riak_core_ring_manager:read_ringfile(RingFile),
+        NewRing = riak_core_ring:rename_node(Ring, OldNode, NewNode),
+        riak_core_ring_manager:do_write_ringfile(NewRing),
+        io:format("New ring file written to ~p~n", 
+            [element(2, riak_core_ring_manager:find_latest_ringfile())])
+    catch
+        Exception:Reason ->
+            log_to_riak_node("reip failed ~p:~p~n", [Exception,
+                    Reason]),
+            io:format("reip failed, see log for details~n"),
+            error
+    end.
 
 %% Check if all nodes in the cluster agree on the partition assignment
 -spec(ringready([]) -> ok | error).
 ringready([]) ->
-    case riak_kv_status:ringready() of
-        {ok, Nodes} ->
-            io:format("TRUE All nodes agree on the ring ~p\n", [Nodes]);
-        {error, {different_owners, N1, N2}} ->
-            io:format("FALSE Node ~p and ~p list different partition owners\n", [N1, N2]),
-            error;
-        {error, {nodes_down, Down}} ->
-            io:format("FALSE ~p down.  All nodes need to be up to check.\n", [Down]),
+    try
+        case riak_kv_status:ringready() of
+            {ok, Nodes} ->
+                io:format("TRUE All nodes agree on the ring ~p\n", [Nodes]);
+            {error, {different_owners, N1, N2}} ->
+                io:format("FALSE Node ~p and ~p list different partition owners\n", [N1, N2]),
+                error;
+            {error, {nodes_down, Down}} ->
+                io:format("FALSE ~p down.  All nodes need to be up to check.\n", [Down]),
+                error
+        end
+    catch
+        Exception:Reason ->
+            log_to_riak_node("ringready failed ~p:~p~n", [Exception,
+                    Reason]),
+            io:format("ringready failed, see log for details~n"),
             error
     end.
 
@@ -103,32 +160,55 @@ ringready([]) ->
 %% and list any owned vnodes that are *not* running
 -spec(transfers([]) -> ok).
 transfers([]) ->
-    {DownNodes, Pending} = riak_kv_status:transfers(),
-    case DownNodes of
-        [] -> ok;
-        _  -> io:format("Nodes ~p are currently down.\n", [DownNodes])
-    end,
-    F = fun({waiting_to_handoff, Node, Count}, Acc) ->
+    try
+        {DownNodes, Pending} = riak_kv_status:transfers(),
+        case DownNodes of
+            [] -> ok;
+            _  -> io:format("Nodes ~p are currently down.\n", [DownNodes])
+        end,
+        F = fun({waiting_to_handoff, Node, Count}, Acc) ->
                 io:format("~p waiting to handoff ~p partitions\n", [Node, Count]),
                 Acc + 1;
-           ({stopped, Node, Count}, Acc) ->
+            ({stopped, Node, Count}, Acc) ->
                 io:format("~p does not have ~p primary partitions running\n", [Node, Count]),
                 Acc + 1
         end,
-    case lists:foldl(F, 0, Pending) of
-        0 ->
-            io:format("No transfers active\n"),
-            ok;
-        _ ->
+        case lists:foldl(F, 0, Pending) of
+            0 ->
+                io:format("No transfers active\n"),
+                ok;
+            _ ->
+                error
+        end
+    catch
+        Exception:Reason ->
+            log_to_riak_node("transfers failed ~p:~p~n", [Exception,
+                    Reason]),
+            io:format("transfers failed, see log for details~n"),
             error
     end.
 
+
 cluster_info([OutFile|Rest]) ->
-    case lists:reverse(atomify_nodestrs(Rest)) of
-        [] ->
-            cluster_info:dump_all_connected(OutFile);
-        Nodes ->
-            cluster_info:dump_nodes(Nodes, OutFile)
+    try
+        case lists:reverse(atomify_nodestrs(Rest)) of
+            [] ->
+                cluster_info:dump_all_connected(OutFile);
+            Nodes ->
+                cluster_info:dump_nodes(Nodes, OutFile)
+        end
+    catch
+        error:{badmatch, {error, eacces}} ->
+            io:format("cluster_info failed, permission denied writing to ~p~n", [OutFile]);
+        error:{badmatch, {error, enoent}} ->
+            io:format("cluster_info failed, no such directory ~p~n", [filename:dirname(OutFile)]);
+        error:{badmatch, {error, enotdir}} ->
+            io:format("cluster_info failed, not a directory ~p~n", [filename:dirname(OutFile)]);
+        Exception:Reason ->
+            log_to_riak_node("cluster_info failed ~p:~p~n",
+                [Exception, Reason]),
+            io:format("cluster_info failed, see log for details~n"),
+            error
     end.
 
 format_stats([], Acc) ->
@@ -147,3 +227,15 @@ atomify_nodestrs(Strs) ->
                                          Acc
                                      end
                 end, [], Strs).
+
+%% This function changes the group leader around a call to error_logger. The
+%% reason this code is needed is that when these functions are called via
+%% rpc:call, the group leader is on the node making the rpc call, in the case
+%% of riak-admin, this is nodetool running as an escript. Since nodetool has
+%% error logging configured, this makes sure that the log message ends up in
+%% riaks's log like we want.
+log_to_riak_node(Format, Args) ->
+    GL = erlang:group_leader(),
+    erlang:group_leader(whereis(user), self()),
+    error_logger:error_msg(Format, Args),
+    erlang:group_leader(GL, self()).


### PR DESCRIPTION
In cases where we can, we print out a friendly error message, in other
cases we indicate to the user that the full error is in the log file.
