### PR TITLE
Rz fix delete

### DIFF
--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -28,7 +28,11 @@
 -include_lib("eunit/include/eunit.hrl").
 %-endif.
 
--export([delete/6]).
+-export([start_link/6, delete/6]).
+
+start_link(ReqId, Bucket, Key, RW, Timeout, Client) ->
+    {ok, proc_lib:spawn_link(?MODULE, delete, [ReqId, Bucket, Key,
+                                               RW, Timeout, Client])}.
 
 %% @spec delete(ReqId :: binary(), riak_object:bucket(), riak_object:key(),
 %%             RW :: integer(), TimeoutMillisecs :: integer(), Client :: pid())

--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -56,13 +56,11 @@ delete(ReqId,Bucket,Key,RW0,Timeout,Client) ->
                     NewObj = riak_object:update_metadata(OrigObj,
                                                          dict:store(<<"X-Riak-Deleted">>, "true", OrigMD)),
                     Reply = C:put(NewObj, RW, RW, RemainingTime),
+                    Client ! {ReqId, Reply},
                     case Reply of
-                        ok -> 
-                            spawn_link(
-                              fun()-> reap(Bucket,Key,RemainingTime) end);
+                        ok -> reap(Bucket,Key,RemainingTime);
                         _ -> nop
-                    end,
-                    Client ! {ReqId, Reply};
+                    end;
                 {error, notfound} ->
                     Client ! {ReqId, {error, notfound}};
                 X ->

--- a/src/riak_kv_delete_sup.erl
+++ b/src/riak_kv_delete_sup.erl
@@ -42,7 +42,7 @@ start_link() ->
 %% @doc supervisor callback.
 init([]) ->
     DeleteSpec = {undefined,
-               {riak_kv_delete, delete, []},
+               {riak_kv_delete, start_link, []},
                temporary, 5000, worker, [riak_kv_delete]},
 
     {ok, {{simple_one_for_one, 10, 10}, [DeleteSpec]}}.


### PR DESCRIPTION
While trying to get all the Search tests to pass I found a bug in the delete functionality of KV that only manifested itself when the Search KV precommit hook is installed.  Upon further investigation I found that the `riak_kv_delete_sup` was spawning `riak_kv_delete` in such a way that the actual work of delete was being done **ON** the supervisor's container process.  This is bad because it will block any other delete request that comes in on that node and is why the Search KV hook was failing during delete (because there is an inner delete inside of it).  This also violates the interface for the supervisor which expects initialization to do as little work as possible and to return `{ok, Pid}`.

Please see commit comments for more info.
