### PR TITLE
Ensure timestamp passed to riak_object:syntactic_merge on read repair.

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -76,7 +76,8 @@
                   robj :: term(),
                   reqid :: non_neg_integer(),
                   bprops :: maybe_improper_list(),
-                  prunetime :: undefined | non_neg_integer()}).
+                  starttime :: non_neg_integer(),
+                  prunetime :: undefined| non_neg_integer()}).
 
 %% TODO: add -specs to all public API funcs, this module seems fragile?
 
@@ -308,6 +309,7 @@ do_put(Sender, {Bucket,_Key}=BKey, RObj, ReqID, StartTime, Options, State) ->
                        robj=RObj,
                        reqid=ReqID,
                        bprops=BProps,
+                       starttime=StartTime,
                        prunetime=PruneTime},
     Reply = perform_put(prepare_put(State, PutArgs), State, PutArgs),
     riak_core_vnode:reply(Sender, Reply),
@@ -319,8 +321,9 @@ prepare_put(#state{mod=Mod,modstate=ModState}, #putargs{bkey=BKey,
                                                         robj=RObj,
                                                         reqid=ReqID,
                                                         bprops=BProps,
+                                                        starttime=StartTime,
                                                         prunetime=PruneTime}) ->
-    case syntactic_put_merge(Mod, ModState, BKey, RObj, ReqID, PruneTime) of
+    case syntactic_put_merge(Mod, ModState, BKey, RObj, ReqID, StartTime) of
         {oldobj, OldObj} ->
             {false, OldObj};
         {newobj, NewObj} ->


### PR DESCRIPTION
Fixes: bz://1094

If the vnode receives a read repair where the RR object is in conflict with the vnode object, syntactic_put_merge would introduce a new vclock entry with an undefined timestamp. This is because read repairs should not trigger vclock pruning and we use the prunetime for deciding whether or not to prune the vclock and for passing into syntactic_put_merge to use for vclock increments.

Fixed by adding an explicit start time field in #putargs and use that in the syntactic_put_merge.

I have been unable to reproduce this outside of the delete_bug code attached to bz://260 as it is very hard to get the vnode/fsm into that state despite lots of fiddling with net kernel and temporarily hacking riak_kv_vnode.
