### PR TITLE
Az419 update delete interface

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -363,7 +363,7 @@ delete(Bucket,Key) -> delete(Bucket,Key,[],?DEFAULT_TIMEOUT).
 %%       {error, notfound} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}
-%% @doc Delete the object at Bucket/Key.  Return a value as soon as RW
+%% @doc Delete the object at Bucket/Key.  Return a value as soon as W/DW (or RW)
 %%      nodes have responded with a value or error.
 %% @equiv delete(Bucket, Key, RW, default_timeout())
 delete(Bucket,Key,Options) when is_list(Options) ->
@@ -379,7 +379,7 @@ delete(Bucket,Key,RW) ->
 %%       {error, timeout} |
 %%       {error, {n_val_violation, N::integer()}} |
 %%       {error, Err :: term()}
-%% @doc Delete the object at Bucket/Key.  Return a value as soon as RW
+%% @doc Delete the object at Bucket/Key.  Return a value as soon as W/DW (or RW)
 %%      nodes have responded with a value or error, or TimeoutMillisecs passes.
 delete(Bucket,Key,Options,Timeout) when is_list(Options) ->
     Me = self(),
@@ -396,7 +396,7 @@ delete(Bucket,Key,RW,Timeout) ->
 %%       {error, notfound} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}
-%% @doc Delete the object at Bucket/Key.  Return a value as soon as RW
+%% @doc Delete the object at Bucket/Key.  Return a value as soon as W/DW (or RW)
 %%      nodes have responded with a value or error.
 %% @equiv delete(Bucket, Key, RW, default_timeout())
 delete_vclock(Bucket,Key,VClock) ->
@@ -408,7 +408,7 @@ delete_vclock(Bucket,Key,VClock) ->
 %%       {error, notfound} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}
-%% @doc Delete the object at Bucket/Key.  Return a value as soon as RW
+%% @doc Delete the object at Bucket/Key.  Return a value as soon as W/DW (or RW)
 %%      nodes have responded with a value or error.
 %% @equiv delete(Bucket, Key, RW, default_timeout())
 delete_vclock(Bucket,Key,VClock,Options) when is_list(Options) ->
@@ -424,7 +424,7 @@ delete_vclock(Bucket,Key,VClock,RW) ->
 %%       {error, timeout} |
 %%       {error, {n_val_violation, N::integer()}} |
 %%       {error, Err :: term()}
-%% @doc Delete the object at Bucket/Key.  Return a value as soon as RW
+%% @doc Delete the object at Bucket/Key.  Return a value as soon as W/DW (or RW)
 %%      nodes have responded with a value or error, or TimeoutMillisecs passes.
 delete_vclock(Bucket,Key,VClock,Options,Timeout) when is_list(Options) ->
     Me = self(),

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -355,7 +355,7 @@ put(RObj, W, DW, Timeout, Options) ->
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as RW
 %%      nodes have responded with a value or error.
 %% @equiv delete(Bucket, Key, RW, default_timeout())
-delete(Bucket,Key) -> delete(Bucket,Key,default,?DEFAULT_TIMEOUT).
+delete(Bucket,Key) -> delete(Bucket,Key,[],?DEFAULT_TIMEOUT).
 
 %% @spec delete(riak_object:bucket(), riak_object:key(), RW :: integer()) ->
 %%        ok |
@@ -366,7 +366,10 @@ delete(Bucket,Key) -> delete(Bucket,Key,default,?DEFAULT_TIMEOUT).
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as RW
 %%      nodes have responded with a value or error.
 %% @equiv delete(Bucket, Key, RW, default_timeout())
-delete(Bucket,Key,RW) -> delete(Bucket,Key,RW,?DEFAULT_TIMEOUT).
+delete(Bucket,Key,Options) when is_list(Options) ->
+    delete(Bucket,Key,Options,?DEFAULT_TIMEOUT);
+delete(Bucket,Key,RW) ->
+    delete(Bucket,Key,[{rw, RW}],?DEFAULT_TIMEOUT).
 
 %% @spec delete(riak_object:bucket(), riak_object:key(), RW :: integer(),
 %%           TimeoutMillisecs :: integer()) ->
