### PR TITLE
make vnode to get_fsm communication avoid a binary_to_term/term_to_binary roundtrip

### DIFF
--- a/include/riak_kv_vnode.hrl
+++ b/include/riak_kv_vnode.hrl
@@ -11,6 +11,10 @@
           bkey :: {binary(), binary()},
           req_id :: non_neg_integer()}).
 
+-record(riak_kv_get_binary_req_v1, {
+          bkey :: {binary(), binary()},
+          req_id :: non_neg_integer()}).
+
 -record(riak_kv_mget_req_v1, {
           bkeys :: list({binary(), binary()}),
           req_id :: non_neg_integer(),
@@ -41,6 +45,7 @@
 
 -define(KV_PUT_REQ, #riak_kv_put_req_v1).
 -define(KV_GET_REQ, #riak_kv_get_req_v1).
+-define(KV_GET_BINARY_REQ, #riak_kv_get_binary_req_v1).
 -define(KV_MGET_REQ, #riak_kv_mget_req_v1).
 -define(KV_LISTKEYS_REQ, #riak_kv_listkeys_req_v2).
 -define(KV_DELETE_REQ, #riak_kv_delete_req_v1).


### PR DESCRIPTION
This optimizes communication from vnodes to the get_fsm, by not doing binary_to_term on the vnode when executing a read, but rather make that happen in the get_fsm.  By doing so, we avoid an extra term_to_binary+binary_to_term imposed by erlang distribution.  It looks pretty silly that vnode gets the binary, turns it into a term and immediately hands it off to erlang distribution (which will then encode it again) for wire transfer.

I don't have hard data on how much CPU we save on this, but our performance measurements indicate that binary_to_term and term_to_binary are hot spots.

I'm not sure this is the right way to do this; and it certainly makes get_fsm/vnode interactions a tad more complicated, so consider this a proposal.
