### PR TITLE
AZ3 switch to new basho/eper repository for eper

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,6 +17,6 @@
                                  {branch, "master"}}},
         {ebloom, "1.0.2", {git, "git://github.com/basho/ebloom",
                                 {branch, "master"}}},
-        {eper, ".*", {git, "git://github.com/dizzyd/eper.git",
+        {eper, ".*", {git, "git://github.com/basho/eper.git",
                         {branch, "master"}}}
        ]}.


### PR DESCRIPTION
This repository is an updated fork of upstream that contains all the
important patches from dizzyd/eper.
