### PR TITLE
Break out core get FSM logic

### DIFF
--- a/ebin/riak_kv.app
+++ b/ebin/riak_kv.app
@@ -22,6 +22,7 @@
              riak_kv_ets_backend,
              riak_kv_fs_backend,
              riak_kv_gb_trees_backend,
+             riak_kv_get_core,
              riak_kv_get_fsm,
              riak_kv_get_fsm_sup,
              riak_kv_js_manager,

--- a/src/riak_kv_get_core.erl
+++ b/src/riak_kv_get_core.erl
@@ -1,0 +1,220 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_get_core: Riak get logic
+%%
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_kv_get_core).
+-export([init/5, add_result/3, enough/1, response/1, 
+         has_all_results/1, final_action/1, info/1]).
+-export_type([getcore/0, result/0, reply/0, final_action/0]).
+
+-type result() :: {ok, riak_object:riak_object()} |
+                  {error, notfound} | % for dialyzer
+                  {error, any()}.
+-type reply() :: {ok, riak_object:riak_object()} |
+                 {error, notfound} |
+                 {error, any()}.
+-type final_action() :: nop |
+                        {read_repair, [non_neg_integer()], riak_object:riak_object()} |
+                        delete.
+-type idxresult() :: {non_neg_integer(), result()}.
+
+-record(getcore, {n :: pos_integer(),
+                  r :: pos_integer(),
+                  fail_threshold :: pos_integer(),
+                  notfound_ok :: boolean(),
+                  allow_mult :: boolean(),
+                  results = [] :: [idxresult()],
+                  merged :: {notfound | tombstone | ok,
+                             riak_object:riak_object() | undefined},
+                  num_ok = 0 :: non_neg_integer(),
+                  num_notfound = 0 :: non_neg_integer(),
+                  num_fail = 0 :: non_neg_integer()}).
+-opaque getcore() :: #getcore{}.
+
+%% ====================================================================
+%% Public API
+%% ====================================================================
+
+%% Initialize a get and return an opaque get core context
+-spec init(pos_integer(), pos_integer(), pos_integer(), boolean(), boolean()) ->
+                  getcore().
+init(N, R, FailThreshold, NotFoundOk, AllowMult) ->
+    #getcore{n = N,
+             r = R,
+             fail_threshold = FailThreshold,
+             notfound_ok = NotFoundOk,
+             allow_mult = AllowMult}.
+
+%% Add a result for a vnode index
+-spec add_result(non_neg_integer(), result(), getcore()) -> getcore().
+add_result(Idx, Result, GetCore = #getcore{results = Results}) ->
+    UpdResults = [{Idx, Result} | Results],
+    case Result of
+        {ok, _RObj} ->
+            GetCore#getcore{results = UpdResults, merged = undefined,
+                            num_ok = GetCore#getcore.num_ok + 1};
+        {error, notfound} ->
+            case GetCore#getcore.notfound_ok of
+                true ->
+                    GetCore#getcore{results = UpdResults, merged = undefined,
+                                    num_ok = GetCore#getcore.num_ok + 1};
+                _ ->
+                    GetCore#getcore{results = UpdResults, merged = undefined,
+                                    num_notfound = GetCore#getcore.num_notfound + 1}
+            end;
+        {error, _Reason} ->
+            GetCore#getcore{results = UpdResults, merged = undefined,
+                            num_fail = GetCore#getcore.num_fail + 1}
+    end.
+
+%% Check if enough results have been added to respond 
+-spec enough(getcore()) -> boolean().
+enough(#getcore{r = R, num_ok = NumOk,
+                num_notfound = NumNotFound,
+                num_fail = NumFail,
+                fail_threshold = FailThreshold}) ->
+    if
+        NumOk >= R ->
+            true;
+        NumNotFound + NumFail >= FailThreshold ->
+            true;
+        true ->
+            false
+    end.
+
+%% Get success/fail response once enough results received
+-spec response(getcore()) -> {reply(), getcore()}.
+response(GetCore = #getcore{r = R, num_ok = NumOk, num_notfound = NumNotFound,
+                            results = Results, allow_mult = AllowMult}) ->
+    {ObjState, _MObj} = Merged = merge(Results, AllowMult),
+    Reply = case NumOk >= R of
+                true ->
+                    case ObjState of
+                        ok ->
+                            Merged; % {ok, MObj}
+                        _ -> % tombstone or notfound
+                            {error, notfound}
+                    end;
+                false ->
+                    DelObjs = length([xx || {_Idx, {ok, RObj}} <- Results,
+                                            riak_kv_util:is_x_deleted(RObj)]),
+                    Fails = [F || F = {_Idx, {error, Reason}} <- Results,
+                                  Reason /= notfound],
+                    fail_reply(R, NumOk, NumOk - DelObjs, 
+                               NumNotFound + DelObjs, Fails)
+            end,
+    {Reply, GetCore#getcore{merged = Merged}}.
+
+%% Check if all expected results have been added
+-spec has_all_results(getcore()) -> boolean().
+has_all_results(#getcore{n = N, num_ok = NOk, 
+                         num_fail = NFail, num_notfound = NNF}) ->
+    NOk + NFail + NNF >= N.
+
+%% Decide on any post-response actions
+%% nop - do nothing
+%% {readrepair, Indices, MObj} - send read repairs iff any vnode has ancestor data 
+%%                               (including tombstones)
+%% delete - issue deletes if all vnodes returned tombstones.  This needs to be
+%%          supplemented with a check that the vnodes were all primaries.
+%% 
+-spec final_action(getcore()) -> {final_action(), getcore()}.
+final_action(GetCore = #getcore{n = N, merged = Merged0, results = Results,
+                                allow_mult = AllowMult}) ->
+    Merged = case Merged0 of
+                 undefined ->
+                     merge(Results, AllowMult);
+                 _ ->
+                     Merged0
+             end,
+    {ObjState, MObj} = Merged,
+    ReadRepairs = case ObjState of
+                      notfound ->
+                          [];
+                      _ -> % ok or tombstone
+                          [Idx || {Idx, {ok, RObj}} <- Results, 
+                                  strict_descendant(MObj, RObj)] ++
+                              [Idx || {Idx, {error, notfound}} <- Results]
+                  end,
+    Action = case ReadRepairs of
+                 [] when ObjState == tombstone ->
+                     %% Allow delete if merge object is deleted,
+                     %% there are no read repairs pending and
+                     %% a value was received from all vnodes
+                     case riak_kv_util:is_x_deleted(MObj) andalso 
+                         length([xx || {_Idx, {ok, _RObj}} <- Results]) == N of
+                         true ->
+                             delete;
+                         _ ->
+                             nop
+                     end;
+                 [] ->
+                     nop;
+                 _ ->
+                     {read_repair, ReadRepairs, MObj}
+             end,
+    {Action, GetCore#getcore{merged = Merged}}.
+
+%% Return request info
+-spec info(undefined | getcore()) -> [{vnode_oks, non_neg_integer()} | 
+                                      {vnode_errors, [any()]}].
+                  
+info(undefined) -> 
+    []; % make uninitialized case easier
+info(#getcore{num_ok = NumOks, num_fail = NumFail, results = Results}) ->
+    Oks = [{vnode_oks, NumOks}],
+    case NumFail of
+        0 ->
+            Oks;
+        _ ->
+            Errors = [Reason || {_Idx, {error, Reason}} <- Results,
+                                Reason /= undefined],
+            [{vnode_errors, Errors} | Oks]
+    end.
+
+%% ====================================================================
+%% Internal functions
+%% ====================================================================
+
+strict_descendant(O1, O2) ->
+    vclock:descends(riak_object:vclock(O1),riak_object:vclock(O2)) andalso
+    not vclock:descends(riak_object:vclock(O2),riak_object:vclock(O1)).
+        
+merge(Replies, AllowMult) ->
+    RObjs = [RObj || {_I, {ok, RObj}} <- Replies],
+    case RObjs of
+        [] ->
+            {notfound, undefined};
+        _ ->
+            Merged = riak_object:reconcile(RObjs, AllowMult), % include tombstones
+            case riak_kv_util:is_x_deleted(Merged) of
+                true ->
+                    {tombstone, Merged};
+                _ ->
+                    {ok, Merged}
+            end
+    end.
+
+fail_reply(_R, _NumR, 0, NumNotFound, []) when NumNotFound > 0 ->
+    {error, notfound};
+fail_reply(R, NumR, _NumNotDeleted, _NumNotFound, _Fails) ->
+    {error, {r_val_unsatisfied, R,  NumR}}.
+
+

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -32,12 +32,20 @@
          handle_info/3, terminate/3, code_change/4]).
 -export([prepare/2,validate/2,execute/2,waiting_vnode_r/2,waiting_read_repair/2]).
 
