### PR TITLE
Az424 listkeys qc test

### DIFF
--- a/test/keys_fsm_eqc.erl
+++ b/test/keys_fsm_eqc.erl
@@ -59,8 +59,13 @@ setup() ->
     error_logger:tty(false),
     error_logger:logfile({open, "keys_fsm_eqc.log"}),
 
+    %% Cleanup in case a previous test did not
+    cleanup(setup),
+    %% Pause the make sure everything is cleaned up
+    timer:sleep(2000),
+    
     %% Start erlang node
-    {ok, _} = net_kernel:start([testnode, shortnames]),
+    net_kernel:start([testnode, shortnames]),
     do_dep_apps(start, dep_apps()),
     ok.
 

--- a/test/keys_fsm_eqc.erl
+++ b/test/keys_fsm_eqc.erl
@@ -144,7 +144,7 @@ prop_basic_listkeys() ->
                                 [ExpectedKeys, Keys])
                   end,
                   conjunction(
-                    [{key_counts, equals(length(Keys), length(ExpectedKeys))},
+                    [
                      {keys, equals(lists:sort(Keys), lists:sort(ExpectedKeys))}
                     ]))
 


### PR DESCRIPTION
Improves the listkeys qc test to generate buckets, bucket n_vals, timeout values, and different size object lists to store in the buckets. Also varies the input between a bucket name and a key filter input tuple.
