### PR TITLE
Fix key listing problem.

### DIFF
--- a/src/riak_kv_leveldb_backend.erl
+++ b/src/riak_kv_leveldb_backend.erl
@@ -151,7 +151,7 @@ fold_bucket_keys(State, Bucket, Fun0, Acc0) ->
     F = fun({BK, _V}, Acc) ->
                 case binary_to_term(BK) of
                     {Bucket, Key} ->
-                        Fun0(Key, Acc);
+                        Fun0(Key, dummy_val, Acc);
                     _ ->
                         Acc
                 end


### PR DESCRIPTION
The newer backend api uses a value parameter as the second argument to the function used to process the keys when fold_bucket_keys is called. 
