### PR TITLE
BZ1126: riak_kv_cache_backend should stop.

### DIFF
--- a/src/riak_kv_cache_backend.erl
+++ b/src/riak_kv_cache_backend.erl
@@ -246,7 +246,7 @@ handle_call({fold, Fun0, Acc}, _From, State) ->
     Reply = do_fold(State, Keys, Fun0, Acc),
     {reply, Reply, State};
 handle_call(stop, _From, State) -> 
-    {reply, ok, State}.
+    {stop, normal, ok, State}.
 
 %% @private
 handle_cast(_, State) -> {noreply, State}.


### PR DESCRIPTION
Just what it says. Without stopping properly, the handoff sender will crash.
