### PR TITLE
Add timeout around bad node ping in put_fsm_eqc.

### DIFF
--- a/test/put_fsm_eqc.erl
+++ b/test/put_fsm_eqc.erl
@@ -70,7 +70,7 @@ eqc_test_() ->
        [%% Check networking/clients are set up 
         ?_assert(node() /= 'nonode@nohost'),
         ?_assertEqual(pong, net_adm:ping(node())),
-        ?_assertEqual(pang, net_adm:ping('nonode@nohost')),
+        {timeout, 60, [?_assertEqual(pang, net_adm:ping('nonode@nohost'))]},
         ?_assertMatch({ok,_C}, riak:local_client()),
         %% Check javascript is working
         ?_assertMatch({ok, 123}, 


### PR DESCRIPTION
The intentionally failing node ping in the put_fsm_eqc was timing out and causing the test suite to fail. Add a 60 second timeout to avoid this.
