### PR TITLE
Az171 add wp rp and insufficent response to clients

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -212,6 +212,7 @@ mapred_dynamic_inputs_stream(FSMPid, InputDef, Timeout) ->
 %%       {error, notfound} |
 %%       {error, timeout} |
 %%       {error, {n_val_violation, N::integer()}} |
+%%       {error, {r_val_unsatisfied, R::integer(), Replies::integer()}} |
 %%       {error, Err :: term()}
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as the default
 %%      R-value for the nodes have responded with a value or error.
@@ -224,6 +225,7 @@ get(Bucket, Key) ->
 %%       {error, notfound} |
 %%       {error, timeout} |
 %%       {error, {n_val_violation, N::integer()}} |
+%%       {error, {r_val_unsatisfied, R::integer(), Replies::integer()}} |
 %%       {error, Err :: term()}
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as R-value for the nodes
 %%      have responded with a value or error.
@@ -240,6 +242,7 @@ get(Bucket, Key, Options) when is_list(Options) ->
 %%       {error, notfound} |
 %%       {error, timeout} |
 %%       {error, {n_val_violation, N::integer()}} |
+%%       {error, {r_val_unsatisfied, R::integer(), Replies::integer()}} |
 %%       {error, Err :: term()}
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as R
 %%      nodes have responded with a value or error.
@@ -253,6 +256,7 @@ get(Bucket, Key, R) ->
 %%       {error, notfound} |
 %%       {error, timeout} |
 %%       {error, {n_val_violation, N::integer()}} |
+%%       {error, {r_val_unsatisfied, R::integer(), Replies::integer()}} |
 %%       {error, Err :: term()}
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as R
 %%      nodes have responded with a value or error, or TimeoutMillisecs passes.

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -59,7 +59,11 @@ start(_Type, _StartArgs) ->
        {w, quorum},
        {pw, 0},
        {dw, quorum},
