### PR TITLE
Fix noproc error for riak_core_ring_manager by just setting ring global.

### DIFF
--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -146,7 +146,8 @@ dep_apps() ->
             application:set_env(riak_kv, storage_backend, riak_kv_ets_backend),
             %% Create a fresh ring for the test
             Ring = riak_core_ring:fresh(),
-            riak_core_ring_manager:set_my_ring(Ring),
+            riak_core_ring_manager:set_ring_global(Ring),
+
             %% Start riak_kv
             timer:sleep(500);
            (stop) ->


### PR DESCRIPTION
Ran into problems with this crashing while testing the put FSM.  It still crashed when run as the only test.

Sidestep the problem by just setting the ring in mochiglobal without having to start up the ring manager at all.