@@ -378,12 +381,14 @@ delete(Bucket,Key,RW) -> delete(Bucket,Key,RW,?DEFAULT_TIMEOUT).
 %%       {error, Err :: term()}
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as RW
 %%      nodes have responded with a value or error, or TimeoutMillisecs passes.
-delete(Bucket,Key,RW,Timeout) ->
+delete(Bucket,Key,Options,Timeout) when is_list(Options) ->
     Me = self(),
     ReqId = mk_reqid(),
-    riak_kv_delete_sup:start_delete(Node, [ReqId, Bucket, Key, RW, Timeout,
+    riak_kv_delete_sup:start_delete(Node, [ReqId, Bucket, Key, Options, Timeout,
                                            Me, ClientId]),
-    wait_for_reqid(ReqId, Timeout).
+    wait_for_reqid(ReqId, Timeout);
+delete(Bucket,Key,RW,Timeout) ->
+    delete(Bucket,Key,[{rw, RW}], Timeout).
 
 %% @spec delete_vclock(riak_object:bucket(), riak_object:key(), vclock:vclock()) ->
 %%        ok |
@@ -394,7 +399,8 @@ delete(Bucket,Key,RW,Timeout) ->
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as RW
 %%      nodes have responded with a value or error.
 %% @equiv delete(Bucket, Key, RW, default_timeout())
-delete_vclock(Bucket,Key,VClock) -> delete_vclock(Bucket,Key,VClock,default,?DEFAULT_TIMEOUT).
+delete_vclock(Bucket,Key,VClock) ->
+    delete_vclock(Bucket,Key,VClock,[{rw,default}],?DEFAULT_TIMEOUT).
 
 %% @spec delete_vclock(riak_object:bucket(), riak_object:key(), vclock::vclock(), RW :: integer()) ->
 %%        ok |
@@ -405,7 +411,10 @@ delete_vclock(Bucket,Key,VClock) -> delete_vclock(Bucket,Key,VClock,default,?DEF
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as RW
 %%      nodes have responded with a value or error.
 %% @equiv delete(Bucket, Key, RW, default_timeout())
-delete_vclock(Bucket,Key,VClock,RW) -> delete_vclock(Bucket,Key,VClock,RW,?DEFAULT_TIMEOUT).
+delete_vclock(Bucket,Key,VClock,Options) when is_list(Options) ->
+    delete_vclock(Bucket,Key,VClock,Options,?DEFAULT_TIMEOUT);
+delete_vclock(Bucket,Key,VClock,RW) ->
+    delete_vclock(Bucket,Key,VClock,[{rw, RW}],?DEFAULT_TIMEOUT).
 
 %% @spec delete_vclock(riak_object:bucket(), riak_object:key(), vclock:vclock(), RW :: integer(),
 %%           TimeoutMillisecs :: integer()) ->
@@ -417,12 +426,14 @@ delete_vclock(Bucket,Key,VClock,RW) -> delete_vclock(Bucket,Key,VClock,RW,?DEFAU
 %%       {error, Err :: term()}
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as RW
 %%      nodes have responded with a value or error, or TimeoutMillisecs passes.
-delete_vclock(Bucket,Key,VClock,RW,Timeout) ->
+delete_vclock(Bucket,Key,VClock,Options,Timeout) when is_list(Options) ->
     Me = self(),
     ReqId = mk_reqid(),
-    riak_kv_delete_sup:start_delete(Node, [ReqId, Bucket, Key, RW, Timeout,
+    riak_kv_delete_sup:start_delete(Node, [ReqId, Bucket, Key, Options, Timeout,
                                            Me, ClientId, VClock]),
-    wait_for_reqid(ReqId, Timeout).
+    wait_for_reqid(ReqId, Timeout);
+delete_vclock(Bucket,Key,VClock,RW,Timeout) ->
+    delete_vclock(Bucket,Key,VClock,[{rw, RW}],Timeout).
 
 
 %% @spec list_keys(riak_object:bucket()) ->

--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -24,25 +24,25 @@
 
 -module(riak_kv_delete).
 
-%-ifdef(TEST).
+-ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
-%-endif.
+-endif.
 
 -export([start_link/6, start_link/7, start_link/8, delete/8]).
 
-start_link(ReqId, Bucket, Key, RW, Timeout, Client) ->
+start_link(ReqId, Bucket, Key, Options, Timeout, Client) ->
     {ok, proc_lib:spawn_link(?MODULE, delete, [ReqId, Bucket, Key,
-                                               RW, Timeout, Client, undefined,
+                                               Options, Timeout, Client, undefined,
                                                undefined])}.
 
-start_link(ReqId, Bucket, Key, RW, Timeout, Client, ClientId) ->
+start_link(ReqId, Bucket, Key, Options, Timeout, Client, ClientId) ->
     {ok, proc_lib:spawn_link(?MODULE, delete, [ReqId, Bucket, Key,
-                                               RW, Timeout, Client, ClientId,
+                                               Options, Timeout, Client, ClientId,
                                                undefined])}.
 
-start_link(ReqId, Bucket, Key, RW, Timeout, Client, ClientId, VClock) ->
+start_link(ReqId, Bucket, Key, Options, Timeout, Client, ClientId, VClock) ->
     {ok, proc_lib:spawn_link(?MODULE, delete, [ReqId, Bucket, Key,
-                                               RW, Timeout, Client, ClientId,
+                                               Options, Timeout, Client, ClientId,
                                                VClock])}.
 
 %% @spec delete(ReqId :: binary(), riak_object:bucket(), riak_object:key(),
@@ -50,34 +50,33 @@ start_link(ReqId, Bucket, Key, RW, Timeout, Client, ClientId, VClock) ->
 %%           -> term()
 %% @doc Delete the object at Bucket/Key.  Direct return value is uninteresting,
 %%      see riak_client:delete/3 for expected gen_server replies to Client.
-delete(ReqId,Bucket,Key,RW0,Timeout,Client,ClientId,undefined) ->
-    case get_rw_val(Bucket, RW0) of
-        error ->
-            Client ! {ReqId, {error, {rw_val_violation, RW0}}};
-        RW ->
+delete(ReqId,Bucket,Key,Options,Timeout,Client,ClientId,undefined) ->
+    case get_rw_options(Bucket, Options) of
+        {error, Reason} ->
+            Client ! {ReqId, {error, Reason}};
+        {R, _W, PR, _PW} ->
             RealStartTime = riak_core_util:moment(),
             {ok, C} = riak:local_client(),
-            case C:get(Bucket,Key,RW,Timeout) of
+            case C:get(Bucket,Key,[{r,R},{pr,PR},{timeout,Timeout}]) of
                 {ok, OrigObj} ->
                     RemainingTime = Timeout - (riak_core_util:moment() - RealStartTime),
-                    delete(ReqId,Bucket,Key,RW,RemainingTime,Client,ClientId,riak_object:vclock(OrigObj));
+                    delete(ReqId,Bucket,Key,Options,RemainingTime,Client,ClientId,riak_object:vclock(OrigObj));
                 {error, notfound} ->
                     Client ! {ReqId, {error, notfound}};
                 X ->
                     Client ! {ReqId, X}
             end
     end;
-delete(ReqId,Bucket,Key,RW0,Timeout,Client,ClientId,VClock) ->
-    case get_rw_val(Bucket, RW0) of
-        error ->
-            Client ! {ReqId, {error, {rw_val_violation, RW0}}};
-        RW ->
-
+delete(ReqId,Bucket,Key,Options,Timeout,Client,ClientId,VClock) ->
+    case get_rw_options(Bucket, Options) of
+        {error, Reason} ->
+            Client ! {ReqId, {error, Reason}};
+        {_R, W, _PR, PW} ->
             Obj0 = riak_object:new(Bucket, Key, <<>>, dict:store(<<"X-Riak-Deleted">>,
                                                                  "true", dict:new())),
             Tombstone = riak_object:set_vclock(Obj0, VClock),
             {ok,C} = riak:local_client(ClientId),
-            Reply = C:put(Tombstone, RW, RW, Timeout),
+            Reply = C:put(Tombstone, [{w,W},{pw,PW},{timeout,Timeout}]),
             Client ! {ReqId, Reply},
             case Reply of
                 ok ->
@@ -87,11 +86,57 @@ delete(ReqId,Bucket,Key,RW0,Timeout,Client,ClientId,VClock) ->
             end
     end.
 
-get_rw_val(Bucket, RW0) ->
+get_rw_options(Bucket, Options) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     BucketProps = riak_core_bucket:get_bucket(Bucket, Ring),
     N = proplists:get_value(n_val,BucketProps),
-    riak_kv_util:expand_rw_value(rw, RW0, BucketProps, N).
+    %% specifying R/W AND RW together doesn't make sense, so check if R or W
+    %is defined first. If not, use RW or default.
+    {R, W} = case proplists:is_defined(r, Options) orelse proplists:is_defined(w, Options) of
+        true ->
+            HasRW = false,
+            R0 = proplists:get_value(r, Options, default),
+            W0 = proplists:get_value(w, Options, default),
+            R1 = riak_kv_util:expand_rw_value(r, R0, BucketProps, N),
+            W1 = riak_kv_util:expand_rw_value(w, W0, BucketProps, N),
+            {R1, W1};
+        false ->
+            HasRW = true,
+            RW0 = proplists:get_value(rw, Options, default),
+            RW = riak_kv_util:expand_rw_value(rw, RW0, BucketProps, N),
+            {RW, RW}
+    end,
+    %% check for errors
+    case {R, W, HasRW} of
+        {error, _, false} ->
+            {error, {r_val_violation, proplists:get_value(r, Options)}};
+        {_, error, false} ->
+            {error, {w_val_violation, proplists:get_value(w, Options)}};
+        {error, error, true} ->
+            {error, {rw_val_violation, proplists:get_value(rw, Options)}};
+        _ ->
+            %% ok, the R/W or the RW values were OK, get PR/PW values
+            PR0 = proplists:get_value(pr, Options, default),
+            case riak_kv_util:expand_rw_value(pr, PR0, BucketProps, N) of
+                error ->
+                    {error, {pr_val_violation, PR0}};
+                PR ->
+                    PW0 = proplists:get_value(pw, Options, default),
+                    case riak_kv_util:expand_rw_value(pw, PW0, BucketProps, N) of
+                        error ->
+                            {error, {pw_val_violation, PW0}};
+                        PW ->
+                            {R, W, PR, PW}
+                    end
+            end
+    end.
+
+
+
+
+
+
+
 
 
 %% ===================================================================
@@ -101,14 +146,17 @@ get_rw_val(Bucket, RW0) ->
 
 delete_test_() ->
     %% Execute the test cases
-    {spawn, [
     { foreach, 
       fun setup/0,
       fun cleanup/1,
       [
-       fun invalid_rw_delete/0
+          fun invalid_r_delete/0,
+          fun invalid_rw_delete/0,
+          fun invalid_w_delete/0,
+          fun invalid_pr_delete/0,
+          fun invalid_pw_delete/0
       ]
-    }]}.
+  }.
 
 invalid_rw_delete() ->
     RW = <<"abc">>,
@@ -117,7 +165,7 @@ invalid_rw_delete() ->
     Bucket = <<"testbucket">>,
     Key = <<"testkey">>,
     Timeout = 60000,
-    riak_kv_delete_sup:start_delete(node(), [RequestId, Bucket, Key, RW, Timeout, self()]),
+    riak_kv_delete_sup:start_delete(node(), [RequestId, Bucket, Key, [{rw,RW}], Timeout, self()]),
     %% Wait for error response
     receive
         {_RequestId, Result} ->
@@ -125,8 +173,76 @@ invalid_rw_delete() ->
     after
         5000 ->
             ?assert(false)
-    end.                
-    
+    end.
+
+invalid_r_delete() ->
+    R = <<"abc">>,
+    %% Start the gen_fsm process
+    RequestId = erlang:phash2(erlang:now()),
+    Bucket = <<"testbucket">>,
+    Key = <<"testkey">>,
+    Timeout = 60000,
+    riak_kv_delete_sup:start_delete(node(), [RequestId, Bucket, Key, [{r,R}], Timeout, self()]),
+    %% Wait for error response
+    receive
+        {_RequestId, Result} ->
+            ?assertEqual({error, {r_val_violation, <<"abc">>}}, Result)
+    after
+        5000 ->
+            ?assert(false)
+    end.
+
+invalid_w_delete() ->
+    W = <<"abc">>,
+    %% Start the gen_fsm process
+    RequestId = erlang:phash2(erlang:now()),
+    Bucket = <<"testbucket">>,
+    Key = <<"testkey">>,
+    Timeout = 60000,
+    riak_kv_delete_sup:start_delete(node(), [RequestId, Bucket, Key, [{w,W}], Timeout, self()]),
+    %% Wait for error response
+    receive
+        {_RequestId, Result} ->
+            ?assertEqual({error, {w_val_violation, <<"abc">>}}, Result)
+    after
+        5000 ->
+            ?assert(false)
+    end.
+
+invalid_pr_delete() ->
+    PR = <<"abc">>,
+    %% Start the gen_fsm process
+    RequestId = erlang:phash2(erlang:now()),
+    Bucket = <<"testbucket">>,
+    Key = <<"testkey">>,
+    Timeout = 60000,
+    riak_kv_delete_sup:start_delete(node(), [RequestId, Bucket, Key, [{pr,PR}], Timeout, self()]),
+    %% Wait for error response
+    receive
+        {_RequestId, Result} ->
+            ?assertEqual({error, {pr_val_violation, <<"abc">>}}, Result)
+    after
+        5000 ->
+            ?assert(false)
+    end.
+
+invalid_pw_delete() ->
+    PW = <<"abc">>,
+    %% Start the gen_fsm process
+    RequestId = erlang:phash2(erlang:now()),
+    Bucket = <<"testbucket">>,
+    Key = <<"testkey">>,
+    Timeout = 60000,
+    riak_kv_delete_sup:start_delete(node(), [RequestId, Bucket, Key, [{pw,PW}], Timeout, self()]),
+    %% Wait for error response
+    receive
+        {_RequestId, Result} ->
+            ?assertEqual({error, {pw_val_violation, <<"abc">>}}, Result)
+    after
+        5000 ->
+            ?assert(false)
+    end.
+
 setup() ->
     %% Shut logging up - too noisy.
     application:load(sasl),
@@ -135,8 +251,9 @@ setup() ->
     error_logger:logfile({open, "riak_kv_delete_test.log"}),
     %% Start erlang node
     {ok, _} = net_kernel:start([testnode, shortnames]),
-    cleanup(unused_arg),
     do_dep_apps(start, dep_apps()),
+    application:set_env(riak_core, default_bucket_props, [{r, quorum},
+            {w, quorum}, {pr, 0}, {pw, 0}, {rw, quorum}, {n_val, 3}]),
     %% There's some weird interaction with the quickcheck tests in put_fsm_eqc
     %% that somehow makes the riak_kv_delete sup not be running if those tests
     %% run before these. I'm sick of trying to figure out what is not being
@@ -147,6 +264,7 @@ setup() ->
         _ ->
             ok
     end,
+    riak_kv_get_fsm_sup:start_link(),
     timer:sleep(500).
 
 cleanup(_Pid) ->
@@ -155,6 +273,9 @@ cleanup(_Pid) ->
     catch exit(whereis(riak_sysmon_filter), kill), %% Leaks occasionally
     net_kernel:stop(),
     %% Reset the riak_core vnode_modules
+    application:unset_env(riak_core, default_bucket_props),
+    application:unset_env(sasl, sasl_error_logger),
+    error_logger:tty(true),
     application:set_env(riak_core, vnode_modules, []).
 
 dep_apps() ->

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -378,6 +378,9 @@ setup() ->
     application:set_env(riak_core, vnode_inactivity_timeout, infinity),
     application:load(riak_kv),
     application:set_env(riak_kv, storage_backend, riak_kv_ets_backend),
+    application:set_env(riak_core, default_bucket_props, [{r, quorum},
+            {w, quorum}, {pr, 0}, {pw, 0}, {rw, quorum}, {n_val, 3},
+            {basic_quorum, true}, {notfound_ok, false}]),
 
     %% Have tracer on hand to grab any traces we want
     riak_core_tracer:start_link(),

--- a/src/riak_kv_wm_raw.erl
+++ b/src/riak_kv_wm_raw.erl
@@ -1107,13 +1107,13 @@ ensure_doc(Ctx) -> Ctx.
 %% @spec delete_resource(reqdata(), context()) -> {true, reqdata(), context()}
 %% @doc Delete the document specified.
 delete_resource(RD, Ctx=#ctx{bucket=B, key=K, client=C, rw=RW, r=R, w=W,
-        pr=PR, pw=PW}) ->
+        pr=PR, pw=PW, dw=DW}) ->
     Result = case wrq:get_req_header(?HEAD_VCLOCK, RD) of
         undefined -> 
-            C:delete(B,K,[{rw, RW}, {r, R}, {w, W}, {pr, PR}, {pw, PW}]);
+            C:delete(B,K,[{rw, RW}, {r, R}, {w, W}, {pr, PR}, {pw, PW}, {dw, DW}]);
         _ ->
             C:delete_vclock(B,K,decode_vclock_header(RD),
-                [{rw, RW}, {r, R}, {w, W}, {pr, PR}, {pw, PW}])
+                [{rw, RW}, {r, R}, {w, W}, {pr, PR}, {pw, PW}, {dw, DW}])
     end,
     case Result of
         {error, Reason} ->

--- a/src/riak_kv_wm_raw.erl
+++ b/src/riak_kv_wm_raw.erl
@@ -347,57 +347,8 @@ malformed_request(RD, Ctx) ->
         false ->
             DocCtx = ensure_doc(ResCtx),
             case DocCtx#ctx.doc of
-                {error, notfound} ->
-                    {{halt, 404},
-                     wrq:set_resp_header("Content-Type", "text/plain",
-                                         wrq:append_to_response_body(
-                                           io_lib:format("not found~n",[]),
-                                           ResRD)),
-                     DocCtx};
-                {error, {deleted, _VClock}} ->
-                    {{halt, 404},
-                      wrq:set_resp_header("Content-Type", "text/plain",
-                                         wrq:append_to_response_body(
-                                           io_lib:format("not found~n",[]),
-                                           encode_vclock_header(ResRD, DocCtx))),
-                     DocCtx};
-                {error, timeout} ->
-                    {{halt, 503},
-                     wrq:set_resp_header("Content-Type", "text/plain",
-                                      wrq:append_to_response_body(
-                                        io_lib:format("request timed out~n",[]),
-                                        ResRD)),
-                     DocCtx};
-                {error, {n_val_violation, _}} ->
-                    {{halt, 400},
-                     wrq:set_resp_header("Content-Type", "text/plain",
-                                  wrq:append_to_response_body(
-                                    io_lib:format("R-value unsatisfiable~n",[]),
-                                    ResRD)),
-                     DocCtx};
-                {error, {r_val_unsatisfied, Requested, Returned}} ->
-                    {{halt, 503},
-                     wrq:set_resp_header("Content-Type", "text/plain",
-                                  wrq:append_to_response_body(
-                                    io_lib:format("R-value unsatisfied: ~p/~p~n",
-                                        [Returned, Requested]),
-                                    ResRD)),
-                    DocCtx};
-                {error, {pr_val_unsatisfied, Requested, Returned}} ->
-                    {{halt, 503},
-                    wrq:set_resp_header("Content-Type", "text/plain",
-                                 wrq:append_to_response_body(
-                                   io_lib:format("PR-value unsatisfied: ~p/~p~n",
-                                        [Returned, Requested]),
-                                   ResRD)),
-                    DocCtx};
-                {error, Err} ->
-                    {{halt, 500},
-                     wrq:set_resp_header("Content-Type", "text/plain",
-                                  wrq:append_to_response_body(
-                                    io_lib:format("Error:~n~p~n",[Err]),
-                                    ResRD)),
-                     DocCtx};
+                {error, Reason} ->
+                    handle_common_error(Reason, ResRD, DocCtx);
                 _ ->
                     {false, ResRD, DocCtx}
             end
@@ -901,28 +852,8 @@ accept_doc_body(RD, Ctx=#ctx{bucket=B, key=K, client=C, links=L}) ->
     Options = case wrq:get_qs_value(?Q_RETURNBODY, RD) of ?Q_TRUE -> [returnbody]; _ -> [] end,
     case C:put(Doc, [{w, Ctx#ctx.w}, {dw, Ctx#ctx.dw}, {pw, Ctx#ctx.pw}, {timeout, 60000} |
                 Options]) of
-        {error, precommit_fail} ->
-            {{halt, 403}, send_precommit_error(RD, undefined), Ctx};
-        {error, {precommit_fail, Reason}} ->
-            {{halt, 403}, send_precommit_error(RD, Reason), Ctx};
-        {error, {n_val_violation, N}} ->
-            Msg = io_lib:format("Specified w/dw/pw values invalid for bucket"
-                                " n value of ~p~n", [N]),
-            {{halt, 400}, wrq:append_to_response_body(Msg, RD), Ctx};
-        {error, {pw_val_unsatisfied, Requested, Returned}} ->
-            Msg = io_lib:format("PW-value unsatisfied: ~p/~p~n", [Returned,
-                    Requested]),
-            {{halt, 503}, wrq:append_to_response_body(Msg, RD), Ctx};
-        {error, too_many_fails} ->
-            {{halt, 503}, wrq:append_to_response_body("Too Many write failures"
-                                                      " to satisfy W/DW\n", RD), Ctx};
-        {error, timeout} ->
-            {{halt, 503},
-             wrq:set_resp_header("Content-Type", "text/plain",
-                                 wrq:append_to_response_body(
-                                   io_lib:format("request timed out~n",[]),
-                                   RD)),
-                     Ctx};
+        {error, Reason} ->
+            handle_common_error(Reason, RD, Ctx);
         ok ->
             {true, RD, Ctx#ctx{doc={ok, Doc}}};
         {ok, RObj} ->
@@ -1175,24 +1106,18 @@ ensure_doc(Ctx) -> Ctx.
 
 %% @spec delete_resource(reqdata(), context()) -> {true, reqdata(), context()}
 %% @doc Delete the document specified.
-delete_resource(RD, Ctx=#ctx{bucket=B, key=K, client=C, rw=RW}) ->
+delete_resource(RD, Ctx=#ctx{bucket=B, key=K, client=C, rw=RW, r=R, w=W,
+        pr=PR, pw=PW}) ->
     Result = case wrq:get_req_header(?HEAD_VCLOCK, RD) of
         undefined -> 
-            C:delete(B,K,RW);
+            C:delete(B,K,[{rw, RW}, {r, R}, {w, W}, {pr, PR}, {pw, PW}]);
         _ ->
-            C:delete_vclock(B,K,decode_vclock_header(RD),RW)
+            C:delete_vclock(B,K,decode_vclock_header(RD),
+                [{rw, RW}, {r, R}, {w, W}, {pr, PR}, {pw, PW}])
     end,
     case Result of
-        {error, notfound} ->
-            {{halt, 404},
-             wrq:set_resp_header("Content-Type", "text/plain",
-                                 wrq:append_to_response_body(
-                                   io_lib:format("not found~n",[]),
-                                   RD)), Ctx};
-        {error, precommit_fail} ->
-            {{halt, 403}, send_precommit_error(RD, undefined), Ctx};
-        {error, {precommit_fail, Reason}} ->
-            {{halt, 403}, send_precommit_error(RD, Reason), Ctx};
+        {error, Reason} ->
+            handle_common_error(Reason, RD, Ctx);
         ok ->
             {true, RD, Ctx}
     end.
@@ -1359,3 +1284,68 @@ send_precommit_error(RD, Reason) ->
                     Reason
             end,
     wrq:append_to_response_body(Error, RD1).
+
+handle_common_error(Reason, RD, Ctx) ->
+    case {error, Reason} of
+        {error, precommit_fail} ->
+            {{halt, 403}, send_precommit_error(RD, undefined), Ctx};
+        {error, {precommit_fail, Reason}} ->
+            {{halt, 403}, send_precommit_error(RD, Reason), Ctx};
+        {error, {n_val_violation, N}} ->
+            Msg = io_lib:format("Specified w/dw/pw values invalid for bucket"
+                " n value of ~p~n", [N]),
+            {{halt, 400}, wrq:append_to_response_body(Msg, RD), Ctx};
+        {error, {pw_val_unsatisfied, Requested, Returned}} ->
+            Msg = io_lib:format("PW-value unsatisfied: ~p/~p~n", [Returned,
+                    Requested]),
+            {{halt, 503}, wrq:append_to_response_body(Msg, RD), Ctx};
+        {error, too_many_fails} ->
+            {{halt, 503}, wrq:append_to_response_body("Too Many write failures"
+                    " to satisfy W/DW\n", RD), Ctx};
+        {error, timeout} ->
+            {{halt, 503},
+                wrq:set_resp_header("Content-Type", "text/plain",
+                    wrq:append_to_response_body(
+                        io_lib:format("request timed out~n",[]),
+                        RD)),
+                Ctx};
+        {error, notfound} ->
+            {{halt, 404},
+                wrq:set_resp_header("Content-Type", "text/plain",
+                    wrq:append_to_response_body(
+                        io_lib:format("not found~n",[]),
+                        RD)),
+                Ctx};
+        {error, {deleted, _VClock}} ->
+            {{halt, 404},
+                wrq:set_resp_header("Content-Type", "text/plain",
+                    wrq:append_to_response_body(
+                        io_lib:format("not found~n",[]),
+                        encode_vclock_header(RD, Ctx))),
+                Ctx};
+        {error, {r_val_unsatisfied, Requested, Returned}} ->
+            {{halt, 503},
+                wrq:set_resp_header("Content-Type", "text/plain",
+                    wrq:append_to_response_body(
+                        io_lib:format("R-value unsatisfied: ~p/~p~n",
+                            [Returned, Requested]),
+                        RD)),
+                Ctx};
+        {error, {pr_val_unsatisfied, Requested, Returned}} ->
+            {{halt, 503},
+                wrq:set_resp_header("Content-Type", "text/plain",
+                    wrq:append_to_response_body(
+                        io_lib:format("PR-value unsatisfied: ~p/~p~n",
+                            [Returned, Requested]),
+                        RD)),
+                Ctx};
+        {error, Err} ->
+            {{halt, 500},
+                wrq:set_resp_header("Content-Type", "text/plain",
+                    wrq:append_to_response_body(
+                        io_lib:format("Error:~n~p~n",[Err]),
+                        RD)),
+                Ctx}
+    end.
+
+


### PR DESCRIPTION
Allow users to specify R/W/PR/PW/DW for deletes instead of the single parameter 'RW'. Compatibility with simply passing RW is maintained, but a list is also now accepted.
