### PR TITLE
Log error if `send_inputs` breaks

### DIFF
--- a/src/riak_kv_pb_socket.erl
+++ b/src/riak_kv_pb_socket.erl
@@ -409,10 +409,11 @@ pipe_mapreduce(Req, State, Inputs, Query, _Timeout) ->
                     Ref = (Pipe#pipe.sink)#fitting.ref,
                     %% TODO: timeout
                     {pause, State#state{req=Req, req_ctx=Ref}};
-                _Error ->
+                Error ->
                     %% even if the structure looks right, it might name
                     %% a non-existent key filter or something
                     riak_pipe:eoi(Pipe),
+                    lager:error("Error sending inputs: ~p", [Error]),
                     send_error("~p", [bad_mapred_inputs], State)
             end;
         false ->


### PR DESCRIPTION
az583

It's not very helpful to just see `bad_mapred_inputs` because you
can't distinguish between the two different places where this can occur.
Furthermore, even if you could it still tells you nothing as to
why it actually broke.
