### PR TITLE
Adds proper URL decoding to Riak's REST API

### DIFF
--- a/ebin/riak_kv.app
+++ b/ebin/riak_kv.app
@@ -67,6 +67,7 @@
              riak_kv_wm_ping,
              riak_kv_wm_raw,
              riak_kv_wm_stats,
+             riak_kv_encoding_migrate,
              riak_object
             ]},
   {applications, [

--- a/src/riak_kv_encoding_migrate.erl
+++ b/src/riak_kv_encoding_migrate.erl
@@ -1,0 +1,228 @@
+%% Support code to help migrate clusters with URL encoded buckets/keys.
+%%
+%% Usage:
+%% 1. Attach to a running riak console.
+%%
+%% 2. Check if cluster needs migration:
+%%      1> riak_kv_encoding_migrate:check_cluster().
+%%
+%% 3. If migration necessary and safe, migrate objects:
+%%      1> riak_kv_encoding_migrate:migrate_objects().
+%%
+%% 4. If all went well, delete migrated objects:
+%%      1> riak_kv_encoding_migrate:delete_migrated_objects().
+%%
+%% This module also provides the post-commit function 'postcommit_rewrite'
+%% that can be installed on a bucket to perform live copying of inserted
+%% objects. This could be used to perfrom live migration of new objects
+%% while the above migration process is running in background copying
+%% existing objects.
+
+-module(riak_kv_encoding_migrate).
+-export([check_cluster/0, migrate_objects/0, delete_migrated_objects/0]).
+-export([map_check/3, reduce_check/2, map_rewrite_unsafe/3,
+         postcommit_rewrite/1, map_delete_unsafe/3]).
+-export([test_migration/0]).
+
+%% Check if the cluster contains unsafe values that need to be migrated
+check_cluster() ->
+    {ok, RC} = riak:local_client(),
+    riak_kv_mapred_cache:clear(),
+    {ok, Buckets} = RC:list_buckets(),
+    case Buckets of
+        [] ->
+            io:format("Cluster is empty. No migration needed.~n", []),
+            {ok, empty};
+        _ ->
+            MR = [RC:mapred(Bucket, [map_check(), reduce_check()])
+                  || Bucket <- Buckets],
+            {ok, [Res]} = lists:foldl(fun erlang:max/2, 0, MR),
+            case Res of
+                0 ->
+                    io:format("Cluster does not contain URL unsafe values. "
+                              "No migration needed.~n", []),
+                    {ok, not_needed};
+                1 ->
+                    io:format("Cluster contains URL unsafe values. "
+                              "Migration needed.~n", []),
+                    {ok, needed};
+                2 ->
+                    io:format("Cluster contains URL unsafe values. However,~n"
+                              "one or more bucket/key exists in both URL~n"
+                              "encoded and non-encoded form. Custom migration "
+                              "necessary.~n", []),
+                    {ok, custom}
+            end
+    end.
+
+map_check() ->
+    {map, {modfun, ?MODULE, map_check}, none, false}.
+map_check(RO, _, _) ->
+    case check_object(RO) of
+        safe ->
+            [0];
+        {_, _, B2, K2} ->
+            {ok, RC} = riak:local_client(),
+            case RC:get(B2, K2) of
+                {error, notfound} ->
+                    [1];
+                _ ->
+                    [2]
+            end
+    end.
+
+reduce_check() ->    
+    {reduce, {modfun, ?MODULE, reduce_check}, none, true}.
+reduce_check(L, _) ->
+    [lists:foldl(fun erlang:max/2, 0, L)].
+
+%% Perform first phase of migration: copying encoded values to
+%% unencoded equivalents.
+migrate_objects() ->
+    {ok, RC} = riak:local_client(),
+    riak_kv_mapred_cache:clear(),
+    {ok, Buckets} = RC:list_buckets(),
+    [RC:mapred(Bucket, [map_rewrite_unsafe()]) || Bucket <- Buckets],
+    io:format("All objects with URL encoded buckets/keys have been copied to "
+              "unencoded equivalents.~n", []).
+
+map_rewrite_unsafe() ->
+    {map, {modfun, ?MODULE, map_rewrite_unsafe}, none, true}.
+map_rewrite_unsafe(RO, _, _) ->
+    case check_object(RO) of
+        safe ->
+            [];
+        {_, _, B2, K2} ->
+            copy_object(RO, B2, K2),
+            []
+    end.
+
+%% Post-commit that can be installed to force live migration of newly
+%% inserted buckets/keys before cluster is switched over to proper
+%% behavior (eg. during migration).
+postcommit_rewrite(RO) ->
+    case check_object(RO) of
+        safe ->
+            ok;
+        {_, _, B2, K2} ->
+            copy_object(RO, B2, K2),
+            ok
+    end.
+
+%% Perform second phase of migration: delete objects with encoded buckets/keys.
+delete_migrated_objects() ->
+    {ok, RC} = riak:local_client(),
+    riak_kv_mapred_cache:clear(),
+    {ok, Buckets} = RC:list_buckets(),
+    [RC:mapred(Bucket, [map_delete_unsafe()]) || Bucket <- Buckets],
+    io:format("All objects with URL encoded buckets/keys have been "
+              "deleted.~n", []).
+
+map_delete_unsafe() ->
+    {map, {modfun, ?MODULE, map_delete_unsafe}, none, true}.
+map_delete_unsafe(RO, _, _) ->
+    case check_object(RO) of
+        safe ->
+            [];
+        {B1, K1, _, _} ->
+            {ok, RC} = riak:local_client(),
+            RC:delete(B1, K1),
+            []
+    end.
+
+%% @private
+check_object(RO) ->
+    B1 = riak_object:bucket(RO),
+    K1 = riak_object:key(RO),
+    B2 = list_to_binary(mochiweb_util:unquote(B1)),
+    K2 = list_to_binary(mochiweb_util:unquote(K1)),
+
+    case {B2, K2} of
+        {B1, K1} ->
+            safe;
+        _ ->
+            {B1, K1, B2, K2}
+    end.
+
+%% @private
+copy_object(RO, B, K) ->
+    {ok, RC} = riak:local_client(),
+    NO1 = riak_object:new(B, K, <<>>),
+    NO2 = riak_object:set_vclock(NO1, riak_object:vclock(RO)),
+    NO3 = riak_object:set_contents(NO2, riak_object:get_contents(RO)),
+    RC:put(NO3).
+
+%% This test is designed to run directly on an empty development
+%% node to avoid cluster bring up/down plumping. It is not an
+%% eunit test.
+test_migration() ->
+    {ok, RC} = riak:local_client(),
+    {ok, empty} = riak_kv_encoding_migrate:check_cluster(),
+
+    O1 = riak_object:new(<<"bucket">>, <<"key">>, <<"val">>),
+    RC:put(O1),
+    {ok, not_needed} = riak_kv_encoding_migrate:check_cluster(),
+
+    MD1 = dict:store(<<"X-MyTag">>, <<"A">>, dict:new()),
+    O2 = riak_object:new(<<"me%40mine">>, <<"key">>, <<"A">>, MD1),
+    RC:put(O2),
+    {ok, needed} = riak_kv_encoding_migrate:check_cluster(),
+    
+    O3 = riak_object:new(<<"me@mine">>, <<"key">>, <<"A">>, MD1),
+    RC:put(O3),
+    {ok, custom} = riak_kv_encoding_migrate:check_cluster(),
+
+    RC:delete(<<"me%40mine">>, <<"key">>),
+    {ok, not_needed} = riak_kv_encoding_migrate:check_cluster(),
+
+    MD2 = dict:store(<<"X-MyTag">>, <<"B">>, dict:new()),
+    O4 = riak_object:new(<<"bucket">>, <<"key%40">>, <<"B">>, MD2),
+    RC:put(O4),
+    {ok, needed} = riak_kv_encoding_migrate:check_cluster(),
+    
+    O5 = riak_object:new(<<"bucket">>, <<"key@">>, <<"B">>, MD2),
+    RC:put(O5),
+    {ok, custom} = riak_kv_encoding_migrate:check_cluster(),
+
+    RC:delete(<<"me@mine">>, <<"key">>),
+    RC:delete(<<"bucket">>, <<"key@">>),
+    RC:put(O2),
+    {ok, needed} = riak_kv_encoding_migrate:check_cluster(),
+
+    riak_kv_encoding_migrate:migrate_objects(),
+    riak_kv_encoding_migrate:delete_migrated_objects(),
+    {ok, not_needed} = riak_kv_encoding_migrate:check_cluster(),
+
+    C1 = riak_object:get_contents(O2),
+    V1 = riak_object:vclock(O2),
+
+    C2 = riak_object:get_contents(O4),
+    V2 = riak_object:vclock(O4),
+
+    {ok, MO1} = RC:get(<<"me@mine">>, <<"key">>),
+    nearly_equal_contents(C1, riak_object:get_contents(MO1)),
+    true = vclock:descends(riak_object:vclock(MO1), V1),
+
+    {ok, MO2} = RC:get(<<"bucket">>, <<"key@">>),
+    nearly_equal_contents(C2, riak_object:get_contents(MO2)),
+    true = vclock:descends(riak_object:vclock(MO2), V2),
+
+    ok.
+
+nearly_equal_contents([], []) ->
+    true;
+nearly_equal_contents([{MD1, V1}|R1], [{MD2, V2}|R2]) ->
+    %% VTag and Last-Modified metadata should be different, but
+    %% everything else should be equal.
+    MD12 = dict:erase(<<"X-Riak-VTag">>, MD1),
+    MD13 = dict:erase(<<"X-Riak-Last-Modified">>, MD12),
+    L1 = lists:keysort(1, dict:to_list(MD13)),
+
+    MD22 = dict:erase(<<"X-Riak-VTag">>, MD2),
+    MD23 = dict:erase(<<"X-Riak-Last-Modified">>, MD22),
+    L2 = lists:keysort(1, dict:to_list(MD23)),
+
+    true = (L1 =:= L2),
+    true = (V1 =:= V2),
+    
+    nearly_equal_contents(R1, R2).

--- a/src/riak_kv_wm_link_walker.erl
+++ b/src/riak_kv_wm_link_walker.erl
@@ -229,12 +229,16 @@ malformed_request(RD, Ctx) ->
 service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
     case get_riak_client(RiakProps) of
         {ok, C} ->
+            CtxBucket =
+                riak_kv_wm_raw:maybe_decode_uri(RD, wrq:path_info(bucket, RD)),
+            CtxKey =
+                riak_kv_wm_raw:maybe_decode_uri(RD, wrq:path_info(key, RD)),
             {true,
              RD,
              Ctx#ctx{
                client=C,
-               bucket=list_to_binary(wrq:path_info(bucket, RD)),
-               key=list_to_binary(wrq:path_info(key, RD))
+               bucket=list_to_binary(CtxBucket),
+               key=list_to_binary(CtxKey)
               }};
         Error ->
             {false,

--- a/src/riak_kv_wm_raw.erl
+++ b/src/riak_kv_wm_raw.erl
@@ -229,11 +229,11 @@ service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
                client=C,
                bucket=case wrq:path_info(bucket, RD) of
                          undefined -> undefined;
-                         B -> list_to_binary(B)
+                         B -> list_to_binary(maybe_decode_uri(B))
                       end,
                key=case wrq:path_info(key, RD) of
                        undefined -> undefined;
-                       K -> list_to_binary(K)
+                       K -> list_to_binary(maybe_decode_uri(K))
                    end,
                vtag=wrq:get_qs_value(?Q_VTAG, RD)
               }};
