### PR TITLE
Remove unecessary call to riak_kv_delete_sup:start_link

### DIFF
--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -112,7 +112,6 @@ setup() ->
     net_kernel:start([testnode, shortnames]),
     cleanup(unused_arg),
     do_dep_apps(start, dep_apps()),
-    {ok, _Pid} = riak_kv_delete_sup:start_link(),
     timer:sleep(500).
 
 cleanup(_Pid) ->


### PR DESCRIPTION
The delete supervisor is actually started by do_dep_apps and this extra
call to start it just makes the setup fail.
