### PR TITLE
Add the bucket props to the key stream output

### DIFF
--- a/src/riak_kv_wm_keylist.erl
+++ b/src/riak_kv_wm_keylist.erl
@@ -152,7 +152,7 @@ produce_bucket_body(RD, Ctx) ->
                         {ok, ReqId} = Client:stream_list_keys(Bucket),
                         stream_keys(ReqId)
                 end,
-            {{stream, {[], F}}, RD, Ctx};
+            {{stream, {mochijson2:encode({struct, BucketPropsJson}), F}}, RD, Ctx};
 
         ?Q_TRUE ->
             %% Get the JSON response...


### PR DESCRIPTION
Current new api code doesn't return bucket props when keys are streamed