@@ -243,6 +243,15 @@ service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
                io_lib:format("Unable to connect to Riak: ~p~n", [Error]),
                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx}
+    end.
+
+%% @private
+maybe_decode_uri(Val) ->
+    case application:get_env(riak_kv, http_url_encoding) of
+        {ok, on} ->
+            mochiweb_util:unquote(Val);
+        _ ->
+            Val
     end.
 
 %% @spec get_riak_client(local|{node(),Cookie::atom()}, term()) ->

--- a/src/riak_kv_wm_raw.erl
+++ b/src/riak_kv_wm_raw.erl
@@ -170,6 +170,7 @@
          produce_sibling_message_body/2,
          produce_multipart_body/2,
          multiple_choices/2,
+         maybe_decode_uri/2,
          delete_resource/2
         ]).
 
@@ -245,7 +246,6 @@ service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
              Ctx}
     end.
 
-%% @private
 maybe_decode_uri(RD, Val) ->
     case application:get_env(riak_kv, http_url_encoding) of
         {ok, on} ->

--- a/test/rest_url_encoding_test.erl
+++ b/test/rest_url_encoding_test.erl
@@ -125,7 +125,21 @@ compat_encoding_case({URL, Node}) ->
                              " \"query\": [{\"link\": {\"keep\":true}}]"
                              "}"},
                       [], []),
