### PR TITLE
az://303 vclock enhancements - *DO NOT MERGE YET*

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -290,9 +290,15 @@ put(RObj) -> THIS:put(RObj, []).
 %%       {error, Err :: term(), details()}
 %% @doc Store RObj in the cluster.
 put(RObj, Options) when is_list(Options) ->
+    UpdObj = case ClientId of
+                 undefined ->
+                     RObj;
+                 _ ->
+                     riak_object:increment_vclock(RObj, ClientId)
+             end,
     Me = self(),
     ReqId = mk_reqid(),
-    riak_kv_put_fsm_sup:start_put_fsm(Node, [{raw, ReqId, Me}, RObj, Options]),
+    riak_kv_put_fsm_sup:start_put_fsm(Node, [{raw, ReqId, Me}, UpdObj, Options]),
     %% TODO: Investigate adding a monitor here and eliminating the timeout.
     Timeout = recv_timeout(Options),
     wait_for_reqid(ReqId, Timeout);

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -290,10 +290,9 @@ put(RObj) -> THIS:put(RObj, []).
 %%       {error, Err :: term(), details()}
 %% @doc Store RObj in the cluster.
 put(RObj, Options) when is_list(Options) ->
-    UpdObj = riak_object:increment_vclock(RObj, ClientId),
     Me = self(),
     ReqId = mk_reqid(),
-    riak_kv_put_fsm_sup:start_put_fsm(Node, [{raw, ReqId, Me}, UpdObj, Options]),
+    riak_kv_put_fsm_sup:start_put_fsm(Node, [{raw, ReqId, Me}, RObj, Options]),
     %% TODO: Investigate adding a monitor here and eliminating the timeout.
     Timeout = recv_timeout(Options),
     wait_for_reqid(ReqId, Timeout);

--- a/src/riak_kv_put_core.erl
+++ b/src/riak_kv_put_core.erl
@@ -102,8 +102,9 @@ enough(#putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW,
         (NumW < W andalso NumFail >= WFailThreshold).
 
 %% True if coordinator result has been returned - anything other than w.
-coord_result(CoordIdx, Results) ->
-    [Result || {Idx, Result} <- Results, Idx == CoordIdx] -- [w] /= [].
+coord_result(_CoordIdx, _Results) ->
+    true.
+%    [Result || {Idx, Result} <- Results, Idx == CoordIdx] -- [w] /= [].
 
 %% Get success/fail response once enough results received
 -spec response(putcore()) -> {reply(), putcore()}.

--- a/src/riak_kv_put_core.erl
+++ b/src/riak_kv_put_core.erl
@@ -20,8 +20,9 @@
 %%
 %% -------------------------------------------------------------------
 -module(riak_kv_put_core).
--export([init/7, add_result/2, enough/1, response/1, 
+-export([init/7, coord_idx/2, add_result/2, enough/1, response/1, 
          final/1]).
+-export([coord_result/2]).%% DEBUG
 -export_type([putcore/0, result/0, reply/0]).
 
 -type vput_result() :: any().
@@ -43,6 +44,7 @@
                   dw_fail_threshold :: pos_integer(),
                   returnbody :: boolean(),
                   allowmult :: boolean(),
+                  coord_idx :: non_neg_integer(),
                   results = [] :: [idxresult()],
                   final_obj :: undefined | riak_object:riak_object(),
                   num_w = 0 :: non_neg_integer(),
@@ -64,6 +66,9 @@ init(N, W, DW, WFailThreshold, DWFailThreshold, AllowMult, ReturnBody) ->
              allowmult = AllowMult,
              returnbody = ReturnBody}.
 
+coord_idx(Idx, PutCore) ->
+    PutCore#putcore{coord_idx = Idx}.
+   
 %% Add a result from the vnode
 -spec add_result(vput_result(), putcore()) -> putcore().
 add_result({w, Idx, _ReqId}, PutCore = #putcore{results = Results,
@@ -90,10 +95,15 @@ add_result(_Other, PutCore = #putcore{num_fail = NumFail}) ->
 -spec enough(putcore()) -> boolean().
 enough(#putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW, 
                 num_fail = NumFail, w_fail_threshold = WFailThreshold,
-                dw_fail_threshold = DWFailThreshold}) ->
-    (NumW >= W andalso NumDW >= DW) orelse
+                dw_fail_threshold = DWFailThreshold,
+                coord_idx = CoordIdx, results = Results}) ->
+    (NumW >= W andalso NumDW >= DW andalso coord_result(CoordIdx, Results)) orelse
         (NumW >= W andalso NumFail >= DWFailThreshold) orelse
         (NumW < W andalso NumFail >= WFailThreshold).
+
+%% True if coordinator result has been returned - anything other than w.
+coord_result(CoordIdx, Results) ->
+    [Result || {Idx, Result} <- Results, Idx == CoordIdx] -- [w] /= [].
 
 %% Get success/fail response once enough results received
 -spec response(putcore()) -> {reply(), putcore()}.

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -267,13 +267,13 @@ precommit(timeout, State = #state{precommit = [Hook | Rest], robj = RObj}) ->
                                                 precommit = Rest}, 0}
     end.
 
-execute_local(timeout, StateData0=#state{robj=RObj0, req_id = ReqId,
+execute_local(timeout, StateData0=#state{robj=RObj, req_id = ReqId,
                                          timeout=Timeout, bkey=BKey,
-                                         coord_idx_node = {_Index, Node} = CoordIndexNode,
+                                         coord_idx_node = {_Index, _Node} = CoordIndexNode,
                                          vnode_options=VnodeOptions,
                                          putcore=PutCore,
                                          starttime = StartTime}) ->
