### PR TITLE
Az596 backend refactoring phase2

### DIFF
--- a/src/riak_index_backend.erl
+++ b/src/riak_index_backend.erl
@@ -36,7 +36,7 @@ behaviour_info(callbacks) ->
      {index, 2},       % (State, Postings)
      {delete, 2},      % (State, Postings)
      {lookup_sync, 4}, % (State, Index, Field, Term)
-     {fold_index, 6},  % (State, Index, Query, SKFun, Acc, FinalFun)
+     {fold_index, 4},  % (FoldFun, Acc, Opts, State)
      {drop,1},         % (State)
      {callback,3}];    % (State, Ref, Msg) ->
 behaviour_info(_Other) ->

--- a/src/riak_index_mi_backend.erl
+++ b/src/riak_index_mi_backend.erl
@@ -128,19 +128,6 @@ fold_index(FoldFun, Acc, Opts, State) ->
     Results = case Query of
                   [{eq, Field, Term}] ->
                       merge_index:lookup_sync(Pid, Bucket, Field, Term, FilterFun);
-
-                  [{lt, Field, Term}] ->
-                      merge_index:range_sync(Pid, Bucket, Field, undefined, inc(Term, -1), ?SIZE, FilterFun);
-
-                  [{gt, Field, Term}] ->
-                      merge_index:range_sync(Pid, Bucket, Field, inc(Term, 1), undefined, ?SIZE, FilterFun);
-
-                  [{lte, Field, Term}] ->
-                      merge_index:range_sync(Pid, Bucket, Field, undefined, Term, ?SIZE, FilterFun);
-
-                  [{gte, Field, Term}] ->
-                      merge_index:range_sync(Pid, Bucket, Field, Term, undefined, ?SIZE, FilterFun);
-
                   [{gte, Field, StartTerm}, {lte, Field, EndTerm}] ->
                       merge_index:range_sync(Pid, Bucket, Field, StartTerm, EndTerm, ?SIZE, FilterFun);
                   [{all, _Field}] ->

--- a/src/riak_index_mi_backend.erl
+++ b/src/riak_index_mi_backend.erl
@@ -12,7 +12,7 @@
          index/2,
          delete/2,
          lookup_sync/4,
-         fold_index/6,
+         fold_index/4,
          drop/1,
          callback/3
         ]).
@@ -106,9 +106,19 @@ lookup_sync(State, Index, Field, Term) ->
     FilterFun = fun(_Value, _Props) -> true end,
     merge_index:lookup_sync(Pid, Index, Field, Term, FilterFun).
 
-%% @spec fold_index(State :: state(), Bucket :: binary(), Query :: riak_index:query_elements(),
-%%                  SKFun :: function(), Acc :: term(), FinalFun :: function()) -> term().
-fold_index(State, Index, Query, SKFun, Acc, FinalFun) ->
+%% @spec fold_index(FoldFun :: function(), Acc :: term(),
+%%                   Opts :: [term()], State :: state()) -> term().
+fold_index(FoldFun, Acc, Opts, State) ->
+    case lists:keyfind(index, 1, Opts) of
+        false ->
+            %% At this point a check has already been done to verify
+            %% that a tuple of the form {index, Bucket, Query} or
+            %% {bucket, Bucket, Query} exists so we are safe in
+            %% assuming this call to keyfind will return the tuple.
+            {_, Bucket, Query} = lists:keyfind(bucket, 1, Opts);
+        {_, Bucket, Query} ->
+            ok
+    end,                
     Pid = State#state.pid,
     FilterFun = fun(_Value, _Props) -> true end,
 
@@ -116,45 +126,48 @@ fold_index(State, Index, Query, SKFun, Acc, FinalFun) ->
     %% this will run more complicated queries, and will run them
     %% asynchronously.
     Results = case Query of
-                  [{eq, Field, [Term]}] ->
-                      merge_index:lookup_sync(Pid, Index, Field, Term, FilterFun);
+                  [{eq, Field, Term}] ->
+                      merge_index:lookup_sync(Pid, Bucket, Field, Term, FilterFun);
 
-                  [{lt, Field, [Term]}] ->
-                      merge_index:range_sync(Pid, Index, Field, undefined, inc(Term, -1), ?SIZE, FilterFun);
+                  [{lt, Field, Term}] ->
+                      merge_index:range_sync(Pid, Bucket, Field, undefined, inc(Term, -1), ?SIZE, FilterFun);
 
-                  [{gt, Field, [Term]}] ->
-                      merge_index:range_sync(Pid, Index, Field, inc(Term, 1), undefined, ?SIZE, FilterFun);
+                  [{gt, Field, Term}] ->
+                      merge_index:range_sync(Pid, Bucket, Field, inc(Term, 1), undefined, ?SIZE, FilterFun);
 
-                  [{lte, Field, [Term]}] ->
-                      merge_index:range_sync(Pid, Index, Field, undefined, Term, ?SIZE, FilterFun);
+                  [{lte, Field, Term}] ->
+                      merge_index:range_sync(Pid, Bucket, Field, undefined, Term, ?SIZE, FilterFun);
 
-                  [{gte, Field, [Term]}] ->
-                      merge_index:range_sync(Pid, Index, Field, Term, undefined, ?SIZE, FilterFun);
+                  [{gte, Field, Term}] ->
+                      merge_index:range_sync(Pid, Bucket, Field, Term, undefined, ?SIZE, FilterFun);
 
-                  [{range, Field, [StartTerm, EndTerm]}] ->
-                      merge_index:range_sync(Pid, Index, Field, StartTerm, EndTerm, ?SIZE, FilterFun);
-
+                  [{gte, Field, StartTerm}, {lte, Field, EndTerm}] ->
+                      merge_index:range_sync(Pid, Bucket, Field, StartTerm, EndTerm, ?SIZE, FilterFun);
+                  [{all, _Field}] ->
+                      %% Don't think merge_index currently supports
+                      %% a way to use a wildcard to collect all
+                      %% results.
+                      %% @TODO Decide what to do about returning
+                      %% all keys for a given index.
+                      {error, {unsupported_query_element, Query}};
                   _ ->
                       {error, {unknown_query_element, Query}}
               end,
 
-    %% If Results is a list of results, then call SKFun to accumulate
-    %% the results.
-    Results1 = case is_list(Results) of
-                   true -> SKFun({results, Results}, Acc);
-                   false -> {ok, Results}
-               end,
-
-    %% Call FinalFun on the results.
-    case Results1 of
-        {ok, NewAcc} ->
-            FinalFun(done, NewAcc);
+    case Results of 
         {error, Reason} ->
-            FinalFun({error, Reason}, Acc);
-        done ->
-            FinalFun(done, Acc);
-        Other ->
-            FinalFun({error, {unexpected_result, Other}}, Acc)
+            {error, Reason};
+        _ ->
+            FoldKeysFun = fold_keys_fun(FoldFun, Bucket),
+            FoldResults = lists:foldl(FoldKeysFun, Acc, Results),
+            {ok, FoldResults}
+    end.
+
+%% @private
+%% Return a function to fold over keys on this backend
+fold_keys_fun(FoldFun, Bucket) ->
+    fun({Key, _}, Acc) ->
+            FoldFun(Bucket, Key, Acc)
     end.
 
 %% @spec drop(State::state()) -> ok.

--- a/src/riak_index_mi_backend.erl
+++ b/src/riak_index_mi_backend.erl
@@ -168,28 +168,6 @@ drop(State) ->
 callback(_State, _Ref, _Msg) ->
     ok.
 
-
-%% @private
-%% @spec inc(term(), Amt :: integer()) -> term().
-%%
-%% @doc Increments or decrements an Erlang data type by one
-%%      position. Used during construction of exclusive range searches.
-inc(Term, Amt)  when is_integer(Term) ->
-    Term + Amt;
-inc(Term, _Amt) when is_float(Term) ->
-    Term; %% Doesn't make sense to have exclusive range on floats.
-inc(Term, Amt)  when is_list(Term) ->
-    NewTerm = inc(list_to_binary(Term), Amt),
-    binary_to_list(NewTerm);
-inc(Term, Amt)  when is_binary(Term) ->
-    Bits = size(Term) * 8,
-    <<Int:Bits/integer>> = Term,
-    NewInt = inc(Int, Amt),
-    <<NewInt:Bits/integer>>;
-inc(Term, _) ->
-    throw({unhandled_type, binary_inc, Term}).
-
-
 %% ===================================================================
 %% EUnit tests
 %% ===================================================================

