### PR TITLE
Az528 integrate indexes with coverage

### DIFF
--- a/ebin/riak_kv.app
+++ b/ebin/riak_kv.app
@@ -33,6 +33,8 @@
              riak_kv_get_fsm,
              riak_kv_get_fsm_sup,
              riak_kv_index_backend,
+             riak_kv_index_fsm,
+             riak_kv_index_fsm_sup,
              riak_kv_js_manager,
              riak_kv_js_sup,
              riak_kv_js_vm,

--- a/include/riak_kv_vnode.hrl
+++ b/include/riak_kv_vnode.hrl
@@ -32,6 +32,11 @@
 -record(riak_kv_listbuckets_req_v1, {
           item_filter :: function()}).
 
+-record(riak_kv_index_req_v1, {
+          bucket :: binary() | tuple(),
+          item_filter :: function(),
+          qry :: riak_index:query_def()}).
+
 -record(riak_kv_delete_req_v1, {
           bkey :: {binary(), binary()},
           req_id :: non_neg_integer()}).
@@ -51,6 +56,7 @@
 -define(KV_MGET_REQ, #riak_kv_mget_req_v1).
 -define(KV_LISTBUCKETS_REQ, #riak_kv_listbuckets_req_v1).
 -define(KV_LISTKEYS_REQ, #riak_kv_listkeys_req_v3).
+-define(KV_INDEX_REQ, #riak_kv_index_req_v1).
 -define(KV_DELETE_REQ, #riak_kv_delete_req_v1).
 -define(KV_MAP_REQ, #riak_kv_map_req_v1).
 -define(KV_VCLOCK_REQ, #riak_kv_vclock_req_v1).

--- a/src/riak_index_backend.erl
+++ b/src/riak_index_backend.erl
@@ -36,7 +36,7 @@ behaviour_info(callbacks) ->
      {index, 2},       % (State, Postings)
      {delete, 2},      % (State, Postings)
      {lookup_sync, 4}, % (State, Index, Field, Term) 
-     {fold_index, 4},  % (State, Index, Query, Acc)
+     {fold_index, 6},  % (State, Index, Query, SKFun, Acc, FinalFun)
      {drop,1},         % (State)
      {callback,3}];    % (State, Ref, Msg) ->
 behaviour_info(_Other) ->

--- a/src/riak_index_backend.erl
+++ b/src/riak_index_backend.erl
@@ -36,7 +36,7 @@ behaviour_info(callbacks) ->
      {index, 2},       % (State, Postings)
      {delete, 2},      % (State, Postings)
      {lookup_sync, 4}, % (State, Index, Field, Term) 
-     {fold_index, 6},  % (State, Index, Query, SKFun, Acc, FinalFun)
+     {fold_index, 4},  % (State, Index, Query, Acc)
      {drop,1},         % (State)
      {callback,3}];    % (State, Ref, Msg) ->
 behaviour_info(_Other) ->

--- a/src/riak_index_backend.erl
+++ b/src/riak_index_backend.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% riak_index_backend: Riak Index backend behaviour 
+%% riak_index_backend: Riak Index backend behaviour
 %%
 %% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
 %%
@@ -32,10 +32,10 @@
 -spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
 behaviour_info(callbacks) ->
     [{start,2},        % (Partition, Config)
-     {stop,1},         % (State) 
+     {stop,1},         % (State)
      {index, 2},       % (State, Postings)
      {delete, 2},      % (State, Postings)
-     {lookup_sync, 4}, % (State, Index, Field, Term) 
+     {lookup_sync, 4}, % (State, Index, Field, Term)
      {fold_index, 6},  % (State, Index, Query, SKFun, Acc, FinalFun)
      {drop,1},         % (State)
      {callback,3}];    % (State, Ref, Msg) ->
@@ -76,7 +76,7 @@ standard_test(BackendMod, Config) ->
                  {<<"bucket">>, "field", "term2", "value_f", [], 1}
                 ],
     BackendMod:index(State, Postings2),
-    
+
     %% Retrieve what we just indexed...
     Results2 = [
                 {"value_d", [{"field", "term2"}]},
@@ -84,7 +84,7 @@ standard_test(BackendMod, Config) ->
                 {"value_f", [{"field", "term2"}]}
                ],
     ?assertEqual(Results2, BackendMod:lookup_sync(State, <<"bucket">>, "field", "term2")),
-    
+
     %% Delete some postings...
     Postings3 = [
                  {<<"bucket">>, "field", "term1", "value_a", [], 2},

--- a/src/riak_index_mi_backend.erl
+++ b/src/riak_index_mi_backend.erl
@@ -12,7 +12,7 @@
          index/2,
          delete/2,
          lookup_sync/4,
-         fold_index/6,
+         fold_index/4,
          drop/1,
          callback/3
         ]).
@@ -107,9 +107,11 @@ lookup_sync(State, Index, Field, Term) ->
     merge_index:lookup_sync(Pid, Index, Field, Term, FilterFun).
 
 
-%% @spec fold_index(State :: state(), Bucket :: binary(), Query :: riak_index:query_elements(),
-%%                  SKFun :: function(), Acc :: term(), FinalFun :: function()) -> term().
-fold_index(State, Index, Query, SKFun, Acc, FinalFun) ->
+%% @spec fold_index(State :: state(), 
+%%                  Bucket :: binary(),
+%%                  Query :: riak_index:query_elements(),
+%%                  Acc :: term()) -> term().
+fold_index(State, Index, Query, Acc) ->
     Pid = State#state.pid,
     FilterFun = fun(_Value, _Props) -> true end,
 
@@ -138,6 +140,29 @@ fold_index(State, Index, Query, SKFun, Acc, FinalFun) ->
                   _ -> 
                       {error, {unknown_query_element, Query}}
               end,
+
+    %% This is needs discussion. Our design notes call for results to
+    %% feed into SKFun using {sk, SecondaryKey, PrimaryKey}, but this
+    %% doesn't account for Properties. We also need to add a clause
+    %% for when we reach the limit.
+    SKFun = fun({results, Results1}, Acc1) ->
+                    {ok, Results1 ++ Acc1};
+               ({error, Reason}, _Acc1) ->
+                    {error, Reason};
+               (done, Acc1) ->
+                    {ok, Acc1}
+            end,
+
+    %% Also, for this round of changes, FinalFun is going to just
+    %% return the output of SKFun. Normally, this would call
+    %% riak_core_vnode:reply/N. Here, we just transform the list of
+    %% results from [{Key, Props}] to [Key].
+    FinalFun = fun({error, Reason}, _Acc1) ->
+                       {error, Reason};
+                  (done, Acc1) ->
+                       [K || {K, _} <- Acc1]
+               end,
+
     
     %% If Results is a list of results, then call SKFun to accumulate
     %% the results.

--- a/src/riak_index_mi_backend.erl
+++ b/src/riak_index_mi_backend.erl
@@ -32,7 +32,7 @@
 %% @type state() = term().
 -record(state, {partition, pid}).
 
-%% @type posting() :: {Index::binary(), Field::term(), Term::term(), 
+%% @type posting() :: {Index::binary(), Field::term(), Term::term(),
 %%                     Value::term(), Properties::term(), Timestamp::Integer}.
 
 %% @spec start(Partition :: integer(), Config :: proplist()) ->
@@ -41,13 +41,13 @@
 %% @doc Start this backend.
 start(Partition, Config) ->
     %% Get the data root directory
-    DataRoot = 
+    DataRoot =
         case proplists:get_value(data_root, Config) of
             undefined ->
                 case application:get_env(merge_index, data_root) of
                     {ok, Dir} ->
                         Dir;
-                    _ -> 
+                    _ ->
                         riak:stop("riak_index data_root unset, failing.")
                 end;
             Value ->
@@ -84,7 +84,7 @@ index(State, Postings) ->
 %%
 %% @doc Delete the specified postings in the index. Postings are a
 %%      6-tuple of the form {Index, Field, Term, Value, Properties,
-%%      Timestamp}. 
+%%      Timestamp}.
 delete(State, Postings) ->
     Pid = State#state.pid,
     %% Merge_index deletes a posting when you send it into the system
@@ -96,7 +96,7 @@ delete(State, Postings) ->
     merge_index:index(Pid, Postings1).
 
 
-%% @spec lookup_sync(State :: state(), Index::term(), Field::term(), Term::term()) -> 
+%% @spec lookup_sync(State :: state(), Index::term(), Field::term(), Term::term()) ->
 %%           [{Value::term(), Props::term()}].
 %%
 %% @doc Return a list of matching values stored under the provided
@@ -107,7 +107,7 @@ lookup_sync(State, Index, Field, Term) ->
     merge_index:lookup_sync(Pid, Index, Field, Term, FilterFun).
 
 %% @spec fold_index(State :: state(), Bucket :: binary(), Query :: riak_index:query_elements(),
-%%                  SKFun :: function(), Acc :: term(), FinalFun :: function()) -> term().    
+%%                  SKFun :: function(), Acc :: term(), FinalFun :: function()) -> term().
 fold_index(State, Index, Query, SKFun, Acc, FinalFun) ->
     Pid = State#state.pid,
     FilterFun = fun(_Value, _Props) -> true end,
@@ -134,11 +134,11 @@ fold_index(State, Index, Query, SKFun, Acc, FinalFun) ->
                   [{range, Field, [StartTerm, EndTerm]}] ->
                       merge_index:range_sync(Pid, Index, Field, StartTerm, EndTerm, ?SIZE, FilterFun);
 
-                  _ -> 
+                  _ ->
                       {error, {unknown_query_element, Query}}
               end,
 
-    
+
     %% If Results is a list of results, then call SKFun to accumulate
     %% the results.
     Results1 = case is_list(Results) of
@@ -172,7 +172,7 @@ callback(_State, _Ref, _Msg) ->
 
 %% @private
 %% @spec inc(term(), Amt :: integer()) -> term().
-%% 
+%%
 %% @doc Increments or decrements an Erlang data type by one
 %%      position. Used during construction of exclusive range searches.
 inc(Term, Amt)  when is_integer(Term) ->

--- a/src/riak_kv_coverage_filter.erl
+++ b/src/riak_kv_coverage_filter.erl
@@ -150,7 +150,6 @@ compose([Filter1|Filters], F0) ->
     {FilterMod, FilterFun, Args} = Filter1,
     Fun1 = FilterMod:FilterFun(Args),
     F1 = fun(CArgs) -> 
-                 io:format("CArgs: ~p~n", [CArgs]),
                  Fun1(CArgs) andalso F0(CArgs) end,
     compose(Filters, F1).
 

--- a/src/riak_kv_coverage_filter.erl
+++ b/src/riak_kv_coverage_filter.erl
@@ -148,12 +148,7 @@ compose(Filters) ->
 compose([], FilterFuns) ->
     TruthFun =
         fun(X) ->
-                case X of
-                    true ->
-                        true;
-                    _ ->
-                        false
-                end
+                X =:= true
         end,
     fun(Val) ->
             lists:all(TruthFun, [FilterFun(Val) || FilterFun <- FilterFuns])

--- a/src/riak_kv_coverage_filter.erl
+++ b/src/riak_kv_coverage_filter.erl
@@ -143,12 +143,14 @@ build_preflist_fun(Bucket, Ring) ->
 compose([]) ->
     none;
 compose(Filters) ->
-    compose(Filters, fun(V) -> V end).
+    compose(Filters, fun(_X) -> true end).
 
 compose([], F0) -> F0;
 compose([Filter1|Filters], F0) ->
     {FilterMod, FilterFun, Args} = Filter1,
     Fun1 = FilterMod:FilterFun(Args),
-    F1 = fun(CArgs) -> Fun1(F0(CArgs)) end,
+    F1 = fun(CArgs) -> 
+                 io:format("CArgs: ~p~n", [CArgs]),
+                 Fun1(CArgs) andalso F0(CArgs) end,
     compose(Filters, F1).
 

--- a/src/riak_kv_coverage_filter.erl
+++ b/src/riak_kv_coverage_filter.erl
@@ -34,7 +34,7 @@
 -export([build_filter/3]).
 
 -type bucket() :: binary().
--type filter() :: none | fun().
+-type filter() :: none | fun((any()) -> boolean()) | [{atom(), atom(), [any()]}].
 -type index() :: non_neg_integer().
 
 %% ===================================================================
@@ -42,6 +42,16 @@
 %% ===================================================================
 
 %% @doc Build the list of filter functions for any required VNode indexes.
+%%
+%% The ItemFilterInput parameter can be the atom `none' to indicate
+%% no filtering based on the request items, a function that returns
+%% a boolean indicating whether or not the item should be included
+%% in the final results, or a list of tuples of the form 
+%% {Module, Function, Args}. The latter is the form used by 
+%% MapReduce filters such as those in the {@link riak_kv_mapred_filters}
+%% module. The list of tuples is composed into a function that is
+%% used to determine if an item should be included in the final 
+%% result set.
 -spec build_filter(bucket(), filter(), [index()]) -> filter().
 build_filter(Bucket, ItemFilterInput, FilterVNode) ->
     ItemFilter = build_item_filter(ItemFilterInput),
@@ -119,7 +129,7 @@ build_item_filter(none) ->
 build_item_filter(FilterInput) when is_function(FilterInput) ->
     FilterInput;
 build_item_filter(FilterInput) ->
-    %% FilterInput is a list of MFA tuples
+    %% FilterInput is a list of {Module, Fun, Args} tuples
     compose(FilterInput).
 
 

--- a/src/riak_kv_index_backend.erl
+++ b/src/riak_kv_index_backend.erl
@@ -35,6 +35,7 @@
          list/1,
          list_bucket/2,
          fold/3,
+         fold_index/3,
          fold_keys/3,
          fold_bucket_keys/4,
          drop/1,
@@ -177,41 +178,15 @@ fold_keys(State, Fun, Extra) ->
     #state { kv_mod = KVMod, kv_state = KVState } = State,
     KVMod:fold_keys(KVState, Fun, Extra).
 
-
-%% HACK - This is how we're funneling Riak Index queries until we add
-%% "covering cast" functionality to riak_core. For now, we're going to
-%% focus on getting the request to the Index backend with the correct
-%% arguments roughly in place and running basic queries.
-fold_bucket_keys(State, {index_query, Bucket, Query}, _Fun, _Extra) ->
-    #state { index_mod = IndexMod, index_state = IndexState } = State,
-
+%% @doc Pass the fold_index request through to the Index backend.
+fold_index(#state {index_mod = IndexMod, 
+                   index_state = IndexState},
+           Bucket, Query) ->
     %% Update riak_kv_stat...
-    riak_kv_stat:update(vnode_index_read),
+    riak_kv_stat:update(vnode_index_read),    
 
-    %% This is needs discussion. Our design notes call for results to
-    %% feed into SKFun using {sk, SecondaryKey, PrimaryKey}, but this
-    %% doesn't account for Properties. We also need to add a clause
-    %% for when we reach the limit.
-    SKFun = fun({results, Results}, Acc) ->
-                    {ok, Results ++ Acc};
-               ({error, Reason}, _Acc) ->
-                    {error, Reason};
-               (done, Acc) ->
-                    {ok, Acc}
-            end,
-
-    %% Also, for this round of changes, FinalFun is going to just
-    %% return the output of SKFun. Normally, this would call
-    %% riak_core_vnode:reply/N. Here, we just transform the list of
-    %% results from [{Key, Props}] to [Key].
-    FinalFun = fun({error, Reason}, _Acc) ->
-                       {error, Reason};
-                  (done, Acc) ->
-                       [K || {K, _} <- Acc]
-               end,
-
-    %% Pass the fold_index request through to the Index backend.
-    IndexMod:fold_index(IndexState, Bucket, Query, SKFun, [], FinalFun);
+    %% Call fold_index on the Index backend
+    IndexMod:fold_index(IndexState, Bucket, Query, []).
 
 %% @spec fold_bucket_keys(state(), binary(), function(), term()) -> [Key :: binary()].
 %%

--- a/src/riak_kv_index_backend.erl
+++ b/src/riak_kv_index_backend.erl
@@ -68,7 +68,7 @@ start(Partition, Config) ->
     {ok, IndexState} = IndexMod:start(Partition, Config),
 
     %% Create the state and return...
-    State = #state { 
+    State = #state {
       kv_mod = KVMod,
       kv_state = KVState,
       index_mod = IndexMod,
@@ -79,7 +79,7 @@ start(Partition, Config) ->
 %% @spec stop(state()) -> ok | {error, Reason :: term()}.
 %%
 %% @doc Stop backends, bubble up any errors.
-stop(State) -> 
+stop(State) ->
     #state { kv_mod = KVMod, kv_state = KVState, index_mod = IndexMod, index_state = IndexState } = State,
     KVResult = KVMod:stop(KVState),
     IndexResult = IndexMod:stop(IndexState),
@@ -91,7 +91,7 @@ stop(State) ->
     end.
 
 %% @spec get(state(), Key :: binary()) -> {ok, Val :: binary()} | {error, Reason :: term()}.
-%% 
+%%
 %% @doc Pass a get request through to the KV backend.
 get(State, BKey) ->
     #state { kv_mod = KVMod, kv_state = KVState } = State,
@@ -101,7 +101,7 @@ get(State, BKey) ->
 %%
 %% @doc Index the Riak object using fields stored in metadata under
 %%       <<"index">>, then store the object in the KV backend.
-put(State, BKey, Val) -> 
+put(State, BKey, Val) ->
     #state { kv_mod = KVMod, kv_state = KVState, index_mod = IndexMod, index_state = IndexState } = State,
 
     %% Since the two backends are separate, we can't have a true
@@ -116,9 +116,9 @@ put(State, BKey, Val) ->
     end.
 
 %% @spec delete(state(), Key :: binary()) -> ok | {error, Reason :: term()}.
-%% 
+%%
 %% @doc Delete the object from the Index backend and the KV backend.
-delete(State, BKey) -> 
+delete(State, BKey) ->
     #state { kv_mod = KVMod, kv_state = KVState, index_mod = IndexMod, index_state = IndexState } = State,
 
     %% Since the two backends are separate, we can't have a true
@@ -140,7 +140,7 @@ list(State) ->
     KVMod:list(KVState).
 
 %% @spec list_bucket(state(), list_bucket_def()) -> [Key :: binary()].
-%% @type list_bucket_def() -> Bucket :: binary() 
+%% @type list_bucket_def() -> Bucket :: binary()
 %%                          | Any :: '_'
 %%                          | Filter :: {filter, Bucket::binary(), FilterFun :: function()}
 %%
@@ -167,23 +167,23 @@ drop(State) ->
 %% @spec fold(state(), function(), term()) -> [Key :: binary()].
 %%
 %% @doc Pass fold requests through to the KV backend.
-fold(State, Fun, Extra) ->    
+fold(State, Fun, Extra) ->
     #state { kv_mod = KVMod, kv_state = KVState } = State,
     KVMod:fold(KVState, Fun, Extra).
 
 %% @spec fold_keys(state(), function(), term()) -> [Key :: binary()].
-%% 
+%%
 %% @doc Pass fold_keys requests through to the KV backend.
 fold_keys(State, Fun, Extra) ->
     #state { kv_mod = KVMod, kv_state = KVState } = State,
     KVMod:fold_keys(KVState, Fun, Extra).
 
 %% @doc Pass the fold_index request through to the Index backend.
-fold_index(#state {index_mod = IndexMod, 
+fold_index(#state {index_mod = IndexMod,
                    index_state = IndexState},
            Bucket, Query) ->
     %% Update riak_kv_stat...
-    riak_kv_stat:update(vnode_index_read),    
+    riak_kv_stat:update(vnode_index_read),
 
     %% This is needs discussion. Our design notes call for results to
     %% feed into SKFun using {sk, SecondaryKey, PrimaryKey}, but this
@@ -232,7 +232,7 @@ fold_bucket_keys(State, Bucket, Fun, Extra) ->
 
 %% @spec callback(state(), ref(), term()) -> ok.
 %%
-%% @doc Pass any callbacks through to the KV backend. 
+%% @doc Pass any callbacks through to the KV backend.
 callback(State, Ref, Msg) ->
     %% Callbacks are handled using the same method as multi-backend:
     %% call the callback function on each backend, don't check for any
@@ -246,9 +246,9 @@ callback(State, Ref, Msg) ->
 %%% PRIVATE FUNCTIONS %%%
 
 
-%% @private 
+%% @private
 %% @spec do_index_put(IndexMod :: module(), IndexState :: term(), BKey :: riak_object:bkey(), Val :: binary()) -> ok.
-%%       
+%%
 %% @doc Index the BKey/Value in the Index backend.
 do_index_put(IndexMod, IndexState, BKey, Val) ->
     %% Get the old proxy object. If it exists, then delete all of its
@@ -274,11 +274,11 @@ do_index_put(IndexMod, IndexState, BKey, Val) ->
     %% get anything back except for {ok, IndexFields} then fail
     %% loudly, as it's an unanticipated code path.
     IndexFields = case riak_index:parse_object(Obj) of
-                      {ok, IFs} -> 
+                      {ok, IFs} ->
                           %% No properties for now. This is here for future planning.
                           EmptyProps = [],
                           [{Field, Value, EmptyProps} || {Field, Value} <- IFs];
-                      {error, Reasons} -> 
+                      {error, Reasons} ->
                           throw({error_parsing_index_fields, Reasons})
                   end,
 
@@ -292,24 +292,24 @@ do_index_put(IndexMod, IndexState, BKey, Val) ->
 
     %% Store the new postings...
     Postings = [{Bucket, Field, Token, Key, Props, TS2} || {Field, Token, Props} <- IndexFields],
-    try 
+    try
         %% io:format("DEBUG: Indexing new postings for ~p:~n~p~n", [BKey, Postings]),
         IndexMod:index(IndexState, Postings),
         riak_kv_stat:update({vnode_index_write, length(Postings)}),
         ok
-    catch 
+    catch
         _Type : Reason ->
             {error, Reason}
     end.
 
-%% @private 
+%% @private
 %% @spec do_kv_put(KVMod :: module(), KVState :: term(), BKey :: riak_object:bkey(), Val :: binary()) -> ok.
-%% 
+%%
 %% @doc Store the BKey/Value in the KV backend.
 do_kv_put(KVMod, KVState, BKey, Val) ->
     KVMod:put(KVState, BKey, Val).
 
-%% @private 
+%% @private
 %% @spec do_index_delete(IndexMod :: module(), IndexState :: term(), BKey :: riak_object:bkey()) -> ok | {error, Reason}
 %%
 %% @doc Delete the BKey from the Index backend.
@@ -333,9 +333,9 @@ do_index_delete(IndexMod, IndexState, BKey) ->
             ok
     end.
 
-%% @private 
+%% @private
 %% @spec do_kv_delete(KVMod :: module(), KVState :: term(), BKey :: riak_object:bkey()) -> ok.
-%% 
+%%
 %% @doc Delete the BKey from the KV backend.
 do_kv_delete(KVMod, KVState, BKey) ->
     KVMod:delete(KVState, BKey).

--- a/src/riak_kv_index_fsm.erl
+++ b/src/riak_kv_index_fsm.erl
@@ -1,0 +1,122 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_index_fsm: Manage secondary index queries.
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc The index fsm manages the execution of secondary index queries.
+%%
+%%      The index fsm creates a plan to achieve coverage
+%%      of the cluster using the minimum
+%%      possible number of VNodes, sends index query
+%%      commands to each of those VNodes, and compiles the
+%%      responses.
+%%
+%%      The number of VNodes required for full
+%%      coverage is based on the number
+%%      of partitions, the number of available physical
+%%      nodes, and the bucket n_val.
+
+-module(riak_kv_index_fsm).
+
+-behaviour(riak_core_coverage_fsm).
+
+-include_lib("riak_kv_vnode.hrl").
+
+-export([init/2,
+         process_results/2,
+         finish/2]).
+
+-type from() :: {atom(), req_id(), pid()}.
+-type req_id() :: non_neg_integer().
+
+-record(state, {client_type :: plain | mapred,
+                from :: from()}).
+
+%% @doc Return a tuple containing the ModFun to call per vnode,
+%% the number of primary preflist vnodes the operation
+%% should cover, the service to use to check for available nodes,
+%% and the registered name to use to access the vnode master process.
+init(From={_, _, ClientPid}, [Bucket, ItemFilter, Query, Timeout, ClientType]) ->
+    case ClientType of
+        %% Link to the mapred job so we die if the job dies
+        mapred ->
+            link(ClientPid);
+        _ ->
+            ok
+    end,
+    %% Get the bucket n_val for use in creating a coverage plan
+    BucketProps = riak_core_bucket:get_bucket(Bucket),
+    NVal = proplists:get_value(n_val, BucketProps),
+    %% Construct the key listing request
+    Req = ?KV_INDEX_REQ{bucket=Bucket,
+                        item_filter=ItemFilter,
+                        qry=Query},
+    {Req, all, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout,
+     #state{client_type=ClientType, from=From}}.
+
+process_results({results, {Bucket, Results}},
+                StateData=#state{client_type=ClientType,
+                                 from={raw, ReqId, ClientPid}}) ->
+    process_query_results(ClientType, Bucket, Results, ReqId, ClientPid),
+    {ok, StateData};
+process_results({final_results, {Bucket, Results}},
+                StateData=#state{client_type=ClientType,
+                                 from={raw, ReqId, ClientPid}}) ->
+    process_query_results(ClientType, Bucket, Results, ReqId, ClientPid),
+    {done, StateData}.
+
+finish({error, Error},
+       StateData=#state{from={raw, ReqId, ClientPid},
+                        client_type=ClientType}) ->
+    case ClientType of
+        mapred ->
+            %% An error occurred or the timeout interval elapsed
+            %% so all we can do now is die so that the rest of the
+            %% MapReduce processes will also die and be cleaned up.
+            exit(Error);
+        plain ->
+            %% Notify the requesting client that an error
+            %% occurred or the timeout has elapsed.
+            ClientPid ! {ReqId, Error}
+    end,
+    {stop, normal, StateData};
+finish(clean,
+       StateData=#state{from={raw, ReqId, ClientPid},
+                        client_type=ClientType}) ->
+    case ClientType of
+        mapred ->
+            luke_flow:finish_inputs(ClientPid);
+        plain ->
+            ClientPid ! {ReqId, done}
+    end,
+    {stop, normal, StateData}.
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+process_query_results(plain, _Bucket, Results, ReqId, ClientPid) ->
+    ClientPid ! {ReqId, {results, Results}};
+process_query_results(mapred, Bucket, Results, _ReqId, ClientPid) ->
+    try
+        luke_flow:add_inputs(ClientPid, [{Bucket, Result} || Result <- Results])
+    catch _:_ ->
+            exit(self(), normal)
+    end.

--- a/src/riak_kv_index_fsm_sup.erl
+++ b/src/riak_kv_index_fsm_sup.erl
@@ -1,0 +1,49 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_index_fsm_sup: supervise the riak_kv index state machines.
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc supervise the riak_kv index state machines used to
+%% process secondary index queries.
+
+-module(riak_kv_index_fsm_sup).
+
+-behaviour(supervisor).
+
+-export([start_index_fsm/2]).
+-export([start_link/0]).
+-export([init/1]).
+
+start_index_fsm(Node, Args) ->
+    supervisor:start_child({?MODULE, Node}, Args).
+
+%% @spec start_link() -> ServerRet
+%% @doc API for starting the supervisor.
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% @spec init([]) -> SupervisorTree
+%% @doc supervisor callback.
+init([]) ->
+    IndexFsmSpec = {undefined,
+               {riak_core_coverage_fsm, start_link, [riak_kv_index_fsm]},
+               temporary, 5000, worker, [riak_kv_index_fsm]},
+
+    {ok, {{simple_one_for_one, 10, 10}, [IndexFsmSpec]}}.

--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -104,6 +104,9 @@ init([]) ->
     KeysFsmSup = {riak_kv_keys_fsm_sup,
                  {riak_kv_keys_fsm_sup, start_link, []},
                  permanent, infinity, supervisor, [riak_kv_keys_fsm_sup]},
+    IndexFsmSup = {riak_kv_index_fsm_sup,
+                   {riak_kv_index_fsm_sup, start_link, []},
+                   permanent, infinity, supervisor, [riak_kv_index_fsm_sup]},
     %% @TODO This code is only here to support
     %% rolling upgrades and will be removed.
     LegacyKeysFsmSup = {riak_kv_keys_fsm_legacy_sup,
@@ -126,6 +129,7 @@ init([]) ->
         DeleteSup,
         BucketsFsmSup,
         KeysFsmSup,
+        IndexFsmSup,
         LegacyKeysFsmSup,
         KLSup,
         KLMaster,

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -242,6 +242,10 @@ handle_command({mapexec_reply, JobId, Result}, _Sender, #state{mrjobs=Jobs}=Stat
                end,
     {noreply, NewState}.
 
+%% @doc Handle a coverage request. 
+%% More information about the specification for the ItemFilter
+%% parameter can be found in the documentation for the
+%% {@link riak_kv_coverage_filter} module.
 handle_coverage(?KV_LISTBUCKETS_REQ{item_filter=ItemFilter},
                 _FilterVNodes,
                 Sender,

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -592,7 +592,7 @@ index_query(Sender, Bucket, Query, Filter, Mod, ModState) ->
         _ ->
             FilteredResults = lists:foldl(Filter, [], QueryResults),
             riak_core_vnode:reply(Sender, {final_results, {Bucket, FilteredResults}})
-    end.    
+    end.
 
 %% @private
 do_delete(BKey, Mod, ModState) ->


### PR DESCRIPTION
Change secondary indexes to use coverage instead of legacy key listing code.
