### PR TITLE
AZ570 - MapReduce Support for 2I

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -42,6 +42,7 @@
 -export([filter_keys/2,filter_keys/3]).
 -export([list_buckets/0,list_buckets/2]).
 -export([get_index/3,get_index/2]).
+-export([stream_get_index/3,stream_get_index/2]).
 -export([set_bucket/2,get_bucket/1]).
 -export([reload_all/1]).
 -export([remove_from_cluster/1]).
@@ -672,6 +673,30 @@ get_index(Bucket, Query, Timeout) ->
     ReqId = mk_reqid(),
     riak_kv_index_fsm_sup:start_index_fsm(Node, [{raw, ReqId, Me}, [Bucket, none, Query, Timeout, plain]]),
     wait_for_query_results(ReqId, Timeout).
+
+%% @spec stream_get_index(Bucket :: binary(),
+%%                        Query :: riak_index:query_def()) ->
+%%       {ok, pid()} |
+%%       {error, timeout} |
+%%       {error, Err :: term()}.
+%%
+%% @doc Run the provided index query, return a stream handle.
+stream_get_index(Bucket, Query) ->
+    stream_get_index(Bucket, Query, ?DEFAULT_TIMEOUT).
+
+%% @spec stream_get_index(Bucket :: binary(),
+%%                        Query :: riak_index:query_def(),
+%%                        TimeoutMillisecs :: integer()) ->
+%%       {ok, pid()} |
+%%       {error, timeout} |
+%%       {error, Err :: term()}.
+%%
+%% @doc Run the provided index query, return a stream handle.
+stream_get_index(Bucket, Query, Timeout) ->
+    Me = self(),
+    ReqId = mk_reqid(),
+    riak_kv_index_fsm_sup:start_index_fsm(Node, [{raw, ReqId, Me}, [Bucket, none, Query, Timeout, plain]]),
+    {ok, ReqId}.
 
 %% @spec set_bucket(riak_object:bucket(), [BucketProp :: {atom(),term()}]) -> ok
 %% @doc Set the given properties for Bucket.

--- a/src/riak_kv_mapred_filters.erl
+++ b/src/riak_kv_mapred_filters.erl
@@ -118,7 +118,6 @@ between(Args) ->
     end.
 
 matches([MS|_]) ->
-    io:format("[~s:~p] DEBUG - MS: ~p~n", [?MODULE, ?LINE, MS]),
     {ok, CMS} = re:compile(MS),
     fun(V) ->
         case re:run(V, CMS) of

--- a/src/riak_kv_mapred_filters.erl
+++ b/src/riak_kv_mapred_filters.erl
@@ -118,6 +118,7 @@ between(Args) ->
     end.
 
 matches([MS|_]) ->
+    io:format("[~s:~p] DEBUG - MS: ~p~n", [?MODULE, ?LINE, MS]),
     {ok, CMS} = re:compile(MS),
     fun(V) ->
         case re:run(V, CMS) of

--- a/src/riak_kv_mrc_pipe.erl
+++ b/src/riak_kv_mrc_pipe.erl
@@ -345,6 +345,20 @@ send_inputs(Pipe, {Bucket, FilterExprs}, _Timeout) ->
         {ok, ReqId} -> send_key_list(Pipe, Bucket, ReqId);
         Error       -> Error
     end;
+send_inputs(Pipe, {index, Bucket, Index, Key}, Timeout) ->
+    Query = [{eq, Index, [Key]}],
+    NewInput = {modfun, riak_index, mapred_index, [Bucket, Query]},
+    send_inputs(Pipe, NewInput, Timeout);
+send_inputs(Pipe, {index, Bucket, Index, StartKey, EndKey}, Timeout) ->
+    Query = [{range, Index, [StartKey, EndKey]}],
+    NewInput = {modfun, riak_index, mapred_index, [Bucket, Query]},
+    send_inputs(Pipe, NewInput, Timeout);
+send_inputs(Pipe, {search, Bucket, Query}, Timeout) ->
+    NewInput = {modfun, riak_search, mapred_search, [Bucket, Query, []]},
+    send_inputs(Pipe, NewInput, Timeout);
+send_inputs(Pipe, {search, Bucket, Query, Filter}, Timeout) ->
+    NewInput = {modfun, riak_search, mapred_search, [Bucket, Query, Filter]},
+    send_inputs(Pipe, NewInput, Timeout);
 send_inputs(Pipe, {modfun, Mod, Fun, Arg} = Modfun, Timeout) ->
     try Mod:Fun(Pipe, Arg, Timeout) of
         {ok, Bucket, ReqId} ->


### PR DESCRIPTION
Updated RiakKV to feed an index lookup into map/reduce:

```
   "inputs": {
       "bucket":"mybucket",
       "index":"field1_bin",
       "key":"val3"
   }
```

Also added first class support to feed search results into map/reduce. (Previous support required the use of a modfun, which was clunky):