-       {rw, quorum}]),
+       {rw, quorum},
+       {pr, 0},
+       {basic_quorum, true},
+       {notfound_ok, false}
+   ]),
 
     %% Check the storage backend
     StorageBackend = app_helper:get_env(riak_kv, storage_backend),

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -184,8 +184,9 @@ validate(timeout, StateData=#state{from = {raw, ReqId, _Pid}, options = Options,
             client_reply({error, {pr_val_unsatisfied, PR, NumPrimaries}}, StateData),
             {stop, normal, StateData};
         true ->
+            BQ0 = get_option(basic_quorum, Options, true),
             FailThreshold = 
-                case get_option(basic_quorum, Options, true) of
+                case riak_kv_util:expand_value(basic_quorum, BQ0, BucketProps) of
                     true ->
                         erlang:min((N div 2)+1, % basic quorum, or
                                    (N-R+1)); % cannot ever get R 'ok' replies
@@ -193,7 +194,8 @@ validate(timeout, StateData=#state{from = {raw, ReqId, _Pid}, options = Options,
                         N - R + 1 % cannot ever get R 'ok' replies
                 end,
             AllowMult = proplists:get_value(allow_mult,BucketProps),
-            NotFoundOk = get_option(notfound_ok, Options, false),
+            NFOk0 = get_option(notfound_ok, Options, false),
+            NotFoundOk = riak_kv_util:expand_value(notfound_ok, NFOk0, BucketProps),
             {next_state, execute, StateData#state{r = R,
                                                   fail_threshold = FailThreshold,
                                                   timeout = Timeout,

--- a/src/riak_kv_pb_socket.erl
+++ b/src/riak_kv_pb_socket.erl
@@ -184,7 +184,7 @@ process_message(#rpbgetreq{bucket=B, key=K, r=R0, pr=PR0, notfound_ok=NFOk,
     end;
 
 process_message(#rpbputreq{bucket=B, key=K, vclock=PbVC, content=RpbContent,
-                           w=W0, dw=DW0, return_body=ReturnBody}, 
+                           w=W0, dw=DW0, pw=PW0, return_body=ReturnBody},
                 #state{client=C} = State) ->
 
     case K of
@@ -203,8 +203,10 @@ process_message(#rpbputreq{bucket=B, key=K, vclock=PbVC, content=RpbContent,
     % erlang_protobuffs encodes as 1/0/undefined
     W = normalize_rw_value(W0),
     DW = normalize_rw_value(DW0),
+    PW = normalize_rw_value(PW0),
     Options = case ReturnBody of 1 -> [returnbody]; true -> [returnbody]; _ -> [] end,
-    case C:put(O, default_if_undef(W), default_if_undef(DW), default_timeout(), Options) of
+    case C:put(O, [{w, default_if_undef(W)}, {dw, default_if_undef(DW)},
+                   {pw, default_if_undef(PW)}, {timeout, default_timeout()} | Options]) of
         ok when is_binary(ReturnKey) ->
             PutResp = #rpbputresp{key = ReturnKey},
             send_msg(PutResp, State);

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -210,7 +210,7 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
             process_reply({error, {w_val_violation, W0}}, StateData0);
         DW =:= error ->
             process_reply({error, {dw_val_violation, DW0}}, StateData0);
-        (W > N) or (DW > N) ->
+        (W > N) or (DW > N) or (PW > N) ->
             process_reply({error, {n_val_violation, N}}, StateData0);
         PW > NumPrimaries ->
             process_reply({error, {pw_val_unsatisfied, PW, NumPrimaries}}, StateData0);

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -29,6 +29,7 @@
          obj_not_deleted/1,
          try_cast/3,
          fallback/4,
+         expand_value/3,
          expand_rw_value/4,
          normalize_rw_value/2,
          make_request/2]).
@@ -112,17 +113,21 @@ make_request(Request, Index) ->
                                         {fsm, undefined, self()},
                                         Index).
 
-get_default_rw_val(Type, BucketProps) ->
-    {ok, DefaultProps} = application:get_env(riak_core, default_bucket_props),
-    case {proplists:get_value(Type, BucketProps),
-          proplists:get_value(Type, DefaultProps)} of
-        {undefined, Val} -> Val;
-        {Val, undefined} -> Val;
-        {Val1, _Val2} -> Val1
+get_bucket_option(Type, BucketProps) ->
+    case proplists:get_value(Type, BucketProps, default) of
+        default ->
+            {ok, DefaultProps} = application:get_env(riak_core, default_bucket_props),
+            proplists:get_value(Type, DefaultProps, error);
+        Val -> Val
     end.
-            
+
+expand_value(Type, default, BucketProps) ->
+    get_bucket_option(Type, BucketProps);
+expand_value(_Type, Value, _BucketProps) ->
+    Value.
+
 expand_rw_value(Type, default, BucketProps, N) ->
-    normalize_rw_value(get_default_rw_val(Type, BucketProps), N);    
+    normalize_rw_value(get_bucket_option(Type, BucketProps), N);
 expand_rw_value(_Type, Val, _BucketProps, N) ->
     normalize_rw_value(Val, N).
 

--- a/src/riak_kv_wm_raw.erl
+++ b/src/riak_kv_wm_raw.erl
@@ -453,7 +453,8 @@ malformed_rw_param({Idx, Name, Default}, {Result, RD, Ctx}) ->
         _ ->
             {true,
              wrq:append_to_resp_body(
-               io_lib:format("~s query parameter must be an integer~n",
+               io_lib:format("~s query parameter must be an integer or "
+                   "one of the following words: 'one', 'quorum' or 'all'~n",
                              [Name]),
                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx}

--- a/test/put_fsm_eqc.erl
+++ b/test/put_fsm_eqc.erl
@@ -465,7 +465,7 @@ expect(H, N, PW, RealPW, W, RealW, DW, EffDW, Options, Precommit, Postcommit, Ob
             DW =:= garbage ->
                 {error, {dw_val_violation, garbage}};
 
-            RealW > N orelse EffDW > N ->
+            RealW > N orelse EffDW > N orelse RealPW > N ->
                 {error, {n_val_violation, N}};
 
             RealPW > NumPrimaries ->


### PR DESCRIPTION
This adds server side support for the new options in the Put and Get FSMs; pr, pw, basic_quorum and notfound_ok.

It also does some incidental code cleanups.
