### PR TITLE
Use pseudo-random node names to avoid problems with racing with epmd to r

### DIFF
--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -285,7 +285,8 @@ setup() ->
     error_logger:tty(false),
     error_logger:logfile({open, "riak_kv_delete_test.log"}),
     %% Start erlang node
-    TestNode = list_to_atom("testnode" ++ integer_to_list(element(3, now()))),
+    TestNode = list_to_atom("testnode" ++ integer_to_list(element(3, now())) ++
+                                integer_to_list(element(2, now()))),
     {ok, _} = net_kernel:start([TestNode, shortnames]),
     do_dep_apps(start, dep_apps()),
     application:set_env(riak_core, default_bucket_props, [{r, quorum},

--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -285,7 +285,8 @@ setup() ->
     error_logger:tty(false),
     error_logger:logfile({open, "riak_kv_delete_test.log"}),
     %% Start erlang node
-    {ok, _} = net_kernel:start([testnode, shortnames]),
+    TestNode = list_to_atom("testnode" ++ integer_to_list(element(3, now()))),
+    {ok, _} = net_kernel:start([TestNode, shortnames]),
     do_dep_apps(start, dep_apps()),
     application:set_env(riak_core, default_bucket_props, [{r, quorum},
             {w, quorum}, {pr, 0}, {pw, 0}, {rw, quorum}, {n_val, 3}]),

--- a/test/keys_fsm_eqc.erl
+++ b/test/keys_fsm_eqc.erl
@@ -65,7 +65,8 @@ setup() ->
     timer:sleep(2000),
 
     %% Start erlang node
-    net_kernel:start([testnode, shortnames]),
+    TestNode = list_to_atom("testnode" ++ integer_to_list(element(3, now()))),
+    net_kernel:start([TestNode, shortnames]),
     do_dep_apps(start, dep_apps()),
     ok.
 
@@ -198,6 +199,8 @@ prepare() ->
     error_logger:delete_report_handler(sasl_report_tty_h),
     error_logger:delete_report_handler(error_logger_tty_h),
 
+    TestNode = list_to_atom("testnode" ++ integer_to_list(element(3, now())) ++
+                                "@localhost"),
     {ok, _} = net_kernel:start([testnode, longnames]),
     do_dep_apps(start, dep_apps()),
     ok.

--- a/test/put_fsm_eqc.erl
+++ b/test/put_fsm_eqc.erl
@@ -96,7 +96,7 @@ setup() ->
                     %% not been run from the commandline.
                     os:cmd("epmd -daemon"),
                     timer:sleep(100),
-                    TestNode = list_to_atom("putfsmeqc" ++ integer_to_list(element(3, now()))),
+                    TestNode = list_to_atom("putfsmeqc" ++ integer_to_list(element(3, now())) ++ integer_to_list(element(2, now()))),
                     {ok, _Pid} = net_kernel:start([TestNode, shortnames]),
                     started
             end,

--- a/test/put_fsm_eqc.erl
+++ b/test/put_fsm_eqc.erl
@@ -96,7 +96,8 @@ setup() ->
                     %% not been run from the commandline.
                     os:cmd("epmd -daemon"),
                     timer:sleep(100),
-                    {ok, _Pid} = net_kernel:start(['putfsmeqc@localhost', shortnames]),
+                    TestNode = list_to_atom("putfsmeqc" ++ integer_to_list(element(3, now()))),
+                    {ok, _Pid} = net_kernel:start([TestNode, shortnames]),
                     started
             end,
     %% Shut logging up - too noisy.


### PR DESCRIPTION
Use pseudo-random node names to avoid problems with racing with epmd to reuse a node name
