### PR TITLE
Az479 empty reduce

### DIFF
--- a/src/riak_kv_w_reduce.erl
+++ b/src/riak_kv_w_reduce.erl
@@ -31,6 +31,8 @@
          handoff/2,
          validate_arg/1]).
 -export([chashfun/1, reduce_compat/1]).
+%% Special export for riak_pipe_fitting
+-export([no_input_run_reduce_once/0]).
 
 -include_lib("riak_pipe/include/riak_pipe.hrl").
 -include_lib("riak_pipe/include/riak_pipe_log.hrl").
@@ -53,7 +55,8 @@
          {ok, state()}.
 init(Partition, FittingDetails) ->
     DelayMax = calc_delay_max(FittingDetails),
-    {ok, #state{acc=[], delay=0, delay_max = DelayMax,
+    Acc = reduce([], #state{fd=FittingDetails}, "riak_kv_w_reduce init"),
+    {ok, #state{acc=Acc, delay=0, delay_max = DelayMax,
                 p=Partition, fd=FittingDetails}}.
 
 %% @doc Process looks up the previous result for the `Key', and then
@@ -158,6 +161,9 @@ reduce_compat({modfun, Module, Function}) ->
     reduce_compat({qfun, erlang:make_fun(Module, Function, 2)});
 reduce_compat({qfun, Fun}) ->
     Fun.
+
+no_input_run_reduce_once() ->
+    true.
 
 stored_js_source(Bucket, Key) ->
     {ok, C} = riak:local_client(),

--- a/test/mapred_test.erl
+++ b/test/mapred_test.erl
@@ -198,6 +198,12 @@ compat_basic1_test_() ->
                  {IntsBucket, <<"bar1">>} = hd(lists:sort(BKeys))
              end),
           ?_test(
+             %% AZ 479: Reduce with zero inputs -> call reduce once w/empty list
+             begin
+                 Spec = [{reduce, {qfun, ReduceSumFun}, none, true}],
+                 {ok, [0]} = riak_kv_mrc_pipe:mapred([], Spec)
+             end),
+          ?_test(
              %% Basic compatibility: keep both stages
              begin
                  Spec = 


### PR DESCRIPTION
Create special callback function in riak_kv_w_reduce,
no_input_run_reduce_once(), to assist riak_pipe_fitting's decision-making
process when a fitting receives an eoi.