```
   "inputs": {
       "bucket":"mybucket",
       "query":"data1 OR data2"
   }
```

Mainly involved changes to riak_kv_mapred_json for parsing the input statement.

Tested using the following curl commands:

``` bash
#
# Before running examples:
#
#1. Turn on indexing, search, and pipe mapreduce.
#    In app.config:
#    In "riak_kv" section:
#      - {storage_backend, riak_kv_index_backend},
#      - {mapred_system, pipe},
#
#    In "riak_search" section:
#      - {enabled, false}
#
#2. Enable search hooks on the "mybucket" bucket.
#    bin/search-cmd install mybucket
#


# Store some objects
curl -v -X PUT \
-d 'data1' \
-H "x-riak-index-field1_bin: val1" \
-H "x-riak-index-field2_int: 1001" \
http://127.0.0.1:8098/riak/mybucket/mykey1

curl -v -X PUT \
-d 'data2' \
-H "x-riak-index-Field1_bin: val2" \
-H "x-riak-index-Field2_int: 1002" \
http://127.0.0.1:8098/riak/mybucket/mykey2

curl -v -X PUT \
-d 'data3' \
-H "X-RIAK-INDEX-FIELD1_BIN: val3" \
-H "X-RIAK-INDEX-FIELD2_INT: 1003" \
http://127.0.0.1:8098/riak/mybucket/mykey3

curl -v -X PUT \
-d 'data4' \
-H "x-riak-index-field1_bin: val4" \
-H "x-riak-index-field2_int: 1004" \
http://127.0.0.1:8098/riak/mybucket/mykey4

# Call MapReduce over the entire bucket...
curl -X POST \
-H "content-type: application/json" \
-d @- \
http://localhost:8098/mapred \
<<EOF
{
   "inputs":"mybucket",
   "query":[
      {
         "reduce":{
            "language":"erlang",
            "module":"riak_kv_mapreduce",
            "function":"reduce_identity",
            "keep":true
         }
      }
   ]
}
EOF

# Call MapReduce over bucket with key filter ...
curl -X POST \
-H "content-type: application/json" \
-d @- \
http://localhost:8098/mapred \
<<EOF
{
   "inputs": {
      "bucket":"mybucket",
      "key_filters":[["matches", "mykey1.*"]]
   },
   "query":[
      {
         "reduce":{
            "language":"erlang",
            "module":"riak_kv_mapreduce",
            "function":"reduce_identity",
            "keep":true
         }
      }
   ]
}
EOF

# Call MapReduce over a few keys...
curl -X POST \
-H "content-type: application/json" \
-d @- \
http://localhost:8098/mapred \
<<EOF
{
   "inputs":[["mybucket","mykey1"],["mybucket","mykey2"]],
   "query":[
      {
         "reduce":{
            "language":"erlang",
            "module":"riak_kv_mapreduce",
            "function":"reduce_identity",
            "keep":true
         }
      }
   ]
}
EOF

# Call MapReduce with a 2i exact match search...
curl -X POST \
-H "content-type: application/json" \
-d @- \
http://localhost:8098/mapred \
<<EOF
{
   "inputs":{
       "bucket":"mybucket",
       "index":"field1_bin",
       "key":"val3"
   },
   "query":[
      {
         "reduce":{
            "language":"erlang",
            "module":"riak_kv_mapreduce",
            "function":"reduce_identity",
            "keep":true
         }
      }
   ]
}
EOF

# Call MapReduce with a 2i range query...
curl -X POST \
-H "content-type: application/json" \
-d @- \
http://localhost:8098/mapred \
<<EOF
{
   "inputs":{
       "bucket":"mybucket",
       "index":"field1_bin",
       "start":"val2",
       "end":"val4"
   },
   "query":[
      {
         "reduce":{
            "language":"erlang",
            "module":"riak_kv_mapreduce",
            "function":"reduce_identity",
            "keep":true
         }
      }
   ]
}
EOF

# Call MapReduce with a search query...
curl -X POST \
-H "content-type: application/json" \
-d @- \
http://localhost:8098/mapred \
<<EOF
{
   "inputs":{
       "bucket":"mybucket",
       "query":"data1 OR data2"
   },
   "query":[
      {
         "reduce":{
            "language":"erlang",
            "module":"riak_kv_mapreduce",
            "function":"reduce_identity",
            "keep":true
         }
      }
   ]
}
EOF

# Call MapReduce with a modfun query...
curl -X POST \
-H "content-type: application/json" \
-d @- \
http://localhost:8098/mapred \
<<EOF
{
   "inputs":{
       "module":"riak_search",
       "function":"mapred_search",
       "arg":["mybucket","data1 OR data2"]
   },
   "query":[
      {
         "reduce":{
            "language":"erlang",
            "module":"riak_kv_mapreduce",
            "function":"reduce_identity",
            "keep":true
         }
      }
   ]
}
EOF
```
