### PR TITLE
Make sure to stop backends after use in riak_kv_multi_backend tests.

### DIFF
--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -244,6 +244,9 @@ multi_backend_test_() ->
 
                         % Check the default...
                         {second_backend, riak_kv_ets_backend, _} = get_backend(<<"b3">>, State),
+                            
+                        % Stop the backend
+                        stop(State),
                         ok
                     end
                 }
@@ -310,6 +313,7 @@ extra_callback_test() ->
                 {gb_trees, riak_kv_gb_trees_backend, []}]}],
     {ok, State} = start(0, Config),
     callback(State, make_ref(), ignore_me),
+    stop(State),
     application:unload(bitcask).
     
            


### PR DESCRIPTION
Makes sure all multi_backend tests cleanup after themselves.