-    ?assertEqual("[[\"rest1\",\"%40compat\",\"tag\"]]", Map2).
+    ?assertEqual("[[\"rest1\",\"%40compat\",\"tag\"]]", Map2),
+    
+    %% Test 'X-Riak-URL-Encoding' header.
+    httpc:request(put, {URL ++ "/riak/rest3/%40compat",
+                        [{"X-Riak-URL-Encoding", "on"}],
+                        "text/plain",
+                        "Test"},
+                  [], []),
+
+    %% Retrieve key list and check that the key was decoded.
+    {ok, {_, _, HBody}} =
+        httpc:request(get, {"http://localhost:8091/riak/rest3?keys=true",
+                            []}, [], []),
+    {struct, HProps} = mochijson2:decode(HBody),
+    ?assertMatch([<<"@compat">>], proplists:get_value(<<"keys">>, HProps)).
 
 sane_encoding_case({URL, Node}) ->
     %% Ensure the cluster is running in sane mode

--- a/test/rest_url_encoding_test.erl
+++ b/test/rest_url_encoding_test.erl
@@ -1,0 +1,207 @@
+%% Test proper URL decoding behavior over REST API.
+%%
+%% This test is designed to run against a running Riak node, and will be
+%% skipped if the following environment variables are not set:
+%% (example values corresponding to standard dev1 release follow)
+%%   RIAK_TEST_HOST="127.0.0.1"
+%%   RIAK_TEST_HTTP_PORT="8091"
+%%   RIAK_TEST_NODE="dev1@127.0.0.1"
+%%   RIAK_TEST_COOKIE="riak"
+%%   RIAK_EUNIT_NODE="eunit@127.0.0.1"
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-module(rest_url_encoding_test).
+-compile(export_all).
+
+url_encoding_test_() ->
+    Envs = ["RIAK_TEST_HOST", "RIAK_TEST_HTTP_PORT", "RIAK_TEST_NODE",
+            "RIAK_TEST_COOKIE", "RIAK_EUNIT_NODE"],
+    Vals = [os:getenv(Env) || Env <- Envs],
+    case lists:member(false, Vals) of
+        true ->
+            ?debugFmt("Skipping rest_url_encoding_test~n", []),
+            [];
+        false ->
+            [HostV, PortV, NodeV, CookieV, ENodeV] = Vals,
+            URL = "http://" ++ HostV ++ ":" ++ PortV,
+            Node = list_to_atom(NodeV),
+            Cookie = list_to_atom(CookieV),
+            ENode = list_to_atom(ENodeV),
+
+            {spawn, [{setup,
+                      fun() ->
+                              net_kernel:start([ENode]),
+                              erlang:set_cookie(node(), Cookie),
+                              inets:start(),
+                              inets:start(httpc, [{profile, eunit}]),
+                              {URL, Node}
+                      end,
+                      fun(_) ->
+                              inets:stop(),
+                              ok
+                      end,
+                      fun(Args) ->
+                              [?_test(compat_encoding_case(Args)),
+                               ?_test(sane_encoding_case(Args))]
+                      end
+                     }]}
+    end.
+
+compat_encoding_case({URL, Node}) ->
+    %% Ensure the cluster is running in compat mode
+    ok = rpc:call(Node, application, set_env,
+                  [riak_kv, http_url_encoding, compat]),
+
+    %% Write URL encoded key
+    httpc:request(put, {URL ++ "/riak/rest1/%40compat",
+                        [],
+                        "text/plain",
+                        "Test"},
+                  [], []),
+
+    %% Retrieve key list and check that the key was not decoded
+    {ok, {_, _, Body}} =
+        httpc:request(get, {"http://localhost:8091/riak/rest1?keys=true",
+                            []}, [], []),
+
+    {struct, Props} = mochijson2:decode(Body),
+    ?assertMatch([<<"%40compat">>], proplists:get_value(<<"keys">>, Props)),
+
+    %% Add URL encoded link
+    httpc:request(put, {URL ++ "/riak/rest_links/compat",
+                        [{"Link", "</riak/rest1/%40compat>; riaktag=\"tag\""}],
+                        "text/plain",
+                        "Test"},
+                  [], []),
+
+    %% Retrieve link header and check that it is singly encoded, corresponding
+    %% to a decoded internal link.
+    {ok, {_, Headers, _}} = 
+        httpc:request(get, {"http://localhost:8091/riak/rest_links/compat",
+                            []}, [], []),
+
+
+    Links = proplists:get_value("link", Headers),
+    ?assert(string:str(Links, "</riak/rest1/%40compat>;") /= 0),
+
+    %% Link walk should fail because key is encoded but link is decoded.
+    %% Test by performing link walk and verifying link was not returned.
+    {ok, {_, _, LWalk}} =
+        httpc:request(get, {URL ++ "/riak/rest_links/compat/_,_,1", []},
+                      [], []),
+    ?assert(string:str(LWalk, "Location: /riak/rest1/%40compat") == 0),
+
+
+    %% Add doubly encoded link
+    httpc:request(put, {URL ++ "/riak/rest_links/compat2",
+                        [{"Link", "</riak/rest1/%2540compat>; riaktag=\"tag\""}],
+                        "text/plain",
+                        "Test"},
+                  [], []),
+
+    %% Verify that link walk against doubly encoded link works.
+    {ok, {_, _, LWalk2}} =
+        httpc:request(get, {URL ++ "/riak/rest_links/compat2/_,_,1", []},
+                      [], []),
+    ?assert(string:str(LWalk2, "Location: /riak/rest1/%2540compat") /= 0),
+
+    %% Test map/reduce link walking behavior.
+    {ok, {_, _, Map1}} =
+        httpc:request(post, {URL ++ "/mapred",
+                             [],
+                             "application/json",
+                             "{\"inputs\": [[\"rest_links\", \"compat\"]],"
+                             " \"query\": [{\"link\": {\"keep\":true}}]"
+                             "}"},
+                      [], []),
+    ?assertEqual("[[\"rest1\",\"@compat\",\"tag\"]]", Map1),
+
+    {ok, {_, _, Map2}} =
+        httpc:request(post, {URL ++ "/mapred",
+                             [],
+                             "application/json",
+                             "{\"inputs\": [[\"rest_links\", \"compat2\"]],"
+                             " \"query\": [{\"link\": {\"keep\":true}}]"
+                             "}"},
+                      [], []),
+    ?assertEqual("[[\"rest1\",\"%40compat\",\"tag\"]]", Map2).
+
+sane_encoding_case({URL, Node}) ->
+    %% Ensure the cluster is running in sane mode
+    ok = rpc:call(Node, application, set_env,
+                  [riak_kv, http_url_encoding, on]),
+
+    %% Write URL encoded key
+    httpc:request(put, {URL ++ "/riak/rest2/%40sane",
+                        [],
+                        "text/plain",
+                        "Test"},
+                  [], []),
+
+    %% Retrieve key list and check that the key was decoded
+    {ok, {_, _, Body}} =
+        httpc:request(get, {"http://localhost:8091/riak/rest2?keys=true",
+                            []}, [], []),
+
+    {struct, Props} = mochijson2:decode(Body),
+    ?assertMatch([<<"@sane">>], proplists:get_value(<<"keys">>, Props)),
+
+    %% Add URL encoded link
+    httpc:request(put, {URL ++ "/riak/rest_links/sane",
+                        [{"Link", "</riak/rest2/%40sane>; riaktag=\"tag\""}],
+                        "text/plain",
+                        "Test"},
+                  [], []),
+
+    %% Retrieve link header and check that it is singly encoded, corresponding
+    %% to a decoded internal link.
+    {ok, {_, Headers, _}} = 
+        httpc:request(get, {"http://localhost:8091/riak/rest_links/sane",
+                            []}, [], []),
+
+    Links = proplists:get_value("link", Headers),
+    ?assert(string:str(Links, "</riak/rest2/%40sane>;") /= 0),
+
+    %% Verify that link walk succeeds.
+    {ok, {_, _, LWalk}} =
+        httpc:request(get, {URL ++ "/riak/rest_links/sane/_,_,1", []},
+                      [], []),
+    ?assert(string:str(LWalk, "Location: /riak/rest2/%40sane") /= 0),
+
+    %% Add doubly encoded link
+    httpc:request(put, {URL ++ "/riak/rest_links/sane2",
+                        [{"Link", "</riak/rest2/%2540sane>; riaktag=\"tag\""}],
+                        "text/plain",
+                        "Test"},
+                  [], []),
+
+    %% Verify that link walk against doubly encoded link fails, because key
+    %% does not exist.
+    {ok, {_, _, LWalk2}} =
+        httpc:request(get, {URL ++ "/riak/rest_links/sane2/_,_,1", []},
+                      [], []),
+    ?assert(string:str(LWalk2, "Location: /riak/rest2/%2540sane") == 0),
+
+    %% Test map/reduce link walking behavior.
+    {ok, {_, _, Map1}} =
+        httpc:request(post, {URL ++ "/mapred",
+                             [],
+                             "application/json",
+                             "{\"inputs\": [[\"rest_links\", \"sane\"]],"
+                             " \"query\": [{\"link\": {\"keep\":true}}]"
+                             "}"},
+                      [], []),
+    ?assertEqual("[[\"rest2\",\"@sane\",\"tag\"]]", Map1),
+
+    {ok, {_, _, Map2}} =
+        httpc:request(post, {URL ++ "/mapred",
+                             [],
+                             "application/json",
+                             "{\"inputs\": [[\"rest_links\", \"sane2\"]],"
+                             " \"query\": [{\"link\": {\"keep\":true}}]"
+                             "}"},
+                      [], []),
+    ?assertEqual("[[\"rest2\",\"%40sane\",\"tag\"]]", Map2).
+
+-endif.

