### PR TITLE
Az340 handle flow timeouts

### DIFF
--- a/src/riak_kv_mapper.erl
+++ b/src/riak_kv_mapper.erl
@@ -60,10 +60,10 @@ start_link(VNode, Id, QTerm, MapInputs, PhasePid) ->
     gen_fsm:start_link(?MODULE, [VNode, Id, QTerm, MapInputs, PhasePid], []).
 
 init([VNode, Id, QTerm0, MapInputs, PhasePid]) ->
+    erlang:link(PhasePid),
+    gen_fsm:send_event(PhasePid, {register_mapper, Id, self()}),
     QTermFun = xform_link_walk(QTerm0),
     {_, _, ReqId} = erlang:now(),
-    gen_fsm:send_event(PhasePid, {register_mapper, Id, self()}),
-    erlang:link(PhasePid),
     riak_kv_stat:update(mapper_start),
     {ok, CacheRef} = riak_kv_mapred_cache:cache_ref(),
     CacheKeyBase = generate_cache_key_base(QTermFun(undefined)),


### PR DESCRIPTION
Improve error handling and process interaction in the MapReduce code to prevent
the termination of all active MapReduce jobs if a single MapReduce job times
out or terminates unexpectedly.

Recreating the issue is timing dependent, but here is a way that worked for me:
- Add a `timer:sleep(1000)` call before [line 66](https://github.com/basho/riak_kv/blob/master/src/riak_kv_mapper.erl#L66) ([line 63](https://github.com/basho/riak_kv/blob/az340-handle-flow-timeouts/src/riak_kv_mapper.erl#L63) for the topic branch) of riak_kv_mapper.erl.
- Start riak and on the console get a local client: `C=riak:local_client().`
- MapReduce over a decent sized bucket (I used the google data set from the wiki with 1048 objects) with a relatively low timeout. Here's what I ran from the console:
  
  `C:mapred(<<"goog">>,[{map, {modfun, riak_kv_mapreduce,map_object_value},<<"include_notfound">>, false},{reduce, {modfun, riak_kv_mapreduce,reduce_set_union},undefined, true}], 300).`

Using the current master branch you should see quite a few errors including this:

`=ERROR REPORT==== 6-May-2011::10:02:39 ===
** Generic server riak_kv_map_master terminating 
** Last message in was {new_mapper,
`

Using the topic branch there will be errors for the terminating map phase and mapper processes, but riak_kv_map_master should not terminate. You can verify this with `whereis(riak_kv_map_master)`. 

The significance of riak_kv_map_master terminating is that it causes any active MapReduce jobs to be terminated. This can be a significant amount of process termination depending on the level of active MapReduce usage when really only the MapReduce job that timed out should fail and the rest should be allowed to continue. 
