### PR TITLE
Add "backlog" tcp option to pb socket opts

### DIFF
--- a/src/riak_kv_pb_listener.erl
+++ b/src/riak_kv_pb_listener.erl
@@ -38,7 +38,9 @@ start_link() ->
 init([PortNum]) -> 
     {ok, #state{portnum=PortNum}}.
 
-sock_opts() -> [binary, {packet, 4}, {reuseaddr, true}].
+sock_opts() ->
+    BackLog = app_helper:get_env(riak_kv, pb_backlog, 5),
+    [binary, {packet, 4}, {reuseaddr, true}, {backlog, BackLog}].
 
 handle_call(_Req, _From, State) -> 
     {reply, not_implemented, State}.


### PR DESCRIPTION
When (not that) many connections are opened simultaneously (as few as 30) by the PB client, often a few (or more) throw "connection reset by peer" exceptions.

Expose the backlog tcp option as an application env parameter to mitigate problem.

See bz://1075 for more details

Defaults to the (default) value of 5, can be set in app.config for riak_kv app as

```
{riak_kv, [
     {pb_backlog, 128}
    ]
}
```

is this the right approach?

what do I do to get this into:

a) the app.config?
b) the wiki?