--- a/test/rest_url_encoding_test.erl
+++ b/test/rest_url_encoding_test.erl
@@ -1,3 +1,23 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2011 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License. You may obtain
+%% a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied. See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
 %% Test proper URL decoding behavior over REST API.
 %%
 %% This test is designed to run against a running Riak node, and will be
@@ -66,7 +86,7 @@ compat_encoding_case({URL, Node}) ->
 
     %% Retrieve key list and check that the key was not decoded
     {ok, {_, _, Body}} =
-        httpc:request(get, {"http://localhost:8091/riak/rest1?keys=true",
+        httpc:request(get, {URL ++ "/riak/rest1?keys=true",
                             []}, [], []),
 
     {struct, Props} = mochijson2:decode(Body),
@@ -82,7 +102,7 @@ compat_encoding_case({URL, Node}) ->
     %% Retrieve link header and check that it is singly encoded, corresponding
     %% to a decoded internal link.
     {ok, {_, Headers, _}} = 
-        httpc:request(get, {"http://localhost:8091/riak/rest_links/compat",
+        httpc:request(get, {URL ++ "/riak/rest_links/compat",
                             []}, [], []),
 
 
@@ -112,7 +132,7 @@ compat_encoding_case({URL, Node}) ->
 
     %% Test that link walk starting at encoded key works.
     {ok, {_, _, EWalk}} = 
-        httpc:request(get, {"http://localhost:8091/riak/rest1/%40compat/_,_,1",
+        httpc:request(get, {URL ++ "/riak/rest1/%40compat/_,_,1",
                             []}, [], []),
     ?assert(string:str(EWalk, "Location: /riak/basic/obj") /= 0),
 
@@ -146,7 +166,7 @@ compat_encoding_case({URL, Node}) ->
 
     %% Retrieve key list and check that the key was decoded.
     {ok, {_, _, HBody}} =
-        httpc:request(get, {"http://localhost:8091/riak/rest3?keys=true",
+        httpc:request(get, {URL ++ "/riak/rest3?keys=true",
                             []}, [], []),
     {struct, HProps} = mochijson2:decode(HBody),
     ?assertMatch([<<"@compat">>], proplists:get_value(<<"keys">>, HProps)).
@@ -169,7 +189,7 @@ sane_encoding_case({URL, Node}) ->
 
     %% Retrieve key list and check that the key was decoded
     {ok, {_, _, Body}} =
-        httpc:request(get, {"http://localhost:8091/riak/rest2?keys=true",
+        httpc:request(get, {URL ++ "/riak/rest2?keys=true",
                             []}, [], []),
 
     {struct, Props} = mochijson2:decode(Body),
@@ -185,7 +205,7 @@ sane_encoding_case({URL, Node}) ->
     %% Retrieve link header and check that it is singly encoded, corresponding
     %% to a decoded internal link.
     {ok, {_, Headers, _}} = 
-        httpc:request(get, {"http://localhost:8091/riak/rest_links/sane",
+        httpc:request(get, {URL ++ "/riak/rest_links/sane",
                             []}, [], []),
 
     Links = proplists:get_value("link", Headers),
@@ -213,7 +233,7 @@ sane_encoding_case({URL, Node}) ->
 
     %% Test that link walk starting at encoded key works.
     {ok, {_, _, EWalk}} = 
-        httpc:request(get, {"http://localhost:8091/riak/rest2/%40sane/_,_,1",
+        httpc:request(get, {URL ++ "/riak/rest2/%40sane/_,_,1",
                             []}, [], []),
     ?assert(string:str(EWalk, "Location: /riak/basic/obj") /= 0),
 


### PR DESCRIPTION
Addresses bz://617 and bz://1003.

New sane behavior where Riak URL decodes buckets/keys sent as URLs and Headers over REST API. Behavior is configurable through 'http_url_decoding' app.config parameter where 'on' defaults to new behavior, and missing/anything else defaults to compatibility mode where links are decoded but buckets/keys are not.

This pull request also includes migration support that can help users migrate an existing cluster with encoded bucket/keys to one without. This is handled in riak_kv_encoding_migrate.erl.