-    RObj = riak_object:increment_vclock(RObj0, Node, StartTime),
+    %RObj = riak_object:increment_vclock(RObj0, Node, StartTime),
     TRef = schedule_timeout(Timeout),
     riak_kv_vnode:coord_put(CoordIndexNode, BKey, RObj, ReqId, StartTime, VnodeOptions),
     StateData = StateData0#state{robj = RObj, tref = TRef},

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -298,7 +298,7 @@ waiting_local_vnode(Result, StateData = #state{putcore = PutCore}) ->
             case Result of
                 {fail, _Idx, _ReqId} ->
                     %% Local vnode failure is enough to sink whole operation
-                    process_reply({error, fail}, StateData#state{putcore = UpdPutCore1});
+                    process_reply({error, too_many_fails}, StateData#state{putcore = UpdPutCore1});
                 {w, _Idx, _ReqId} ->
                     {next_state, waiting_local_vnode, StateData#state{putcore = UpdPutCore1}};
                 {dw, _Idx, PutObj, _ReqId} ->

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -290,10 +290,10 @@ waiting_local_vnode(request_timeout, StateData) ->
     process_reply({error,timeout}, StateData);
 waiting_local_vnode(Result, StateData = #state{putcore = PutCore}) ->
     UpdPutCore1 = riak_kv_put_core:add_result(Result, PutCore),
-    case riak_kv_put_core:enough(PutCore) of
+    case riak_kv_put_core:enough(UpdPutCore1) of
         true ->
-            {Reply, UpdPutCore} = riak_kv_put_core:response(PutCore),
-            process_reply(Reply, StateData#state{putcore = UpdPutCore});
+            {Reply, UpdPutCore2} = riak_kv_put_core:response(UpdPutCore1),
+            process_reply(Reply, StateData#state{putcore = UpdPutCore2});
         false ->
             case Result of
                 {fail, _Idx, _ReqId} ->

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -40,8 +40,9 @@
 -export([init/1, handle_event/3, handle_sync_event/4,
          handle_info/3, terminate/3, code_change/4]).
 -export([prepare/2, validate/2, precommit/2,
-         execute_local/2, waiting_local_vnode/2,
-         execute_remote/2, waiting_remote_vnode/2,
+         execute_local/2,
+         waiting_local_vnode/2,
+         waiting_remote_vnode/2,
          postcommit/2, finish/2]).
 
 
@@ -209,10 +210,12 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
     DW1 = riak_kv_util:expand_rw_value(dw, DW0, BucketProps, N),
     %% If no error occurred expanding DW also ensure that DW <= W
     case DW1 of
-         error ->
-             DW = error;
-         _ ->
-             DW = erlang:min(DW1, W)
+        error ->
+            DW = error;
+        _ ->
+            %% DW must always be 1 with node-based vclocks.
+            %% The coord vnode is responsible for incrementing the vclock
+            DW = erlang:min(DW1, erlang:max(1, W))
     end,
     NumPrimaries = length([x || {_,primary} <- Preflist2]),
     NumVnodes = length(Preflist2),
@@ -271,64 +274,34 @@ execute_local(timeout, StateData0=#state{robj=RObj, req_id = ReqId,
                                          timeout=Timeout, bkey=BKey,
                                          coord_idx_node = {_Index, _Node} = CoordIndexNode,
                                          vnode_options=VnodeOptions,
-                                         putcore=PutCore,
                                          starttime = StartTime}) ->
     %RObj = riak_object:increment_vclock(RObj0, Node, StartTime),
     TRef = schedule_timeout(Timeout),
     riak_kv_vnode:coord_put(CoordIndexNode, BKey, RObj, ReqId, StartTime, VnodeOptions),
     StateData = StateData0#state{robj = RObj, tref = TRef},
-    case riak_kv_put_core:enough(PutCore) of
-        true ->
-            {Reply, UpdPutCore} = riak_kv_put_core:response(PutCore),
-            process_reply(Reply, StateData#state{putcore = UpdPutCore});
-        false ->
-            new_state(waiting_local_vnode, StateData)
-    end.
+    %% Must always wait for local vnode - it contains the object with updated vclock
+    %% to use for the remotes. (Ignore optimization for N=1 case for now).
+    new_state(waiting_local_vnode, StateData).
 
 %% @private
 waiting_local_vnode(request_timeout, StateData) ->
     process_reply({error,timeout}, StateData);
 waiting_local_vnode(Result, StateData = #state{putcore = PutCore}) ->
     UpdPutCore1 = riak_kv_put_core:add_result(Result, PutCore),
-    case riak_kv_put_core:enough(UpdPutCore1) of
-        true ->
-            {Reply, UpdPutCore2} = riak_kv_put_core:response(UpdPutCore1),
-            process_reply(Reply, StateData#state{putcore = UpdPutCore2});
-        false ->
-            case Result of
-                {fail, _Idx, _ReqId} ->
-                    %% Local vnode failure is enough to sink whole operation
-                    process_reply({error, too_many_fails}, StateData#state{putcore = UpdPutCore1});
-                {w, _Idx, _ReqId} ->
-                    {next_state, waiting_local_vnode, StateData#state{putcore = UpdPutCore1}};
-                {dw, _Idx, PutObj, _ReqId} ->
-                    %% Either returnbody is true or coord put merged with the existing
-                    %% object and bumped the vclock.  Either way use the returned
-                    %% object for the remote vnode
-                    new_state_timeout(execute_remote, StateData#state{robj = PutObj,
-                                                                      putcore = UpdPutCore1});
-                {dw, _Idx, _ReqId} ->
-                    %% Write succeeded without changes to vclock required and returnbody false
-                    new_state_timeout(execute_remote, StateData#state{putcore = UpdPutCore1})
-            end
-    end.
-
-%% @private
-execute_remote(timeout, StateData=#state{robj=RObj, req_id = ReqId,
-                                         preflist2 = Preflist2, bkey=BKey,
-                                         coord_idx_node = CoordIndexNode,
-                                         vnode_options=VnodeOptions,
-                                         putcore=PutCore,
-                                         starttime = StartTime}) ->
-    Preflist = [IndexNode || {IndexNode, _Type} <- Preflist2,
-                             IndexNode /= CoordIndexNode],
-    riak_kv_vnode:put(Preflist, BKey, RObj, ReqId, StartTime, VnodeOptions),
-    case riak_kv_put_core:enough(PutCore) of
-        true ->
-            {Reply, UpdPutCore} = riak_kv_put_core:response(PutCore),
-            process_reply(Reply, StateData#state{putcore = UpdPutCore});
-        false ->
-            new_state(waiting_remote_vnode, StateData)
+    case Result of
+        {fail, _Idx, _ReqId} ->
+            %% Local vnode failure is enough to sink whole operation
+            process_reply({error, local_put_failed}, StateData#state{putcore = UpdPutCore1});
+        {w, _Idx, _ReqId} ->
+            {next_state, waiting_local_vnode, StateData#state{putcore = UpdPutCore1}};
+        {dw, _Idx, PutObj, _ReqId} ->
+            %% Either returnbody is true or coord put merged with the existing
+            %% object and bumped the vclock.  Either way use the returned
+            %% object for the remote vnode
+            execute_remote(StateData#state{robj = PutObj, putcore = UpdPutCore1});
+        {dw, _Idx, _ReqId} ->
+            %% Write succeeded without changes to vclock required and returnbody false
+            execute_remote(StateData#state{putcore = UpdPutCore1})
     end.
 
 %% @private
@@ -435,6 +408,27 @@ process_reply(Reply, StateData = #state{postcommit = PostCommit,
             new_state_timeout(postcommit, StateData2);
         _ ->
             new_state_timeout(finish, StateData2)
+    end.
+
+
+%% @private
+%% Send the put requests to any remote nodes if necessary and decided if 
+%% enough responses have been received yet (i.e. if W/DW=1)
+execute_remote(StateData=#state{robj=RObj, req_id = ReqId,
+                                preflist2 = Preflist2, bkey=BKey,
+                                coord_idx_node = CoordIndexNode,
+                                vnode_options=VnodeOptions,
+                                putcore=PutCore,
+                                starttime = StartTime}) ->
+    Preflist = [IndexNode || {IndexNode, _Type} <- Preflist2,
+                             IndexNode /= CoordIndexNode],
+    riak_kv_vnode:put(Preflist, BKey, RObj, ReqId, StartTime, VnodeOptions),
+    case riak_kv_put_core:enough(PutCore) of
+        true ->
+            {Reply, UpdPutCore} = riak_kv_put_core:response(PutCore),
+            process_reply(Reply, StateData#state{putcore = UpdPutCore});
+        false ->
+            new_state(waiting_remote_vnode, StateData)
     end.
 
 %%

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -61,7 +61,7 @@ is_x_deleted(Obj) ->
 %%      are marked deleted, or the input Obj if any of them are not.
 obj_not_deleted(Obj) ->
     case [{M, V} || {M, V} <- riak_object:get_contents(Obj),
-                    dict:is_key(<<"X-Riak-Deleted">>, M) =:= false] of
+                    orddict:is_key(<<"X-Riak-Deleted">>, M) =:= false] of
         [] -> undefined;
         _ -> Obj
     end.
@@ -165,7 +165,7 @@ normalize_test() ->
 deleted_test() ->
     O = riak_object:new(<<"test">>, <<"k">>, "v"),
     false = is_x_deleted(O),
-    MD = dict:new(),
+    MD = orddict:new(),
     O1 = riak_object:apply_updates(
            riak_object:update_metadata(
              O, dict:store(<<"X-Riak-Deleted">>, true, MD))),

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -61,7 +61,7 @@ is_x_deleted(Obj) ->
 %%      are marked deleted, or the input Obj if any of them are not.
 obj_not_deleted(Obj) ->
     case [{M, V} || {M, V} <- riak_object:get_contents(Obj),
-                    orddict:is_key(<<"X-Riak-Deleted">>, M) =:= false] of
+                    dict:is_key(<<"X-Riak-Deleted">>, M) =:= false] of
         [] -> undefined;
         _ -> Obj
     end.
@@ -165,7 +165,7 @@ normalize_test() ->
 deleted_test() ->
     O = riak_object:new(<<"test">>, <<"k">>, "v"),
     false = is_x_deleted(O),
-    MD = orddict:new(),
+    MD = dict:new(),
     O1 = riak_object:apply_updates(
            riak_object:update_metadata(
              O, dict:store(<<"X-Riak-Deleted">>, true, MD))),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -58,6 +58,7 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-export([coord_put_merge/4]). %% For fsm_eqc_vnode
 -endif.
 
 -record(mrjob, {cachekey :: term(),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -347,7 +347,7 @@ get_counter(Id, VC) ->
     case lists:keyfind(Id, 1, VC) of
         false ->
             0;
-        {Counter, _TS} ->
+        {_Id, {Counter, _TS}} ->
             Counter
     end.
 

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -70,7 +70,7 @@
                 mod :: module(),
                 modstate :: term(),
                 mrjobs :: term(),
-                vnode_epoch :: undefined | integer(),
+                vnodeid :: undefined | binary(),
                 in_handoff = false :: boolean()}).
 
 -record(putargs, {returnbody :: boolean(),
@@ -179,8 +179,8 @@ init([Index]) ->
     Mod = app_helper:get_env(riak_kv, storage_backend),
     Configuration = app_helper:get_env(riak_kv),
     {ok, ModState} = Mod:start(Index, Configuration),
-    {ok, VE} = get_vnode_epoch(Index),
-    {ok, #state{idx=Index, mod=Mod, modstate=ModState, vnode_epoch=VE, mrjobs=dict:new()}}.
+    {ok, VId} = get_vnodeid(Index),
+    {ok, #state{idx=Index, mod=Mod, modstate=ModState, vnodeid=VId, mrjobs=dict:new()}}.
 
 handle_command(?KV_PUT_REQ{bkey=BKey,
                            object=Object,
@@ -288,9 +288,10 @@ is_empty(State=#state{mod=Mod, modstate=ModState}) ->
     {Mod:is_empty(ModState), State}.
 
 delete(State=#state{idx=Index, mod=Mod, modstate=ModState}) ->
+    %% clear vnodeid first, if drop removes data but fails
+    %% want to err on the side of creating a new vnodeid
+    {ok, cleared} = clear_vnodeid(Index),
     ok = Mod:drop(ModState),
-    VnodeStatus = vnode_status_filename(Index),
-    ok = delete_vnode_status(VnodeStatus), %% Should make delete/terminate atomic IMO
     {ok, State}.
 
 terminate(_Reason, #state{mod=Mod, modstate=ModState}) ->
@@ -314,17 +315,15 @@ handle_exit(_Pid, _Reason, State) ->
 %% the updated object
 do_coord_put(Sender, BKey, UpdObj, ReqId, StartTime, _Options,
              #state{idx = Idx, mod = Mod, modstate = ModState,
-                    vnode_epoch = VE}) ->
-    CoordNode = {vc, node(), VE},
-    UpdObj1 = riak_object:increment_vclock(UpdObj, CoordNode, StartTime),
+                    vnodeid = VId}) ->
+    UpdObj1 = riak_object:increment_vclock(UpdObj, VId, StartTime),
     PutObj = case Mod:get(ModState, BKey) of
                  {error, notfound} ->
                      UpdObj1;
                  {ok, CurObj} ->
                      coord_put_merge(binary_to_term(CurObj), UpdObj1, 
-                                     CoordNode, StartTime)
+                                     VId, StartTime)
              end,
-    %ReturnBody = proplists:get_value(returnbody, Options, false),
     Result = case Mod:put(ModState, BKey, term_to_binary(PutObj)) of
                  ok ->
                      {dw, Idx, PutObj, ReqId};
@@ -334,33 +333,21 @@ do_coord_put(Sender, BKey, UpdObj, ReqId, StartTime, _Options,
     riak_core_vnode:reply(Sender, Result),
     riak_kv_stat:update(vnode_put).
 
-coord_put_merge(CurObj, UpdObj, CoordId, Timestamp) ->
-    %% Make sure UpdObj descends from CurObj and that CoordId is greater
+coord_put_merge(CurObj, UpdObj, VId, Timestamp) ->
+    %% Make sure UpdObj descends from CurObj and that VId is greater
     CurVC = riak_object:vclock(CurObj),
     UpdVC = riak_object:vclock(UpdObj),
 
     %% Valid coord put replacing current object
-    case get_counter(CoordId, UpdVC) > get_counter(CoordId, CurVC) andalso
+    case vclock:get_counter(VId, UpdVC) > vclock:get_counter(VId, CurVC) andalso
         vclock:descends(CurVC, UpdVC) == false andalso 
         vclock:descends(UpdVC, CurVC) == true of
         true ->
             UpdObj;
         false ->
             riak_object:increment_vclock(riak_object:merge(CurObj, UpdObj),
-                                         CoordId, Timestamp)
+                                         VId, Timestamp)
     end.
-
-get_counter(Id, VC) ->            
-    case lists:keyfind(Id, 1, VC) of
-        false ->
-            0;
-        {_Id, {Counter, _TS}} ->
-            Counter
-    end.
-
-
-%store_call(State=#state{mod=Mod, modstate=ModState}, Msg) ->
-%    Mod:call(ModState, Msg).
 
 %% @private
 % upon receipt of a client-initiated put
@@ -610,18 +597,66 @@ do_diffobj_put(BKey={Bucket,_}, DiffObj,
     end.
 
 %% @private
-get_vnode_epoch(Index) ->
+
+%% Get the vnodeid, assigning and storing if necessary
+get_vnodeid(Index) ->
+    F = fun(Status) ->
+                case proplists:get_value(vnodeid, Status, undefined) of
+                    undefined ->
+                        assign_vnodeid(os:timestamp(), 
+                                       riak_core_nodeid:get(),
+                                       Status);
+                    VnodeId ->
+                        {VnodeId, Status}
+                end
+        end,
+    update_vnode_status(F, Index). % Returns {ok, VnodeId} | {error, Reason}
+
+%% Assign a unique vnodeid, making sure the timestamp is unique by incrementing
+%% into the future if necessary.
+assign_vnodeid(Now, NodeId, Status) ->
+    {Mega, Sec, _Micro} = Now,
+    NowEpoch = 1000000*Mega + Sec,
+    LastVnodeEpoch = proplists:get_value(last_epoch, Status, 0),
+    VnodeEpoch = erlang:max(NowEpoch, LastVnodeEpoch+1),
+    VnodeId = <<NodeId/binary, VnodeEpoch:32/integer>>,
+    UpdStatus = [{vnodeid, VnodeId}, {last_epoch, VnodeEpoch} | 
+                 proplists:delete(vnodeid, 
+                   proplists:delete(last_epoch, Status))],
+    {VnodeId, UpdStatus}.
+                
+%% Clear the vnodeid - returns {ok, cleared}
+clear_vnodeid(Index) ->
+    F = fun(Status) ->
+                {cleared, proplists:delete(vnodeid, Status)}
+        end,
+    update_vnode_status(F, Index). % Returns {ok, VnodeId} | {error, Reason}
+
+update_vnode_status(F, Index) ->
     VnodeFile = vnode_status_filename(Index),
     ok = filelib:ensure_dir(VnodeFile),
     case read_vnode_status(VnodeFile) of
         {ok, Status} ->
-            {ok, proplists:get_value(epoch, Status)};
+            update_vnode_status2(F, Status, VnodeFile);
         {error, enoent} ->
-            create_vnode_status(VnodeFile);
+            update_vnode_status2(F, [], VnodeFile);
         ER ->
             ER
     end.
 
+update_vnode_status2(F, Status, VnodeFile) ->
+    case F(Status) of
+        {Ret, Status} -> % No change
+            {ok, Ret};
+        {Ret, UpdStatus} ->
+            case write_vnode_status(UpdStatus, VnodeFile) of
+                ok ->
+                    {ok, Ret};
+                ER ->
+                    ER
+            end
+    end.
+ 
 vnode_status_filename(Index) ->
     VnodeStatusDir = app_helper:get_env(riak_kv, vnode_status, "data/kv_vnode"),
     filename:join(VnodeStatusDir, integer_to_list(Index)).
@@ -629,28 +664,115 @@ vnode_status_filename(Index) ->
 read_vnode_status(File) ->
     case file:consult(File) of
         {ok, [Status]} when is_list(Status) ->
-            {ok, Status};
+            {ok, proplists:delete(version, Status)};
         ER ->
             ER
     end.
 
-create_vnode_status(File) -> 
-    {Mega, Sec, _Micro} = now(),
-    VE = 1000000*Mega + Sec,
-    Status = [{version, 1}, {epoch, VE}],
-    case file:write_file(File, io_lib:format("~p.", [Status])) of
+write_vnode_status(Status, File) ->
+    VersionedStatus = [{version, 1} | proplists:delete(version, Status)],
+    TmpFile = File ++ "~",
+    case file:write_file(TmpFile, io_lib:format("~p.", [VersionedStatus])) of
         ok ->
-            {ok, VE};
+            file:rename(TmpFile, File);
         ER ->
             ER
     end.
-
-delete_vnode_status(File) ->
-    file:delete(File).
-
-
 
 -ifdef(TEST).
+
+%% Check assigning a vnodeid twice in the same second
+assign_vnodeid_restart_same_ts_test() ->
+    Now1 = {1314,224520,343446}, %% TS=1314224520
+    Now2 = {1314,224520,345865}, %% as unsigned net-order int <<78,85,121,136>>
+    NodeId = <<1, 2, 3, 4>>,
+    {Vid1, Status1} = assign_vnodeid(Now1, NodeId, []),
+    ?assertEqual(<<1, 2, 3, 4, 78, 85, 121, 136>>, Vid1),
+    %% Simulate clear
+    Status2 = proplists:delete(vnodeid, Status1),
+    %% Reassign
+    {Vid2, _Status3} = assign_vnodeid(Now2, NodeId, Status2),
+    ?assertEqual(<<1, 2, 3, 4, 78, 85, 121, 137>>, Vid2).
+
+%% Check assigning a vnodeid with a later date
+assign_vnodeid_restart_later_ts_test() ->
+    Now1 = {1000,000000,0}, %% <<59,154,202,0>>
+    Now2 = {2000,000000,0}, %% <<119,53,148,0>>
+    NodeId = <<1, 2, 3, 4>>,
+    {Vid1, Status1} = assign_vnodeid(Now1, NodeId, []),
+    ?assertEqual(<<1, 2, 3, 4, 59,154,202,0>>, Vid1),
+    %% Simulate clear
+    Status2 = proplists:delete(vnodeid, Status1),
+    %% Reassign
+    {Vid2, _Status3} = assign_vnodeid(Now2, NodeId, Status2),
+    ?assertEqual(<<1, 2, 3, 4, 119,53,148,0>>, Vid2).
+
+%% Check assigning a vnodeid with a later date - just in case of clock skew
+assign_vnodeid_restart_earlier_ts_test() ->
+    Now1 = {2000,000000,0}, %% <<119,53,148,0>>
+    Now2 = {1000,000000,0}, %% <<59,154,202,0>>
+    NodeId = <<1, 2, 3, 4>>,
+    {Vid1, Status1} = assign_vnodeid(Now1, NodeId, []),
+    ?assertEqual(<<1, 2, 3, 4, 119,53,148,0>>, Vid1),
+    %% Simulate clear
+    Status2 = proplists:delete(vnodeid, Status1),
+    %% Reassign
+    %% Should be greater than last offered - which is the 2mil timestamp
+    {Vid2, _Status3} = assign_vnodeid(Now2, NodeId, Status2),
+    ?assertEqual(<<1, 2, 3, 4, 119,53,148,1>>, Vid2).
+        
+%% Test 
+vnode_status_test_() ->
+    {setup,
+     fun() ->
+             os:cmd("chmod u+rwx kv_vnode_status_test"),
+             os:cmd("rm -rf kv_vnode_status_test"),
+             application:set_env(riak_kv, vnode_status, "kv_vnode_status_test"),
+             ok
+     end,
+     fun(_) ->
+             application:unset_env(riak_kv, vnode_status),
+             ?cmd("chmod u+rwx kv_vnode_status_test"),
+             ?cmd("rm -rf kv_vnode_status_test"),
+             ok
+     end,
+     [?_test(begin % initial create failure
+                 ?cmd("rm -rf kv_vnode_status_test || true"),
+                 ?cmd("mkdir kv_vnode_status_test"),
+                 ?cmd("chmod -w kv_vnode_status_test"),
+                 F = fun([]) ->
+                             {shouldfail, [badperm]}
+                     end,
+                 Index = 0,
+                 ?assertEqual({error, eacces},  update_vnode_status(F, Index))
+             end),
+      ?_test(begin % create successfully
+                 ?cmd("chmod +w kv_vnode_status_test"),
+
+                 F = fun([]) ->
+                             {created, [created]}
+                     end,
+                 Index = 0,
+                 ?assertEqual({ok, created}, update_vnode_status(F, Index))
+             end),
+      ?_test(begin % update successfully
+                 F = fun([created]) ->
+                             {updated, [updated]}
+                     end,
+                 Index = 0,
+                 ?assertEqual({ok, updated}, update_vnode_status(F, Index))
+             end),
+      ?_test(begin % update failure
+                 ?cmd("chmod 000 kv_vnode_status_test/0"),
+                 ?cmd("chmod 500 kv_vnode_status_test"),
+                 F = fun([updated]) ->
+                             {shouldfail, [updatedagain]}
+                     end,
+                 Index = 0,
+                 ?assertEqual({error, eacces},  update_vnode_status(F, Index))
+            end)
+
+     ]}.
 
 dummy_backend(BackendMod) ->
     Ring = riak_core_ring:fresh(16,node()),

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -497,8 +497,8 @@ merge2_test() ->
     O1 = riak_object:increment_vclock(object_test(), node1),
     O2 = riak_object:increment_vclock(riak_object:new(B,K,V), node2),
     O3 = riak_object:syntactic_merge(O1, O2, other_node),
-    [other_node, node1, node2] = [N || {N,_} <- riak_object:vclock(O3)],
-    2 = riak_object:value_count(O3).
+    ?assertEqual([node1, node2], [N || {N,_} <- riak_object:vclock(O3)]),
+    ?assertEqual(2, riak_object:value_count(O3)).
 
 merge3_test() ->
     O0 = riak_object:new(<<"test">>, <<"test">>, hi),

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -46,7 +46,7 @@
           key :: key(),
           contents :: [#r_content{}],
           vclock = vclock:fresh() :: vclock:vclock(),
-          updatemetadata=dict:store(clean, true, dict:new()) :: dict(),
+          updatemetadata=orddict:store(clean, true, orddict:new()) :: dict(),
           updatevalue :: term()
          }).
 -opaque riak_object() :: #r_object{}.
@@ -71,7 +71,7 @@ new(B, K, V) when is_binary(B), is_binary(K) ->
 -spec new(Bucket::bucket(), Key::key(), Value::value(), 
           string() | dict() | no_initial_metadata) -> riak_object().
 new(B, K, V, C) when is_binary(B), is_binary(K), is_list(C) ->
-    new(B, K, V, dict:from_list([{?MD_CTYPE, C}]));
+    new(B, K, V, orddict:from_list([{?MD_CTYPE, C}]));
 
 %% @doc Constructor for new riak objects with an initial metadata dict.
 %%
@@ -84,7 +84,7 @@ new(B, K, V, MD) when is_binary(B), is_binary(K) ->
         false ->
             case MD of
                 no_initial_metadata ->
-                    Contents = [#r_content{metadata=dict:new(), value=V}],
+                    Contents = [#r_content{metadata=orddict:new(), value=V}],
                     #r_object{bucket=B,key=K,
                               contents=Contents,vclock=vclock:fresh()};
                 _ ->
@@ -115,8 +115,8 @@ equal1(Obj1,Obj2) ->
         true -> equal2(Obj1,Obj2)
     end.
 equal2(Obj1,Obj2) ->
-    UM1 = lists:sort(dict:to_list(Obj1#r_object.updatemetadata)),
-    UM2 = lists:sort(dict:to_list(Obj2#r_object.updatemetadata)),
+    UM1 = lists:sort(orddict:to_list(Obj1#r_object.updatemetadata)),
+    UM2 = lists:sort(orddict:to_list(Obj2#r_object.updatemetadata)),
     case UM1 =:= UM2 of
         false -> false;
         true ->
@@ -132,8 +132,8 @@ equal_contents([],[]) -> true;
 equal_contents(_,[]) -> false;
 equal_contents([],_) -> false;
 equal_contents([C1|R1],[C2|R2]) ->
-    MD1 = lists:sort(dict:to_list(C1#r_content.metadata)),
-    MD2 = lists:sort(dict:to_list(C2#r_content.metadata)),
+    MD1 = lists:sort(orddict:to_list(C1#r_content.metadata)),
+    MD2 = lists:sort(orddict:to_list(C2#r_content.metadata)),
     case MD1 =:= MD2 of
         false -> false;
         true ->
@@ -162,7 +162,7 @@ reconcile(Objects, AllowMultiple) ->
     VClock = vclock:merge([O#r_object.vclock || O <- RObjs]),
     HdObj = hd(RObjs),
     HdObj#r_object{contents=Contents,vclock=VClock,
-                   updatemetadata=dict:store(clean, true, dict:new()),
+                   updatemetadata=orddict:store(clean, true, orddict:new()),
                    updatevalue=undefined}.
 
 %% @spec ancestors([riak_object()]) -> [riak_object()]
@@ -198,8 +198,8 @@ rem_dup_objs([O|Rest],Acc) ->
 compare_content_dates(C1,C2) ->
     % true if C1 was modifed later than C2
     riak_core_util:compare_dates(
-      dict:fetch(<<"X-Riak-Last-Modified">>, C1#r_content.metadata),
-      dict:fetch(<<"X-Riak-Last-Modified">>, C2#r_content.metadata)).
+      orddict:fetch(<<"X-Riak-Last-Modified">>, C1#r_content.metadata),
+      orddict:fetch(<<"X-Riak-Last-Modified">>, C2#r_content.metadata)).
 
 %% @spec merge(riak_object(), riak_object()) -> riak_object()
 %% @doc  Merge the contents and vclocks of OldObject and NewObject.
@@ -210,7 +210,7 @@ merge(OldObject, NewObject) ->
                                              lists:usort(OldObject#r_object.contents)),
                        vclock=vclock:merge([OldObject#r_object.vclock,
                           NewObj1#r_object.vclock]),
-                       updatemetadata=dict:store(clean, true, dict:new()),
+                       updatemetadata=orddict:store(clean, true, orddict:new()),
                        updatevalue=undefined}.
 
 %% @spec apply_updates(riak_object()) -> riak_object()
@@ -223,7 +223,7 @@ apply_updates(Object=#r_object{}) ->
              _ ->
                  [Object#r_object.updatevalue]
          end,
-    MD = case dict:find(clean, Object#r_object.updatemetadata) of
+    MD = case orddict:find(clean, Object#r_object.updatemetadata) of
              {ok,_} ->
                  MDs = [C#r_content.metadata || C <- Object#r_object.contents],
                  case Object#r_object.updatevalue of
@@ -231,11 +231,11 @@ apply_updates(Object=#r_object{}) ->
                      _ -> [hd(MDs)]
                  end;
              error ->
-                 [dict:erase(clean,Object#r_object.updatemetadata) || _X <- VL]
+                 [orddict:erase(clean,Object#r_object.updatemetadata) || _X <- VL]
          end,
     Contents = [#r_content{metadata=M,value=V} || {M,V} <- lists:zip(MD, VL)],
     Object#r_object{contents=Contents,
-                 updatemetadata=dict:store(clean, true, dict:new()),
+                 updatemetadata=orddict:store(clean, true, orddict:new()),
                  updatevalue=undefined}.
 
 %% @spec bucket(riak_object()) -> bucket()
@@ -291,7 +291,7 @@ get_value(Object=#r_object{}) ->
 %% @spec update_metadata(riak_object(), dict()) -> riak_object()
 %% @doc  Set the updated metadata of an object to M.
 update_metadata(Object=#r_object{}, M) ->
-    Object#r_object{updatemetadata=dict:erase(clean, M)}.
+    Object#r_object{updatemetadata=orddict:erase(clean, M)}.
 
 %% @spec update_value(riak_object(), value()) -> riak_object()
 %% @doc  Set the updated value of an object to V
@@ -367,7 +367,7 @@ jsonify_metadata(MD) ->
               ({Name, Value}) ->
                    {Name, Value}
            end,
-    {struct, lists:map(MDJS, dict:to_list(MD))}.
+    {struct, lists:map(MDJS, orddict:to_list(MD))}.
 
 %% @doc convert strings to binaries, and proplists to JSON objects
 jsonify_metadata_list([]) -> [];
@@ -412,11 +412,11 @@ dejsonify_values([{<<"metadata">>, {struct, MD0}},
                                       end}
                         end
                 end,
-    MD = dict:from_list([Converter(KV) || KV <- MD0]),
+    MD = orddict:from_list([Converter(KV) || KV <- MD0]),
     dejsonify_values(T, [{MD, D}|Accum]).
 
 is_updated(_Object=#r_object{updatemetadata=M,updatevalue=V}) ->
-    case dict:find(clean, M) of
+    case orddict:find(clean, M) of
         error -> true;
         {ok,_} ->
             case V of
@@ -445,8 +445,8 @@ syntactic_merge(CurrentObject, NewObject, FromClientId, Timestamp) ->
                 true ->
                     NewObject;
                 false ->
-                    increment_vclock(
-                      merge(CurrentObject, NewObject), FromClientId, Timestamp)
+                    %%increment_vclock(
+                    merge(CurrentObject, NewObject) %, FromClientId, Timestamp)
             end
     end.
 
@@ -528,8 +528,8 @@ merge5_test() ->
                  riak_object:syntactic_merge(O2, O1, syn_put_mrg, TS)).
 
 equality1_test() ->
-    MD0 = dict:new(),
-    MD = dict:store("X-Riak-Test", "value", MD0),
+    MD0 = orddict:new(),
+    MD = orddict:store("X-Riak-Test", "value", MD0),
     O1 = riak_object:new(<<"test">>, <<"a">>, "value"),
     O2 = riak_object:new(<<"test">>, <<"a">>, "value"),
     O3 = riak_object:increment_vclock(O1, self()),
@@ -555,7 +555,7 @@ inequality_metadata_test() ->
     O2 = riak_object:new(<<"test">>, <<"a">>, "value"),
     O1p = riak_object:apply_updates(
             riak_object:update_metadata(
-              O1, dict:store(<<"X-Riak-Test">>, "value",
+              O1, orddict:store(<<"X-Riak-Test">>, "value",
                              riak_object:get_metadata(O1)))),
     false = riak_object:equal(O1p, O2).
 
@@ -574,9 +574,9 @@ inequality_bucket_test() ->
     false = riak_object:equal(O1, O2).
 
 inequality_updatecontents_test() ->
-    MD1 = dict:new(),
-    MD2 = dict:store("X-Riak-Test", "value", MD1),
-    MD3 = dict:store("X-Riak-Test", "value1", MD1),
+    MD1 = orddict:new(),
+    MD2 = orddict:store("X-Riak-Test", "value", MD1),
+    MD3 = orddict:store("X-Riak-Test", "value1", MD1),
     O1 = riak_object:new(<<"test">>, <<"a">>, "value"),
     O2 = riak_object:new(<<"test">>, <<"a">>, "value"),
     O3 = riak_object:update_metadata(O1, MD2),
@@ -600,7 +600,7 @@ date_reconcile_test() ->
     O2 = apply_updates(
            riak_object:update_metadata(
              increment_vclock(O, date),
-             dict:store(
+             orddict:store(
                <<"X-Riak-Last-Modified">>,
                httpd_util:rfc1123_date(
                  calendar:gregorian_seconds_to_datetime(D)),
@@ -608,7 +608,7 @@ date_reconcile_test() ->
     O4 = apply_updates(
            riak_object:update_metadata(
              O3,
-             dict:store(
+             orddict:store(
                <<"X-Riak-Last-Modified">>,
                httpd_util:rfc1123_date(
                  calendar:gregorian_seconds_to_datetime(D+1)),
@@ -627,7 +627,7 @@ get_update_value_test() ->
 get_update_metadata_test() ->
     O = riak_object:new(<<"test">>, <<"test">>, val),
     OldMD = riak_object:get_metadata(O),
-    NewMD = dict:store(<<"X-Riak-Test">>, "testval", OldMD),
+    NewMD = orddict:store(<<"X-Riak-Test">>, "testval", OldMD),
     ?assertNot(NewMD =:= OldMD),
     ?assertEqual(NewMD,
                  riak_object:get_update_metadata(
@@ -637,7 +637,7 @@ is_updated_test() ->
     O = riak_object:new(<<"test">>, <<"test">>, test),
     ?assertNot(is_updated(O)),
     OMu = riak_object:update_metadata(
-            O, dict:store(<<"X-Test-Update">>, "testupdate",
+            O, orddict:store(<<"X-Test-Update">>, "testupdate",
                           riak_object:get_metadata(O))),
     ?assert(is_updated(OMu)),
     OVu = riak_object:update_value(O, testupdate),
@@ -653,10 +653,10 @@ remove_duplicates_test() ->
 
 new_with_ctype_test() ->
     O = riak_object:new(<<"b">>, <<"k">>, <<"{\"a\":1}">>, "application/json"),
-    ?assertEqual("application/json", dict:fetch(?MD_CTYPE, riak_object:get_metadata(O))).
+    ?assertEqual("application/json", orddict:fetch(?MD_CTYPE, riak_object:get_metadata(O))).
 
 new_with_md_test() ->
-    O = riak_object:new(<<"b">>, <<"k">>, <<"abc">>, dict:from_list([{?MD_CHARSET,"utf8"}])),
-    ?assertEqual("utf8", dict:fetch(?MD_CHARSET, riak_object:get_metadata(O))).
+    O = riak_object:new(<<"b">>, <<"k">>, <<"abc">>, orddict:from_list([{?MD_CHARSET,"utf8"}])),
+    ?assertEqual("utf8", orddict:fetch(?MD_CHARSET, riak_object:get_metadata(O))).
 
 -endif.

--- a/test/ec_eqc.erl
+++ b/test/ec_eqc.erl
@@ -1,0 +1,258 @@
+-module(ec_eqc).
+-include_lib("eqc/include/eqc.hrl").
+-compile([export_all]).
+
+%% FSM scheduler EQC test.
+
+test() ->
+    test(100).
+
+test(N) ->
+    quickcheck(numtests(N, prop())).
+
+check() ->
+    check(prop(), current_counterexample()).
+
+%% Client requests must be processed in sequence.
+%% Client also gets to have it's own state.
+
+-record(client, { %% pri/id must be first two fields for next to work correctly
+          pri,    %% Priority for next request (undefined if req active)
+          cid,    %% Client id
+          rid,    %% request id
+          reqs,   %% Requests to execute - {Pri,Req}
+          clntst %% Client state
+         }). 
+                 
+
+-record(proc, {
+          name,   %% term to reference this process in from / to for messages
+          procst  %% Process state
+          }).
+        
+-record(msg, {
+          pri = 0, %% Priority
+          from,    %% Sender
+          to,      %% Receipient
+          c}).     %% Contents
+
+-record(params, {q}).
+
+-record(state, {verbose = false,
+                step = 1, 
+                params,
+                next_rid = 1,
+                clients = [],     %% [#client]
+                procs = [],       %% {Name, State}
+                pending_msgs = [],
+                history = []}).
+
+nni() ->
+    ?LET(Xs, int(), abs(Xs)).
+
+gen_req() ->
+    {ping, {node, nni()}}.
+
+gen_client_seeds() ->
+    non_empty(list(#client{reqs = non_empty(list({nni(), gen_req()}))})).
+
+prop() ->
+    ?FORALL({ClientSeeds,QSeed},{gen_client_seeds(),choose(0, 10)},
+            begin
+                Q = 1 + abs(QSeed),
+                Params = #params{q = Q},
+                NodeProcs = make_nodes(Q),
+                Initial = #state{params = Params, 
+                                 procs = NodeProcs},
+                Clients = make_clients(ClientSeeds, Params),
+                Start = Initial#state{clients = Clients},
+                case exec(Start) of
+                    {ok, Final} ->
+                        true;
+                    {What, Reason, Next, FailS} ->
+                        io:format(user, "FAILED: ~p: ~p\nNext: ~p\nInitial:\n~p\n"
+                                  "FailS:\n~p\n",
+                                  [What, Reason, Initial, Next, FailS]),
+                        false
+                end
+            end).
+
+exec(S) ->
+    Next = next(S),
+    try
+        status(S, Next),
+        case Next of
+            done ->
+                {ok, S};
+            deliver_msg ->
+                exec(inc_step(deliver_msg(S)));
+            {client, Cid}->
+                exec(inc_step(client_req(Cid, S)))
+        end
+    catch
+        What:Reason ->
+            {What, Reason, Next, S}
+    end.
+
+status(#state{verbose = true} = S, Next) ->
+    io:format(user, "--- Step ~p - ~p ---\n~p\n",
+              [S#state.step, Next, S]);
+status(_S, _Next) ->
+    ok.
+
+inc_step(#state{step = Step} = S) ->
+    S#state{step = Step + 1}.
+
+next(#state{clients = Clients, pending_msgs = PendingMsgs}) ->
+    %% Work out which client ids are active
+    {ClientPri, Cid} = case lists:sort([C || C <- Clients, C#client.pri /= undefined]) of
+                           [] ->
+                               %% No clients ready
+                               {undefined, undefined};
+                           RCs -> % ready clients
+                               C = hd(RCs),
+                               {C#client.pri, C#client.cid}
+                       end,
+    MsgPri = case PendingMsgs of
+                 [] ->
+                     undefined;
+                 [Msg|_] ->
+                     Msg#msg.pri
+             end,
+    if
+        MsgPri == undefined andalso ClientPri == undefined ->
+            case Clients of
+                [] ->
+                    done;
+                _ -> % oh no, there was client work to do, but we've run out of msgs
+                    stalled
+            end;
+        ClientPri == undefined orelse MsgPri =< ClientPri ->
+            deliver_msg;
+        
+        true ->
+            {client, Cid}
+    end.
+
+%% Deliver next client request for Cid
+client_req(Cid, #state{next_rid = ReqId, clients = Clients, pending_msgs = PendingMsgs} = S) ->
+    C = get_client(Cid, Clients),
+    true = (C#client.pri /= undefined), % paranoia - make sure this was scheduled right
+    {NewMsgs, UpdC} = start_req({req, ReqId}, C),
+    S#state{next_rid = ReqId + 1,
+            clients = update_client(UpdC#client{rid= ReqId, pri = undefined}, Clients),
+            pending_msgs = PendingMsgs ++ NewMsgs}.
+
+%% Deliver next pending msg
+deliver_msg(#state{pending_msgs = [#msg{to = {req, ReqId}} = Msg | Msgs],
+                   clients = Clients,
+                   history = H} = S) ->
+    [C] = [C || #client{rid = ReqId0}=C <- Clients, ReqId0 == ReqId],
+    Result = end_req(Msg, C),
+    UpdC = next_req(C),
+    NewH = proplists:get_value(history, Result, []),
+    UpdClients = case UpdC of
+                     #client{reqs = [], cid = Cid} ->
+                         delete_client(Cid, Clients);
+                     _ ->
+                         update_client(UpdC, Clients)
+                 end,
+    S#state{clients = UpdClients,
+            pending_msgs = Msgs,
+            history = H ++ NewH};
+
+deliver_msg(#state{pending_msgs = [#msg{to = To} = Msg | Msgs],
+                   procs = Procs} = S) ->
+    Proc = get_proc(To, Procs),
+    %% Deliver message - as a result, the process could do any/all of
+    %% create new processes
+    %% stop itself
+    %% send a message to another process 
+    %% complete a request
+    %%            
+    Result = deliver(Msg, Proc),
+    NewMsgs = proplists:get_value(msgs, Result, []),
+    S#state{pending_msgs = Msgs ++ NewMsgs}.
+
+make_nodes(Q) ->
+    [#proc{name={node, I}, procst=nostate} || I <- lists:seq(1, Q)].
+
+make_clients(ClientSeeds, Params) ->
+    make_clients(ClientSeeds, 1, Params, []).
+
+make_clients([], _Cid, _Params, Acc) ->
+    lists:reverse(Acc);
+make_clients([#client{reqs = ReqSeeds} = CS | CSs], Cid, Params, Acc) ->
+    Reqs = make_reqs(ReqSeeds, Params),
+    [{Pri, _}|_] = Reqs,
+    C = CS#client{cid = Cid, pri = Pri, reqs = Reqs},
+    make_clients(CSs, Cid + 1, Params, [C | Acc]).
+    
+make_reqs(ReqSeeds, Params) ->
+    make_reqs(ReqSeeds, Params, []).
+
+make_reqs([], _Params, Acc) ->
+    lists:reverse(Acc);
+make_reqs([ReqSeed | ReqSeeds], Params, Acc) ->
+    Req = make_req(ReqSeed, Params),
+    make_reqs(ReqSeeds, Params, [Req | Acc]).
+
+make_req({Pri, {ping, {node, NodeSeed}}}, #params{q = Q}) ->
+    {Pri, {ping, {node, make_range(NodeSeed, 1, Q)}}}.
+
+%% Move the client on to the next request, setting priority if present
+next_req(#client{reqs = [_|Reqs]} = C) ->
+    case Reqs of
+        [] ->
+            C#client{reqs = []};
+        [{Pri,_} | _] ->
+            C#client{pri = Pri, reqs = Reqs}
+    end.
+    
+
+%% Deliver a message to a process
+deliver(#msg{from = From, c = ping}, #proc{name = {node, _}=Name}) ->
+    [{msgs, [#msg{from = Name, to = From, c = pong}]}].
+               
+    
+%% Start the next client request
+start_req(Name, #client{reqs = [{_Pri, {ping, NodeName}} | _Reqs]} = C) ->
+    NewMsgs = [#msg{from = Name, to = NodeName, c = ping}],
+    {NewMsgs, C#client{clntst = {pinged, NodeName}}}.
+
+end_req(#msg{from = Name, c = pong},
+        #client{cid = Cid, reqs = [{_Pri, {ping, Name}}|_Reqs]}) ->
+    [{history, [{Cid, ponged, Name}]},
+     done].
+
+%% Get client by cid from list of clients - blow up if missing
+get_client(Cid, Clients) ->
+    case lists:keysearch(Cid, #client.cid, Clients) of
+        {value, C} ->
+            C;
+        false ->
+            throw({bad_cid, Cid, [Cid0 || #client{cid = Cid0} <- Clients]})
+    end.
+
+delete_client(Cid, Clients) ->
+    lists:keydelete(Cid, #client.cid, Clients).
+
+update_client(C, Clients) ->
+    lists:keyreplace(C#client.cid, #client.cid, Clients, C).
+
+%% Get proc by name - blow up if missing
+get_proc(Name, Procs) ->
+    case lists:keysearch(Name, #proc.name, Procs) of
+        {value, Proc} ->
+            Proc;
+        false ->
+            throw({bad_proc, Name, [N || #proc{name = N} <- Procs]})
+    end.
+
+
+%% Make a value between min and max inclusive using the seed
+make_range(Seed, Min, Max) when Min =< Seed, Seed =< Max ->
+    Seed;
+make_range(Seed, Min, Max) ->
+    Range = Max - Min + 1,
+    Min + (abs(Seed) rem Range).

--- a/test/ec_eqc.erl
+++ b/test/ec_eqc.erl
@@ -224,8 +224,11 @@ make_vnodes(#params{n = N}) ->
 make_clients(ClientSeeds, Params) ->
     make_clients(ClientSeeds, 1, Params, []).
 
-make_clients([], _Cid, _Params, Acc) ->
-    lists:reverse(Acc);
+make_clients([], _Cid, #params{n = N}, Acc) ->
+    %% Make sure the last request is a get.
+    Req = new_req({get, [{kv_vnode, I, I} || I <- lists:seq(1, N)]}),
+    LastC = #client{cid = 1000001, reqs = [Req#req{pri = 1000002}]},
+    lists:reverse([LastC | Acc]);
 make_clients([#client{reqs = ReqSeeds} = CS | CSs], Cid, Params, Acc) ->
     Reqs = make_reqs(ReqSeeds, Params),
     C = CS#client{cid = Cid, reqs = Reqs},

--- a/test/ec_eqc.erl
+++ b/test/ec_eqc.erl
@@ -21,7 +21,7 @@ check() ->
 -define(B, <<"b">>).
 -define(K, <<"k">>).
 
--define(FINALDBG(Fmt,Args), io:format("XXX" ++ Fmt, Args)).
+-define(FINALDBG(Fmt,Args), io:format("= " ++ Fmt, Args)).
 %-define(FINALDBG(_Fmt,_Args), ok).
 
 %% Client requests must be processed in sequence.
@@ -71,8 +71,8 @@ nni() ->
 gen_pris() ->
     non_empty(resize(40, list(nni()))).
 
-gen_pl_seed() -> %% Seed for preference lists
-    non_empty(list(int())).
+gen_pl_seed() -> %% Seed for preference lists -- used as downed nodes
+    list(int()).
     
 gen_params() ->
     #params{n = choose(0, 10),
@@ -80,8 +80,9 @@ gen_params() ->
             w = choose(1, 5)}.
             
 gen_req() ->
-    elements([{get, gen_pl_seed()},
-              {update, gen_pl_seed(), gen_pl_seed()}]).
+    ?SHRINK(elements([{get, gen_pl_seed()},
+                      {update, gen_pl_seed(), gen_pl_seed()}]),
+            [{update, gen_pl_seed(), gen_pl_seed()}]).
 
 gen_client_seeds() ->
     non_empty(list(#client{reqs = non_empty(list(gen_req()))})).
@@ -131,15 +132,15 @@ check_final(#state{history = H}) ->
 %% Todo, stop overloading Result
 
 check_final([{result, _, #req{op = {get, PL}}, Result}], Must, _May, _ClientView) ->
-    Values = case Result of
-                 {error, notfound} ->
-                     [];
-                 {ok, Obj} ->
-                     riak_object:get_values(Obj)
-             end,
+    {Values, VClock} = case Result of
+                           {ok, Obj} ->
+                               {riak_object:get_values(Obj), riak_object:vclock(Obj)};
+                           {error, _} ->
+                               {[], []}
+                       end,
     Fallbacks = [{I,J} || {kv_vnode, I, J} <- PL, I /= J],
-    ?FINALDBG("Final GOT VALUES: ~p Must: ~p May: ~p Fallbacks: ~p\n",
-              [Values, Must, _May, Fallbacks]),
+    ?FINALDBG("Final GOT VALUES: ~p VC: ~w Must: ~p May: ~p Fallbacks: ~w\n",
+              [Values, VClock, Must, _May, Fallbacks]),
     ?WHENFAIL(io:format(user, "Must: ~p\nMay: ~p\nValues: ~p\n", [Must, _May, Values]),
               equals(Must -- Values, []));
               %% conjunction([{must_leftover, equals(Must -- Values, [])},
@@ -148,38 +149,43 @@ check_final([{result, _, #req{op = {get, PL}}, Result}], Must, _May, _ClientView
 check_final([{result, Cid, #req{op = {get, PL}}, Result} | Results],
             Must, May, ClientViews) ->
     %% TODO: Check if _Result matches expected values
-    ValuesAtGet = case Result of
-                      {ok, Obj} ->
-                          riak_object:get_values(Obj);
-                      {error, _} ->
-                          []
+    {ValuesAtGet, VClockAtGet} = case Result of
+                                     {ok, Obj} ->
+                                         {riak_object:get_values(Obj), riak_object:vclock(Obj)};
+                                     {error, _} ->
+                                         {[], []}
                   end,
     Fallbacks = [{I,J} || {kv_vnode, I, J} <- PL, I /= J],
-    ?FINALDBG("Cid ~p GOT VALUES: ~p FALLBACKS: ~p\n",
-              [Cid, ValuesAtGet, Fallbacks]),
+    ?FINALDBG("Cid ~p GOT VALUES: ~p VC: ~w FALLBACKS: ~w\n",
+              [Cid, ValuesAtGet, VClockAtGet, Fallbacks]),
     UpdClientViews = lists:keystore(Cid, 1, ClientViews, {Cid, ValuesAtGet}),
     check_final(Results, Must, May, UpdClientViews);
-check_final([{result, Cid, #req{rid = _ReqId, op = {put, PL, V}}, Result} | Results],
+check_final([{result, Cid, #req{rid = _ReqId, op = {put, PL, V}}, {Result, PutObj}} | Results],
             Must, May, ClientViews) ->
     {Cid, ValuesAtGet} = lists:keyfind(Cid, 1, ClientViews),
     ValNotInMay = not lists:member(V, May),
     Fallbacks = [{I,J} || {kv_vnode, I, J} <- PL, I /= J],
     UpdMust = case Result of
-                  ok when ValNotInMay, Fallbacks == [] ->
+                  ok when ValNotInMay -> %, Fallbacks == [] ->
                       %% This put could have already been overwritten
                       %% Only add to must if not in may
                       %% Only add if writing against primaries, otherwise all bets are off
                       %% until vclocks are changed
                       [V | lists:usort(Must -- ValuesAtGet)];
-                  _  ->
+                  ok  ->
                       %% This value has already been overwritten
-                                %% so the values that it overwrote should also be removed 
+                      %% so the values that it overwrote should also be removed 
                       %% from must.
-                      Must -- ValuesAtGet
+                      Must -- ValuesAtGet;
+                  
+                  _ ->
+                      %% Put failed, not sure what must be there for now
+                      %% TODO: Work out what should be here.
+                      []
               end,
     UpdMay = lists:usort(May ++ ValuesAtGet),
-    ?FINALDBG("Cid ~p PUT ~p OVER ~p MUST: ~p MAY: ~p FALLBACKS: ~p\n",
-             [Cid, V, ValuesAtGet, UpdMust, UpdMay, Fallbacks]),
+    ?FINALDBG("Cid ~p PUT: ~p RESPONSE: ~p VC: ~w OVER ~p MUST: ~p MAY: ~p FALLBACKS: ~w\n",
+             [Cid, V, Result, riak_object:vclock(PutObj), ValuesAtGet, UpdMust, UpdMay, Fallbacks]),
     UpdClientViews = lists:keydelete(Cid, 1, ClientViews),
     check_final(Results, UpdMust, UpdMay, UpdClientViews);
 check_final([_ | Results], Must, May, ClientViews) ->
@@ -289,18 +295,21 @@ deliver_msg(#state{msgs = [#msg{to = To} = Msg | Msgs],
              S#state{procs = update_proc(UpdP, Procs),
                      history = History ++ [{deliver_msg, Msg}]}).
 
-make_params(#params{n = NSeed, r = R, w = W} = P) ->
-    %% Ensure R >= N, W >= N and R+W>N
-    MinN = lists:max([R, W]),
-    N = make_range(R + W - NSeed, MinN, R+W-1),
-    %% Force N to be odd while testing
-    {N1,R1} = case N rem 2 == 0 of
-                true ->
-                    {N + 1, R + 1};
-                false ->
-                    {N, R}
-        end,
-    P#params{n = N1, r = R1, m = N1, dw = W}. 
+%% make_params(#params{n = NSeed, r = R, w = W} = P) ->
+%%     %% Ensure R >= N, W >= N and R+W>N
+%%     MinN = lists:max([R, W]),
+%%     N = make_range(R + W - NSeed, MinN, R+W-1),
+%%     %% Force N to be odd while testing
+%%     {N1,R1} = case N rem 2 == 0 of
+%%                 true ->
+%%                     {N + 1, R + 1};
+%%                 false ->
+%%                     {N, R}
+%%         end,
+%%     P#params{n = N1, r = R1, m = N1, dw = W}. 
+make_params(#params{} = P) ->
+    P#params{n = 3, r = 2, m = 5, w = 3, dw = 3}.
+
 
 make_vnodes(#params{n = N, m = M}) ->
     [#proc{name={kv_vnode, I, J}, handler=kv_vnode, procst=undefined} || I <- lists:seq(1, N),
@@ -330,16 +339,47 @@ make_reqs([ReqSeed | ReqSeeds], Cid, Params, CReqNum, Acc) ->
     Reqs = make_req(ReqSeed, Cid, Params, CReqNum),
     make_reqs(ReqSeeds, Cid, Params, CReqNum + 1, lists:reverse(Reqs) ++ Acc).
 
-%% Full EC test make_pl - create a pref list that shrinks to primaries as
-%% seed shrinks to [0]
-make_pl(N, M, PLSeed) ->
-    make_pl(N, M, PLSeed, []).
 
-make_pl(0, _M, _PLSeed, PL) ->
-    PL;
-make_pl(Idx, M, [PLSeedH|PLSeedT], PL) ->
-    Node = (abs(Idx - 1 + PLSeedH) rem M) + 1, % Node between 1 and M
-    make_pl(Idx - 1, M, PLSeedT ++ [PLSeedH], [{kv_vnode, Idx, Node} | PL]).
+%% Make a preference list for partitions 1..N from nodes 1..M.
+%% Owner for partition P == node P.
+%% Replace any downed nodes with fallbacks.  If all nodes are down, 
+%% generate default preflist.
+%% Pick the fallbacks by using non-primaries then fallback 
+%%
+make_pl(N, M, DownNodesSeed) ->
+    %% Convert seed to 1..M
+    DownNodes = [(abs(Seed - 1) rem M) + 1 || Seed <- DownNodesSeed],
+    %% Generate list of primaries and fallbacks
+    Primaries = lists:seq(1, N) -- DownNodes,
+    NonPrimaries = lists:seq(N+1, M) -- DownNodes,
+    Fallbacks = NonPrimaries ++ Primaries,
+    %% Work out which partitions need fallbacks
+    NeedFallbacks = lists:seq(1, N) -- Primaries,
+    case Fallbacks == [] andalso NeedFallbacks /= [] of 
+        true -> %% System unavailable, not a very interesting test so use a perfect one
+            [{kv_vnode, Idx, Idx} || Idx <- lists:seq(1, N)];
+        _ ->
+            make_pl_add_fallbacks(NeedFallbacks,
+                    Fallbacks,
+                    [{kv_vnode, Primary, Primary} || Primary <- lists:reverse(Primaries)])
+    end.
+
+make_pl_add_fallbacks([], _, PL) ->
+    lists:reverse(PL);
+make_pl_add_fallbacks([Idx | NeedFallbacks], [Node | Fallbacks], PL) ->
+    make_pl_add_fallbacks(NeedFallbacks, Fallbacks ++ [Node], [{kv_vnode, Idx, Node} | PL]).
+    
+
+%% %% Full EC test make_pl - create a pref list that shrinks to primaries as
+%% %% seed shrinks to [0]
+%% make_pl(N, M, PLSeed) ->
+%%     make_pl(N, M, PLSeed, []).
+
+%% make_pl(0, _M, _PLSeed, PL) ->
+%%     PL;
+%% make_pl(Idx, M, [PLSeedH|PLSeedT], PL) ->
+%%     Node = (abs(Idx - 1 + PLSeedH) rem M) + 1, % Node between 1 and M
+%%     make_pl(Idx - 1, M, PLSeedT ++ [PLSeedH], [{kv_vnode, Idx, Node} | PL]).
 
 
 %% %% Use PLSeed to change one entry at random when N > 1
@@ -428,10 +468,13 @@ new_req(Op) ->
     #req{pri = next_pri(), op = Op}.
 
 new_msg(From, To, Contents) ->
-    #msg{pri = next_pri(), from = From, to = To, c = Contents}.
+    new_msg(From, To, Contents, next_pri()).
+
+new_msg(From, To, Contents, Pri) ->
+    #msg{from = From, to = To, c = Contents, pri = Pri}.
 
 add_msgs(NewMsgs, Msgs, S) ->
-    S#state{msgs = lists:merge(Msgs, lists:sort(NewMsgs))}.
+    S#state{msgs = lists:keymerge(#msg.pri, Msgs, lists:keysort(#msg.pri, NewMsgs))}.
 
 set_pri(Pris) ->
     put(pri, Pris).
@@ -463,7 +506,7 @@ client_req(#client{reqs = [#req{op = {get, PL}, rid = ReqId} | _]}, Params) ->
     [{procs, NewProcs},
      {msgs, NewMsgs}];
 client_req(#client{reqs = [#req{op = {put, PL, UpdV}, rid = ReqId} | _],
-                   cid = Cid,  clntst = {#req{op={get, _PL}}, GetResult}},
+                   cid = _Cid,  clntst = {#req{op={get, _PL}}, GetResult}},
            Params) ->
     Proc = put_fsm_proc(ReqId, Params),
     NewProcs = [Proc],
@@ -473,8 +516,7 @@ client_req(#client{reqs = [#req{op = {put, PL, UpdV}, rid = ReqId} | _],
                  {ok, Obj} ->
                      riak_object:apply_updates(riak_object:update_value(Obj, UpdV))
              end,
-    UpdObj2 = riak_object:increment_vclock(UpdObj, <<Cid:32>>),
-    NewMsgs = [new_msg({req, ReqId}, Proc#proc.name, {put, PL, UpdObj2})],
+    NewMsgs = [new_msg({req, ReqId}, Proc#proc.name, {put, PL, UpdObj})],
     [{procs, NewProcs},
      {msgs, NewMsgs}];
 client_req(#client{reqs = [#req{op = handoff_fallbacks, rid = ReqId} | _]},
@@ -533,11 +575,15 @@ get_fsm(#msg{from = {kv_vnode, Idx, _}, c = {r, Result, Idx, _ReqId}},
     end.
 
 -record(putfsmst, {reply_to,
+                   putobj,
                    responded = false,
                    putcore}).
-put_fsm_proc(ReqId, #params{n = N, w = W, dw = DW}) ->
+put_fsm_proc(ReqId, #params{n = N, w = _X_W, dw = _X_DW}) ->
     AllowMult = true,
     ReturnBody = false,
+    %% TEMPORARILY SET W=DW=N for now -- check if it fixes the EC problem
+    W = N,
+    DW = N,
     PutCore = riak_kv_put_core:init(N, W, DW, 
                                     N-W+1,   % cannot ever get W replies
                                     N-DW+1,  % cannot ever get DW replies
@@ -546,13 +592,29 @@ put_fsm_proc(ReqId, #params{n = N, w = W, dw = DW}) ->
     #proc{name = {put_fsm, ReqId}, handler = put_fsm, procst = #putfsmst{putcore = PutCore}}.
 
 put_fsm(#msg{from = From, c = {put, PL, Obj}},
-        #proc{name = {put_fsm, ReqId}= Name, procst = ProcSt} = P) ->
-    Ts = ReqId, % re-use ReqId for a timestamp to make them unique
+        #proc{name = {put_fsm, ReqId}= Name, procst = #putfsmst{putcore = PutCore} = ProcSt} = P) ->
+    _Ts = ReqId, % re-use ReqId for a timestamp to make them unique
+    %% Decide on the coordinating vnode and require that as part of the response.
+    %% As indices are fixed, pick lowest index of primary node, falling back to 
+    %% lowest index secondary node
+    {_, CoordIdx, Node} = hd(lists:sort([{case Idx == Node of
+                                               true -> 1; 
+                                               false -> 2
+                                           end, Idx, Node} ||
+                                             {kv_vnode, Idx, Node} <- PL])),
+    NodeId = <<Node:32>>,
+    UpdObj = riak_object:increment_vclock(Obj, NodeId, ts),
+    %% TODO, find some way to make putcore wait on the response from the local vnode.
+    %% Temporarily set dw to all.
+
     %% Kick off requests to the vnodes
-    [{msgs, [new_msg(Name, Vnode, {put, Obj, ReqId, Ts}) || Vnode <- PL]},
-     {updp, P#proc{procst = ProcSt#putfsmst{reply_to = From}}}];
+    [{msgs, [new_msg(Name, Vnode, {put, ReqId, UpdObj, NodeId}) || Vnode <- PL]},
+     {updp, P#proc{procst = ProcSt#putfsmst{putcore = riak_kv_put_core:coord_idx(CoordIdx, PutCore),
+                                            putobj = UpdObj,
+                                            reply_to = From}}}];
 put_fsm(#msg{from = {kv_vnode, _, _}, c = Result},
         #proc{name = Name, procst = #putfsmst{reply_to = ReplyTo,
+                                              putobj = PutObj,
                                               responded = Responded,
                                               putcore = PutCore} = ProcSt} = P) ->
     UpdPutCore = riak_kv_put_core:add_result(Result, PutCore),
@@ -560,7 +622,7 @@ put_fsm(#msg{from = {kv_vnode, _, _}, c = Result},
         true when Responded == false ->
             %% Worry about read repairs later
             {Response, UpdPutCore2} = riak_kv_put_core:response(UpdPutCore),
-            [{msgs, [new_msg(Name, ReplyTo, Response)]},
+            [{msgs, [new_msg(Name, ReplyTo, {Response, PutObj})]},
              {updp, P#proc{procst = ProcSt#putfsmst{responded = true,
                                                     putcore = UpdPutCore2}}}];
         _ ->
@@ -577,20 +639,21 @@ kv_vnode(#msg{from = From, c = {get, ReqId}},
                      {ok, CurObj}
              end,
     [{msgs, [new_msg(Name, From, {r, Result, Idx, ReqId})]}];
-kv_vnode(#msg{from = From, c = {put, NewObj, ReqId, Ts}},
+kv_vnode(#msg{from = From, c = {put, ReqId, NewObj, CoordId}},
          #proc{name = {kv_vnode, Idx, _Node} = Name, procst = CurObj} = P) ->
-    WMsg = new_msg(Name, From, {w, Idx, ReqId}),
-    case syntactic_put_merge(CurObj, NewObj, ReqId, Ts) of
+    [Pri1, Pri2] = lists:sort([next_pri(), next_pri()]),
+    WMsg = new_msg(Name, From, {w, Idx, ReqId}, Pri1),
+    case coord_put_merge(CurObj, NewObj, CoordId) of
         keep ->
-            FailMsg = new_msg(Name, From, {fail, Idx, ReqId}),
+            FailMsg = new_msg(Name, From, {fail, Idx, ReqId}, Pri2),
             [{msgs, [WMsg, FailMsg]}];
         UpdObj ->
-            DWMsg = new_msg(Name, From, {dw, Idx, ReqId}), % ignore returnbody for now
+            DWMsg = new_msg(Name, From, {dw, Idx, ReqId}, Pri2), % ignore returnbody for now
             [{msgs, [WMsg, DWMsg]},
              {updp, P#proc{procst = UpdObj}}]
     end;
 kv_vnode(#msg{from = From, c = {handoff_to, To}},
-         #proc{procst = CurObj}) ->
+         #proc{procst = CurObj} = P) ->
     %% Send current object to node if there is one
     %% TODO: Schedule message to make this vnode reset itself if unchanged
     NewMsgs = case CurObj of
@@ -599,7 +662,8 @@ kv_vnode(#msg{from = From, c = {handoff_to, To}},
                   _ ->
                       [new_msg(From, To, {handoff_obj, CurObj})]
               end,
-    [{msgs, NewMsgs}];
+    [{msgs, NewMsgs},
+     {updp, P#proc{procst = undefined}}];
 kv_vnode(#msg{c = {handoff_obj, HandoffObj}},
          #proc{procst = CurObj} = P) ->
     %% Simulate a do_diffobj_put
@@ -626,3 +690,35 @@ syntactic_put_merge(CurObj, UpdObj, ReqId, Ts) ->
                 false -> ResObj %% {newobj, ResObj}
             end
     end.
+
+
+coord_put_merge(undefined, UpdObj, _CoordId) ->
+    UpdObj;
+coord_put_merge(CurObj, UpdObj, CoordId) ->
+    %% Make sure UpdObj descends from CurObj and that CoordId is greater
+    CurVC = riak_object:vclock(CurObj),
+    UpdVC = riak_object:vclock(UpdObj),
+    case get_counter(CoordId, UpdVC) > get_counter(CoordId, CurVC) of
+        true ->
+            %% Valid coord put replacing current object
+            case vclock:descends(CurVC, UpdVC) == false andalso 
+                vclock:descends(UpdVC, CurVC) == true of
+                true ->
+                    UpdObj;
+                false ->
+                    riak_object:merge(CurObj, UpdObj)
+            end;
+        false ->
+            keep
+    end.
+
+
+get_counter(Id, VC) ->            
+    case lists:keyfind(Id, 1, VC) of
+        false ->
+            0;
+        {Counter, _TS} ->
+            Counter
+    end.
+            
+    

--- a/test/ec_eqc.erl
+++ b/test/ec_eqc.erl
@@ -579,12 +579,9 @@ get_fsm(#msg{from = {kv_vnode, Idx, _}, c = {r, Result, Idx, _ReqId}},
                    remotevnodes, %% Messages to send to remove vnodes
                    responded = false,
                    putcore}).
-put_fsm_proc(ReqId, #params{n = N, w = _X_W, dw = _X_DW}) ->
+put_fsm_proc(ReqId, #params{n = N, w = W, dw = DW}) ->
     AllowMult = true,
     ReturnBody = false,
-    %% TEMPORARILY SET W=DW=N for now -- check if it fixes the EC problem
-    W = N,
-    DW = N,
     PutCore = riak_kv_put_core:init(N, W, DW, 
                                     N-W+1,   % cannot ever get W replies
                                     N-DW+1,  % cannot ever get DW replies

--- a/test/ec_eqc.erl
+++ b/test/ec_eqc.erl
@@ -201,15 +201,12 @@ deliver_msg(#state{msgs = [#msg{to = To} = Msg | Msgs],
                      history = History ++ [{deliver_msg, Msg}]}).
 
 make_params(#params{n = NSeed, r = R, w = W} = P) ->
+    %% Ensure R >= N, W >= N and R+W>N
     MinN = lists:max([R, W]),
-    P#params{n = make_range(R + W - NSeed, MinN, R+W-1)}. % Ensure R >= N, W >= N and R+W>N
-
-%% make_nodes(Q) ->
-%%     [#proc{name={node, I}, procst=nostate} || I <- lists:seq(1, Q)].
+    P#params{n = make_range(R + W - NSeed, MinN, R+W-1)}. 
 
 make_vnodes(#params{n = N}) ->
     [#proc{name={kv_vnode, I, I}, handler=kv_vnode, procst=[]} || I <- lists:seq(1, N)].
-
 
 make_clients(ClientSeeds, Params) ->
     make_clients(ClientSeeds, 1, Params, []).

--- a/test/ec_eqc.erl
+++ b/test/ec_eqc.erl
@@ -26,8 +26,9 @@ check() ->
                  
 
 -record(proc, {
-          name,   %% term to reference this process in from / to for messages
-          procst  %% Process state
+          name,    %% Term to reference this process in from / to for messages
+          handler, %% Handler function for messages
+          procst   %% Process state
           }).
         
 -record(msg, {
@@ -36,7 +37,10 @@ check() ->
           to,      %% Receipient
           c}).     %% Contents
 
--record(params, {q}).
+-record(params, {q,
+                 n,
+                 r,
+                 w}).
 
 -record(state, {verbose = false,
                 step = 1, 
@@ -50,29 +54,38 @@ check() ->
 nni() ->
     ?LET(Xs, int(), abs(Xs)).
 
+gen_params() ->
+    #params{n = choose(0, 10),
+            r = choose(1, 5),
+            w = choose(1, 5)}.
+            
 gen_req() ->
-    {ping, {node, nni()}}.
+    get.
 
 gen_client_seeds() ->
     non_empty(list(#client{reqs = non_empty(list({nni(), gen_req()}))})).
 
 prop() ->
-    ?FORALL({ClientSeeds,QSeed},{gen_client_seeds(),choose(0, 10)},
+    ?FORALL({ClientSeeds,ParamsSeed},{gen_client_seeds(),gen_params()},
             begin
-                Q = 1 + abs(QSeed),
-                Params = #params{q = Q},
-                NodeProcs = make_nodes(Q),
+                Params = make_params(ParamsSeed),
+                io:format(user, "Params = ~p\n", [Params]),
+                %NodeProcs = make_nodes(Q),
+                VnodeProcs = make_vnodes(Params),
                 Initial = #state{params = Params, 
-                                 procs = NodeProcs},
+                                 procs = VnodeProcs},
                 Clients = make_clients(ClientSeeds, Params),
                 Start = Initial#state{clients = Clients},
                 case exec(Start) of
-                    {ok, Final} ->
+                    {ok, _Final} ->
+                        io:format("Params:\n~p\nHistory:\n~p\n",
+                                  [_Final#state.params,
+                                   _Final#state.history]),
                         true;
                     {What, Reason, Next, FailS} ->
                         io:format(user, "FAILED: ~p: ~p\nNext: ~p\nInitial:\n~p\n"
                                   "FailS:\n~p\n",
-                                  [What, Reason, Initial, Next, FailS]),
+                                  [What, Reason, Next, Initial, FailS]),
                         false
                 end
             end).
@@ -96,7 +109,7 @@ exec(S) ->
 
 status(#state{verbose = true} = S, Next) ->
     io:format(user, "--- Step ~p - ~p ---\n~p\n",
-              [S#state.step, Next, S]);
+              [S#state.step, Next, ann_state(S)]);
 status(_S, _Next) ->
     ok.
 
@@ -135,13 +148,18 @@ next(#state{clients = Clients, pending_msgs = PendingMsgs}) ->
     end.
 
 %% Deliver next client request for Cid
-client_req(Cid, #state{next_rid = ReqId, clients = Clients, pending_msgs = PendingMsgs} = S) ->
+client_req(Cid, #state{next_rid = ReqId, clients = Clients, procs = Procs,
+                       pending_msgs = PendingMsgs} = S) ->
     C = get_client(Cid, Clients),
     true = (C#client.pri /= undefined), % paranoia - make sure this was scheduled right
-    {NewMsgs, UpdC} = start_req({req, ReqId}, C),
+    Result = start_req({req, ReqId}, C),
+    NewProcs = proplists:get_value(procs, Result, []),
+    NewMsgs = proplists:get_value(msgs, Result, []),
+    UpdC = proplists:get_value(updc, Result, C),
     S#state{next_rid = ReqId + 1,
-            clients = update_client(UpdC#client{rid= ReqId, pri = undefined}, Clients),
-            pending_msgs = PendingMsgs ++ NewMsgs}.
+            clients = update_client(UpdC#client{rid = ReqId, pri = undefined}, Clients),
+            pending_msgs = PendingMsgs ++ NewMsgs,
+            procs = Procs ++ NewProcs}.
 
 %% Deliver next pending msg
 deliver_msg(#state{pending_msgs = [#msg{to = {req, ReqId}} = Msg | Msgs],
@@ -163,19 +181,24 @@ deliver_msg(#state{pending_msgs = [#msg{to = {req, ReqId}} = Msg | Msgs],
 
 deliver_msg(#state{pending_msgs = [#msg{to = To} = Msg | Msgs],
                    procs = Procs} = S) ->
-    Proc = get_proc(To, Procs),
-    %% Deliver message - as a result, the process could do any/all of
-    %% create new processes
-    %% stop itself
-    %% send a message to another process 
-    %% complete a request
-    %%            
-    Result = deliver(Msg, Proc),
+    P = get_proc(To, Procs),
+    Handler = P#proc.handler,
+    Result = ?MODULE:Handler(Msg, P),
     NewMsgs = proplists:get_value(msgs, Result, []),
-    S#state{pending_msgs = Msgs ++ NewMsgs}.
+    UpdP = proplists:get_value(updp, Result, P),
+    S#state{pending_msgs = Msgs ++ NewMsgs,
+            procs = update_proc(UpdP, Procs)}.
 
-make_nodes(Q) ->
-    [#proc{name={node, I}, procst=nostate} || I <- lists:seq(1, Q)].
+make_params(#params{n = NSeed, r = R, w = W} = P) ->
+    MaxN = lists:max([R, W, R+W-1]),
+    P#params{n = make_range(R + W - NSeed, 1, MaxN)}. % Ensure R+W>N
+
+%% make_nodes(Q) ->
+%%     [#proc{name={node, I}, procst=nostate} || I <- lists:seq(1, Q)].
+
+make_vnodes(#params{n = N}) ->
+    [#proc{name={kv_vnode, I, I}, handler=kv_vnode, procst=[]} || I <- lists:seq(1, N)].
+
 
 make_clients(ClientSeeds, Params) ->
     make_clients(ClientSeeds, 1, Params, []).
@@ -197,8 +220,6 @@ make_reqs([ReqSeed | ReqSeeds], Params, Acc) ->
     Req = make_req(ReqSeed, Params),
     make_reqs(ReqSeeds, Params, [Req | Acc]).
 
-make_req({Pri, {ping, {node, NodeSeed}}}, #params{q = Q}) ->
-    {Pri, {ping, {node, make_range(NodeSeed, 1, Q)}}}.
 
 %% Move the client on to the next request, setting priority if present
 next_req(#client{reqs = [_|Reqs]} = C) ->
@@ -208,22 +229,6 @@ next_req(#client{reqs = [_|Reqs]} = C) ->
         [{Pri,_} | _] ->
             C#client{pri = Pri, reqs = Reqs}
     end.
-    
-
-%% Deliver a message to a process
-deliver(#msg{from = From, c = ping}, #proc{name = {node, _}=Name}) ->
-    [{msgs, [#msg{from = Name, to = From, c = pong}]}].
-               
-    
-%% Start the next client request
-start_req(Name, #client{reqs = [{_Pri, {ping, NodeName}} | _Reqs]} = C) ->
-    NewMsgs = [#msg{from = Name, to = NodeName, c = ping}],
-    {NewMsgs, C#client{clntst = {pinged, NodeName}}}.
-
-end_req(#msg{from = Name, c = pong},
-        #client{cid = Cid, reqs = [{_Pri, {ping, Name}}|_Reqs]}) ->
-    [{history, [{Cid, ponged, Name}]},
-     done].
 
 %% Get client by cid from list of clients - blow up if missing
 get_client(Cid, Clients) ->
@@ -249,6 +254,10 @@ get_proc(Name, Procs) ->
             throw({bad_proc, Name, [N || #proc{name = N} <- Procs]})
     end.
 
+%% Update a proc
+update_proc(P, Procs) ->
+    lists:keyreplace(P#proc.name, #proc.name, Procs, P).
+
 
 %% Make a value between min and max inclusive using the seed
 make_range(Seed, Min, Max) when Min =< Seed, Seed =< Max ->
@@ -256,3 +265,75 @@ make_range(Seed, Min, Max) when Min =< Seed, Seed =< Max ->
 make_range(Seed, Min, Max) ->
     Range = Max - Min + 1,
     Min + (abs(Seed) rem Range).
+
+
+%% Create a request for a client
+make_req({Pri, {ping, {node, NodeSeed}}}, #params{q = Q}) ->
+    {Pri, {ping, {node, make_range(NodeSeed, 1, Q)}}};
+
+make_req({Pri, get}, #params{n = N}) ->
+    {Pri, {get, [{kv_vnode, I, I} || I <- lists:seq(1, N)]}}.
+
+
+
+%% Start the next client request
+%% start_req(Name, #client{reqs = [{_Pri, {ping, NodeName}} | _Reqs]} = C) ->
+%%     NewMsgs = [#msg{from = Name, to = NodeName, c = ping}],
+%%     {NewMsgs, C#client{clntst = {pinged, NodeName}}}.
+
+start_req({req, ReqId} = Name, #client{reqs = [{_Pri, {get, PL}} | _Reqs]} = C) ->
+    Proc = get_fsm_proc(ReqId),
+    NewProcs = [Proc],
+    NewMsgs = [#msg{from = Name, to = Proc#proc.name, c = {get, PL}}],
+    UpdC = C#client{clntst = {get, ReqId}},
+    [{procs, NewProcs},
+     {msgs, NewMsgs},
+     {updc, UpdC}].
+ 
+%% end_req(#msg{from = Name, c = pong},
+%%         #client{cid = Cid, reqs = [{_Pri, {ping, Name}}|_Reqs]}) ->
+%%     [{history, [{Cid, ponged, Name}]},
+%%      done].
+end_req(#msg{c = R},
+        #client{cid = Cid, reqs = [{_Pri, Req}|_Reqs]}) ->
+    [{history, [{Cid, Req, R}]},
+     done].
+
+
+%% Deliver a message to a process
+%% node_proc(#msg{from = From, c = ping}, #proc{name = {node, _}=Name}) ->
+%%     [{msgs, [#msg{from = Name, to = From, c = pong}]}].
+               
+
+kv_vnode(#msg{from = From, c = get}, #proc{name = Name}) ->
+    [{msgs, [#msg{from = Name, to = From, c = {error, notfound}}]}].
+
+-record(getfsmst, {reply_to,
+                   expect, %% Number of replies expected
+                   replies}).
+
+get_fsm_proc(ReqId) ->
+    #proc{name = {get_fsm, ReqId}, handler = get_fsm, procst = #getfsmst{}}.
+
+get_fsm(#msg{from = From, c = {get, PL}},
+        #proc{name = Name, procst = ProcSt} = P) ->
+    %% Kick off requests to the vnodes
+    [{msgs, [#msg{from = Name, to = Vnode, c = get} || Vnode <- PL]},
+     {updp, P#proc{procst = ProcSt#getfsmst{reply_to = From, expect = length(PL)}}}];
+get_fsm(#msg{from = {kv_vnode, _, _}},
+        #proc{name = Name, procst = #getfsmst{expect = 1, reply_to = ReplyTo}}) ->
+    %% Final expected response from vnodes
+    %% TODO: Find a way to mark the process as stopped, can just build up for now.
+    [{msgs, [#msg{from = Name, to = ReplyTo, c = {error, notfound}}]}];
+get_fsm(#msg{from = {kv_vnode, _, _}},
+        #proc{procst = #getfsmst{expect = Expect} = ProcSt} = P) ->
+    %% Response from vnode
+    [{updp, P#proc{procst = ProcSt#getfsmst{expect = Expect - 1}}}].
+    
+    
+ann_state(R) ->
+    Elements = tuple_to_list(R),
+    Type = hd(Elements),
+    Fields = record_info(fields, state),
+    {Type, lists:zip(Fields, tl(Elements))}.
+    

--- a/test/fsm_eqc_vnode.erl
+++ b/test/fsm_eqc_vnode.erl
@@ -209,7 +209,7 @@ send_vput_replies([{LIdx, FirstResp} | Rest], Idx, Sender, ReqId, PutObj, Option
                #state{lidx_map = LIdxMap} = State) ->
     %% Check have not seen this logical index before and store it
     error = orddict:find(LIdx, LIdxMap),
-    NewState1 = State#state{lidx_map = orddict:store(LIdx, {Idx, PutObj}, LIdxMap)},
+    NewState1 = State#state{lidx_map = orddict:store(LIdx, {Idx, PutObj, Options}, LIdxMap)},
     Reply = case FirstResp of
                 w ->
                     {w, Idx, ReqId};
@@ -218,14 +218,15 @@ send_vput_replies([{LIdx, FirstResp} | Rest], Idx, Sender, ReqId, PutObj, Option
             end,
     NewState2 = record_reply(Sender, Reply, NewState1),
     Rest2 = fail_on_bad_obj(LIdx, PutObj, Rest),
-    send_vput_extra(Rest2, Sender, ReqId, Options, NewState2).
+                    
+    send_vput_extra(Rest2, Sender, ReqId, NewState2).
 
-send_vput_extra([], {fsm, undefined, Pid} = _Sender, _ReqId, _Options, State) ->
+send_vput_extra([], {fsm, undefined, Pid} = _Sender, _ReqId, State) ->
     Pid ! request_timeout, % speed things along by sending the request timeout
     State#state{vput_replies = []};
-send_vput_extra([{LIdx, {dw, CurObj, _CurLin}} | Rest], Sender, ReqId, Options,
+send_vput_extra([{LIdx, {dw, CurObj, _CurLin}} | Rest], Sender, ReqId,
                 #state{lidx_map = LIdxMap} = State) ->
-    {Idx, PutObj} = orddict:fetch(LIdx, LIdxMap),
+    {Idx, PutObj, Options} = orddict:fetch(LIdx, LIdxMap),
     Obj = put_merge(CurObj, PutObj, Options, ReqId),
     NewState = case (proplists:get_value(returnbody, Options, false) orelse
                      proplists:get_value(coord, Options, false)) of
@@ -234,18 +235,18 @@ send_vput_extra([{LIdx, {dw, CurObj, _CurLin}} | Rest], Sender, ReqId, Options,
                    false ->
                        record_reply(Sender, {dw, Idx, ReqId}, State)
                end,
-    send_vput_extra(Rest, Sender, ReqId, Options, NewState);
-send_vput_extra([{LIdx, fail} | Rest], Sender, ReqId, Options,
+    send_vput_extra(Rest, Sender, ReqId, NewState);
+send_vput_extra([{LIdx, fail} | Rest], Sender, ReqId,
                 #state{lidx_map = LIdxMap} = State) ->
-    Idx = orddict:fetch(LIdx, LIdxMap),
+    {Idx, _PutObj, _Options} = orddict:fetch(LIdx, LIdxMap),
     NewState = record_reply(Sender, {fail, Idx, ReqId}, State),
-    send_vput_extra(Rest, Sender, ReqId, Options, NewState);
-send_vput_extra([{LIdx, {timeout, 2}} | Rest], Sender, ReqId, Options,
+    send_vput_extra(Rest, Sender, ReqId, NewState);
+send_vput_extra([{LIdx, {timeout, 2}} | Rest], Sender, ReqId,
                 #state{lidx_map = LIdxMap} = State) ->
-    Idx = orddict:fetch(LIdx, LIdxMap),
+    {Idx, _PutObj, _Options} = orddict:fetch(LIdx, LIdxMap),
     NewState = record_reply(Sender, {{timeout, 2}, Idx, ReqId}, State),
-    send_vput_extra(Rest, Sender, ReqId, Options, NewState);
-send_vput_extra(VPutReplies, _Sender, _ReqId, _Options, State) ->
+    send_vput_extra(Rest, Sender, ReqId, NewState);
+send_vput_extra(VPutReplies, _Sender, _ReqId, State) ->
     State#state{vput_replies = VPutReplies}.
 
 record_reply(Sender, Reply, #state{reply_history = H} = State) ->
@@ -272,8 +273,15 @@ fail_on_bad_obj(LIdx, _Obj, VPutReplies) ->
 
 %% TODO: The riak_kv_vnode code should be refactored to expose this function
 %%       so we are close to testing the real thing.
-put_merge(notfound, UpdObj, _Options, _ReqId) ->
-    UpdObj;
+put_merge(notfound, UpdObj, Options, _ReqId) ->
+    case proplists:get_value(coord, Options, true) of
+        true ->
+            VnodeId = <<1, 1, 1, 1, 1, 1, 1, 1>>,
+            Ts = vclock:timestamp(),
+            riak_object:increment_vclock(UpdObj, VnodeId, Ts);
+        false ->
+            UpdObj
+    end;                
 put_merge(CurObj, UpdObj, Options, ReqId) ->
     case proplists:get_value(coord, Options, true) of
         true ->

--- a/test/put_fsm_eqc.erl
+++ b/test/put_fsm_eqc.erl
@@ -250,6 +250,7 @@ w_dw_seed() ->
                {10, one},
                {10, all},
                {10, fsm_eqc_util:largenat()},
+               { 5, 0},
                { 1, garbage}]).
 
 %%====================================================================
@@ -270,6 +271,8 @@ prop_basic_put() ->
         {PW, RealPW} = pw_val(N, 1000000, PWSeed),
         {W, RealW} = w_dw_val(N, 1000000, WSeed),
         {DW, RealDW}  = w_dw_val(N, RealW, DWSeed),
+
+        io:format(user, "N=~p PW=~p W=~p DW=~p\n", [N, PW, W, DW]),
 
         %% {Q, _Ring, NodeStatus} = fsm_eqc_util:mock_ring(N + NQdiff, NodeStatus0), 
 
@@ -372,7 +375,8 @@ prop_basic_put() ->
            end,
            conjunction([{result, equals(RetResult, Expected)},
                         {details, check_details(RetInfo, Options)},
-                        {postcommit, equals(PostCommits, ExpectedPostCommits)}]))
+                        {postcommit, equals(PostCommits, ExpectedPostCommits)},
+                        {puts_sent, check_puts_sent(N, H)}]))
     end).
 
 make_options([], Options) ->
@@ -790,6 +794,20 @@ check_details(Info, Options) ->
         _ -> % some info being returned is good enough for now
             true
     end.
+
+
+%% Check a 'w' message was sent for each planned response.
+%% i.e. make sure that the put FSM really sent N 
+check_puts_sent(N, VPutResp) ->
+    Requests = [normal || {w,_,_} <- VPutResp] ++
+        [timeout || {{timeout, 1},_,_} <- VPutResp],
+    NumPutReqs = length(Requests),
+    ?WHENFAIL(begin
+                  io:format(user, "VPutResp:\n~p\n", [VPutResp]),
+                  io:format(user, "Requests: ~p = ~p\n", [Requests, NumPutReqs])
+              end,
+              equals(N, NumPutReqs)).
+
 %%====================================================================
 %% Javascript helpers 
 %%====================================================================

--- a/test/put_fsm_eqc.erl
+++ b/test/put_fsm_eqc.erl
@@ -334,8 +334,9 @@ prop_basic_put() ->
         %% and returned to the client.
         EffDW = get_effective_dw(RealDW, Options, Postcommit),
         ExpectObject = expect_object(H, RealW, EffDW, AllowMult),
-        {Expected, ExpectedPostCommits} = expect(H, N, PW, RealPW, W, RealW, DW, EffDW, Options,
-                                                 Precommit, Postcommit, ExpectObject, PL2),
+        {Expected, ExpectedPostCommits, ExpectedVnodePuts} = 
+            expect(VPutResp, H, N, PW, RealPW, W, RealW, DW, EffDW, Options,
+                   Precommit, Postcommit, ExpectObject, PL2),
 
         {RetResult, RetInfo} = case Res of 
                                    timeout ->
@@ -357,6 +358,7 @@ prop_basic_put() ->
         ?WHENFAIL(
            begin
                io:format(user, "BucketProps: ~p\n", [BucketProps]),
+               io:format(user, "VPutResp = ~p\n", [VPutResp]),
                io:format(user, "VPutReplies = ~p\n", [VPutReplies]),
                io:format(user, "PrefList2: ~p\n", [PL2]),
                io:format(user, "N: ~p PW: ~p RealPW: ~p W:~p RealW: ~p DW: ~p RealDW: ~p EffDW: ~p"
@@ -376,7 +378,7 @@ prop_basic_put() ->
            conjunction([{result, equals(RetResult, Expected)},
                         {details, check_details(RetInfo, Options)},
                         {postcommit, equals(PostCommits, ExpectedPostCommits)},
-                        {puts_sent, check_puts_sent(N, H)}]))
+                        {puts_sent, check_puts_sent(ExpectedVnodePuts, H)}]))
     end).
 
 make_options([], Options) ->
@@ -413,16 +415,19 @@ make_vput_replies(VPutResp, Objects, Options) ->
     make_vput_replies(VPutResp, Objects, Options, 1, []).
     
 make_vput_replies([], _Objects, _Options, _LIdx, SeqReplies) ->
-    {_Seqs, Replies} = lists:unzip(lists:sort(SeqReplies)),
-    Replies;
+    %% Randomize the order of replies - make sure the first vnode
+    %% is handled before the others to simulate local/remote vnodes
+    [{_Seq1, Local1}, {_Seq2, Local2} | SeqRemotes] = lists:reverse(SeqReplies),
+    {_Seqs, Replies} = lists:unzip(lists:sort(SeqRemotes)),
+    [Local1, Local2 | Replies];
 make_vput_replies([{_CurObj, _First, _FirstSeq, _Second, _SecondSeq, down} | Rest],
                   Objects, Options, LIdx, Replies) ->
     make_vput_replies(Rest, Objects, Options, LIdx, Replies); 
 make_vput_replies([{_CurObj, {timeout, 1}, FirstSeq, _Second, SecondSeq, _NodeStatus} | Rest],
                   Objects, Options, LIdx, Replies) ->
     make_vput_replies(Rest, Objects, Options, LIdx + 1, 
-                     [{FirstSeq, {LIdx, {timeout, 1}}},
-                      {FirstSeq+SecondSeq+1, {LIdx, {timeout, 2}}} | Replies]);
+                     [{FirstSeq+SecondSeq+1, {LIdx, {timeout, 2}}}, 
+                      {FirstSeq, {LIdx, {timeout, 1}}} | Replies]);
 make_vput_replies([{CurPartVal, First, FirstSeq, dw, SecondSeq, _NodeStatus} | Rest],
                   Objects, Options, LIdx, Replies) ->
     %% Lookup the lineage for the current object and prepare it for
@@ -434,13 +439,13 @@ make_vput_replies([{CurPartVal, First, FirstSeq, dw, SecondSeq, _NodeStatus} | R
                             {proplists:get_value(PartValLin, Objects), PartValLin}
                      end,
     make_vput_replies(Rest, Objects, Options, LIdx + 1,
-                      [{FirstSeq, {LIdx, First}},
-                       {FirstSeq+SecondSeq+1, {LIdx, {dw, Obj, CurLin}}} | Replies]);
+                      [{FirstSeq+SecondSeq+1, {LIdx, {dw, Obj, CurLin}}},
+                       {FirstSeq, {LIdx, First}} | Replies]);
 make_vput_replies([{_CurObj, First, FirstSeq, Second, SecondSeq, _NodeStatus} | Rest],
                   Objects, Options, LIdx, Replies) ->
     make_vput_replies(Rest, Objects, Options, LIdx + 1,
-                     [{FirstSeq, {LIdx, First}},
-                      {FirstSeq+SecondSeq+1, {LIdx, Second}} | Replies]).
+                     [{FirstSeq+SecondSeq+1, {LIdx, Second}},
+                      {FirstSeq, {LIdx, First}} | Replies]).
 
 
 make_bucket_props(N, AllowMult, Precommit, Postcommit) ->
@@ -478,7 +483,8 @@ make_bucket_props(N, AllowMult, Precommit, Postcommit) ->
 %%====================================================================
 
 %% Work out the expected return value from the FSM and the expected postcommit log.
-expect(H, N, PW, RealPW, W, RealW, DW, EffDW, Options, Precommit, Postcommit, Object, PL2) ->
+expect(VPutResp, H, N, PW, RealPW, W, RealW, DW, EffDW, Options, 
+       Precommit, Postcommit, Object, PL2) ->
     ReturnObj = case proplists:get_value(returnbody, Options, false) of
                     true ->
                         Object;
@@ -488,29 +494,48 @@ expect(H, N, PW, RealPW, W, RealW, DW, EffDW, Options, Precommit, Postcommit, Ob
     NumPrimaries = length([xx || {_,primary} <- PL2]),
     UpNodes =  length(PL2),
     MinNodes = erlang:max(1, erlang:max(RealW, EffDW)),
-    ExpectResult = 
+    {ExpectResult, ExpectVnodePuts} = 
         if
             PW =:= garbage ->
-                {error, {pw_val_violation, garbage}};
+                {{error, {pw_val_violation, garbage}}, 0};
 
             W =:= garbage ->
-                {error, {w_val_violation, garbage}};
+                {{error, {w_val_violation, garbage}}, 0};
 
             DW =:= garbage ->
-                {error, {dw_val_violation, garbage}};
+                {{error, {dw_val_violation, garbage}}, 0};
 
             RealW > N orelse EffDW > N orelse RealPW > N ->
-                {error, {n_val_violation, N}};
+                {{error, {n_val_violation, N}}, 0};
 
             RealPW > NumPrimaries ->
-                {error, {pw_val_unsatisfied, RealPW, NumPrimaries}};
+                {{error, {pw_val_unsatisfied, RealPW, NumPrimaries}}, 0};
 
             UpNodes < MinNodes ->
-                {error,{insufficient_vnodes,UpNodes,need,MinNodes}};
+                {{error,{insufficient_vnodes,UpNodes,need,MinNodes}}, 0};
            
            true ->
                 HNoTimeout = filter_timeouts(H),
-                expect(HNoTimeout, {H, N, RealW, EffDW, 0, 0, 0, ReturnObj, Precommit})
+                VPuts = case precommit_should_fail(Precommit) of
+                            false ->
+                                %% If the first local W/DW times out, 
+                                %% the remote ones will not be sent.
+                                case hd(VPutResp) of
+                                    {_,w,_,dw,_,_} ->
+                                        N;
+                                    _ ->
+                                        1
+                                end;
+                            _ ->
+                                0
+                        end,
+                case H of
+                    [{w, _, _}, {fail, _, _} | _] ->
+                        {maybe_add_robj({error, local_put_failed}, ReturnObj, Precommit), VPuts};
+                    _ ->
+                        {expect(HNoTimeout, {H, N, RealW, EffDW, 0, 0, 0, ReturnObj, Precommit}), 
+                         VPuts}
+                end
         end,
     ExpectPostcommit = case {ExpectResult, Postcommit} of
                            {{error, _}, _} ->
@@ -523,21 +548,21 @@ expect(H, N, PW, RealPW, W, RealW, DW, EffDW, Options, Precommit, Postcommit, Ob
                                %% Postcommit should be called for each ok hook registered.
                                [Object || Hook <- Postcommit, Hook =:= {erlang, postcommit_ok}]
                        end,
-    {ExpectResult, ExpectPostcommit}.
+    {ExpectResult, ExpectPostcommit, ExpectVnodePuts}.
 
-expect([], {_H, _N, _W, DW, _NumW, _NumDW, _NumFail, RObj, Precommit}=S) ->
+expect([], {_H, _N, _W, _DW, _NumW, _NumDW, _NumFail, RObj, Precommit}=S) ->
     case enough_replies(S) of % this handles W=0 case
         {true, Expect} ->
-            maybe_add_robj(Expect, RObj, Precommit, DW);
+            maybe_add_robj(Expect, RObj, Precommit);
         false ->
-            maybe_add_robj({error, timeout}, RObj, Precommit, DW)
+            maybe_add_robj({error, timeout}, RObj, Precommit)
     end;
 expect([{w, _, _}|Rest], {H, N, W, DW, NumW, NumDW, NumFail, RObj, Precommit}) ->
     S = {H, N, W, DW, NumW + 1, NumDW, NumFail, RObj, Precommit},
 
     case enough_replies(S) of
         {true, Expect} ->
-            maybe_add_robj(Expect, RObj, Precommit, DW);
+            maybe_add_robj(Expect, RObj, Precommit);
         
         false ->
             expect(Rest, S)
@@ -547,18 +572,18 @@ expect([DWReply|Rest], {H, N, W, DW, NumW, NumDW, NumFail,
     S = {H, N, W, DW, NumW, NumDW + 1, NumFail, RObj, Precommit},
     case enough_replies(S) of
         {true, Expect} ->
-            maybe_add_robj(Expect, RObj, Precommit, DW);
+            maybe_add_robj(Expect, RObj, Precommit);
         false ->
             expect(Rest, S)
     end;
 %% Fail on coordindating vnode - request fails
-expect([{fail, {1, _}, _}|_Rest], {_H, _N, _W, DW, _NumW, _NumDW, _NumFail, RObj, Precommit}) ->
-    maybe_add_robj({error, too_many_fails}, RObj, Precommit, DW);
+expect([{fail, {1, _}, _}|_Rest], {_H, _N, _W, _DW, _NumW, _NumDW, _NumFail, RObj, Precommit}) ->
+    maybe_add_robj({error, too_many_fails}, RObj, Precommit);
 expect([{fail, _, _}|Rest], {H, N, W, DW, NumW, NumDW, NumFail, RObj, Precommit}) ->
     S = {H, N, W, DW, NumW, NumDW, NumFail + 1, RObj, Precommit},
     case enough_replies(S) of
         {true, Expect} ->
-            maybe_add_robj(Expect, RObj, Precommit, DW);
+            maybe_add_robj(Expect, RObj, Precommit);
         false ->
             expect(Rest, S)
     end;
@@ -595,7 +620,7 @@ w_dw_val(_N, _Min, garbage) ->
     {garbage, 1000000};
 w_dw_val(N, Min, Seed) when is_number(Seed) ->
     Val = Seed rem (N + 2),
-    {Val, erlang:min(Min, Val)};
+    {Val, erlang:max(1, erlang:min(Min, Val))};
 w_dw_val(N, Min, Seed) ->
     Val = case Seed of
               one -> 1;
@@ -603,7 +628,7 @@ w_dw_val(N, Min, Seed) ->
               X when X == quorum; X == default; X == missing -> (N div 2) + 1;
               _ -> Seed
           end,
-    {Seed, erlang:min(Min, Val)}.
+    {Seed, erlang:max(1, erlang:min(Min, Val))}.
 
 %% Work out W and DW given a seed.
 %% Generate a value from 0..N+1
@@ -666,8 +691,8 @@ enough_replies({_H, N, W, DW, NumW, NumDW, NumFail, _RObj, _Precommit}) ->
             false
     end.
  
-maybe_add_robj(ok, RObj, Precommit, DW) ->
-    case precommit_should_fail(Precommit, DW) of
+maybe_add_robj(ok, RObj, Precommit) ->
+    case precommit_should_fail(Precommit) of
         {true, Expect} ->
             Expect;
         
@@ -679,11 +704,11 @@ maybe_add_robj(ok, RObj, Precommit, DW) ->
                     {ok, RObj}
             end
     end;
-maybe_add_robj({error, timeout}, _Robj, Precommit, DW) ->
+maybe_add_robj({error, timeout}, _Robj, Precommit) ->
     %% Catch cases where it would fail before sending to vnodes, otherwise
     %% timeout rather than receive an {error, too_many_fails} message - it 
     %% will never come if the put FSM times out.
-    case precommit_should_fail(Precommit, DW) of
+    case precommit_should_fail(Precommit) of
         {true, {error, precommit_fail}} ->
             {error, precommit_fail};
         {true, {error, {precommit_fail, Why}}} ->
@@ -695,7 +720,7 @@ maybe_add_robj({error, timeout}, _Robj, Precommit, DW) ->
         false ->
             {error, timeout}
     end;
-maybe_add_robj(Expect, _Robj, _Precommit, _DW) ->
+maybe_add_robj(Expect, _Robj, _Precommit) ->
     Expect.
 
 %%====================================================================
@@ -754,26 +779,26 @@ apply_precommit(Object, [{_, precommit_append_value} | Rest]) ->
 apply_precommit(Object, [_ | Rest]) ->
     apply_precommit(Object, Rest).
 
-precommit_should_fail([], _DW) ->
+precommit_should_fail([]) ->
     false;
-precommit_should_fail([{garbage, garbage} | _Rest], _DW) ->
+precommit_should_fail([{garbage, garbage} | _Rest]) ->
     {true, {error, {precommit_fail, {invalid_hook_def, not_a_hook_def}}}};
-precommit_should_fail([{garbage, empty} | _Rest], _DW) ->
+precommit_should_fail([{garbage, empty} | _Rest]) ->
     {true, {error, {precommit_fail, {invalid_hook_def, no_hook}}}};
-precommit_should_fail([{erlang,precommit_undefined} | _Rest], _DW) ->
+precommit_should_fail([{erlang,precommit_undefined} | _Rest]) ->
     {true, {error, {precommit_fail, 
                     {hook_crashed,{put_fsm_eqc,precommit_undefined,error,undef}}}}};
-precommit_should_fail([{erlang,precommit_crash} | _Rest], _DW) ->
+precommit_should_fail([{erlang,precommit_crash} | _Rest]) ->
     {true, {error, {precommit_fail, 
                     {hook_crashed,{put_fsm_eqc,precommit_crash,
                                    error,{badmatch,precommit_crash}}}}}};
-precommit_should_fail([{_Lang,Hook} | _Rest], _DW) when Hook =:= precommit_fail;
-                                                        Hook =:= precommit_crash;
-                                                        Hook =:= precommit_undefined ->
+precommit_should_fail([{_Lang,Hook} | _Rest]) when Hook =:= precommit_fail;
+                                                   Hook =:= precommit_crash;
+                                                   Hook =:= precommit_undefined ->
     {true, {error, precommit_fail}};
-precommit_should_fail([{_Lang,precommit_fail_reason}| _Rest], _DW) ->
+precommit_should_fail([{_Lang,precommit_fail_reason}| _Rest]) ->
     {true, {error, {precommit_fail, ?HOOK_SAYS_NO}}};
-precommit_should_fail([{Lang, precommit_nonobj} | _Rest], _DW) ->
+precommit_should_fail([{Lang, precommit_nonobj} | _Rest]) ->
     %% Javascript precommit returning a non-object crashes the JS VM.
     Details = case Lang of
                   js ->
@@ -782,8 +807,8 @@ precommit_should_fail([{Lang, precommit_nonobj} | _Rest], _DW) ->
                       {?MODULE, precommit_nonobj, not_an_obj}
               end,
     {true, {error, {precommit_fail, {invalid_return, Details}}}};
-precommit_should_fail([_LangHook | Rest], DW) ->
-    precommit_should_fail(Rest, DW).
+precommit_should_fail([_LangHook | Rest]) ->
+    precommit_should_fail(Rest).
 
 check_details(Info, Options) ->
     case proplists:get_value(details, Options, false) of
@@ -798,7 +823,7 @@ check_details(Info, Options) ->
 
 %% Check a 'w' message was sent for each planned response.
 %% i.e. make sure that the put FSM really sent N 
-check_puts_sent(N, VPutResp) ->
+check_puts_sent(ExpectedPuts, VPutResp) ->
     Requests = [normal || {w,_,_} <- VPutResp] ++
         [timeout || {{timeout, 1},_,_} <- VPutResp],
     NumPutReqs = length(Requests),
@@ -806,7 +831,7 @@ check_puts_sent(N, VPutResp) ->
                   io:format(user, "VPutResp:\n~p\n", [VPutResp]),
                   io:format(user, "Requests: ~p = ~p\n", [Requests, NumPutReqs])
               end,
-              equals(N, NumPutReqs)).
+              equals(ExpectedPuts, NumPutReqs)).
 
 %%====================================================================
 %% Javascript helpers 


### PR DESCRIPTION
Hey all,

Here's a pull request for node-based vclocks.  It changes the put FSM to work the way it is described in the Dynamo paper and is resistant to vclock explosion (but not sibling explosion) in the face of poorly behaved clients / multiple updates on a partitioned cluster by a client that can see both sides / syntactic put merge.

The changes
- Require a member of the preflist to coordinate a put.
- Complete the put on the local vnode first using a modified vnode put that ensures a conflicting vclock with other nodes in the cluster (which must be true as only the local node can update that vclock).
- Issue the object put successfully put on the local vnode to the remote vnodes.
- Remove syntactic put merge.
- Add an eventual consistency test that verifies this method works correctly in the face of updates during continuous partitioning of the cluster.
- Update the existing put FSM test for new behavior.

Things still to do for put FSM:
- Add a way to generate a shorter vclock nodeid (maybe initially generate from an ethernet MAC then store/retrieve from the ring, need to handle multiple instances per physical node).
- May need to use a modified vclock nodeid for fallback nodes to ensure uniqueness.

Things to do to riak_kv before we can merge
- Make any long-running vnode operation run on another thread.  Operations are serialized on the local vnode, so (for N=3) it is no longer best two latencies out of three, it's latency of local vnode put + best one of two remote vnode put latencies.

For testing it requires riak_core az303-vclock-enhancements checked out for a minor tweak to riak_core_vnode_master:command.  All k/v eunit tests should pass.

Once those changes have been made we can merge this pull request into mainline, but not before.  I'm submitting it for review now so the logic can be checked.

Cheers, Jon

P.S. DO NOT MERGE THIS YET.
