### PR TITLE
AZ566 - Update PB interface to support 2I

### DIFF
--- a/src/riak_kv_mapred_term.erl
+++ b/src/riak_kv_mapred_term.erl
@@ -24,7 +24,7 @@
 
 -module(riak_kv_mapred_term).
 
--export([parse_request/1]).
+-export([parse_request/1, valid_inputs/1]).
 
 -define(DEFAULT_TIMEOUT, 60000).
 
@@ -60,17 +60,25 @@ parse_request(BinReq) ->
 %%                        |bucket()
 %%                        |{bucket(), list()}
 %%                        |{modfun, atom(), atom(), list()}
-valid_inputs(Bucket) when is_binary(Bucket) ->    
+valid_inputs(Bucket) when is_binary(Bucket) ->
     ok;
 valid_inputs(Targets) when is_list(Targets) ->
     valid_input_targets(Targets);
 valid_inputs({modfun, Module, Function, _Options})
   when is_atom(Module), is_atom(Function) ->
     ok;
+valid_inputs({index, _Bucket, _Index, _Key}) ->
+    ok;
+valid_inputs({index, _Bucket, _Index, _StartKey, _EndKey}) ->
+    ok;
+valid_inputs({search, _Bucket, _Query}) ->
+    ok;
+valid_inputs({search, _Bucket, _Query, _Filter}) ->
+    ok;
 valid_inputs({Bucket, Filters}) when is_binary(Bucket), is_list(Filters) ->
     ok;
 valid_inputs(Invalid) ->
-    {error, {"Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of target tuples, or a modfun tuple:", Invalid}}.
+    {error, {"Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of target tuples, or a search, index, or modfun tuple:", Invalid}}.
 
 %% @type bucket_key() = {binary(), binary()}
 %%                     |{{binary(), binary()}, term()}


### PR DESCRIPTION
## IMPORTANT

This code depends on https://github.com/basho/riak-erlang-client/pull/34
## GET Operations
- Modified `riakc_pb:pbify_rpbcontent_entry/3` to correctly encode index metadata. Stored in the "indexes" pb field.
- All index field names and values are encoded as lists on the client side (but it accepts integers, too.) Had three options, the first option seemed best:
  1. Encode everything as lists, ignoring data types.
  2. Have the `riakc_pb` module call into the `riak_index` module, making the `riakc` project dependent on the `riak_kv` project.
  3. Duplicate the field parsing logic. We use lists and not binaries to stay consistent with the User Metadata.
## PUT Operations
- Modified `riakc_pb:erlify_rpbcontent/1` to correctly decode indexes pb field into index metadata.
## Index Queries
- Piggybacked on top of map/reduce, just like search.
- Modified `riak_kv_mapred_term:valid_inputs/1` to account for 'index' and 'search' type queries.
- Modified `riak_kv_pb_socket:pipe_mapreduce/N` to remove duplicate input validation.
- Modify `riakc_kv_pb_socket` to expose `get_index/N` functions.
- Return error message on incorrectly formatted inputs. Unlike the HTTP interface, we're not adding a detailed error description here, as this should be wrapped by PB clients (and never done by hand).
## Some Thoughts for Future Consideration
- Currently, the Erlang PB client sends input commands via a `term_to_binary` encoding of data, which is decoded and validated using `riak_kv_mapred_term`. Other PB clients encode the data as JSON. This means we are duplicating some logic. In the future, we should modify the Erlang PB client to encode the input as JSON on the client side, allowing us to consolidate server side logic.
- Currently, the Erlang PB client contains functions like `get_bucket(Pid, Bucket)`, `get_bucket(Pid, Bucket, Timeout)`, and `get_bucket(Pid, Bucket, Timeout, CallTimeout)`. Notice three separate functions in order to add timeout options. We should instead change this to `get_bucket(Pid, Bucket)` and `get_bucket(Pid, Bucket, Options)`.
## Tests
### Store an object w/ curl, read w/ PB

