### PR TITLE
2I - Implement Querying via ListKeys (AZ459)

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -40,6 +40,7 @@
          stream_list_keys/4,stream_list_keys/5]).
 -export([filter_keys/2,filter_keys/3]).
 -export([list_buckets/0,list_buckets/1]).
+-export([get_index/2]).
 -export([set_bucket/2,get_bucket/1]).
 -export([reload_all/1]).
 -export([remove_from_cluster/1]).
@@ -538,6 +539,16 @@ list_buckets() ->
 %%      a bucket.
 list_buckets(Timeout) ->
     list_keys('_', Timeout).
+
+%% @spec get_index(Bucket :: binary(), Query :: riak_index:query_def()) ->
+%%       {ok, [Key :: riak_object:key()]} |
+%%       {error, timeout} |
+%%       {error, Err :: term()}.
+%%
+%% @doc Run the provided index query.
+get_index(Bucket, Query) ->
+    FakeBucket = {index_query, Bucket, Query},
+    list_keys({FakeBucket, []}).
 
 %% @spec set_bucket(riak_object:bucket(), [BucketProp :: {atom(),term()}]) -> ok
 %% @doc Set the given properties for Bucket.

--- a/src/riak_index_backend.erl
+++ b/src/riak_index_backend.erl
@@ -36,6 +36,7 @@ behaviour_info(callbacks) ->
      {index, 2},       % (State, Postings)
      {delete, 2},      % (State, Postings)
      {lookup_sync, 4}, % (State, Index, Field, Term) 
+     {fold_index, 6},  % (State, Index, Query, SKFun, Acc, FinalFun)
      {drop,1},         % (State)
      {callback,3}];    % (State, Ref, Msg) ->
 behaviour_info(_Other) ->

--- a/src/riak_index_mi_backend.erl
+++ b/src/riak_index_mi_backend.erl
@@ -12,6 +12,7 @@
          index/2,
          delete/2,
          lookup_sync/4,
+         fold_index/6,
          drop/1,
          callback/3
         ]).
@@ -23,6 +24,15 @@
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
+
+%% MIN_VALUE and MAX_VALUE are used during range searches. MIN_VALUE
+%% is a number because floats sort smallest in Erlang. See
+%% http://www.erlang.org/doc/reference_manual/expressions.html. MAX_VALUE
+%% is undefined because merge_index understands undefined to mean no
+%% upper bound.
+-define(MIN_VALUE, -9223372036854775808). %% -1 * (2^63)).
+-define(MAX_VALUE, undefined).
+-define(SIZE, all).
 
 %% @type state() = term().
 -record(state, {partition, pid}).
@@ -101,6 +111,55 @@ lookup_sync(State, Index, Field, Term) ->
     FilterFun = fun(_Value, _Props) -> true end,
     merge_index:lookup_sync(Pid, Index, Field, Term, FilterFun).
 
+
+%% @spec fold_index(State :: state(), Bucket :: binary(), Query :: riak_index:query_elements(),
+%%                  SKFun :: function(), Acc :: term(), FinalFun :: function()) -> term().
+fold_index(State, Index, Query, SKFun, Acc, FinalFun) ->
+    Pid = State#state.pid,
+    FilterFun = fun(Value, Props) -> true end,
+
+    %% Run a synchronous query against merge_index. In the future,
+    %% this will run more complicated queries, and will run them
+    %% asynchronously.
+    Results = case Query of
+                  [{eq, Field, Term}] ->
+                      merge_index:lookup_sync(Pid, Index, Field, Term, FilterFun);
+
+                  [{lt, Field, Term}] ->
+                      merge_index:range_sync(Pid, Index, Field, undefined, inc(Term, -1), ?SIZE, FilterFun);
+
+                  [{gt, Field, Term}] ->
+                      merge_index:range_sync(Pid, Index, Field, inc(Term, 1), undefined, ?SIZE, FilterFun);
+
+                  [{lte, Field, Term}] ->
+                      merge_index:range_sync(Pid, Index, Field, undefined, Term, ?SIZE, FilterFun);
+
+                  [{gte, Field, Term}] ->
+                      merge_index:range_sync(Pid, Index, Field, Term, undefined, ?SIZE, FilterFun);
+
+                  _ -> 
+                      FinalFun({error, {unknown_query_element, Query}}, Acc)
+              end,
+    
+    %% If Results is a list of results, then call SKFun to accumulate
+    %% the results.
+    Results1 = case is_list(Results) of
+                   true -> SKFun({results, Results}, Acc);
+                   false -> {ok, Results}
+               end,
+
+    %% Call FinalFun on the results.
+    case Results1 of
+        {ok, NewAcc} ->
+            FinalFun(done, NewAcc);
+        {error, Reason} ->
+            FinalFun({error, Reason}, Acc);
+        done ->
+            FinalFun(done, Acc);
+        Other ->
+            FinalFun({error, {unexpected_result, Other}}, Acc)
+    end.
+
 %% @spec drop(State::state()) -> ok.
 %%
 %% @doc Delete all values from the index.
@@ -111,6 +170,28 @@ drop(State) ->
 %% Ignore callbacks for other backends so multi backend works
 callback(_State, _Ref, _Msg) ->
     ok.
