### PR TITLE
Az167 add pr to get fsm + more cleanups.

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -231,6 +231,11 @@ get(Bucket, Key) ->
 %%       {error, Err :: term()}
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as R-value for the nodes
 %%      have responded with a value or error.
+-spec get(binary(), binary(), riak_kv_get_fsm:options()) ->
+                 {ok, any()} | %% TODO: Replace any() with opaque type for riak_object
+                 {ok, any(), [any()]} |
+                 {error, any()} |
+                 {error, any(), [any()]}.
 get(Bucket, Key, Options) when is_list(Options) ->
     Me = self(),
     ReqId = mk_reqid(),

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -527,9 +527,7 @@ mk_reqid() -> erlang:phash2(erlang:now()). % only has to be unique per-pid
 %% @private
 wait_for_reqid(ReqId, Timeout) ->
     receive
-        {ReqId, {error, Err}} -> {error, Err};
-        {ReqId, ok} -> ok;
-        {ReqId, {ok, Res}} -> {ok, Res}
+        {ReqId, Response} -> Response
     after Timeout ->
             {error, timeout}
     end.

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -220,7 +220,24 @@ mapred_dynamic_inputs_stream(FSMPid, InputDef, Timeout) ->
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as the default
 %%      R-value for the nodes have responded with a value or error.
 %% @equiv get(Bucket, Key, R, default_timeout())
-get(Bucket, Key) -> get(Bucket, Key, default, ?DEFAULT_TIMEOUT).
+get(Bucket, Key) -> 
+    get(Bucket, Key, []).
+
+%% @spec get(riak_object:bucket(), riak_object:key(), options()) ->
+%%       {ok, riak_object:riak_object()} |
+%%       {error, notfound} |
+%%       {error, timeout} |
+%%       {error, {n_val_violation, N::integer()}} |
+%%       {error, Err :: term()}
+%% @doc Fetch the object at Bucket/Key.  Return a value as soon as R-value for the nodes
+%%      have responded with a value or error.
+get(Bucket, Key, Options) when is_list(Options) ->
+    Me = self(),
+    ReqId = mk_reqid(),
+    riak_kv_get_fsm_sup:start_get_fsm(Node, [{raw, ReqId, Me}, Bucket, Key, Options]),
+    %% TODO: Investigate adding a monitor here and eliminating the timeout.
+    Timeout = recv_timeout(Options),
+    wait_for_reqid(ReqId, Timeout);
 
 %% @spec get(riak_object:bucket(), riak_object:key(), R :: integer()) ->
 %%       {ok, riak_object:riak_object()} |
@@ -231,7 +248,8 @@ get(Bucket, Key) -> get(Bucket, Key, default, ?DEFAULT_TIMEOUT).
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as R
 %%      nodes have responded with a value or error.
 %% @equiv get(Bucket, Key, R, default_timeout())
-get(Bucket, Key, R) -> get(Bucket, Key, R, ?DEFAULT_TIMEOUT).
+get(Bucket, Key, R) -> 
+    get(Bucket, Key, [{r, R}]).
 
 %% @spec get(riak_object:bucket(), riak_object:key(), R :: integer(),
 %%           TimeoutMillisecs :: integer()) ->
@@ -245,10 +263,8 @@ get(Bucket, Key, R) -> get(Bucket, Key, R, ?DEFAULT_TIMEOUT).
 get(Bucket, Key, R, Timeout) when is_binary(Bucket), is_binary(Key),
                                   (is_atom(R) or is_integer(R)),
                                   is_integer(Timeout) ->
-    Me = self(),
-    ReqId = mk_reqid(),
-    riak_kv_get_fsm_sup:start_get_fsm(Node, [ReqId, Bucket, Key, R, Timeout, Me]),
-    wait_for_reqid(ReqId, Timeout).
+    get(Bucket, Key, [{r, R}, {timeout, Timeout}]).
+
 
 %% @spec put(RObj :: riak_object:riak_object()) ->
 %%        ok |