``` bash
%% # Store an object...
curl -v -X PUT \
-d 'data1 via HTTP' \
-H "Content-Type: application/json" \
-H "x-riak-index-field1_bin: val1" \
-H "x-riak-index-field2_int: 1001" \
http://127.0.0.1:8098/riak/mybucket/mykey1
```

``` erlang
%% Make sure we can read the object via PB
f().
{ok, Pid} = riakc_pb_socket:start_link("127.0.0.1", 8087).
rp(riakc_pb_socket:get(Pid, <<"mybucket">>, <<"mykey1">>)).
```
### Store an object w/ PB, read w/ curl

``` erlang
f().
{ok, Pid} = riakc_pb_socket:start_link("127.0.0.1", 8087).
Object1 = riakc_obj:update_metadata(
            riakc_obj:new(<<"mybucket">>, <<"mykey1">>, <<"data1 via PB">>),
            dict:from_list(
              [{<<"index">>, [
                             {"field1_bin", "val1"},
                             {"field2_int", 1}
                            ]}])).
riakc_pb_socket:put(Pid, Object1).
```

``` bash
# Make sure we can read the object via HTTP
curl -i http://127.0.0.1:8098/riak/mybucket/mykey1
```
### Store some objects for later tests

``` erlang
%% Index some objects...
f().
{ok, Pid} = riakc_pb_socket:start_link("127.0.0.1", 8087).
Object1 = riakc_obj:update_metadata(
            riakc_obj:new(<<"mybucket">>, <<"mykey1">>, <<"myval1">>),
            dict:from_list(
              [{<<"index">>, [
                             {"field1_bin", "val1"},
                             {"field2_int", 1}
                            ]}])).
riakc_pb_socket:put(Pid, Object1).

Object2 = riakc_obj:update_metadata(
            riakc_obj:new(<<"mybucket">>, <<"mykey2">>, <<"myval2">>),
            dict:from_list(
              [{<<"index">>, [
                             {"field1_bin", "val2"},
                             {"field2_int", 2}
                            ]}])).
riakc_pb_socket:put(Pid, Object2).

Object3 = riakc_obj:update_metadata(
            riakc_obj:new(<<"mybucket">>, <<"mykey3">>, <<"myval3">>),
            dict:from_list(
              [{<<"index">>, [
                             {"field1_bin", "val3"},
                             {"field2_int", 3}
                            ]}])).
riakc_pb_socket:put(Pid, Object3).

Object4 = riakc_obj:update_metadata(
            riakc_obj:new(<<"mybucket">>, <<"mykey4">>, <<"myval4">>),
            dict:from_list(
              [{<<"index">>, [
                             {"field1_bin", "val4"},
                             {"field2_int", 4}
                            ]}])).
riakc_pb_socket:put(Pid, Object4).
```
### Do some secondary index queries w/ Riak PB client

``` erlang
%% Exact match queries...
f().
{ok, Pid} = riakc_pb_socket:start_link("127.0.0.1", 8087).
riakc_pb_socket:get_index(Pid, <<"mybucket">>, <<"field1_bin">>, <<"val2">>).

%% Range query...
f().
{ok, Pid} = riakc_pb_socket:start_link("127.0.0.1", 8087).
riakc_pb_socket:get_index(Pid, <<"mybucket">>, <<"field1_bin">>, <<"val2">>, <<"val4">>).
```
### Run some secondary index queries with Python PB client

``` python
# Create a PB client...
import riak
client = riak.RiakClient(port=8087, transport_class=riak.RiakPbcTransport)

# Perform an exact match query...
mr = riak.RiakMapReduce(client)
mr._inputs = {
    'bucket': "mybucket",
    'index' : "field1_bin",
    'key'   : "val2" }
results = mr.run()
print "Exact Match: "
for i in results:
    print i.get_bucket() + " : " + i.get_key()

# Perform a range query...
mr = riak.RiakMapReduce(client)
mr._inputs = {
    'bucket': "mybucket",
    'index' : "field1_bin",
    'start' : "val2",
    'end'   : "val4"}
results = mr.run()
print "Range: "
for i in results:
    print i.get_bucket() + " : " + i.get_key()
```
