### PR TITLE
Remove special case formatting for vnode_gets.

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -213,8 +213,6 @@ cluster_info([OutFile|Rest]) ->
 
 format_stats([], Acc) ->
     lists:reverse(Acc);
-format_stats([{vnode_gets, V}|T], Acc) ->
-    format_stats(T, [io_lib:format("vnode gets : ~p~n", [V])|Acc]);
 format_stats([{Stat, V}|T], Acc) ->
     format_stats(T, [io_lib:format("~p : ~p~n", [Stat, V])|Acc]).
 


### PR DESCRIPTION
There's no apparent reason for this function clause and it screws up attempts to do automated parsing of the output.