@@ -566,4 +582,15 @@ build_exprs([[FunName|Args]|T], Accum) ->
             {error, {bad_filter, FunName}};
         Fun ->
             build_exprs(T, [{riak_kv_mapred_filters, Fun, Args}|Accum])
+    end.
+
+recv_timeout(Options) ->
+    case proplists:get_value(recv_timeout, Options) of
+        undefined ->
+            %% If no reply timeout given, use the FSM timeout + 100ms to give it a chance
+            %% to respond.
+            proplists:get_value(timeout, Options, ?DEFAULT_TIMEOUT) + 100;
+        Timeout ->
+            %% Otherwise use the directly supplied timeout.
+            Timeout
     end.

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -32,8 +32,12 @@
          handle_info/3, terminate/3, code_change/4]).
 -export([prepare/2,validate/2,execute/2,waiting_vnode_r/2,waiting_read_repair/2]).
 
+-type option() :: {r, pos_integer()} |
+                  {timeout, pos_integer() | infinity}.
+-type options() :: [option()].
+
 -record(state, {from :: {integer(), pid()},
-                options=[],
+                options=[] :: options(),
                 n :: pos_integer(),
                 r :: pos_integer(),
                 fail_threshold :: pos_integer(),
@@ -57,7 +61,7 @@
                }).
 
 -define(DEFAULT_TIMEOUT, 60000).
--define(DEFAULT_R, quorum).
+-define(DEFAULT_R, default).
 
 %% In place only for backwards compatibility
 start(ReqId,Bucket,Key,R,Timeout,From) ->

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -417,7 +417,7 @@ client_info(true, StateData, Acc) ->
 client_info([], _StateData, Acc) ->
     Acc;
 client_info([timing | Rest], StateData = #state{get_usecs = GetUsecs}, Acc) ->
-    client_info(Rest, StateData, [{get_usecs, GetUsecs} | Acc]);
+    client_info(Rest, StateData, [{duration, GetUsecs} | Acc]);
 client_info([vnodes | Rest], StateData = #state{num_r = NumOks,
                                                 replied_fail = Fail}, Acc) ->
     Oks = [{vnode_oks, NumOks}],
@@ -539,10 +539,16 @@ n_val_violation_case() ->
     R = 5,
     Timeout = 1000,
     BucketProps = bucket_props(Bucket, Nval),
