### PR TITLE
Fix syntax error in last commit

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -214,7 +214,7 @@ key_counts(RootDir) ->
     [begin
          {Keys, _} = status(filename:join(RootDir, Dir)),
          {Dir, Keys}
-     end || Dir <- element(2, file:list_dir(RootDir))];
+     end || Dir <- element(2, file:list_dir(RootDir))].
 
 %% ===================================================================
 %% Internal functions


### PR DESCRIPTION
Replace semicolon with fullstop to terminate function def
