### PR TITLE
Erase the reference to a map executor in the case of a notfound

### DIFF
--- a/src/riak_kv_map_phase.erl
+++ b/src/riak_kv_map_phase.erl
@@ -265,7 +265,7 @@ handle_not_found_reply(VNode, BKey, Executor, #state{fsms=FSMs, mapper_data=Mapp
     %% entries have been checked.
     try riak_kv_mapred_planner:plan_map(NewKeys) of
         ClaimLists ->
-            FSMs1 = update_counter(Executor, FSMs),
+            FSMs1 = dict:erase(Executor, FSMs),
             {NewFSMs, _ClaimLists1, FsmKeys} = schedule_input(NewKeys, ClaimLists, QTerm, FSMs1, State),
             MapperData1 = lists:keydelete(Executor, 1, MapperData ++ FsmKeys),
             maybe_done(State#state{mapper_data=MapperData1, fsms=NewFSMs})


### PR DESCRIPTION
instead of decrementing the input counter.

Fixes: az445 bz1112

When a notfound error occurs during a map phase the phase creates a new map plan and retries using a difference preference list entry. A lingering reference to the original map phase executor used to track input counts was the source of the error. The solution is to remove the reference to the original map phase executor in the case of a notfound error instead of simply decrementing the associated counter.

A simple case to reproduce the original error and verify the fix is outlined [here](https://issues.basho.com/show_bug.cgi?id=1112).