+    %% Fake three nodes
+    Indices = [1, 2, 3],
+    Preflist2 = [begin 
+                     {{Idx, self()}, primary}
+                 end || Idx <- Indices],
     {ok, _FsmPid1} = test_link(ReqId1, Bucket, Key, R, Timeout, self(),
                                [{starttime, 63465712389},
                                {n, Nval},
-                               {bucket_props, BucketProps}]),
+                               {bucket_props, BucketProps},
+                               {preflist2, Preflist2}]),
     ?assertEqual({error, {n_val_violation, 3}}, wait_for_reqid(ReqId1, Timeout + 1000)).
  
     

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -141,8 +141,14 @@ validate(timeout, StateData=#state{from = {raw, ReqId, _Pid}, options = Options,
             client_reply({error, {n_val_violation, N}}, StateData),
             {stop, normal, StateData};
         true ->
-            FailThreshold = erlang:min((N div 2)+1, % basic quorum, or
-                                       (N-R+1)), % cannot ever get R 'ok' replies
+            FailThreshold = 
+                case get_option(basic_quorum, Options, true) of
+                    true ->
+                        erlang:min((N div 2)+1, % basic quorum, or
+                                   (N-R+1)); % cannot ever get R 'ok' replies
+                    false ->
+                        N - R + 1 % cannot ever get R 'ok' replies
+                end,
             AllowMult = proplists:get_value(allow_mult,BucketProps),
             NotFoundOk = get_option(notfound_ok, Options, false),
             {next_state, execute, StateData#state{r = R,

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -28,6 +28,8 @@
 -endif.
 -include("riak_kv_wm_raw.hrl").
 
+-export_type([key/0, bucket/0, riak_object/0]).
+
 -type key() :: binary().
 -type bucket() :: binary().
 %% -type bkey() :: {bucket(), key()}.

--- a/test/fsm_eqc_util.erl
+++ b/test/fsm_eqc_util.erl
@@ -234,10 +234,8 @@ wait_for_req_id(ReqId, Pid) ->
         {'EXIT', _OtherPid, _Reason} ->
             %% Probably from previous test death
             wait_for_req_id(ReqId, Pid);
-        {ReqId, {ok, Reply1}} ->
-            {ok, Reply1};
-        {ReqId, Error1} ->
-            Error1;
+        {ReqId, Response} ->
+            Response;
         Anything1 ->
             {anything, Anything1}
     after 400 ->

--- a/test/fsm_eqc_util.erl
+++ b/test/fsm_eqc_util.erl
@@ -170,14 +170,24 @@ cycle(Zs, N, []) ->
     cycle(Zs, N, Zs).
 
 start_mock_servers() ->
+    %% Start original mock vnode
     case whereis(riak_kv_vnode_master) of
         undefined -> ok;
-        Pid       ->
-            unlink(Pid),
-            exit(Pid, shutdown),
-            riak_kv_test_util:wait_for_pid(Pid)
+        Pid1      ->
+            unlink(Pid1),
+            exit(Pid1, shutdown),
+            riak_kv_test_util:wait_for_pid(Pid1)
     end,
     get_fsm_qc_vnode_master:start_link(),
+    %% Start new core_vnode based EQC FSM test mock
+    case whereis(fsm_eqc_vnode) of
+        undefined -> ok;
+        Pid2      ->
+            unlink(Pid2),
+            exit(Pid2, shutdown),
+            riak_kv_test_util:wait_for_pid(Pid2)
+    end,
+    {ok, _Pid3} = fsm_eqc_vnode:start_link(),
     application:unload(riak_core),
     ok = application:load(riak_core),
     application:start(crypto),

--- a/test/fsm_eqc_vnode.erl
+++ b/test/fsm_eqc_vnode.erl
@@ -19,6 +19,12 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
+%%
+%% Mock vnode for FSM testing.  Originally tried to use riak_core_vnode
+%% directly but we need the index for the tests and no clean way to do
+%% the sync events for resetting, so for now just use a gen_fsm.
+%%
+%% -------------------------------------------------------------------
 
 -module(fsm_eqc_vnode).
 -behaviour(gen_fsm).

--- a/test/fsm_eqc_vnode.erl
+++ b/test/fsm_eqc_vnode.erl
@@ -1,0 +1,268 @@
+%% -------------------------------------------------------------------
+%%
+%% fsm_eqc_vnode: mock vnode for get/put FSM testing
+%%
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(fsm_eqc_vnode).
+-behaviour(gen_fsm).
+-include_lib("riak_kv_vnode.hrl").
+
+-export([start_link/0, start_link/1, set_data/2, get_history/0, get_put_history/0,
+         get_reply_history/0, log_postcommit/1, get_postcommits/0]).
+-export([init/1, 
+         active/2, 
+         active/3, 
+         handle_event/3,
+         handle_sync_event/4, 
+         handle_info/3, 
+         terminate/3, 
+         code_change/4]).
+
+-record(state, {objects, partvals,
+
+                %% Put request handling.
+                %% Before running the put FSM the test sets the mock vnode up 
+                %% with responses for each vnode.  Rather than
+                %% hashing the key and working out a preference
+                %% list, responses are created for 'logical' indices
+                %% from 1..N.  Each logical index will have one or two
+                %% replies (only one if the first is a timeout).  
+                lidx_map=[],
+                vput_replies=[],
+
+                %% What happened during test
+                reply_history=[],
+                history=[], put_history=[],
+                postcommit=[]}).
+
+%% ===================================================================
+%% Test API
+%% ===================================================================
+
+start_link() ->
+    start_link(?MODULE).
+
+start_link(undefined) ->
+    gen_fsm:start_link(?MODULE, [], []);
+start_link(RegName) ->
+    gen_fsm:start_link({local, RegName}, ?MODULE, [], []).
+
+set_data(Objs, PartVals) ->
+    ok = gen_fsm:sync_send_all_state_event(?MODULE, {set_data, Objs, PartVals}).
+
+get_history() ->
+    gen_fsm:sync_send_all_state_event(?MODULE, get_history).
+
+get_put_history() ->
+    gen_fsm:sync_send_all_state_event(?MODULE, get_put_history).
+
+get_reply_history() ->
+    gen_fsm:sync_send_all_state_event(?MODULE, get_reply_history).
+
+log_postcommit(Obj) ->
+    gen_fsm:sync_send_all_state_event(?MODULE, {log_postcommit, Obj}).
+    
+get_postcommits() ->
+    gen_fsm:sync_send_all_state_event(?MODULE, get_postcommits).
+
+%% ====================================================================
+%% gen_fsm callbacks
+%% ====================================================================
+
+init([]) ->
+    {ok, active, #state{}}.
+
+active(?VNODE_REQ{index=Idx,
+                  sender=Sender,
+                  request=?KV_GET_REQ{req_id=ReqId}}, State) ->
+    %io:format(user, "Get ~p reqid ~p\n", [Idx, ReqId]),
+    {Value, State1} = get_data(Idx,State),
+    case Value of
+        {error, timeout} ->
+            ok;
+        _ ->
+            riak_core_vnode:reply(Sender, {r, Value, Idx, ReqId})
+    end,
+    %% Speed things up by banging along a timeout if the last entry
+    case State1#state.partvals of
+        [] ->
+            {fsm, undefined, Pid} = Sender,
+            Pid ! request_timeout;
+        _ ->
+            ok
+    end,
+    {next_state, active, State1};
+%% Handle a put request - send the responses prepared by call to
+%% 'set_vput_replies' up until the next 'w' response for a different partition.
+active(?VNODE_REQ{index=Idx,
+                  sender=Sender,
+                  request=?KV_PUT_REQ{req_id=ReqId,
+                                      object = PutObj,
+                                      options = Options}=Msg}, State) ->
+    %% Send up to the next w or timeout message, substituting indices
+    State1 = send_vput_replies(State#state.vput_replies, Idx,
+                               Sender, ReqId, PutObj, Options, State),
+    {next_state, active, State1#state{put_history=[{Idx,Msg}|State#state.put_history]}};    
+active(?VNODE_REQ{index=Idx, request=?KV_DELETE_REQ{}=Msg}, State) ->
+    {next_state, active, State#state{put_history=[{Idx,Msg}|State#state.put_history]}}.
+
+active(Req=?VNODE_REQ{request=?KV_DELETE_REQ{}},
+            _From, State) ->
+    {next_state, active, NewState} = active(Req, State),
+    {reply, ok, NewState};
+active(_Request, _From, State) ->
+    {stop, bad_request, State}.
+
+%% @private
+handle_event(_Event, _StateName, StateData) ->
+    {stop,badmsg,StateData}.
+
+handle_sync_event({set_data, Objects, Partvals}, _From, StateName, State) ->
+    {reply, ok, StateName, set_data(Objects, Partvals, State)};
+handle_sync_event({set_vput_replies, VPutReplies}, _From, StateName, State) ->
+    {reply, ok, StateName, set_vput_replies(VPutReplies, State)};
+handle_sync_event(get_history, _From, StateName, State) ->
+    {reply, lists:reverse(State#state.history), StateName, State};
+handle_sync_event(get_put_history, _From, StateName, State) -> %
+    {reply, lists:reverse(State#state.put_history), StateName, State};
+handle_sync_event(get_reply_history, _From, StateName, State) -> %
+    {reply, lists:reverse(State#state.reply_history), StateName, State};
+handle_sync_event({log_postcommit, Obj}, _From, StateName, State) -> %
+    {reply, ok, StateName, State#state{postcommit = [Obj | State#state.postcommit]}};
+handle_sync_event(get_postcommits, _From, StateName, State) -> %
+    {reply, lists:reverse(State#state.postcommit), StateName, State}.
+
+%% @private
+handle_info(_Info, _StateName, StateData) ->
+    {stop,badmsg,StateData}.
+
+%% @private
+terminate(Reason, _StateName, _State) ->
+    Reason.
+
+code_change(_OldVsn, StateName, _State, _Extra) -> 
+    {ok, StateName, #state{}}.
+
+%% ====================================================================
+%% Internal functions
+%% ====================================================================
+
+set_data(Objects, Partvals, State) ->
+    State#state{objects=Objects, partvals=Partvals,
+                history=[], put_history=[]}.
+
+set_vput_replies(VPutReplies, State) ->
+    State#state{vput_replies = VPutReplies,
+                reply_history = [],
+                lidx_map=[],
+                postcommit = []}.
+
+get_data(_Partition, #state{partvals=[]} = State) ->
+    {{error, timeout}, State};
+get_data(Partition, #state{objects=Objects, partvals=[Res|Rest]} = State) ->
+    State1 = State#state{partvals = Rest,
+                         history=[{Partition,Res}|State#state.history]},
+    case Res of
+        {ok, Lineage} ->
+            {{ok, proplists:get_value(Lineage, Objects)}, State1};
+        notfound ->
+            {{error, notfound}, State1};
+        timeout ->
+            {{error, timeout}, State1};
+        error ->
+            {{error, error}, State1}
+    end.
+
+
+%% Send the next vnode put response then send any 'extra' responses in sequence
+%% until the next w or the list is emptied.
+send_vput_replies([], _Idx, _Sender, _ReqId, _Obj, _Options, State) ->
+    State;
+send_vput_replies([{LIdx, FirstResp} | Rest], Idx, Sender, ReqId, PutObj, Options,
+               #state{lidx_map = LIdxMap} = State) ->
+    %% Check have not seen this logical index before and store it
+    error = orddict:find(LIdx, LIdxMap),
+    NewState1 = State#state{lidx_map = orddict:store(LIdx, {Idx, PutObj}, LIdxMap)},
+    Reply = case FirstResp of
+                w ->
+                    {w, Idx, ReqId};
+                {timeout, 1} ->
+                    {{timeout, 1}, Idx, ReqId}
+            end,
+    NewState2 = record_reply(Sender, Reply, NewState1),
+    Rest2 = fail_on_bad_obj(LIdx, PutObj, Rest),
+    send_vput_extra(Rest2, Sender, ReqId, Options, NewState2).
+
+send_vput_extra([], {fsm, undefined, Pid} = _Sender, _ReqId, _Options, State) ->
+    Pid ! request_timeout, % speed things along by sending the request timeout
+    State#state{vput_replies = []};
+send_vput_extra([{LIdx, {dw, CurObj, _CurLin}} | Rest], Sender, ReqId, Options,
+                #state{lidx_map = LIdxMap} = State) ->
+    {Idx, PutObj} = orddict:fetch(LIdx, LIdxMap),
+    Obj = put_merge(CurObj, PutObj, ReqId),
+    NewState = case proplists:get_value(returnbody, Options, false) of
+                   true ->
+                       record_reply(Sender, {dw, Idx, Obj, ReqId}, State);
+                   false ->
+                       record_reply(Sender, {dw, Idx, ReqId}, State)
+               end,
+    send_vput_extra(Rest, Sender, ReqId, Options, NewState);
+send_vput_extra([{LIdx, fail} | Rest], Sender, ReqId, Options,
+                #state{lidx_map = LIdxMap} = State) ->
+    Idx = orddict:fetch(LIdx, LIdxMap),
+    NewState = record_reply(Sender, {fail, Idx, ReqId}, State),
+    send_vput_extra(Rest, Sender, ReqId, Options, NewState);
+send_vput_extra([{LIdx, {timeout, 2}} | Rest], Sender, ReqId, Options,
+                #state{lidx_map = LIdxMap} = State) ->
+    Idx = orddict:fetch(LIdx, LIdxMap),
+    NewState = record_reply(Sender, {{timeout, 2}, Idx, ReqId}, State),
+    send_vput_extra(Rest, Sender, ReqId, Options, NewState);
+send_vput_extra(VPutReplies, _Sender, _ReqId, _Options, State) ->
+    State#state{vput_replies = VPutReplies}.
+
+record_reply(Sender, Reply, #state{reply_history = H} = State) ->
+    case Reply of
+        {{timeout,_N},_Idx,_ReqId} ->
+            nop;
+        _ ->
+            riak_core_vnode:reply(Sender, Reply)
+    end,
+    State#state{reply_history = [Reply | H]}.
+
+
+%% If the requested object is not an r_object tuple, make sure the {dw}
+%% response is fail Leave any other failures the same.
+fail_on_bad_obj(_LIdx, Obj, VPutReplies) when element(1, Obj) =:= r_object ->
+   VPutReplies;
+fail_on_bad_obj(LIdx, _Obj, VPutReplies) ->
+    case lists:keysearch(LIdx, 1, VPutReplies) of
+        {value, {LIdx, {dw, _, _}}} ->
+            lists:keyreplace(LIdx, 1, VPutReplies, {LIdx, fail});
+        _ ->
+            VPutReplies
+    end.
+
+%% TODO: The riak_kv_vnode code should be refactored to expose this function
+%%       so we are close to testing the real thing.
+put_merge(notfound, NewObj, _ReqId) ->
+    NewObj;
+put_merge(CurObj, NewObj, ReqId) ->
+    riak_object:syntactic_merge(CurObj,NewObj, ReqId).
+

--- a/test/get_fsm_qc.erl
+++ b/test/get_fsm_qc.erl
@@ -89,14 +89,6 @@ check() ->
 %% Generators
 %%====================================================================
 
-all_distinct(Xs) ->
-    equals(lists:sort(Xs),lists:usort(Xs)).
-
-
-ring(Partitions) ->
-    riak_core_ring:fresh(Partitions, node()).
-
-
 merge_heads([]) ->
     [];
 merge_heads([Lin|Lins]) ->
@@ -140,11 +132,6 @@ nodestatus() ->
     ?SHRINK(frequency([{9, primary},
                        {1, fallback}]),
             [primary]).
-
-prop_len() ->
-    ?FORALL({R, Ps}, {choose(1, 10), fsm_eqc_util:partvals()},
-        collect({R, length(Ps)}, true)
-    ).
 
 r_seed() ->
     frequency([{10, quorum},
@@ -383,7 +370,7 @@ check_info([], _State) ->
     true;
 check_info([{not_a_detail, unknown_detail} | Rest], State) ->
     check_info(Rest, State);
-check_info([{get_usecs, _} | Rest], State) ->
+check_info([{duration, _} | Rest], State) ->
     check_info(Rest, State);
 check_info([{vnode_oks, VnodeOks} | Rest], State = #state{num_oks = NumOks}) ->
     %% How many Ok's in first RealR responses received by FSM.
@@ -450,8 +437,10 @@ check_delete(Objects, RepairH, H, PerfectPreflist) ->
     ?WHENFAIL(io:format("Objects: ~p\nExpected: ~p\nDeletes: ~p\nAllDeleted: ~p\nHasOk: ~p\nH: ~p\n",
                         [Objects, Expected, Deletes, AllDeleted, HasOk, H]),
               equals(lists:sort(Expected), lists:sort(Deletes))).
-   
 
+all_distinct(Xs) ->
+    equals(lists:sort(Xs),lists:usort(Xs)).
+   
 build_merged_object([], _Objects) ->
     undefined;
 build_merged_object(Heads, Objects) ->

--- a/test/get_fsm_qc.erl
+++ b/test/get_fsm_qc.erl
@@ -181,7 +181,7 @@ prop_basic_get() ->
         BucketProps = [{n_val, N}
                        |?DEFAULT_BUCKET_PROPS],
 
-        %% The app set_env will probably go away.
+        %% Needed for riak_kv_util get_default_rw_val
         application:set_env(riak_core,
                             default_bucket_props,
                             BucketProps),
@@ -201,8 +201,6 @@ prop_basic_get() ->
 
         process_flag(trap_exit, true),
         ok = riak_kv_test_util:wait_for_pid(GetPid),
-        % Give read repairs and deletes a chance to go through
-        %timer:sleep(5),
         Res = fsm_eqc_util:wait_for_req_id(ReqId, GetPid),
         process_flag(trap_exit, false),
 

--- a/test/get_fsm_qc_vnode_master.erl
+++ b/test/get_fsm_qc_vnode_master.erl
@@ -117,6 +117,14 @@ handle_cast(?VNODE_REQ{index=Idx,
         _ ->
             riak_core_vnode:reply(Sender, {r, Value, Idx, ReqId})
     end,
+    %% Speed things up by banging along a timeout if the last entry
+    case State1#state.partvals of
+        [] ->
+            {fsm, undefined, Pid} = Sender,
+            Pid ! request_timeout;
+        _ ->
+            ok
+    end,
     {noreply, State1};
 
 %% Handle a put request - send the responses prepared by call to


### PR DESCRIPTION
Refactors the get FSM 
- Replaces r and timeout arguments with options instead.
- Adds pr option to supply a minimum number of primary nodes in the preflist (but does not guarantee responses from them).
- Adds basic_quorum option to control whether basic_quorum is enabled.
- Adds notfound_ok option to count notfound responses towards R.
- Adds details option to get additional information back from the FSM.
- Changed behavior when R is not met to return an {error, {r_val_unsatisfied, R, Got}} message rather than not_found.

<pre>
I'm about to add some features to the get and put FSMs needed by Trifork / Netic for that address the availability requirements for their presciption tracking application.

The big things are
1) Add PR parameter to get FSM to ensure PR vnode owners are involved (was RP during
   earlier discussion but I think PR reads better and matches W/DW model)
2) Add PW parameter to put FSM to ensure PW vnode owners are involved (again, was WP before)
3) Control counting not_found vnode responses towards R.
4) Return R value not satisfied as {error, {r_value_unsatisfied, R, P}} rather than notfound and pass through PBC/HTTP interfaces.

Rather than adding new arguments as we currently do and now we have the quorum information in the bucket props I think we should change the interface to get / put.

The current interfaces of
  riak_kv_get_fsm:start_link(ReqId,Bucket,Key,R,Timeout,From).
  riak_kv_put_fsm:start_link(ReqId,RObj,W,DW,Timeout,From, Options)

Would become
  riak_kv_get_fsm:start_link(From, Bucket, Key, GetOptions) -> {ok, Pid}
  riak_kv_get_fsm:start_link(From, Object, PutOptions) -> {ok, Pid}

  From = {raw, ReqId, Pid}.   %% Reuse the format used by riak_core_vnode.

  GetOptions = [{r, R},
                {pr, PR},
                {notfound_ok, bool()}, % default false, flip in future release
                {timeout, Timeout},
                {details, Details}].

  PutOptions = [{w, DW},
                {dw, DW},
                {pw, PW},
                {timeout, Timeout},
                {details, Details},
                {returnbody, bool()}].

  Details = false | true | [timing, bestnode, primaries, 
                            params, vnodes]

If the details option is set true we'll return an extra element to the tuple with
a proplist giving all details about the request, individual details can be requested
by grouping and if set false we just return normally.

If timing set, add entries for internal timing
  {duration, msecs()}

If bestnode set, return the best node for resubmitting future requests to (initially will be first responder)
  {bestnode, node()}

If primaries set, return the count of primary nodes *successfully* participating in the request.
  {primaries, integer()}

If params set, add entries for FSM parameters (after decoding symbolic names)
  n, r, pr, w, dw, pw

If vnodes set, add entries
  {node_oks, Count}, {node_errors, [Reason]}

The response from get would become {ok, riak_object(), info()} or {error, Reason, info()} - e.g. {error, notfound, info()}
Similarly for put we will return {ok, info()} or {ok, riak_object, info()} or {error, Reason, info()}.

The new interface makes r / w / dw etc optional - so we set as default the way riak_client:put does currently.
</pre>
