### PR TITLE
Reuse clientID when doing a delete to prevent clientID explosion

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -379,7 +379,8 @@ delete(Bucket,Key,RW) -> delete(Bucket,Key,RW,?DEFAULT_TIMEOUT).
 delete(Bucket,Key,RW,Timeout) ->
     Me = self(),
     ReqId = mk_reqid(),
-    riak_kv_delete_sup:start_delete(Node, [ReqId, Bucket, Key, RW, Timeout, Me]),
+    riak_kv_delete_sup:start_delete(Node, [ReqId, Bucket, Key, RW, Timeout,
+                                           Me, ClientId]),
     wait_for_reqid(ReqId, Timeout).
 
 %% @spec list_keys(riak_object:bucket()) ->


### PR DESCRIPTION
Currently we allocate a new client ID when we write the tombstone. This is not necessary. However, we still do use a new clientID for the async get.