--- a/src/riak_kv_backend.erl
+++ b/src/riak_kv_backend.erl
@@ -48,6 +48,7 @@ behaviour_info(callbacks) ->
      {stop,1},        % (State)
      {get,3},         % (Bucket, Key, State)
      {put,4},         % (Bucket, Key, Val, State)
+     {put,5},         % (Bucket, Key, IndexSpecs, Val, State)
      {delete,3},      % (Bucket, Key, State)
      {drop,1},        % (State)
      {fold_buckets,4},% (FoldBucketsFun, Acc, Opts, State),

--- a/src/riak_kv_backend.erl
+++ b/src/riak_kv_backend.erl
@@ -91,9 +91,9 @@ basic_store_and_fetch({Backend, State}) ->
      fun() ->
              [
               ?_assertMatch({ok, _},
-                            Backend:put(<<"b1">>, <<"k1">>, <<"v1">>, State)),
+                            Backend:put(<<"b1">>, <<"k1">>, [], <<"v1">>, State)),
               ?_assertMatch({ok, _},
-                            Backend:put(<<"b2">>, <<"k2">>, <<"v2">>, State)),
+                            Backend:put(<<"b2">>, <<"k2">>, [], <<"v2">>, State)),
               ?_assertMatch({ok,<<"v2">>, _},
                             Backend:get(<<"b2">>, <<"k2">>, State)),
               ?_assertMatch({error, not_found, _},
@@ -232,7 +232,7 @@ fold_objects({Backend, State}) ->
                                 lists:sort(Objects1)
                             end),
               ?_assertMatch({ok, _},
-                            Backend:put(<<"b3">>,<<"k3">>,<<"v3">>, State)),
+                            Backend:put(<<"b3">>, <<"k3">>, [], <<"v3">>, State)),
               ?_assertEqual([{{<<"b1">>,<<"k1">>},<<"v1">>},
                              {{<<"b3">>,<<"k3">>},<<"v3">>}],
                             begin

--- a/src/riak_kv_backend.erl
+++ b/src/riak_kv_backend.erl
@@ -47,7 +47,6 @@ behaviour_info(callbacks) ->
      {start,2},       % (Partition, Config)
      {stop,1},        % (State)
      {get,3},         % (Bucket, Key, State)
-     {put,4},         % (Bucket, Key, Val, State)
      {put,5},         % (Bucket, Key, IndexSpecs, Val, State)
      {delete,3},      % (Bucket, Key, State)
      {drop,1},        % (State)

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -31,6 +31,7 @@
          stop/1,
          get/3,
          put/4,
+         put/5,
          delete/3,
          drop/1,
          fold_buckets/4,
@@ -136,6 +137,21 @@ get(Bucket, Key, #state{ref=Ref}=State) ->
                  {error, term(), state()}.
 put(Bucket, Key, Val, #state{ref=Ref}=State) ->
     BitcaskKey = term_to_binary({Bucket, Key}),
+    case bitcask:put(Ref, BitcaskKey, Val) of
+        ok ->
+            {ok, State};
+        {error, Reason} ->
+            {error, Reason, State}
+    end.
+
+%% @doc Insert an object with secondary index 
+%% information into the bitcask backend
+-type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
+-spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
+                 {ok, state()} |
+                 {error, term(), state()}.
+put(Bucket, PrimaryKey, _IndexSpecs, Val, #state{ref=Ref}=State) ->
+    BitcaskKey = term_to_binary({Bucket, PrimaryKey}),
     case bitcask:put(Ref, BitcaskKey, Val) of
         ok ->
             {ok, State};

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -30,7 +30,6 @@
          start/2,
          stop/1,
          get/3,
-         put/4,
          put/5,
          delete/3,
          drop/1,
@@ -60,7 +59,7 @@
                 opts :: [{atom(), term()}],
                 root :: string()}).
 
--opaque(state() :: #state{}).
+-type state() :: #state{}.
 -type config() :: [{atom(), term()}].
 
 %% ===================================================================
@@ -127,19 +126,6 @@ get(Bucket, Key, #state{ref=Ref}=State) ->
             {error, not_found, State};
         {error, nofile}  ->
             {error, not_found, State};
-        {error, Reason} ->
-            {error, Reason, State}
-    end.
-
-%% @doc Insert an object into the bitcask backend
--spec put(riak_object:bucket(), riak_object:key(), binary(), state()) ->
-                 {ok, state()} |
-                 {error, term(), state()}.
-put(Bucket, Key, Val, #state{ref=Ref}=State) ->
-    BitcaskKey = term_to_binary({Bucket, Key}),
-    case bitcask:put(Ref, BitcaskKey, Val) of
-        ok ->
-            {ok, State};
         {error, Reason} ->
             {error, Reason, State}
     end.

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -132,8 +132,8 @@ get(Bucket, Key, #state{ref=Ref}=State) ->
 
 %% @doc Insert an object into the bitcask backend.
 %% NOTE: The bitcask backend does not currently support
-%% secondary indexing. This function is only here
-%% to conform to the backend API specification.
+%% secondary indexing and the_IndexSpecs parameter
+%% is ignored.
 -type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
 -spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
                  {ok, state()} |

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -144,8 +144,10 @@ put(Bucket, Key, Val, #state{ref=Ref}=State) ->
             {error, Reason, State}
     end.
 
-%% @doc Insert an object with secondary index 
-%% information into the bitcask backend
+%% @doc Insert an object into the bitcask backend.
+%% NOTE: The bitcask backend does not currently support
+%% secondary indexing. This function is only here
+%% to conform to the backend API specification.
 -type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
 -spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
                  {ok, state()} |

--- a/src/riak_kv_buckets_fsm.erl
+++ b/src/riak_kv_buckets_fsm.erl
@@ -58,10 +58,12 @@ init(From={_, _, ClientPid}, [ItemFilter, Timeout, ClientType]) ->
 
 process_results({results, Buckets},
                 StateData=#state{buckets=BucketAcc}) ->
-    {ok, StateData#state{buckets=ordsets:union(Buckets, BucketAcc)}};
+    {ok, StateData#state{buckets=ordsets:union(ordsets:from_list(Buckets),
+                                               BucketAcc)}};
 process_results({final_results, Buckets},
                 StateData=#state{buckets=BucketAcc}) ->
-    {done, StateData#state{buckets=ordsets:union(Buckets, BucketAcc)}}.
+    {done, StateData#state{buckets=ordsets:union(ordsets:from_list(Buckets),
+                                                 BucketAcc)}}.
 
 finish({error, Error},
        StateData=#state{client_type=ClientType,

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -29,6 +29,7 @@
          stop/1,
          get/3,
          put/4,
+         put/5,
          delete/3,
          drop/1,
          fold_buckets/4,
@@ -115,6 +116,23 @@ put(Bucket, Key, Val, #state{ref=Ref,
         {error, Reason} ->
             {error, Reason, State}
     end.
+
+%% @doc Insert an object with secondary index 
+%% information into the eleveldb backend
+-type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
+-spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
+                 {ok, state()} |
+                 {error, term(), state()}.
+put(Bucket, PrimaryKey, _IndexSpecs, Val, #state{ref=Ref,
+                                                 write_opts=WriteOpts}=State) ->
+    StorageKey = sext:encode({Bucket, PrimaryKey}),
+    case eleveldb:put(Ref, StorageKey, Val, WriteOpts) of
+        ok ->
+            {ok, State};
+        {error, Reason} ->
+            {error, Reason, State}
+    end.
+
 
 %% @doc Delete an object from the eleveldb backend
 -spec delete(riak_object:bucket(), riak_object:key(), state()) ->

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -103,9 +103,9 @@ get(Bucket, Key, #state{read_opts=ReadOpts,
     end.
 
 %% @doc Insert an object into the eleveldb backend.
-%% NOTE: The eleveldb backend does not currently support
-%% secondary indexing. This function is only here
-%% to conform to the backend API specification.
+%% NOTE: The eleveldb backend does not currently
+%% support secondary indexing and the _IndexSpecs
+%% parameter is ignored.
 -type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
 -spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
                  {ok, state()} |

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -117,8 +117,10 @@ put(Bucket, Key, Val, #state{ref=Ref,
             {error, Reason, State}
     end.
 
-%% @doc Insert an object with secondary index 
-%% information into the eleveldb backend
+%% @doc Insert an object into the eleveldb backend.
+%% NOTE: The eleveldb backend does not currently support
+%% secondary indexing. This function is only here
+%% to conform to the backend API specification.
 -type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
 -spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
                  {ok, state()} |

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -28,7 +28,6 @@
          start/2,
          stop/1,
          get/3,
-         put/4,
          put/5,
          delete/3,
          drop/1,
@@ -52,7 +51,7 @@
                 write_opts = [],
                 fold_opts = [{fill_cache, false}]}).
 
--opaque(state() :: #state{}).
+-type state() :: #state{}.
 -type config() :: [{atom(), term()}].
 
 %% ===================================================================
@@ -99,20 +98,6 @@ get(Bucket, Key, #state{read_opts=ReadOpts,
             {ok, Value, State};
         not_found  ->
             {error, not_found, State};
-        {error, Reason} ->
-            {error, Reason, State}
-    end.
-
-%% @doc Insert an object into the eleveldb backend
--spec put(riak_object:bucket(), riak_object:key(), binary(), state()) ->
-                 {ok, state()} |
-                 {error, term(), state()}.
-put(Bucket, Key, Val, #state{ref=Ref,
-                             write_opts=WriteOpts}=State) ->
-    StorageKey = sext:encode({Bucket, Key}),
-    case eleveldb:put(Ref, StorageKey, Val, WriteOpts) of
-        ok ->
-            {ok, State};
         {error, Reason} ->
             {error, Reason, State}
     end.

--- a/src/riak_kv_index_backend.erl
+++ b/src/riak_kv_index_backend.erl
@@ -304,6 +304,8 @@ callback(Ref, Msg, #state{kv_mod = KVMod,
                    binary(),
                    module(),
                    term()) -> ok | {error, term()}.
+do_index_put(_, _, [], _, _, _) ->
+    ok;
 do_index_put(Bucket, PrimaryKey, IndexSpecs, _Val, IndexMod, IndexState) ->
     AssemblePostings = 
         fun({Op, Index, SecondaryKey}) ->

--- a/src/riak_kv_index_backend.erl
+++ b/src/riak_kv_index_backend.erl
@@ -352,7 +352,7 @@ do_index_delete(Bucket, PrimaryKey, KVMod, KVState, IndexMod, IndexState) ->
             ok;
         {ok, Val, _UpdModState} ->
             Obj = binary_to_term(Val),
-            IndexSpecs = riak_object:get_index_specs(Obj, remove, true),
+            IndexSpecs = riak_object:get_index_specs(Obj),
             case IndexSpecs of
                 [] ->
                     ok;

--- a/src/riak_kv_index_backend.erl
+++ b/src/riak_kv_index_backend.erl
@@ -31,7 +31,6 @@
          start/2,
          stop/1,
          get/3,
-         put/4,
          put/5,
          delete/3,
          drop/1,
@@ -56,7 +55,7 @@
           index_state   % The Index backend state.
          }).
 
--opaque(state() :: #state{}).
+-type state() :: #state{}.
 -type config() :: [{atom(), term()}].
 -type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
 
@@ -130,19 +129,6 @@ stop(State) ->
 get(Bucket, Key, #state{kv_mod = KVMod,
                         kv_state = KVState}) ->
     KVMod:get(Bucket, Key, KVState).
-
-%% @doc Just store the object in the KV backend.
--spec put(riak_object:bucket(), riak_object:key(), binary(), state()) ->
-                 {ok, state()} |
-                 {error, term(), state()}.
-put(Bucket, Key, Val, #state{kv_mod = KVMod,
-                             kv_state = KVState}=State) ->
-    case do_kv_put(Bucket, Key, Val, KVMod, KVState) of
-        {ok, UpdKVState} ->
-            {ok, State#state{kv_state=UpdKVState}};
-        {error, Reason, UpdKVState} ->
-            {error, Reason, State#state{kv_state=UpdKVState}}
-    end.
 
 %% @doc Insert an object with secondary index 
 %% information into the bitcask backend

--- a/src/riak_kv_index_backend.erl
+++ b/src/riak_kv_index_backend.erl
@@ -322,7 +322,7 @@ do_index_put(Bucket, PrimaryKey, IndexSpecs, _Val, IndexMod, IndexState) ->
                 module(),
                 term()) -> {ok, term()} | {error, term(), term()}.
 do_kv_put(Bucket, Key, Val, KVMod, KVState) ->
-    KVMod:put(Bucket, Key, Val, KVState).
+    KVMod:put(Bucket, Key, [], Val, KVState).
 
 %% @private
 %% @doc Delete the BKey from the Index backend.

--- a/src/riak_kv_index_backend.erl
+++ b/src/riak_kv_index_backend.erl
@@ -338,7 +338,7 @@ do_index_delete(Bucket, PrimaryKey, KVMod, KVState, IndexMod, IndexState) ->
             ok;
         {ok, Val, _UpdModState} ->
             Obj = binary_to_term(Val),
-            IndexSpecs = riak_object:get_index_specs(Obj),
+            IndexSpecs = riak_object:index_specs(Obj),
             case IndexSpecs of
                 [] ->
                     ok;

--- a/src/riak_kv_index_backend.erl
+++ b/src/riak_kv_index_backend.erl
@@ -351,7 +351,7 @@ do_index_delete(Bucket, PrimaryKey, KVMod, KVState, IndexMod, IndexState) ->
             ok;
         {ok, Val, _UpdModState} ->
             Obj = binary_to_term(Val),
-            IndexSpecs = riak_object:get_index_specs(Obj, remove),
+            IndexSpecs = riak_object:get_index_specs(Obj, remove, true),
             case IndexSpecs of
                 [] ->
                     ok;

--- a/src/riak_kv_index_backend.erl
+++ b/src/riak_kv_index_backend.erl
@@ -213,8 +213,9 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{index_mod = IndexMod,
                                          index_state = IndexState,
                                          kv_mod = KVMod,
                                          kv_state = KVState}) ->
-    case lists:keymember(bucket, 1, Opts) orelse 
-        lists:keymember(index, 1, Opts) of
+    case lists:keymember(index, 1, Opts) orelse 
+        (lists:keymember(bucket, 1, Opts) andalso 
+         tuple_size(lists:keyfind(bucket, 1, Opts)) =:= 3) of
         true ->
             IndexMod:fold_index(FoldKeysFun, Acc, Opts, IndexState);
         false ->

--- a/src/riak_kv_index_backend.erl
+++ b/src/riak_kv_index_backend.erl
@@ -170,7 +170,6 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, State=
             {error, Reason1, State}
     end.
 
-
 %% @doc Delete the object from the Index backend and the KV backend.
 -spec delete(riak_object:bucket(), riak_object:key(), state()) ->
                     {ok, state()} |
@@ -178,7 +177,8 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, State=
 delete(Bucket, Key, #state{kv_mod = KVMod,
                            kv_state = KVState,
                            index_mod = IndexMod,
-                           index_state = IndexState}=State) ->
+                           index_state = IndexState
+                          }=State) ->
     %% Since the two backends are separate, we can't have a true
     %% transaction. The best we can do for now is delete from the index
     %% (which is the newer and more complicated code) and if that

--- a/src/riak_kv_index_backend.erl
+++ b/src/riak_kv_index_backend.erl
@@ -284,9 +284,8 @@ callback(Ref, Msg, #state{kv_mod = KVMod,
     %% response, no error handling, return 'ok'.
 
     {ok, UpdKVState} = KVMod:callback(Ref, Msg, KVState),
-    {ok, UpdIndexState} = IndexMod:callback(Ref, Msg, IndexState),
-    {ok, State#state{kv_state=UpdKVState,
-                     index_state=UpdIndexState}}.
+    ok = IndexMod:callback(Ref, Msg, IndexState),
+    {ok, State#state{kv_state=UpdKVState}}.
 
 %% @doc Pass the fold_index request through to the Index backend.
 %% @TODO This function is temporary and will be removed in the next

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -56,6 +56,7 @@
          stop/1,
          get/3,
          put/4,
+         put/5,
          delete/3,
          drop/1,
          fold_buckets/4,
@@ -145,6 +146,21 @@ put(Bucket, Key, Val, State) ->
         {error, Reason} ->
             {error, Reason, State}
     end.
+
+%% @doc Insert an object with secondary index 
+%% information into the memory backend
+-type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
+-spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
+                 {ok, state()} |
+                 {error, term(), state()}.
+put(Bucket, PrimaryKey, _IndexSpecs, Val, State) ->
+    case gen_server:call(State, {put, Bucket, PrimaryKey, Val}) of
+        ok ->
+            {ok, State};
+        {error, Reason} ->
+            {error, Reason, State}
+    end.
+
 
 %% @doc Delete an object from the memory backend
 -spec delete(riak_object:bucket(), riak_object:key(), state()) ->

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -140,18 +140,18 @@ get(Bucket, Key, State=#state{data_ref=DataRef,
     end.
 
 %% @doc Insert an object into the memory backend.
-%% NOTE: The memory backend does not currently support
-%% secondary indexing. This function is only here
-%% to conform to the backend API specification.
+%% NOTE: The memory backend does not currently
+%% support secondary indexing and the _IndexSpecs
+%% parameter is ignored.
 -type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
 -spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
                  {ok, state()} |
                  {error, term(), state()}.
-put(Bucket, PrimaryKey, _, Val, State=#state{data_ref=DataRef,
-                                             max_memory=MaxMemory,
-                                             time_ref=TimeRef,
-                                             ttl=TTL,
-                                             used_memory=UsedMemory}) ->
+put(Bucket, PrimaryKey, _IndexSpecs, Val, State=#state{data_ref=DataRef,
+                                                       max_memory=MaxMemory,
+                                                       time_ref=TimeRef,
+                                                       ttl=TTL,
+                                                       used_memory=UsedMemory}) ->
     Now = now(),
     case TTL of
         undefined ->

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -22,18 +22,18 @@
 
 %% @doc riak_kv_memory_backend is a Riak storage backend that uses ets
 %% tables to store all data in memory.
-%% 
+%%
 %% === Configuration Options ===
 %%
 %% The following configuration options are available for the memory backend.
 %% The options should be specified in the `memory_backend' section of your
-%% app.config file. 
-%% 
+%% app.config file.
+%%
 %% <ul>
 %% <li>`object_expiry_enabled' - Boolean option to enable time-based object
 %%    expiration. Defaults to `false'.</li>
 %% <li>`ttl' - The time in seconds that an object should live before being expired.
-%%    Default is 3600 seconds or 1 hour. This option is ignored unless 
+%%    Default is 3600 seconds or 1 hour. This option is ignored unless
 %%    `object_expiry_enabled' is `true'.</li>
 %% <li>`memory_cap_enabled' - Boolean option to enable a cap on the amount
 %%    of data that can be stored by the memory backend. When the memory
@@ -41,14 +41,13 @@
 %%    are expunged until the amount of memory used is under the limit.
 %%    Default is `false'.</li>
 %% <li>`max_memory' - The amount of memory in megabytes to limit the backend to.
-%%    Default is 100 MB. This option is ignored unless 
+%%    Default is 100 MB. This option is ignored unless
 %%    `memory_cap_enabled' is `true'.</li>
 %% </ul>
 %%
 
 -module(riak_kv_memory_backend).
 -behavior(riak_kv_backend).
--behavior(gen_server).
 
 %% KV Backend API
 -export([api_version/0,
@@ -66,14 +65,6 @@
          status/1,
          callback/3]).
 
-%% gen_server API
--export([init/1,
-         handle_call/3,
-         handle_cast/2,
-         handle_info/2,
-         terminate/2,
-         code_change/3]).
-
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
@@ -83,14 +74,15 @@
 -define (DEFAULT_TTL, 3600). % 1 hour
 -define (DEFAULT_MEMORY,  100).  % 100MB
 
--record(server_state, {data_ref :: integer() | atom(),
+-record(state, {data_ref :: integer() | atom(),
                        time_ref :: integer() | atom(),
                        expiry_enabled :: boolean(),
                        memory_cap_enabled :: boolean(),
                        max_memory :: undefined | integer(),
                        used_memory=0 :: integer(),
                        ttl :: integer()}).
--type state() :: pid().
+
+-opaque(state() :: #state{}).
 -type config() :: [].
 
 %% ===================================================================
@@ -108,41 +100,95 @@ api_version() ->
 %% @doc Start the memory backend
 -spec start(integer(), config()) -> {ok, state()} | {error, term()}.
 start(Partition, Config) ->
-    case gen_server:start_link(?MODULE, [Partition, Config], []) of
-        {ok, Pid} ->
-            {ok, Pid};
-        {error, Reason} ->
-            {error, Reason};
-        ignore ->
-            {error, ignore}
-    end.
+    ExpiryEnabled = config_value(object_expiry_enabled, Config, false),
+    TTL = config_value(ttl, Config, ?DEFAULT_TTL),
+    MemoryCapEnabled = config_value(memory_cap_enabled, Config, false),
+    MaxMemory = config_value(max_memory, Config, ?DEFAULT_MEMORY),
+    case MemoryCapEnabled of
+        true ->
+            TimeRef = ets:new(list_to_atom(integer_to_list(Partition)), [ordered_set]);
+        false ->
+            TimeRef = undefined
+    end,
+    DataRef = ets:new(list_to_atom(integer_to_list(Partition)), []),
+    {ok, #state{data_ref=DataRef,
+                expiry_enabled=ExpiryEnabled,
+                max_memory=MaxMemory * 1024 * 1024,
+                memory_cap_enabled=MemoryCapEnabled,
+                time_ref=TimeRef,
+                ttl=TTL}}.
 
 %% @doc Stop the memory backend
 -spec stop(state()) -> ok.
-stop(State) ->
-    gen_server:call(State, stop).
+stop(#state{data_ref=DataRef,
+                  memory_cap_enabled=MemoryCapEnabled,
+                  time_ref=TimeRef}) ->
+    catch ets:delete(DataRef),
+    case MemoryCapEnabled of
+        true ->
+            catch ets:delete(TimeRef);
+        false ->
+            ok
+    end,
+    ok.
 
 %% @doc Retrieve an object from the memory backend
 -spec get(riak_object:bucket(), riak_object:key(), state()) ->
                  {ok, any(), state()} |
                  {ok, not_found, state()} |
                  {error, term(), state()}.
-get(Bucket, Key, State) ->
-    case gen_server:call(State, {get, Bucket, Key}) of
-        {ok, Value} ->
-            {ok, Value, State};
-        {error, Reason} ->
-            {error, Reason, State}
+get(Bucket, Key, State=#state{data_ref=DataRef,
+                              ttl=TTL}) ->
+    case ets:lookup(DataRef, {Bucket, Key}) of
+        [] -> {error, not_found, State};
+        [{{Bucket, Key}, {{ts, Timestamp}, Val}}] ->
+            case exceeds_ttl(Timestamp, TTL) of
+                true ->
+                    ets:delete(DataRef, {Bucket, Key}),
+                    {error, not_found, State};
+                false ->
+                    {ok, Val, State}
+            end;
+        [{{Bucket, Key}, Val}] ->
+            {ok, Val, State};
+        Error ->
+            {error, Error, State}
     end.
 
 %% @doc Insert an object into the memory backend
 -spec put(riak_object:bucket(), riak_object:key(), binary(), state()) ->
                  {ok, state()} |
                  {error, term(), state()}.
-put(Bucket, Key, Val, State) ->
-    case gen_server:call(State, {put, Bucket, Key, Val}) of
-        ok ->
-            {ok, State};
+put(Bucket, Key, Val, State=#state{data_ref=DataRef,
+                                   expiry_enabled=ExpiryEnabled,
+                                   max_memory=MaxMemory,
+                                   memory_cap_enabled=MemoryCapEnabled,
+                                   time_ref=TimeRef,
+                                   used_memory=UsedMemory}) ->
+    Now = now(),
+    case ExpiryEnabled of
+        true ->
+            Val1 = {{ts, Now}, Val};
+        false ->
+            Val1 = Val
+    end,
+    case do_put(Bucket, Key, Val1, DataRef) of
+        {ok, Size} ->
+            %% If the memory cap is enabled update timestamp table
+            %% and check if the memory usage is over the cap.
+            case MemoryCapEnabled of
+                true ->
+                    time_entry(Bucket, Key, Now, TimeRef),
+                    Freed = trim_data_table(MaxMemory,
+                                            UsedMemory + Size,
+                                            DataRef,
+                                            TimeRef,
+                                            0),
+                    UsedMemory1 = UsedMemory + Size - Freed;
+                false ->
+                    UsedMemory1 = UsedMemory
+            end,
+            {ok, State#state{used_memory=UsedMemory1}};
         {error, Reason} ->
             {error, Reason, State}
     end.
@@ -156,24 +202,18 @@ put(Bucket, Key, Val, State) ->
                  {ok, state()} |
                  {error, term(), state()}.
 put(Bucket, PrimaryKey, _IndexSpecs, Val, State) ->
-    case gen_server:call(State, {put, Bucket, PrimaryKey, Val}) of
-        ok ->
-            {ok, State};
-        {error, Reason} ->
-            {error, Reason, State}
-    end.
-
+    put(Bucket, PrimaryKey, Val, State).
 
 %% @doc Delete an object from the memory backend
 -spec delete(riak_object:bucket(), riak_object:key(), state()) ->
                     {ok, state()} |
                     {error, term(), state()}.
-delete(Bucket, Key, State) ->
-    case gen_server:call(State, {delete, Bucket, Key}) of
-        ok ->
+delete(Bucket, Key, State=#state{data_ref=DataRef}) ->
+    case ets:delete(DataRef, {Bucket, Key}) of
+        true ->
             {ok, State};
-        {error, Reason} ->
-            {error, Reason, State}
+        _ ->
+            {error, ets_delte_failed, State}
     end.
 
 %% @doc Fold over all the buckets.
@@ -181,163 +221,68 @@ delete(Bucket, Key, State) ->
                    any(),
                    [],
                    state()) -> {ok, any()} | {error, term()}.
-fold_buckets(FoldBucketsFun, Acc, _Opts, State) ->
+fold_buckets(FoldBucketsFun, Acc, _Opts, #state{data_ref=DataRef}) ->
     FoldFun = fold_buckets_fun(FoldBucketsFun),
-    gen_server:call(State, {fold_buckets, FoldFun, Acc}).
+    BucketList = ets:match(DataRef, {{'$1', '_'}, '_'}),
+    {Acc0, _} = lists:foldl(FoldFun, {Acc, ordsets:new()}, BucketList),
+    {ok, Acc0}.
 
 %% @doc Fold over all the keys for one or all buckets.
 -spec fold_keys(riak_kv_backend:fold_keys_fun(),
                 any(),
                 [{atom(), term()}],
                 state()) -> {ok, term()} | {error, term()}.
-fold_keys(FoldKeysFun, Acc, Opts, State) ->
+fold_keys(FoldKeysFun, Acc, Opts, #state{data_ref=DataRef}) ->
     Bucket =  proplists:get_value(bucket, Opts),
     FoldFun = fold_keys_fun(FoldKeysFun, Bucket),
-    gen_server:call(State, {fold_keys, FoldFun, Bucket, Acc}).
+    case Bucket of
+        undefined ->
+            KeyList = ets:match(DataRef, {{'$1', '$2'}, '_'});
+        _ ->
+            KeyList = ets:match(DataRef, {{Bucket, '$1'}, '_'})
+    end,
+    Acc0 = lists:foldl(FoldFun, Acc, KeyList),
+    {ok, Acc0}.
+
 
 %% @doc Fold over all the objects for one or all buckets.
 -spec fold_objects(riak_kv_backend:fold_objects_fun(),
                    any(),
                    [{atom(), term()}],
                    state()) -> {ok, any()} | {error, term()}.
-fold_objects(FoldObjectsFun, Acc, Opts, State) ->
+fold_objects(FoldObjectsFun, Acc, Opts, #state{data_ref=DataRef}) ->
     Bucket =  proplists:get_value(bucket, Opts),
     FoldFun = fold_objects_fun(FoldObjectsFun, Bucket),
-    gen_server:call(State, {fold_objects, FoldFun, Bucket, Acc}).
+    case Bucket of
+        undefined ->
+            ObjectList = ets:match_object(DataRef, {{'_', '_'}, '_'});
+        _ ->
+            ObjectList = ets:match_object(DataRef, {{Bucket, '_'}, '_'})
+    end,
+    Acc0 = lists:foldl(FoldFun, Acc, ObjectList),
+    {ok, Acc0}.
 
 %% @doc Delete all objects from this memory backend
--spec drop(state()) -> {ok, state()} | {error, term(), state()}.
-drop(State) ->
-    gen_server:call(State, drop).
+-spec drop(state()) -> {ok, state()}.
+drop(State=#state{data_ref=DataRef}) ->
+    ets:delete_all_objects(DataRef),
+    {ok, State}.
 
 %% @doc Returns true if this memory backend contains any
 %% non-tombstone values; otherwise returns false.
--spec is_empty(state()) -> boolean() | {error, term()}.
-is_empty(State) ->
-    gen_server:call(State, is_empty).
+-spec is_empty(state()) -> boolean().
+is_empty(#state{data_ref=DataRef}) ->
+    ets:info(DataRef, size) =:= 0.
 
 %% @doc Get the status information for this memory backend
 -spec status(state()) -> [{atom(), term()}].
-status(State) ->
-    gen_server:call(State, status).
+status(#state{data_ref=DataRef}) ->
+    ets:info(DataRef).
 
 %% @doc Register an asynchronous callback
 -spec callback(reference(), any(), state()) -> {ok, state()}.
 callback(_Ref, _Msg, State) ->
     {ok, State}.
-
-%% gen_server API
-
-%% @private
-init([Partition, Config]) ->
-    ExpiryEnabled = config_value(object_expiry_enabled, Config, false),
-    TTL = config_value(ttl, Config, ?DEFAULT_TTL),
-    MemoryCapEnabled = config_value(memory_cap_enabled, Config, false),
-    MaxMemory = config_value(max_memory, Config, ?DEFAULT_MEMORY),
-    case MemoryCapEnabled of
-        true ->
-            TimeRef = ets:new(list_to_atom(integer_to_list(Partition)), [ordered_set]);
-        false ->
-            TimeRef = undefined
-    end,
-    DataRef = ets:new(list_to_atom(integer_to_list(Partition)), []),
-    {ok, #server_state{data_ref=DataRef,
-                       expiry_enabled=ExpiryEnabled,
-                       max_memory=MaxMemory * 1024 * 1024,
-                       memory_cap_enabled=MemoryCapEnabled,
-                       time_ref=TimeRef,
-                       ttl=TTL}}.
-
-%% @private
-handle_call(stop, _From, #server_state{data_ref=Ref}=State) ->
-    {reply, srv_stop(Ref), State};
-handle_call({get, Bucket, Key},
-            _From,
-            #server_state{expiry_enabled=ExpiryEnabled,
-                          memory_cap_enabled=MemoryCapEnabled,
-                          ttl=TTL,
-                          data_ref=Ref}=State) when ExpiryEnabled =:= true;
-                                                    MemoryCapEnabled =:= true ->
-    Result = srv_get(Bucket, Key, Ref),
-    case Result of
-        {ok, {{ts, Timestamp}, Val}} ->
-            case exceeds_ttl(Timestamp, TTL) of
-                true ->
-                    srv_delete(Bucket, Key, Ref),
-                    Reply = {error, not_found};
-                false ->
-                    Reply = {ok, Val}
-            end;
-        _ ->
-            Reply = Result
-    end,
-    {reply, Reply, State};
-handle_call({get, Bucket, Key}, _From, #server_state{data_ref=Ref}=State) ->
-    {reply, srv_get(Bucket, Key, Ref), State};
-handle_call({put, Bucket, Key, Val},
-            _From,
-            #server_state{data_ref=DataRef,
-                          expiry_enabled=ExpiryEnabled,
-                          max_memory=MaxMemory,
-                          memory_cap_enabled=MemoryCapEnabled,
-                          time_ref=TimeRef,
-                          used_memory=UsedMemory}=State) when ExpiryEnabled =:= true;
-                                                              MemoryCapEnabled =:= true ->
-    Now = now(),
-    {Reply, Size} = srv_put(Bucket, Key, {{ts, Now}, Val}, DataRef),
-
-    %% If the memory cap is enabled update timestamp table
-    %% and check if the memory usage is over the cap.
-    case MemoryCapEnabled of
-        true ->
-            time_entry(Bucket, Key, Now, TimeRef),
-            Freed = trim_data_table(MaxMemory,
-                                    UsedMemory + Size,
-                                    DataRef,
-                                    TimeRef,
-                                    0),
-            UsedMemory1 = UsedMemory + Size - Freed;
-        false ->
-            UsedMemory1 = UsedMemory
-    end,
-    {reply, Reply, State#server_state{used_memory=UsedMemory1}};
-handle_call({put, Bucket, Key, Val}, _From, #server_state{data_ref=Ref}=State) ->
-    {Reply, _} = srv_put(Bucket, Key, Val, Ref),
-    {reply, Reply, State};
-handle_call({delete, Bucket, Key}, _From, #server_state{data_ref=Ref}=State) ->
-    {reply, srv_delete(Bucket, Key, Ref), State};
-handle_call({fold_buckets, FoldFun, Acc},
-            _From,
-            #server_state{data_ref=Ref}=State) ->
-    {reply, srv_fold_buckets(FoldFun, Acc, Ref), State};
-handle_call({fold_keys, FoldFun, Bucket, Acc},
-            _From,
-            #server_state{data_ref=Ref}=State) ->
-    {reply, srv_fold_keys(FoldFun, Bucket, Acc, Ref), State};
-handle_call({fold_objects, FoldFun, Bucket, Acc},
-            _From,
-            #server_state{data_ref=Ref}=State) ->
-    {reply, srv_fold_objects(FoldFun, Bucket, Acc, Ref), State};
-handle_call(drop, _From, #server_state{data_ref=Ref}=State) ->
-    ets:delete_all_objects(Ref),
-    {reply, {ok, self()}, State};
-handle_call(is_empty, _From, #server_state{data_ref=Ref}=State) ->
-    {reply, ets:info(Ref, size) =:= 0, State};
-handle_call(status, _From, #server_state{data_ref=Ref}=State) ->
-    {reply, ets:info(Ref), State}.
-
-
-%% @private
-handle_cast(_, State) -> {noreply, State}.
-
-%% @private
-handle_info(_Msg, State) -> {noreply, State}.
-
-%% @private
-terminate(_Reason, _State) -> ok.
-
-%% @private
-code_change(_OldVsn, State, _Extra) -> {ok, State}.
 
 %% ===================================================================
 %% Internal functions
@@ -350,8 +295,14 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 %% @private
 %% Return a function to fold over the buckets on this backend
 fold_buckets_fun(FoldBucketsFun) ->
-    fun([Bucket], Acc) ->
-            FoldBucketsFun(Bucket, Acc)
+    fun([Bucket], {Acc, BucketSet}) ->
+            case ordsets:is_element(Bucket, BucketSet) of
+                true ->
+                    {Acc, BucketSet};
+                false ->
+                    {FoldBucketsFun(Bucket, Acc),
+                     ordsets:add_element(Bucket, BucketSet)}
+            end
     end.
 
 %% @private
@@ -373,56 +324,10 @@ fold_objects_fun(FoldObjectsFun, _) ->
     end.
 
 %% @private
-srv_stop(Ref) ->
-    catch ets:delete(Ref),
-    ok.
-
-%% @private
-srv_get(Bucket, Key, Ref) ->
-    case ets:lookup(Ref, {Bucket, Key}) of
-        [] -> {error, not_found};
-        [{{Bucket, Key}, Val}] -> {ok, Val};
-        Error -> {error, Error}
-    end.
-
-%% @private
-srv_put(Bucket, Key, Val, Ref) ->
+do_put(Bucket, Key, Val, Ref) ->
     Object = {{Bucket, Key}, Val},
     true = ets:insert(Ref, Object),
     {ok, object_size(Object)}.
-
-%% @private
-srv_delete(Bucket, Key, Ref) ->
-    true = ets:delete(Ref, {Bucket, Key}),
-    ok.
-
-%% @private
-srv_fold_buckets(FoldFun, Acc, Ref) ->
-    BucketList = ets:match(Ref, {{'$1', '_'}, '_'}),
-    Acc0 = lists:foldl(FoldFun, Acc, BucketList),
-    {ok, Acc0}.
-
-%% @private
-srv_fold_keys(FoldFun, Bucket, Acc, Ref) ->
-    case Bucket of
-        undefined ->
-            KeyList = ets:match(Ref, {{'$1', '$2'}, '_'});
-        _ ->
-            KeyList = ets:match(Ref, {{Bucket, '$1'}, '_'})
-    end,
-    Acc0 = lists:foldl(FoldFun, Acc, KeyList),
-    {ok, Acc0}.
-
-%% @private
-srv_fold_objects(FoldFun, Bucket, Acc, Ref) ->
-    case Bucket of
-        undefined ->
-            ObjectList = ets:match_object(Ref, {{'_', '_'}, '_'});
-        _ ->
-            ObjectList = ets:match_object(Ref, {{Bucket, '_'}, '_'})
-    end,
-    Acc0 = lists:foldl(FoldFun, Acc, ObjectList),
-    {ok, Acc0}.
 
 %% @private
 config_value(Key, Config, Default) ->
@@ -503,21 +408,20 @@ ttl_test_() ->
     Key = <<"Key">>,
     Value = <<"Value">>,
 
-    {spawn,
-     [
-      %% Put an object
-      ?_assertEqual({ok, State}, put(Bucket, Key, Value, State)),
-      %% Wait 1 second to access it
-      ?_assertEqual(ok, timer:sleep(1000)),
-      ?_assertEqual({ok, Value, State}, get(Bucket, Key, State)),
-      %% Wait 3 seconds and access it again
-      ?_assertEqual(ok, timer:sleep(3000)),
-      ?_assertEqual({ok, Value, State}, get(Bucket, Key, State)),
-      %% Wait 15 seconds and it should expire
-      {timeout, 30000, ?_assertEqual(ok, timer:sleep(15000))},
-      %% This time it should be gone
-      ?_assertEqual({error, not_found, State}, get(Bucket, Key, State))
-     ]}.
+    [
+     %% Put an object
+     ?_assertEqual({ok, State}, put(Bucket, Key, Value, State)),
+     %% Wait 1 second to access it
+     ?_assertEqual(ok, timer:sleep(1000)),
+     ?_assertEqual({ok, Value, State}, get(Bucket, Key, State)),
+     %% Wait 3 seconds and access it again
+     ?_assertEqual(ok, timer:sleep(3000)),
+     ?_assertEqual({ok, Value, State}, get(Bucket, Key, State)),
+     %% Wait 15 seconds and it should expire
+     {timeout, 30000, ?_assertEqual(ok, timer:sleep(15000))},
+     %% This time it should be gone
+     ?_assertEqual({error, not_found, State}, get(Bucket, Key, State))
+    ].
 
 %% @private
 max_memory_test_() ->
@@ -532,21 +436,18 @@ max_memory_test_() ->
     Key2 = <<"Key2">>,
     Value2 = list_to_binary(string:copies("2", 1024)),
 
-    {spawn,
-     [
-      %% Write Key1 to the datastore
-      ?_assertEqual({ok, State}, put(Bucket, Key1, Value1, State)),
-      %% Fetch it
-      ?_assertEqual({ok, Value1, State}, get(Bucket, Key1, State)),
-      %% Pause for a second to let clocks increment
-      ?_assertEqual(ok, timer:sleep(timer:seconds(1))),
-      %% Write Key2 to the datastore
-      ?_assertEqual({ok, State}, put(Bucket, Key2, Value2, State)),
-      %% Key1 should be kicked out
-      ?_assertEqual({error, not_found, State}, get(Bucket, Key1, State)),
-      %% Key2 should still be present
-      ?_assertEqual({ok, Value2, State}, get(Bucket, Key2, State))
-     ]}.
+    %% Write Key1 to the datastore
+    {ok, State1} = put(Bucket, Key1, Value1, State), 
+    timer:sleep(timer:seconds(1)),
+    %% Write Key2 to the datastore
+    {ok, State2} = put(Bucket, Key2, Value2, State1),
+
+    [    
+     %% Key1 should be kicked out
+     ?_assertEqual({error, not_found, State2}, get(Bucket, Key1, State2)),
+     %% Key2 should still be present
+     ?_assertEqual({ok, Value2, State2}, get(Bucket, Key2, State2))
+    ].
 
 -ifdef(EQC).
 

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -147,8 +147,10 @@ put(Bucket, Key, Val, State) ->
             {error, Reason, State}
     end.
 
-%% @doc Insert an object with secondary index 
-%% information into the memory backend
+%% @doc Insert an object into the memory backend.
+%% NOTE: The memory backend does not currently support
+%% secondary indexing. This function is only here
+%% to conform to the backend API specification.
 -type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
 -spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
                  {ok, state()} |

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -29,6 +29,7 @@
          stop/1,
          get/3,
          put/4,
+         put/5,
          delete/3,
          drop/1,
          fold_buckets/4,
@@ -182,6 +183,16 @@ put(Bucket, Key, Value, State) ->
             {error, Reason, NewState}
     end.
 
+
+%% @doc Insert an object with secondary index 
+%% information into the kv backend
+-type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
+-spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
+                 {ok, state()} |
+                 {error, term(), state()}.
+put(Bucket, PrimaryKey, IndexSpecs, Value, State) ->
+    {_Name, Module, SubState} = get_backend(Bucket, State),
+    Module:put(Bucket, PrimaryKey, IndexSpecs, Value, SubState).
 
 %% @doc Delete an object from the backend
 -spec delete(riak_object:bucket(), riak_object:key(), state()) ->

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -28,7 +28,6 @@
          start/2,
          stop/1,
          get/3,
-         put/4,
          put/5,
          delete/3,
          drop/1,
@@ -49,7 +48,7 @@
 -record (state, {backends :: [{atom(), atom(), term()}],
                  default_backend :: atom()}).
 
--opaque(state() :: #state{}).
+-type state() :: #state{}.
 -type config() :: [{atom(), term()}].
 
 %% @doc riak_kv_multi_backend allows you to run multiple backends within a
@@ -163,21 +162,6 @@ get(Bucket, Key, State) ->
         {ok, Value, NewSubState} ->
             NewState = update_backend_state(Name, Module, NewSubState, State),
             {ok, Value, NewState};
-        {error, Reason, NewSubState} ->
-            NewState = update_backend_state(Name, Module, NewSubState, State),
-            {error, Reason, NewState}
-    end.
-
-%% @doc Insert an object into the eleveldb backend
--spec put(riak_object:bucket(), riak_object:key(), binary(), state()) ->
-                 {ok, state()} |
-                 {error, term(), state()}.
-put(Bucket, Key, Value, State) ->
-    {Name, Module, SubState} = get_backend(Bucket, State),
-    case Module:put(Bucket, Key, Value, SubState) of
-        {ok, NewSubState} ->
-            NewState = update_backend_state(Name, Module, NewSubState, State),
-            {ok, NewState};
         {error, Reason, NewSubState} ->
             NewState = update_backend_state(Name, Module, NewSubState, State),
             {error, Reason, NewState}

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -550,12 +550,7 @@ syntactic_put_merge(Mod, ModState, {Bucket, Key}, Obj1, ReqId, IndexBackend, Sta
                                                  StartTime),
             case IndexBackend of
                 true ->
-                    case riak_object:value_count(ResObj) of
-                        1 ->
-                            IndexSpecs = riak_object:get_index_specs(Obj0, Obj1);
-                        _ ->
-                            IndexSpecs = riak_object:resolve_index_specs(Obj0, Obj1)
-                    end;
+                    IndexSpecs = riak_object:get_index_specs(Obj0, Obj1, ResObj);
                 false ->
                     IndexSpecs = []
             end,

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -524,7 +524,7 @@ syntactic_put_merge(Mod, ModState, {Bucket, Key}, Obj1, ReqId, IndexBackend, Sta
         {error, not_found, _UpdModState} ->
             case IndexBackend of
                 true ->
-                    NewIndexSpecs = riak_object:get_index_specs(Obj1, add),
+                    NewIndexSpecs = riak_object:get_index_specs(Obj1, add, true),
                     {newobj, Obj1, NewIndexSpecs};
                 false ->
                     {newobj, Obj1, []}
@@ -551,11 +551,11 @@ syntactic_put_merge(Mod, ModState, {Bucket, Key}, Obj1, ReqId, IndexBackend, Sta
 
 %% @private
 get_index_specs(Mod, ModState, {Bucket, Key}, Obj1) ->
-    NewIndexSpecs = riak_object:get_index_specs(Obj1, add),
     case Mod:get(Bucket, Key, ModState) of
         {error, not_found, _UpdModState} ->
-            NewIndexSpecs;
+            riak_object:get_index_specs(Obj1, add, true);
         {ok, Val0, _UpdModState} ->
+            NewIndexSpecs = riak_object:get_index_specs(Obj1, add, false),
             Obj0 = binary_to_term(Val0),
             OldIndexSpecs = riak_object:get_index_specs(Obj0, remove),
             OldIndexSpecs ++ NewIndexSpecs
@@ -833,7 +833,7 @@ do_get_vclock({Bucket, Key}, Mod, ModState) ->
     end.
 
 %% @private
-                                                % upon receipt of a handoff datum, there is no client FSM
+%% upon receipt of a handoff datum, there is no client FSM
 do_diffobj_put(BKey={Bucket, Key}, DiffObj,
                _StateData=#state{index_backend=IndexBackend,
                                  mod=Mod,

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -397,11 +397,6 @@ handle_exit(_Pid, Reason, State) ->
     lager:error("Linked process exited. Reason: ~p", [Reason]),
     {stop, linked_process_crash, State}.
 
-%% old vnode helper functions
-
-%% store_call(State=#state{mod=Mod, modstate=ModState}, Msg) ->
-%% Mod:call(ModState, Msg).
-
 %% @private
 %% upon receipt of a client-initiated put
 do_put(Sender, {Bucket,_Key}=BKey, RObj, ReqID, StartTime, Options, State) ->

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -336,25 +336,13 @@ increment_vclock(Object=#r_object{}, ClientId, Timestamp) ->
 -spec get_index_specs(riak_object(), index_op(), boolean()) ->
                              [{index_op(), binary(), index_value()}].
 get_index_specs(RObj, IndexOp, WithSpecialFields) ->
-    case value_count(RObj) > 1 of
-        true ->
-            MetaDatas = get_metadatas(RObj),
-            IndexSpecs = 
-                [begin
-                     Indexes = dict:fetch(?MD_INDEX, MD),
-                     assemble_index_specs(Indexes, IndexOp, WithSpecialFields)
-                 end || MD <- MetaDatas, dict:is_key(?MD_INDEX, MD)],
-            lists:flatten(IndexSpecs);
-        false ->
-            MD = get_metadata(RObj),
-            case dict:is_key(?MD_INDEX, MD) of
-                true ->
-                    Indexes = dict:fetch(?MD_INDEX, MD),
-                    assemble_index_specs(Indexes, IndexOp, WithSpecialFields);
-                false ->
-                    []
-            end
-    end.
+    MetaDatas = get_metadatas(RObj),
+    IndexSpecs = 
+        [begin
+             Indexes = dict:fetch(?MD_INDEX, MD),
+             assemble_index_specs(Indexes, IndexOp, WithSpecialFields)
+         end || MD <- MetaDatas, dict:is_key(?MD_INDEX, MD)],
+    lists:flatten(IndexSpecs).
 
 %% @doc Assemble a list of index specs in the
 %% form of triplets of the form

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -354,9 +354,8 @@ diff_index_specs(Obj, OldObj) ->
     AllIndexes = index_data(Obj),
     AllIndexSet = ordsets:from_list(AllIndexes),
     NewIndexSet = ordsets:subtract(AllIndexSet, OldIndexSet),
-    RemoveIndexSet = ordsets:subtract(
-                       ordsets:subtract(OldIndexSet, AllIndexSet),
-                       NewIndexSet),
+    RemoveIndexSet = 
+        ordsets:subtract(OldIndexSet, AllIndexSet),
     NewIndexSpecs =
         assemble_index_specs(ordsets:subtract(NewIndexSet, OldIndexSet),
                              add),

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -63,7 +63,7 @@
 -export([get_update_metadata/1, get_update_value/1, get_contents/1]).
 -export([merge/2, apply_updates/1, syntactic_merge/3, syntactic_merge/4]).
 -export([to_json/1, from_json/1]).
--export([get_index_specs/2]).
+-export([get_index_specs/2, resolve_index_specs/2]).
 -export([set_contents/2, set_vclock/2]). %% INTERNAL, only for riak_*
 
 %% @doc Constructor for new riak objects.
@@ -332,13 +332,79 @@ increment_vclock(Object=#r_object{}, ClientId, Timestamp) ->
 -spec get_index_specs(riak_object(), index_op()) ->
                              [{index_op(), binary(), index_value()}].
 get_index_specs(RObj, IndexOp) ->
-    MetaDatas = get_metadatas(RObj),
-    IndexSpecs = 
-        [begin
-             Indexes = dict:fetch(?MD_INDEX, MD),
-             [{IndexOp, Index, Value} || {Index, Value} <- Indexes]
-         end || MD <- MetaDatas, dict:is_key(?MD_INDEX, MD)],
-    lists:flatten(IndexSpecs).
+    case value_count(RObj) > 1 of
+        true ->
+            MetaDatas = get_metadatas(RObj),
+            IndexSpecs = 
+                [begin
+                     Indexes = dict:fetch(?MD_INDEX, MD),
+                     [{IndexOp, Index, Value} || {Index, Value} <- Indexes]
+                 end || MD <- MetaDatas, dict:is_key(?MD_INDEX, MD)],
+            lists:flatten(IndexSpecs);
+        false ->
+            MD = get_metadata(RObj),
+            case dict:is_key(?MD_INDEX, MD) of
+                true ->
+                    Indexes = dict:fetch(?MD_INDEX, MD),
+                    [{IndexOp, Index, Value} || {Index, Value} <- Indexes];
+                false ->
+                    []
+            end
+    end.
+
+%% @doc Prepare a list of index specifications
+%% to pass to the backend including the resolution
+%% of any conflicting index specifications among
+%% the object's siblings.
+-spec resolve_index_specs(riak_object(), riak_object()) ->
+                             [{index_op(), binary(), index_value()}].
+resolve_index_specs(CurrentObj, NewObj) ->
+    case value_count(CurrentObj) > 1 of
+        true ->
+            NewMD = get_metadata(NewObj),
+            case dict:is_key(?MD_INDEX, NewMD) of
+                true ->
+                    NewIndexes = dict:fetch(?MD_INDEX, NewMD),
+                    MetaDatas = get_metadatas(CurrentObj),
+                    CurrentIndexes = 
+                        lists:flatten(
+                          [begin
+                               dict:fetch(?MD_INDEX, MD)
+                           end || MD <- MetaDatas, dict:is_key(?MD_INDEX, MD)]
+                         ),
+                    IndexResolver = 
+                        fun({Index, Value}, Acc) ->
+                             case orddict:is_key(Index, CurrentIndexes) of
+                                 true ->
+                                     CurrentValue =
+                                         orddict:fetch(Index, CurrentIndexes),
+                                     case Value < CurrentValue of
+                                         true ->
+                                             [{remove, Index, CurrentValue},
+                                              {add, Index, Value}]  ++ Acc;
+                                         false ->
+                                             Acc
+                                     end;
+                                 false ->
+                                     [{add, Index, Value} | Acc]
+                             end
+                         end,
+                    lists:foldl(IndexResolver, [], NewIndexes);
+                false ->
+                    %% Since the current object has siblings we
+                    %% preserve all existing indexes rather than
+                    %% purge them all as is the case when there
+                    %% are no siblings.
+                    []
+            end;
+        false ->
+            %% Current object has no siblings so we replace
+            %% the current indexes with the indexes from the
+            %% new object.
+            CurrentIndexes = get_index_specs(CurrentObj, remove),
+            NewIndexes = get_index_specs(NewObj, add),
+            CurrentIndexes ++ NewIndexes
+    end.
 
 %% @spec set_contents(riak_object(), [{dict(), value()}]) -> riak_object()
 %% @doc  INTERNAL USE ONLY.  Set the contents of riak_object to the

--- a/test/backend_eqc.erl
+++ b/test/backend_eqc.erl
@@ -240,7 +240,7 @@ postcondition(_From, _To, S,
               {call, _M, fold_buckets, [_FoldFun, _Acc, _Opts, _BeState]}, {ok, R}) ->
     ExpectedEntries = orddict:to_list(S#qcst.d),
     Buckets = [Bucket || {{Bucket, _}, _} <- ExpectedEntries],
-    lists:sort(Buckets) =:= lists:sort(R);
+    lists:usort(Buckets) =:= lists:sort(R);
 postcondition(_From, _To, S,
               {call, _M, fold_keys, [_FoldFun, _Acc, _Opts, _BeState]}, {ok, R}) ->
     ExpectedEntries = orddict:to_list(S#qcst.d),

--- a/test/backend_eqc.erl
+++ b/test/backend_eqc.erl
@@ -190,7 +190,7 @@ next_state_data(running, stopped, S, _R,
            olds = sets:add_element(S#qcst.s, S#qcst.olds)};
 next_state_data(_From, _To, S, R, {call, _M, init_backend, _}) ->
     S#qcst{s=R};
-next_state_data(_From, _To, S, _R, {call, _M, put, [Bucket, Key, Val, _]}) ->
+next_state_data(_From, _To, S, _R, {call, _M, put, [Bucket, Key, [], Val, _]}) ->
     S#qcst{d = orddict:store({Bucket, Key}, Val, S#qcst.d)};
 next_state_data(_From, _To, S, _R, {call, _M, delete, [Bucket, Key, _]}) ->
     S#qcst{d = orddict:erase({Bucket, Key}, S#qcst.d)};
@@ -208,7 +208,7 @@ stopped(#qcst{backend=Backend,
 running(#qcst{backend=Backend,
               s=State}) ->
     [
-     {history, {call, Backend, put, [bucket(), key(), val(), State]}},
+     {history, {call, Backend, put, [bucket(), key(), [], val(), State]}},
      {history, {call, Backend, get, [bucket(), key(), State]}},
      {history, {call, Backend, delete, [bucket(), key(), State]}},
      {history, {call, Backend, fold_buckets, [fold_buckets_fun(), [], [], State]}},


### PR DESCRIPTION
These changes add support secondary indexing to the backend api and makes changes to `riak_kv_vnode` and the secondary index code to use these changes. These changes include a number of optimizations to improve the performance of the index backend including discontinuing the use of a proxy object to store the index information in `merge_index`. My benchmarking shows that standard kv performance (_i.e._ get, put, update, delete) is very similar to the performance using bitcask alone. Benchmarking the performance of index creation and querying remains an outstanding task.
