### PR TITLE
Resolve warning in keys_fsm_eqc introduced by commit 078272dac465e876a2f871464efd38633a228b29.

### DIFF
--- a/test/keys_fsm_eqc.erl
+++ b/test/keys_fsm_eqc.erl
@@ -201,7 +201,7 @@ prepare() ->
 
     TestNode = list_to_atom("testnode" ++ integer_to_list(element(3, now())) ++
                                 "@localhost"),
-    {ok, _} = net_kernel:start([testnode, longnames]),
+    {ok, _} = net_kernel:start([TestNode, longnames]),
     do_dep_apps(start, dep_apps()),
     ok.
 


### PR DESCRIPTION
Warning introduced during test cleanup day.
