### PR TITLE
Map phase retries on not_found causes "500 Internal Server Error" response (function_clause) when nodes are down

### DIFF
--- a/src/riak_kv_mapred_planner.erl
+++ b/src/riak_kv_mapred_planner.erl
@@ -39,10 +39,12 @@ build_claim_list(InputData) ->
     PartList0 = lists:sort(F, InputData1),
     claim_keys(PartList0, [], Keys).
 
-claim_keys([], _, _) ->
+claim_keys([], [], _) ->
     exit(exhausted_preflist);
 claim_keys(_, ClaimList, []) ->
     ClaimList;
+claim_keys([], _, _) ->
+    exit(exhausted_preflist);
 claim_keys([H|T], ClaimList, Keys) ->
     {P, PKeys} = H,
     PKeys1 = lists:filter(fun(PK) ->

--- a/src/riak_kv_mapred_planner.erl
+++ b/src/riak_kv_mapred_planner.erl
@@ -39,7 +39,7 @@ build_claim_list(InputData) ->
     PartList0 = lists:sort(F, InputData1),
     claim_keys(PartList0, [], Keys).
 
-claim_keys([], [], _) ->
+claim_keys([], _, _) ->
     exit(exhausted_preflist);
 claim_keys(_, ClaimList, []) ->
     ClaimList;


### PR DESCRIPTION
Catch exit with reason exhausted_preflist on the call to schedule_input after a nodedown message is received.

Fixes: az449 bz1113 bz1114

The schedule_input function in riak_kv_map_phase calls itself
in the case that it catches a nodedown exit while trying to
start mapper processes. If all the primary preference list
entries have been checked or their nodes are down this inner
call to schedule_input will result in an exit with reason
exhausted_preflist. Instead of just having the map phase
process exit, this change catches the exit and returns an
error to the caller of schedule_input so that notfound results
can be returned in the case of bz1113 or a more descriptive
error message can be return in the case of bz1114.

Steps to reproduce can be found [here](https://issues.basho.com/show_bug.cgi?id=1113) and [here](https://issues.basho.com/show_bug.cgi?id=1114). I did not add any testing to mapred_verify for this issue because the problems only show up on cluster setups where a portion of the nodes are down, but maybe this is a good test that basho_expect could handle.