+
+
+%% @private
+%% @spec inc(term(), Amt :: integer()) -> term().
+%% 
+%% @doc Increments or decrements an Erlang data type by one
+%%      position. Used during construction of exclusive range searches.
+inc(Term, Amt)  when is_integer(Term) ->
+    Term + Amt;
+inc(Term, _Amt) when is_float(Term) ->
+    Term; %% Doesn't make sense to have exclusive range on floats.
+inc(Term, Amt)  when is_list(Term) ->
+    NewTerm = inc(list_to_binary(Term), Amt),
+    binary_to_list(NewTerm);
+inc(Term, Amt)  when is_binary(Term) ->
+    Bits = size(Term) * 8,
+    <<Int:Bits/integer>> = Term,
+    NewInt = inc(Int, Amt),
+    <<NewInt:Bits/integer>>;
+inc(Term, _) ->
+    throw({unhandled_type, binary_inc, Term}).
+
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_index_mi_backend.erl
+++ b/src/riak_index_mi_backend.erl
@@ -25,13 +25,8 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
-%% MIN_VALUE and MAX_VALUE are used during range searches. MIN_VALUE
-%% is a number because floats sort smallest in Erlang. See
-%% http://www.erlang.org/doc/reference_manual/expressions.html. MAX_VALUE
-%% is undefined because merge_index understands undefined to mean no
-%% upper bound.
--define(MIN_VALUE, -9223372036854775808). %% -1 * (2^63)).
--define(MAX_VALUE, undefined).
+%% A size of 'all' tells merge_index to ignore the size parameter when
+%% performing a range query.
 -define(SIZE, all).
 
 %% @type state() = term().
@@ -138,7 +133,7 @@ fold_index(State, Index, Query, SKFun, Acc, FinalFun) ->
                       merge_index:range_sync(Pid, Index, Field, Term, undefined, ?SIZE, FilterFun);
 
                   _ -> 
-                      FinalFun({error, {unknown_query_element, Query}}, Acc)
+                      {error, {unknown_query_element, Query}}
               end,
     
     %% If Results is a list of results, then call SKFun to accumulate

--- a/src/riak_index_mi_backend.erl
+++ b/src/riak_index_mi_backend.erl
@@ -116,7 +116,7 @@ lookup_sync(State, Index, Field, Term) ->
 %%                  SKFun :: function(), Acc :: term(), FinalFun :: function()) -> term().
 fold_index(State, Index, Query, SKFun, Acc, FinalFun) ->
     Pid = State#state.pid,
-    FilterFun = fun(Value, Props) -> true end,
+    FilterFun = fun(_Value, _Props) -> true end,
 
     %% Run a synchronous query against merge_index. In the future,
     %% this will run more complicated queries, and will run them


### PR DESCRIPTION
   Add riak_client:get_index/2 function for running index queries. This function constructs a "fake" listkeys bucket of the form {index_query, Bucket, Query} and calls `Client:list_keys/N`. List keys eventually calls `riak_kv_index_backend:fold_bucket_keys/N` on riak_kv_index_backend with the provided "fake" bucket. (NOTE: This is temporary code, we will replace it once we finish the "covering cast" work in riak_core.)

  This calls the new riak_index_mi_backend:fold_index/6 function to perform the query. For the purposes of this Kanban ticket, Query will run against a single field, and is a tuple of the form {Operation, Field, Value} where Operation is 'eq', 'lt', 'lte', etc., Field is the string field, and Value is the parsed value. Future tickets will enable more complexity, and will do some sanity checking on Field Names.

  This change also adds bucket and key indexing with an update to riak_index:parse_object/1. The bucket field is "$bucket" and the key field is "$key".

  This round of changes deviates in a few key areas from the plan we discussed:
- SKFun accepts a batch of results, rather than a single result.
- SKFun results are of the form {PrimaryKey, Properties} rather than {SecondaryKey, PrimaryKey}, and properties contains an entry for {Field, SecondaryKey}. This was done to keep in line with what merge_index already produces which has served well for Riak Search and for early Riak Index prototypes.
- We create "special" fields for bucket and key ($bucket and $key, respectively) rather than exposing operations for 'lt_pk', 'gt_pk', etc. Seemed like a more elegant way to expose the functionality, and took fewer lines of code.
- Speaking of the "$bucket" field, it seems weird to have operations like `get_index(<<"mybucket">>, [{eq, "$bucket", <<"mybucket">>}])`. Queries are already scoped to the bucket. Should we instead support a `{bucket}` operation that reads all keys for the current bucket? 
- riak_kv_index_backend takes advantage of merge_index's ability to store large data by using it to store the "proxy" object, which is the collection of postings indexed for a particular object. This is used to cleanup old postings when objects are updated or deleted. Bitcask is probably a better storage engine for this kind of data, but should we store it in the bitcask instance for the current partition, or create a new bitcask instance? Alternatively, we could avoid storing a proxy object, or store the parsed fields as additional metadata, but that would require changes to riak_kv_vnode in order to send the old copy of the object to the backend during put/delete requests.

```
 # Store an object with field types...
 curl -v -X PUT \
 -d '{"bar":"baz"}' \
 -H "Content-Type: application/json" \
 -H "x-riak-index-field1_id: A" \
 -H "x-riak-INDEX-field2_int: 1" \
 -H "x-Riak-INDEX-field3_float: 3.14" \
 http://127.0.0.1:8098/riak/mybucket/mykey

 # Retrieve the object...
 curl -i http://127.0.0.1:8098/riak/mybucket/mykey?returnbody=true

 %% Query the index...
 {ok, Client} = riak:local_client().
 Client:get_index(<<"mybucket">>, [{eq, "$key", <<"mykey">>}]).
 Client:get_index(<<"mybucket">>, [{eq, "field2_int", 1}]).
```