+-type detail() :: timing |
+                  vnodes.
+-type details() :: [detail()].
+
 -type option() :: {r, pos_integer()} |         %% Minimum number of successful responses
                   {pr, non_neg_integer()} |    %% Minimum number of primary vnodes participating
                   {basic_quorum, boolean()} |  %% Whether to use basic quorum (return early 
                                                %% in some failure cases.
                   {notfound_ok, boolean()}  |  %% Count notfound reponses as successful.
-                  {timeout, pos_integer() | infinity}. %% Timeout for vnode responses
+                  {timeout, pos_integer() | infinity} | %% Timeout for vnode responses
+                  {details, details()} |       %% Return extra details as a 3rd element
+                  {details, true} |
+                  details.
+
 -type options() :: [option()].
 -type req_id() :: non_neg_integer().
 

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -43,24 +43,26 @@
 
 -export_type([options/0, option/0]).
 
+
+-record(getcore, {n :: pos_integer(),
+                  r :: pos_integer(),
+                  fail_threshold :: pos_integer(),
+                  notfound_ok :: boolean(),
+                  allow_mult :: boolean(),
+                  results = [] :: list(),
+                  merged :: notfound | {tombstone, riak_object:riak_object()} | 
+                            riak_object:riak_object(),
+                  num_ok = 0 :: non_neg_integer(),
+                  num_notfound = 0 :: non_neg_integer(),
+                  num_fail = 0 :: non_neg_integer()}).
+
 -record(state, {from :: {raw, req_id(), pid()},
                 options=[] :: options(),
                 n :: pos_integer(),
-                r :: pos_integer(),
-                fail_threshold :: non_neg_integer(),
-                allowmult :: boolean(),
-                notfound_ok :: boolean(),
                 preflist2 :: riak_core_apl:preflist2(),
                 req_id :: non_neg_integer(),
                 starttime :: pos_integer(),
-                replied_r = [] :: list(),
-                replied_notfound = [] :: list(),
-                replied_fail = [] :: list(),
-                num_r = 0 :: non_neg_integer(),
-                num_notfound = 0 :: non_neg_integer(),
-                num_fail = 0 :: non_neg_integer(),
-                final_obj :: {ok, riak_object:riak_object()} |
-                             tombstone | {error, notfound},
+                get_core :: #getcore{},
                 timeout :: infinity | pos_integer(),
                 tref    :: reference(),
                 bkey :: {riak_object:bucket(), riak_object:key()},
@@ -196,11 +198,9 @@ validate(timeout, StateData=#state{from = {raw, ReqId, _Pid}, options = Options,
             AllowMult = proplists:get_value(allow_mult,BucketProps),
             NFOk0 = get_option(notfound_ok, Options, false),
             NotFoundOk = riak_kv_util:expand_value(notfound_ok, NFOk0, BucketProps),
-            {next_state, execute, StateData#state{r = R,
-                                                  fail_threshold = FailThreshold,
+            GetCore = initgc(N, R, FailThreshold, NotFoundOk, AllowMult),
+            {next_state, execute, StateData#state{get_core = GetCore,
                                                   timeout = Timeout,
-                                                  allowmult = AllowMult,
-                                                  notfound_ok = NotFoundOk,
                                                   req_id = ReqId}, 0}
     end.
 
@@ -215,27 +215,30 @@ execute(timeout, StateData0=#state{timeout=Timeout,req_id=ReqId,
     {next_state,waiting_vnode_r,StateData}.
 
 %% @private
-waiting_vnode_r({r, VnodeResult, Idx, _ReqId}, StateData) ->
-    NewStateData1 = add_vnode_result(Idx, VnodeResult, StateData),
-    case enough_results(NewStateData1) of
-        {reply, Reply, NewStateData2} ->
+waiting_vnode_r({r, VnodeResult, Idx, _ReqId}, StateData = #state{get_core = GetCore}) ->
+    UpdGetCore = add_result(Idx, VnodeResult, GetCore),
+    case enough(UpdGetCore) of
+        true ->
+            {Reply, UpdGetCore2} = response(UpdGetCore),
+            NewStateData2 = update_timing(StateData#state{get_core = UpdGetCore2}),
             client_reply(Reply, NewStateData2),
             update_stats(NewStateData2),
-            finalize(NewStateData2);
-        {false, NewStateData2} ->
-            {next_state, waiting_vnode_r, NewStateData2}
+            maybe_finalize(NewStateData2);
+        false ->
+            {next_state, waiting_vnode_r, StateData#state{get_core = UpdGetCore}}
     end;
-waiting_vnode_r(request_timeout, StateData=#state{replied_r=Replied,allowmult=AllowMult}) ->
+waiting_vnode_r(request_timeout, StateData) ->
     update_stats(StateData),
     client_reply({error,timeout}, StateData),
-    really_finalize(StateData#state{final_obj=merge(Replied, AllowMult)}).
+    finalize(StateData).
 
 %% @private
-waiting_read_repair({r, VnodeResult, Idx, _ReqId}, StateData) ->
-    NewStateData1 = add_vnode_result(Idx, VnodeResult, StateData),
-    finalize(NewStateData1#state{final_obj = undefined});
+waiting_read_repair({r, VnodeResult, Idx, _ReqId},
+                    StateData = #state{get_core = GetCore}) ->
+    UpdGetCore = add_result(Idx, VnodeResult, GetCore),
+    maybe_finalize(StateData#state{get_core = UpdGetCore});
 waiting_read_repair(request_timeout, StateData) ->
-    really_finalize(StateData).
+    finalize(StateData).
 
 %% @private
 handle_event(_Event, _StateName, StateData) ->
@@ -260,124 +263,201 @@ terminate(Reason, _StateName, _State) ->
 code_change(_OldVsn, StateName, State, _Extra) -> {ok, StateName, State}.
 
 %% ====================================================================
-%% Internal functions
+%% Get core functions
 %% ====================================================================
 
-add_vnode_result(Idx, {ok, RObj}, StateData = #state{replied_r = Replied,
-                                                     num_r = NumR}) ->
-    StateData#state{replied_r = [{RObj, Idx} | Replied],
-                    num_r = NumR + 1};
-add_vnode_result(Idx, {error, notfound}, StateData = #state{replied_notfound = NotFound,
-                                                            num_notfound = NumNotFound,
-                                                            notfound_ok = false}) ->
-    StateData#state{replied_notfound = [Idx | NotFound],
-                    num_notfound = NumNotFound + 1};
-add_vnode_result(Idx, {error, notfound}, StateData = #state{replied_notfound = NotFound,
-                                                            num_r = NumR,
-                                                            notfound_ok = true}) ->
-    StateData#state{replied_notfound = [Idx | NotFound],
-                    num_r = NumR + 1};
-add_vnode_result(Idx, {error, Err}, StateData = #state{replied_fail = Fail,
-                                                       num_fail = NumFail}) ->
-    StateData#state{replied_fail = [{Err, Idx} | Fail],
-                   num_fail = NumFail + 1}.
+initgc(N, R, FailThreshold, NotFoundOk, AllowMult) ->
+    #getcore{n = N,
+             r = R,
+             fail_threshold = FailThreshold,
+             notfound_ok = NotFoundOk,
+             allow_mult = AllowMult}.
 
-enough_results(StateData = #state{r = R, allowmult = AllowMult,
-                                  fail_threshold = FailThreshold,
-                                  replied_r = Replied, num_r = NumR,
-                                  num_notfound = NumNotFound,
-                                  replied_fail = Fails, num_fail = NumFail}) ->
+add_result(Idx, Result, GetCore = #getcore{results = Results}) ->
+    UpdResults = [{Idx, Result} | Results],
+    case Result of
+        {ok, _RObj} ->
+            GetCore#getcore{results = UpdResults, merged = undefined,
+                            num_ok = GetCore#getcore.num_ok + 1};
+        {error, notfound} when GetCore#getcore.notfound_ok == true ->
+            GetCore#getcore{results = UpdResults, merged = undefined,
+                            num_ok = GetCore#getcore.num_ok + 1};
+        {error, notfound} ->
+            GetCore#getcore{results = UpdResults, merged = undefined,
+                            num_notfound = GetCore#getcore.num_notfound + 1};
+        {error, _Reason} ->
+            GetCore#getcore{results = UpdResults, merged = undefined,
+                            num_fail = GetCore#getcore.num_fail + 1}
+    end.
+
+enough(#getcore{r = R, num_ok = NumOk,
+                num_notfound = NumNotFound,
+                num_fail = NumFail,
+                fail_threshold = FailThreshold}) ->
     if
-        NumR >= R ->
-            {Reply, Final} = respond(Replied, AllowMult),
-            {reply, Reply, update_timing(StateData#state{final_obj = Final})};
+        NumOk >= R ->
+            true;
         NumNotFound + NumFail >= FailThreshold ->
-            DelObjs = length([xx || {RObj, _Idx} <- Replied, riak_kv_util:is_x_deleted(RObj)]),
-            Reply = fail_reply(R, NumR, NumR - DelObjs, NumNotFound + DelObjs, Fails),
-            Final = merge(Replied, AllowMult),
-            {reply, Reply, update_timing(StateData#state{final_obj = Final})};
+            true;
         true ->
-            {false, StateData}
-    end.
-                    
-has_all_replies(#state{replied_r=R,replied_fail=F,replied_notfound=NF, n=N}) ->
-    length(R) + length(F) + length(NF) >= N.
-
-finalize(StateData=#state{replied_r=[]}) ->
-    case has_all_replies(StateData) of
-        true -> {stop,normal,StateData};
-        false -> {next_state,waiting_read_repair,StateData}
-    end;
-finalize(StateData) ->
-    case has_all_replies(StateData) of
-        true -> really_finalize(StateData);
-        false -> {next_state,waiting_read_repair,StateData}
+            false
     end.
 
-really_finalize(StateData=#state{allowmult = AllowMult,
-                                 final_obj = FinalObj,
-                                 preflist2=Sent,
-                                 replied_r=RepliedR,
-                                 bkey=BKey,
-                                 req_id=ReqId,
-                                 replied_notfound=NotFound,
-                                 starttime=StartTime,
-                                 bucket_props=BucketProps}) ->
-    Final = case FinalObj of
-                undefined -> %% Recompute if extra read repairs have arrived
-                    merge(RepliedR,AllowMult);
-                _ ->
-                    FinalObj
-            end,
-    case Final of
-        tombstone ->
-            maybe_finalize_delete(StateData);
-        {ok,_} ->
-            maybe_do_read_repair(Sent,Final,RepliedR,NotFound,BKey,
-                                 ReqId,StartTime,BucketProps);
-        _ -> nop
-    end,
-    {stop,normal,StateData}.
+has_all_replies(#getcore{n = N, num_ok = NOk, 
+                         num_fail = NFail, num_notfound = NNF}) ->
+    NOk + NFail + NNF >= N.
 
-maybe_finalize_delete(_StateData=#state{replied_notfound=NotFound,n=N,
-                                        replied_r=RepliedR,
-                                        preflist2=Sent,req_id=ReqId,
-                                        bkey=BKey}) ->
-    IdealNodes = [{I,Node} || {{I,Node},primary} <- Sent],
-    case length(IdealNodes) of
-        N -> % this means we sent to a perfect preflist
-            case (length(RepliedR) + length(NotFound)) of
-                N -> % and we heard back from all nodes with non-failure
-                    case lists:all(fun(X) -> riak_kv_util:is_x_deleted(X) end,
-                                   [O || {O,_I} <- RepliedR]) of
-                        true -> % and every response was X-Deleted, go!
-                            riak_kv_vnode:del(IdealNodes, BKey, ReqId);
-                        _ -> nop
+response(GetCore = #getcore{r = R, num_ok = NumOk, num_notfound = NumNotFound,
+                            results = Results, allow_mult = AllowMult}) ->
+    {ObjState, _MObj} = Merged = merge(Results, AllowMult),
+    Reply = case NumOk >= R of
+                true ->
+                    case ObjState of
+                        ok ->
+                            Merged; % {ok, MObj}
+                        _ -> % tombstone or notfound
+                            {error, notfound}
                     end;
-                _ -> nop
-            end;
-        _ -> nop
-    end.
+                false ->
+                    DelObjs = length([xx || {_Idx, {ok, RObj}} <- Results,
+                                            riak_kv_util:is_x_deleted(RObj)]),
+                    Fails = [F || F = {_Idx, {error, Reason}} <- Results,
+                                  Reason /= notfound],
+                    fail_reply(R, NumOk, NumOk - DelObjs, 
+                               NumNotFound + DelObjs, Fails)
+            end,
+    {Reply, GetCore#getcore{merged = Merged}}.
 
-maybe_do_read_repair(Sent,Final,RepliedR,NotFound,BKey,ReqId,StartTime,BucketProps) ->
-    Targets = ancestor_indices(Final, RepliedR) ++ NotFound,
-    {ok, FinalRObj} = Final,
-    case Targets of
-        [] -> nop;
+%% Decide on final actions
+%% nop - do nothing
+%% readrepair - send read repairs iff any vnode has ancestor data (including tombstones)
+%% delete - issue deletes if all vnodes returned tombstones.  This needs to be
+%%          supplemented with a check that the vnodes were all primaries.
+%% 
+final_action(GetCore = #getcore{n = N, merged = Merged0, results = Results,
+                                allow_mult = AllowMult}) ->
+    Merged = case Merged0 of
+                 undefined ->
+                     merge(Results, AllowMult);
+                 _ ->
+                     Merged0
+             end,
+    {ObjState, MObj} = Merged,
+    ReadRepairs = case ObjState of
+                      notfound ->
+                          [];
+                      _ -> % ok or tombstone
+                          [Idx || {Idx, {ok, RObj}} <- Results, 
+                                  strict_descendant(MObj, RObj)] ++
+                              [Idx || {Idx, {error, notfound}} <- Results]
+                  end,
+    Action = case ReadRepairs of
+                 [] when ObjState == tombstone ->
+                     %% Allow delete if merge object is deleted,
+                     %% there are no read repairs pending and
+                     %% a value was received from all vnodes
+                     case riak_kv_util:is_x_deleted(MObj) andalso 
+                         length([xx || {_Idx, {ok, _RObj}} <- Results]) == N of
+                         true ->
+                             delete;
+                         _ ->
+                             nop
+                     end;
+                 [] ->
+                     nop;
+                 _ ->
+                     {read_repair, ReadRepairs, MObj}
+             end,
+    {Action, GetCore#getcore{merged = Merged}}.
+
+%% Return request info
+info(undefined) -> 
+    []; % make uninitialized case easier
+info(#getcore{num_ok = NumOks, num_fail = NumFail, results = Results}) ->
+    Oks = [{vnode_oks, NumOks}],
+    case NumFail of
+        0 ->
+            Oks;
         _ ->
-            RepairPreflist = [{Idx, Node} || {{Idx,Node},_Type} <- Sent, 
-                                            lists:member(Idx, Targets)],
-            riak_kv_vnode:readrepair(RepairPreflist, BKey, FinalRObj, ReqId, 
-                                     StartTime, [{returnbody, false},
-                                                 {bucket_props, BucketProps}]),
-            riak_kv_stat:update(read_repairs)
+            Errors = [Reason || {_Idx, {error, Reason}} <- Results,
+                                Reason /= undefined],
+            [{vnode_errors, Errors} | Oks]
     end.
 
+strict_descendant(O1, O2) ->
+    vclock:descends(riak_object:vclock(O1),riak_object:vclock(O2)) andalso
+    not vclock:descends(riak_object:vclock(O2),riak_object:vclock(O1)).
+
+merge(Replies, AllowMult) ->
+    RObjs = [RObj || {_I, {ok, RObj}} <- Replies],
+    case RObjs of
+        [] ->
+            {notfound, undefined};
+        _ ->
+            Merged = riak_object:reconcile(RObjs, AllowMult), % include tombstones
+            case riak_kv_util:is_x_deleted(Merged) of
+                true ->
+                    {tombstone, Merged};
+                _ ->
+                    {ok, Merged}
+            end
+    end.
 
 fail_reply(_R, _NumR, 0, NumNotFound, []) when NumNotFound > 0 ->
     {error, notfound};
 fail_reply(R, NumR, _NumNotDeleted, _NumNotFound, _Fails) ->
     {error, {r_val_unsatisfied, R,  NumR}}.
+
+
+    
+%% ====================================================================
+%% Internal functions
+%% ====================================================================
+
+maybe_finalize(StateData=#state{get_core = GetCore}) ->
+    case has_all_replies(GetCore) of
+        true -> finalize(StateData);
+        false -> {next_state,waiting_read_repair,StateData}
+    end.
+
+finalize(StateData=#state{get_core = GetCore}) ->
+    {Action, UpdGetCore} = final_action(GetCore),
+    UpdStateData = StateData#state{get_core = UpdGetCore},
+    case Action of
+        delete ->
+            maybe_delete(UpdStateData);
+        {read_repair, Indices, RepairObj} ->
+            read_repair(Indices, RepairObj, UpdStateData);
+        _Nop ->
+            ok
+    end,
+    {stop,normal,StateData}.
+
+%% Maybe issue deletes if all primary nodes are available.
+%% Get core will only requestion deletion if all vnodes
+%% replies with the same value.
+maybe_delete(_StateData=#state{n = N, preflist2=Sent,
+                               req_id=ReqId, bkey=BKey}) ->
+    %% Check sent to a perfect preflist and we can delete
+    IdealNodes = [{I, Node} || {{I, Node}, primary} <- Sent],
+    case length(IdealNodes) == N of
+        true ->
+            riak_kv_vnode:del(IdealNodes, BKey, ReqId);
+        _ ->
+            nop
+    end.
+
+%% Issue read repairs for any vnodes that are out of date
+read_repair(Indices, RepairObj,
+            #state{req_id = ReqId, starttime = StartTime,
+                   preflist2 = Sent, bkey = BKey, bucket_props = BucketProps}) ->
+    RepairPreflist = [{Idx, Node} || {{Idx, Node}, _Type} <- Sent, 
+                                     lists:member(Idx, Indices)],
+    riak_kv_vnode:readrepair(RepairPreflist, BKey, RepairObj, ReqId, 
+                             StartTime, [{returnbody, false},
+                                         {bucket_props, BucketProps}]),
+    riak_kv_stat:update(read_repairs).
+
 
 get_option(Name, Options, Default) ->
     proplists:get_value(Name, Options, Default).
@@ -400,45 +480,6 @@ client_reply(Reply, StateData = #state{from = {raw, ReqId, Pid}, options = Optio
           end,
     Pid ! Msg. 
 
-respond(VResponses,AllowMult) ->
-    Merged = merge(VResponses, AllowMult),
-    case Merged of
-        tombstone ->
-            Reply = {error,notfound};
-        {error, notfound} ->
-            Reply = Merged;
-        {ok, Obj} ->
-            case riak_kv_util:is_x_deleted(Obj) of
-                true ->
-                    Reply = {error, notfound};
-                false ->
-                    Reply = {ok, Obj}
-            end
-    end,
-    {Reply, Merged}.
-
-merge(VResponses, AllowMult) ->
-   merge_robjs([R || {R,_I} <- VResponses],AllowMult).
-
-merge_robjs([], _) ->
-    {error, notfound};
-merge_robjs(RObjs0,AllowMult) ->
-    RObjs1 = [X || X <- [riak_kv_util:obj_not_deleted(O) ||
-                            O <- RObjs0], X /= undefined],
-    case RObjs1 of
-        [] -> tombstone;
-        _ ->
-            RObj = riak_object:reconcile(RObjs0,AllowMult),
-            {ok, RObj}
-    end.
-
-strict_descendant(O1, O2) ->
-    vclock:descends(riak_object:vclock(O1),riak_object:vclock(O2)) andalso
-    not vclock:descends(riak_object:vclock(O2),riak_object:vclock(O1)).
-
-ancestor_indices({ok, Final},AnnoObjects) ->
-    [Idx || {O,Idx} <- AnnoObjects, strict_descendant(Final, O)].
-
 update_timing(StateData = #state{startnow = StartNow}) ->
     EndNow = now(),
     StateData#state{get_usecs = timer:now_diff(EndNow, StartNow)}.
@@ -452,19 +493,12 @@ client_info([], _StateData, Acc) ->
     Acc;
 client_info([timing | Rest], StateData = #state{get_usecs = GetUsecs}, Acc) ->
     client_info(Rest, StateData, [{duration, GetUsecs} | Acc]);
-client_info([vnodes | Rest], StateData = #state{num_r = NumOks,
-                                                replied_fail = Fail}, Acc) ->
-    Oks = [{vnode_oks, NumOks}],
-    Info = case Fail of
-               [] ->
-                   Oks;
-               _ ->
-                   Errors = [Err || {Err, _Idx} <- Fail],
-                   [{vnode_errors, Errors} | Oks]
-           end,
+client_info([vnodes | Rest], StateData = #state{get_core = GetCore}, Acc) ->
+    Info = info(GetCore),
     client_info(Rest, StateData, Info ++ Acc);
 client_info([Unknown | Rest], StateData, Acc) ->
     client_info(Rest, StateData, [{Unknown, unknown_detail} | Acc]).
+
 
 details() ->
     [timing,

--- a/test/get_fsm_qc.erl
+++ b/test/get_fsm_qc.erl
@@ -372,24 +372,15 @@ check_info([{vnode_errors, _Errors} | Rest], State) ->
     %% The first RealR errors from the vnode history
     check_info(Rest, State).
 
+%% Check the read repairs - no need to worry about delete objects, deletes can only
+%% happen when all read repairs are complete.
 
 check_repair(Objects, RepairH, H) ->
     Actual = [ Part || {Part, ?KV_PUT_REQ{}} <- RepairH ],
     Heads  = merge_heads([ Lineage || {_, {ok, Lineage}} <- H ]),
-    
-    AllDeleted = lists:all(fun({_, {ok, Lineage}}) ->
-                                Obj1 = proplists:get_value(Lineage, Objects),
-                                riak_kv_util:is_x_deleted(Obj1);
-                              (_) -> true
-                           end, H),
-    Expected = case AllDeleted of
-            false -> expected_repairs(H);
-            true  -> []  %% we don't expect read repair if everyone has a tombstone
-        end,
-
     RepairObject  = (catch build_merged_object(Heads, Objects)),
+    Expected =expected_repairs(H),
     RepairObjects = [ Obj || {_Idx, ?KV_PUT_REQ{object=Obj}} <- RepairH ],
-
     conjunction(
         [{puts, equals(lists:sort(Expected), lists:sort(Actual))},
          {sanity, equals(length(RepairObjects), length(Actual))},
@@ -403,27 +394,21 @@ check_repair(Objects, RepairH, H) ->
 check_delete(Objects, RepairH, H, PerfectPreflist) ->
     Deletes  = [ Part || {Part, ?KV_DELETE_REQ{}} <- RepairH ],
 
-    %% Used to have a check for for node() - no longer easy
-    %% with new core vnode code.  Not sure it is necessary.
-    AllDeleted = lists:all(fun({_Idx, {ok, Lineage}}) ->
-                                Obj = proplists:get_value(Lineage, Objects),
-                                Rc = riak_kv_util:is_x_deleted(Obj),
-                                Rc;
-                              ({_Idx, notfound}) -> true;
-                              ({_, error})    -> false;
-                              ({_, timeout})  -> false
-                           end, H),
-
-    HasOk = lists:any(fun({_, {ok, _}}) -> true;
-                         (_) -> false
-                      end, H),
-
-    Expected = case AllDeleted andalso HasOk andalso PerfectPreflist of
-        true  -> [ P || {P, _} <- H ];  %% send deletes to notfound nodes as well
-        false -> []
-    end,
-    ?WHENFAIL(io:format("Objects: ~p\nExpected: ~p\nDeletes: ~p\nAllDeleted: ~p\nHasOk: ~p\nH: ~p\n",
-                        [Objects, Expected, Deletes, AllDeleted, HasOk, H]),
+    %% Should get deleted if all vnodes returned the same object
+    %% and a perfect preflist and the object is deleted
+    RetLins = [Lineage || {_Idx, {ok, Lineage}} <- H],
+    URetLins = lists:usort(RetLins),
+    Expected = case PerfectPreflist andalso 
+                   length(RetLins) == length(H) andalso 
+                   length(URetLins) == 1 andalso
+                   riak_kv_util:is_x_deleted(proplists:get_value(hd(URetLins), Objects)) of
+                   true ->
+                       [P || {P, _} <- H];  %% send deletes to all nodes
+                   false ->
+                       []
+               end,
+    ?WHENFAIL(io:format("Objects: ~p\nExpected: ~p\nDeletes: ~p\nH: ~p\n",
+                        [Objects, Expected, Deletes, H]),
               equals(lists:sort(Expected), lists:sort(Deletes))).
 
 all_distinct(Xs) ->


### PR DESCRIPTION
This breaks out the core logic of the get FSM so it can be reused for modelling and other places.

It also fixes an edge case with deletion - now deletion only takes place if all vnodes respond with the same object and there are no read repairs.  Otherwise it is possible for vnodes to be an ancestor of the deleted object without the tombstone in the metadata.  If the delete is not processed on the ancestor vnodes, but succeeds on the tombstone vnodes the object would be resurrected (could happen on an out-of-disk-space bitcask node).
