### PR TITLE
Allow reloading of Erlang code in the add_paths env var.

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -33,7 +33,8 @@
          ringready/1,
          transfers/1,
          cluster_info/1,
-         down/1]).
+         down/1,
+         reload_code/1]).
 
 join([NodeStr]) ->
     try
@@ -299,7 +300,7 @@ reload_file(Filename) ->
     Mod = list_to_atom(filename:basename(Filename, ".beam")),
     case code:is_loaded(Mod) of
         {file, Filename} ->
-            code:purge(Mod),
+            code:soft_purge(Mod),
             code:load_file(Mod),
             io:format("Reloaded module ~w from ~s.~n", [Mod, Filename]);
         {file, Other} ->

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -283,6 +283,21 @@ cluster_info([OutFile|Rest]) ->
             error
     end.
 
+reload_code([]) ->
+    case app_helper:get_env(riak_kv, add_paths) of
+        List when is_list(List) ->
+            [ reload_path(Path) || Path <- List ],
+            ok;
+        _ -> ok
+    end.
+
+reload_path(Path) ->
+    {ok, Beams} = file:list_dir(Path),
+    [ begin
+          M = list_to_atom(filename:basename(Beam, ".beam")),
+          code:purge(M), code:load_file(M)
+      end || Beam <- Beams ].
+
 format_stats([], Acc) ->
     lists:reverse(Acc);
 format_stats([{vnode_gets, V}|T], Acc) ->


### PR DESCRIPTION
Adds a `riak_kv_console` function to iterate over the paths in `add_paths` and reload all the .beam files found there.  This aids in automated code deployment of map/reduce functions.  Needs application of the corresponding [pull request](https://github.com/basho/riak/pull/48) in the riak repository to add the `erl_reload` command to `riak-admin`.
