### PR TITLE
Bz1062 keylister error handling

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -527,7 +527,8 @@ wait_for_listkeys(ReqId, Timeout) ->
 wait_for_listkeys(ReqId,Timeout,Acc) ->
     receive
         {ReqId, done} -> {ok, lists:flatten(Acc)};
-        {ReqId,{keys,Res}} -> wait_for_listkeys(ReqId,Timeout,[Res|Acc])
+        {ReqId,{keys,Res}} -> wait_for_listkeys(ReqId,Timeout,[Res|Acc]);
+        {ReqId, Error} -> {error, Error}
     after Timeout ->
             {error, timeout, Acc}
     end.

--- a/src/riak_kv_keylister_master.erl
+++ b/src/riak_kv_keylister_master.erl
@@ -25,23 +25,34 @@
 
 %% API
 -export([start_link/0,
-         start_keylist/3]).
+         start_keylist/3,
+         start_keylist/4]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
 -define(SERVER, ?MODULE).
+-define(DEFAULT_TIMEOUT, 5000).
 
 -record(state, {}).
 
 start_keylist(Node, ReqId, Bucket) ->
-    case gen_server:call({?SERVER, Node}, {start_kl, ReqId, self(), Bucket}) of
-        {ok, Pid} ->
-            {ok, Pid};
-        Error ->
-            Error
+    start_keylist(Node, ReqId, Bucket, ?DEFAULT_TIMEOUT).
+
+start_keylist(Node, ReqId, Bucket, Timeout) ->
+    try
+        case gen_server:call({?SERVER, Node}, {start_kl, ReqId, self(), Bucket}, Timeout) of
+            {ok, Pid} ->
+                {ok, Pid};
+            Error ->
+                Error
+        end
+    catch
+        exit:{timeout, _} ->
+            {error, timeout}
     end.
+
 
 start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).

--- a/src/riak_kv_keys_fsm.erl
+++ b/src/riak_kv_keys_fsm.erl
@@ -249,8 +249,8 @@ handle_sync_event(_Event, _From, _StateName, StateData) ->
     {stop,badmsg,StateData}.
 
 %% @private
-handle_info({'EXIT', Pid, normal}, _StateName, #state{client=Pid}=StateData) ->
-    {stop,normal,StateData};
+handle_info({'EXIT', Pid, Reason}, _StateName, #state{client=Pid}=StateData) ->
+    {stop,Reason,StateData};
 handle_info({_ReqId, {ok, _Pid}}, StateName, StateData=#state{timeout=Timeout}) ->
     %% Received a message from a key lister node that 
     %% did not start up within the timeout. Just ignore


### PR DESCRIPTION
These changes add error handling when starting key lister processes and changes riak_kv_keylister_master to use the client timeout value when starting these processes instead of relying on the default timeout value.

The goal of these changes is primarily to avoid 2 situations:
- A timeout occurring on a single node when starting the key lister causing the entire key listing process to fail and leaving the client process unaware and lingering until the client-supplied timeout (defaults to 8 minutes in riak_client) has expired. 
- All nodes timeout while starting the key listers and the keys fsm waits around for key listings to be reported back instead of promptly detecting the failure scenario and returning an error to the client.

In the former situation, the key listing should still be able to succeed in most cases and in the latter situation, the client should be notified as quickly as possible so that resources can be freed and appropriate steps taken.
