### PR TITLE
AZ625 - Simplify 2I HTTP interface

### DIFF
--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -50,12 +50,8 @@
 %% @type bucketname()      :: binary().
 %% @type index_field()     :: binary().
 %% @type index_value()     :: binary() | integer().
-%% @type query_elements()  :: [query_element()].
-%% @type query_element()   :: {eq , index_field(), index_value()}
-%%                          | {gt , index_field(), index_value()}
-%%                          | {gte, index_field(), index_value()}
-%%                          | {lt , index_field(), index_value()}
-%%                          | {lte, index_field(), index_value()}.
+%% @type query_element()   :: {eq,    index_field(), [index_value()]},
+%%                         :: {range, index_field(), [index_value(), index_value()}
 
 
 mapred_index(Dest, Args) ->

--- a/src/riak_kv_web.erl
+++ b/src/riak_kv_web.erl
@@ -93,7 +93,7 @@ raw_dispatch(Name) ->
      {["buckets", bucket, "keys", key, '*'],
       riak_kv_wm_link_walker, Props2},
 
-     {["buckets", bucket, "index", field, op, '*'],
+     {["buckets", bucket, "index", field, '*'],
       riak_kv_wm_index, Props2}
     ].
 


### PR DESCRIPTION
TL;DR - For simplicity, this code removes some 2i operations from HTTP interface, bringing it into parity with the MapReduce and PB interfaces.
# Setup

**Enable the index backend before running!**
1. `cd rel/riak`
2. `$EDITOR etc/app.config`
3. `Change storage_backend to riak_kv_index_backend`
# Overview

The first round of changes to the HTTP interface for 2I added support for:
- equality
- range
- greater than
- less than
- greater than or equal
- less than or equal operations.

For simplicity, we only support equality and range operations in the Map/Reduce and PB interfaces.

This change **removes** everything except for equality and range from the HTTP interface. It slightly reduces code complexity, but will make documentation easier if all interface support the same operations.

In the future, we will likely add back more complex operations through a declarative query language.
# Testing

``` bash
# Index some documents...

curl -v -X PUT \
-d 'data1' \
-H "Content-Type: application/json" \
-H "x-riak-index-field1_bin: val1" \
-H "x-riak-index-field2_int: 1001" \
http://127.0.0.1:8098/riak/mybucket/mykey1

curl -v -X PUT \
-d 'data2' \
-H "Content-Type: application/json" \
-H "x-riak-index-Field1_bin: val2" \
-H "x-riak-index-Field2_int: 1002" \
http://127.0.0.1:8098/riak/mybucket/mykey2

curl -v -X PUT \
-d 'data3' \
-H "Content-Type: application/json" \
-H "X-RIAK-INDEX-FIELD1_BIN: val3" \
-H "X-RIAK-INDEX-FIELD2_INT: 1003" \
http://127.0.0.1:8098/riak/mybucket/mykey3

curl -v -X PUT \
-d 'data4' \
-H "Content-Type: application/json" \
-H "x-riak-index-field1_bin: val4" \
-H "x-riak-index-field2_int: 1004" \
http://127.0.0.1:8098/riak/mybucket/mykey4

# Retrieve the documents...

curl -i http://127.0.0.1:8098/riak/mybucket/mykey1
curl -i http://127.0.0.1:8098/riak/mybucket/mykey2
curl -i http://127.0.0.1:8098/riak/mybucket/mykey3
curl -i http://127.0.0.1:8098/riak/mybucket/mykey4

# Query against a binary field...

curl http://localhost:8098/buckets/mybucket/index/field1_bin/val1
curl http://localhost:8098/buckets/mybucket/index/field1_bin/val2/val4

# Query against an integer field...

curl http://localhost:8098/buckets/mybucket/index/field2_int/1001
curl http://localhost:8098/buckets/mybucket/index/field2_int/1002/1004

# Should throw errors: too few / too many args...

curl http://localhost:8098/buckets/mybucket/index/field2_int
curl http://localhost:8098/buckets/mybucket/index/field2_int/1/2/3
```
