### PR TITLE
Az602 - Update ELevelDB Backend to Support 2i (and AZ639)

### DIFF
--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -103,22 +103,10 @@ parse_object(RObj) ->
                         Acc
                 end
         end,
-    IndexFields1 = lists:foldl(F, [], riak_object:get_metadatas(RObj)),
-
-    %% Delete any special fields...
-    IndexFields2 = [{X, Y} || {X, Y} <- IndexFields1,
-                              X /= ?BUCKETFIELD,
-                              X /= ?KEYFIELD],
-
-    %% Add the bucket and key to the list of postings...
-    IndexFields3 = [
-                    {?BUCKETFIELD, riak_object:bucket(RObj)},
-                    {?KEYFIELD, riak_object:key(RObj)}|
-                    IndexFields2
-                   ],
+    IndexFields = lists:foldl(F, [], riak_object:get_metadatas(RObj)),
 
     %% Now parse the fields, returning the result.
-    parse_fields(IndexFields3).
+    parse_fields(IndexFields).
 
 %% @spec parse_fields([Field :: {Key:binary(), Value :: binary()}]) ->
 %%       {ok, [{Field :: binary(), Value :: term()}]} | {error, [failure_reason()]}.
@@ -411,8 +399,6 @@ parse_object_test() ->
 
     ?assertMatch(
        {ok, [
-             {?BUCKETFIELD, <<"B">>},
-             {?KEYFIELD, <<"K">>},
              {<<"field_bin">>, <<"A">>},
              {<<"field_int">>, 1}
        ]},

--- a/src/riak_kv_backend.erl
+++ b/src/riak_kv_backend.erl
@@ -48,7 +48,7 @@ behaviour_info(callbacks) ->
      {stop,1},        % (State)
      {get,3},         % (Bucket, Key, State)
      {put,5},         % (Bucket, Key, IndexSpecs, Val, State)
-     {delete,3},      % (Bucket, Key, State)
+     {delete,4},      % (Bucket, Key, IndexSpecs, State)
      {drop,1},        % (State)
      {fold_buckets,4},% (FoldBucketsFun, Acc, Opts, State),
                       %   FoldBucketsFun(Bucket, Acc)

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -31,7 +31,7 @@
          stop/1,
          get/3,
          put/5,
-         delete/3,
+         delete/4,
          drop/1,
          fold_buckets/4,
          fold_keys/4,
@@ -148,10 +148,13 @@ put(Bucket, PrimaryKey, _IndexSpecs, Val, #state{ref=Ref}=State) ->
     end.
 
 %% @doc Delete an object from the bitcask backend
--spec delete(riak_object:bucket(), riak_object:key(), state()) ->
+%% NOTE: The bitcask backend does not currently support
+%% secondary indexing and the_IndexSpecs parameter
+%% is ignored.
+-spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
                     {ok, state()} |
                     {error, term(), state()}.
-delete(Bucket, Key, #state{ref=Ref}=State) ->
+delete(Bucket, Key, _IndexSpecs, #state{ref=Ref}=State) ->
     BitcaskKey = term_to_binary({Bucket, Key}),
     case bitcask:delete(Ref, BitcaskKey) of
         ok ->

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -304,7 +304,7 @@ fold_buckets_fun(FoldBucketsFun) ->
 %% @private
 %% Return a function to fold over keys on this backend
 fold_keys_fun(FoldKeysFun, undefined) ->
-    %% Fold across a specific bucket...
+    %% Fold across everything...
     fun(StorageKey, Acc) ->
             case from_object_key(StorageKey) of
                 {Bucket, Key} ->

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -38,12 +38,17 @@
          status/1,
          callback/3]).
 
+-compile({inline, [
+                   to_object_key/2, from_object_key/1,
+                   to_index_key/4, from_index_key/1
+                  ]}).
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
 -define(API_VERSION, 1).
--define(CAPABILITIES, []).
+-define(CAPABILITIES, [indexes]).
 
 -record(state, {ref :: reference(),
                 data_root :: string(),
@@ -92,7 +97,7 @@ stop(_State) ->
                  {error, term(), state()}.
 get(Bucket, Key, #state{read_opts=ReadOpts,
                         ref=Ref}=State) ->
-    StorageKey = sext:encode({Bucket, Key}),
+    StorageKey = to_object_key(Bucket, Key),
     case eleveldb:get(Ref, StorageKey, ReadOpts) of
         {ok, Value} ->
             {ok, Value, State};
@@ -103,17 +108,26 @@ get(Bucket, Key, #state{read_opts=ReadOpts,
     end.
 
 %% @doc Insert an object into the eleveldb backend.
-%% NOTE: The eleveldb backend does not currently
-%% support secondary indexing and the _IndexSpecs
-%% parameter is ignored.
 -type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
 -spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
                  {ok, state()} |
                  {error, term(), state()}.
-put(Bucket, PrimaryKey, _IndexSpecs, Val, #state{ref=Ref,
+put(Bucket, PrimaryKey, IndexSpecs, Val, #state{ref=Ref,
                                                  write_opts=WriteOpts}=State) ->
-    StorageKey = sext:encode({Bucket, PrimaryKey}),
-    case eleveldb:put(Ref, StorageKey, Val, WriteOpts) of
+    %% Create the KV update...
+    StorageKey = to_object_key(Bucket, PrimaryKey),
+    Updates1 = [{put, StorageKey, Val}],
+
+    %% Convert IndexSpecs to index updates...
+    F = fun({add, Field, Value}) ->
+                {put, to_index_key(Bucket, PrimaryKey, Field, Value), <<>>};
+           ({remove, Field, Value}) ->
+                {delete, to_index_key(Bucket, PrimaryKey, Field, Value)}
+        end,
+    Updates2 = [F(X) || X <- IndexSpecs],
+
+    %% Perform the write...
+    case eleveldb:write(Ref, Updates1 ++ Updates2, WriteOpts) of
         ok ->
             {ok, State};
         {error, Reason} ->
@@ -127,7 +141,8 @@ put(Bucket, PrimaryKey, _IndexSpecs, Val, #state{ref=Ref,
                     {error, term(), state()}.
 delete(Bucket, Key, #state{ref=Ref,
                            write_opts=WriteOpts}=State) ->
-    StorageKey = sext:encode({Bucket, Key}),
+    %% TODO - Update riak_kv_vnode for IndexSpecs...
+    StorageKey = to_object_key(Bucket, Key),
     case eleveldb:delete(Ref, StorageKey, WriteOpts) of
         ok ->
             {ok, State};
@@ -140,30 +155,50 @@ delete(Bucket, Key, #state{ref=Ref,
                    any(),
                    [],
                    state()) -> {ok, any()}.
-fold_buckets(FoldBucketsFun, Acc, _Opts, #state{fold_opts=FoldOpts,
+fold_buckets(FoldBucketsFun, Acc, _Opts, #state{fold_opts=FoldOpts1,
                                                 ref=Ref}) ->
     FoldFun = fold_buckets_fun(FoldBucketsFun),
-    {Acc0, _LastBucket} =
-        eleveldb:fold_keys(Ref, FoldFun, {Acc, []}, FoldOpts),
-    {ok, Acc0}.
-
-%% @doc Fold over all the keys for one or all buckets.
--spec fold_keys(riak_kv_backend:fold_keys_fun(),
-                any(),
-                [{atom(), term()}],
-                state()) -> {ok, term()}.
-fold_keys(FoldKeysFun, Acc, Opts, #state{fold_opts=FoldOpts1,
-                                         ref=Ref}) ->
-    Bucket =  proplists:get_value(bucket, Opts),
-    FoldOpts = fold_opts(Bucket, FoldOpts1),
-    FoldFun = fold_keys_fun(FoldKeysFun, Bucket),
+    FirstKey = to_first_key(undefined),
+    FoldOpts2 = [{first_key, FirstKey} | FoldOpts1],
     try
-        Acc0 = eleveldb:fold_keys(Ref, FoldFun, Acc, FoldOpts),
+        {Acc0, _} = eleveldb:fold_keys(Ref, FoldFun, {Acc, []}, FoldOpts2),
         {ok, Acc0}
     catch
         {break, AccFinal} ->
             {ok, AccFinal}
     end.
+
+%% @doc Fold over all the keys for one or all buckets.
+-spec fold_keys(riak_kv_backend:fold_keys_fun(),
+                any(),
+                [tuple()],
+                state()) -> {ok, term()}.
+fold_keys(FoldKeysFun, Acc, Opts, #state{fold_opts=FoldOpts1,
+                                         ref=Ref}) ->
+    %% Figure out how we should limit the fold: by bucket, by
+    %% secondary index, or neither (fold across everything.)
+    Bucket = lists:keyfind(bucket, 1, Opts),
+    Index = lists:keyfind(index, 1, Opts),
+    Limiter =
+        if Bucket /= false -> Bucket;
+           Index /= false  -> Index;
+           true            -> undefined
+        end,
+
+    %% Set up the fold...
+    FirstKey = to_first_key(Limiter),
+    FoldFun = fold_keys_fun(FoldKeysFun, Limiter),
+    FoldOpts2 = [{first_key, FirstKey} | FoldOpts1],
+
+    %% Do the fold. ELevelDB uses throw/1 to break out of a fold...
+    try
+        Acc0 = eleveldb:fold_keys(Ref, FoldFun, Acc, FoldOpts2),
+        {ok, Acc0}
+    catch
+        {break, AccFinal} ->
+            {ok, AccFinal}
+    end.
+
 
 %% @doc Fold over all the objects for one or all buckets.
 -spec fold_objects(riak_kv_backend:fold_objects_fun(),
@@ -172,11 +207,23 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{fold_opts=FoldOpts1,
                    state()) -> {ok, any()}.
 fold_objects(FoldObjectsFun, Acc, Opts, #state{fold_opts=FoldOpts1,
                                                ref=Ref}) ->
-    Bucket = proplists:get_value(bucket, Opts),
-    FoldOpts = fold_opts(Bucket, FoldOpts1),
-    FoldFun = fold_objects_fun(FoldObjectsFun, Bucket),
+
+
+    %% Figure out how we should limit the fold: by bucket, by
+    %% secondary index, or neither (fold across everything.)
+    Bucket = lists:keyfind(bucket, 1, Opts),
+    Limiter =
+        if Bucket /= false -> Bucket;
+           true            -> undefined
+        end,
+
+    %% Set up the fold...
+    FirstKey = to_first_key(Limiter),
+    FoldFun = fold_objects_fun(FoldObjectsFun, Limiter),
+    FoldOpts2 = [{first_key, FirstKey} | FoldOpts1],
+
     try
-        Acc0 = eleveldb:fold(Ref, FoldFun, Acc, FoldOpts),
+        Acc0 = eleveldb:fold(Ref, FoldFun, Acc, FoldOpts2),
         {ok, Acc0}
     catch
         {break, AccFinal} ->
@@ -234,59 +281,88 @@ config_value(Key, Config) ->
 %% Return a function to fold over the buckets on this backend
 fold_buckets_fun(FoldBucketsFun) ->
     fun(BK, {Acc, LastBucket}) ->
-            case sext:decode(BK) of
+            case from_object_key(BK) of
                 {LastBucket, _} ->
                     {Acc, LastBucket};
                 {Bucket, _} ->
-                    {FoldBucketsFun(Bucket, Acc), Bucket}
+                    {FoldBucketsFun(Bucket, Acc), Bucket};
+                _ ->
+                    throw({break, Acc})
             end
     end.
+
 
 %% @private
 %% Return a function to fold over keys on this backend
 fold_keys_fun(FoldKeysFun, undefined) ->
-    fun(BK, Acc) ->
-            {Bucket, Key} = sext:decode(BK),
-            FoldKeysFun(Bucket, Key, Acc)
-    end;
-fold_keys_fun(FoldKeysFun, Bucket) ->
-    fun(BK, Acc) ->
-            {B, Key} = sext:decode(BK),
-            if B =:= Bucket ->
-                    FoldKeysFun(B, Key, Acc);
-               true ->
+    %% Fold across a specific bucket...
+    fun(StorageKey, Acc) ->
+            case from_object_key(StorageKey) of
+                {Bucket, Key} ->
+                    FoldKeysFun(Bucket, Key, Acc);
+                _ ->
                     throw({break, Acc})
             end
-    end.
+    end;
+fold_keys_fun(FoldKeysFun, {bucket, FilterBucket}) ->
+    %% Fold across a specific bucket...
+    fun(StorageKey, Acc) ->
+            case from_object_key(StorageKey) of
+                {Bucket, Key} when Bucket == FilterBucket ->
+                    FoldKeysFun(Bucket, Key, Acc);
+                _ ->
+                    throw({break, Acc})
+            end
+    end;
+fold_keys_fun(FoldKeysFun, {index, FilterBucket, {eq, <<"$bucket">>, _}}) ->
+    %% 2I exact match query on special $bucket field...
+    fold_keys_fun(FoldKeysFun, {bucket, FilterBucket});
+fold_keys_fun(FoldKeysFun, {index, FilterBucket, {eq, FilterField, FilterTerm}}) ->
+    %% Rewrite 2I exact match query as a range...
+    NewQuery = {range, FilterField, FilterTerm, FilterTerm},
+    fold_keys_fun(FoldKeysFun, {index, FilterBucket, NewQuery});
+fold_keys_fun(FoldKeysFun, {index, FilterBucket, {range, <<"$key">>, StartKey, EndKey}}) ->
+    %% 2I range query on special $key field...
+    fun(StorageKey, Acc) ->
+            case from_object_key(StorageKey) of
+                {Bucket, Key} when FilterBucket == Bucket,
+                                   StartKey =< Key,
+                                   EndKey >= Key ->
+                    FoldKeysFun(Bucket, Key, Acc);
+                _ ->
+                    throw({break, Acc})
+            end
+    end;
+fold_keys_fun(FoldKeysFun, {index, FilterBucket, {range, FilterField, StartTerm, EndTerm}}) ->
+    %% 2I range query...
+    fun(StorageKey, Acc) ->
+            case from_index_key(StorageKey) of
+                {Bucket, Key, Field, Term} when FilterBucket == Bucket,
+                                                FilterField == Field,
+                                                StartTerm =< Term,
+                                                EndTerm >= Term ->
+                    FoldKeysFun(Bucket, Key, Acc);
+                _ ->
+                    throw({break, Acc})
+            end
+    end;
+fold_keys_fun(_FoldKeysFun, Other) ->
+    throw({unknown_limiter, Other}).
 
 %% @private
 %% Return a function to fold over the objects on this backend
-fold_objects_fun(FoldObjectsFun, undefined) ->
-    fun({BK, Value}, Acc) ->
-            {Bucket, Key} = sext:decode(BK),
-            FoldObjectsFun(Bucket, Key, Value, Acc)
-    end;
-fold_objects_fun(FoldObjectsFun, Bucket) ->
-    fun({BK, Value}, Acc) ->
-            {B, Key} = sext:decode(BK),
-            %% Take advantage of the fact that sext-encoding ensures all
-            %% keys in a bucket occur sequentially. Once we encounter a
-            %% different bucket, the fold is complete
-            if B =:= Bucket ->
-                    FoldObjectsFun(B, Key, Value, Acc);
-               true ->
+fold_objects_fun(FoldObjectsFun, FilterBucket) ->
+    %% 2I does not support fold objects at this time, so this is much
+    %% simpler than fold_keys_fun.
+    fun({StorageKey, Value}, Acc) ->
+            case from_object_key(StorageKey) of
+                {Bucket, Key} when FilterBucket == undefined;
+                                   Bucket == FilterBucket ->
+                    FoldObjectsFun(Bucket, Key, Value, Acc);
+                _ ->
                     throw({break, Acc})
             end
     end.
-
-%% @private
-%% Augment the fold options list if a
-%% bucket is defined.
-fold_opts(undefined, FoldOpts) ->
-    FoldOpts;
-fold_opts(Bucket, FoldOpts) ->
-    BKey = sext:encode({Bucket, <<>>}),
-    [{first_key, BKey} | FoldOpts].
 
 %% @private
 get_status(Dir) ->
@@ -296,6 +372,54 @@ get_status(Dir) ->
             Status;
         {error, Reason} ->
             {error, Reason}
+    end.
+
+%% @private Given a scope limiter, use sext to encode an expression
+%% that represents the starting key for the scope. For example, since
+%% we store objects under {o, Bucket, Key}, the first key for the
+%% bucket "foo" would be `sext:encode({o, <<"foo">>, <<>>}).`
+to_first_key(undefined) ->
+    %% Start at the first object in LevelDB...
+    to_object_key(<<>>, <<>>);
+to_first_key({bucket, Bucket}) ->
+    %% Start at the first object for a given bucket...
+    to_object_key(Bucket, <<>>);
+to_first_key({index, Bucket, {eq, <<"$bucket">>, _Term}}) ->
+    %% 2I exact match query on special $bucket field...
+    to_first_key({bucket, Bucket});
+to_first_key({index, Bucket, {eq, Field, Term}}) ->
+    %% Rewrite 2I exact match query as a range...
+    to_first_key({index, Bucket, {range, Field, Term, Term}});
+to_first_key({index, Bucket, {range, <<"$key">>, StartTerm, _EndTerm}}) ->
+    %% 2I range query on special $key field...
+    to_object_key(Bucket, StartTerm);
+to_first_key({index, Bucket, {range, Field, StartTerm, _EndTerm}}) ->
+    %% 2I range query...
+    to_index_key(Bucket, <<>>, Field, StartTerm);
+to_first_key(Other) ->
+    erlang:throw({unknown_limiter, Other}).
+
+
+to_object_key(Bucket, Key) ->
+    sext:encode({o, Bucket, Key}).
+
+from_object_key(LKey) ->
+    case sext:decode(LKey) of
+        {o, Bucket, Key} ->
+            {Bucket, Key};
+        _ ->
+            undefined
+    end.
+
+to_index_key(Bucket, Key, Field, Term) ->
+    sext:encode({i, Bucket, Field, Term, Key}).
+
+from_index_key(LKey) ->
+    case sext:decode(LKey) of
+        {i, Bucket, Field, Term, Key} ->
+            {Bucket, Key, Field, Term};
+        _ ->
+            undefined
     end.
 
 %% ===================================================================

--- a/src/riak_kv_index_backend.erl
+++ b/src/riak_kv_index_backend.erl
@@ -32,7 +32,7 @@
          stop/1,
          get/3,
          put/5,
-         delete/3,
+         delete/4,
          drop/1,
          fold_buckets/4,
          fold_keys/4,
@@ -157,10 +157,10 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, State=
     end.
 
 %% @doc Delete the object from the Index backend and the KV backend.
--spec delete(riak_object:bucket(), riak_object:key(), state()) ->
+-spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
                     {ok, state()} |
                     {error, term(), state()}.
-delete(Bucket, Key, #state{kv_mod = KVMod,
+delete(Bucket, Key, IndexSpecs, #state{kv_mod = KVMod,
                            kv_state = KVState,
                            index_mod = IndexMod,
                            index_state = IndexState
@@ -171,7 +171,7 @@ delete(Bucket, Key, #state{kv_mod = KVMod,
     %% works, then delete from KV.
     case do_index_delete(Bucket, Key, KVMod, KVState, IndexMod, IndexState) of
         ok ->
-            case do_kv_delete(Bucket, Key, KVMod, KVState) of
+            case do_kv_delete(Bucket, Key, IndexSpecs, KVMod, KVState) of
                 {ok, UpdKVState} ->
                     {ok, State#state{kv_state=UpdKVState}};
                 {error, Reason, UpdKVState} ->
@@ -355,10 +355,11 @@ do_index_delete(Bucket, PrimaryKey, KVMod, KVState, IndexMod, IndexState) ->
 %% @doc Delete the {Bucket, Key} from the KV backend.
 -spec do_kv_delete(riak_object:bucket(),
                    riak_object:key(),
+                   [index_spec()],
                    module(),
                    term()) -> {ok, term()} | {error, term(), term()}.
-do_kv_delete(Bucket, Key, KVMod, KVState) ->
-    KVMod:delete(Bucket, Key, KVState).
+do_kv_delete(Bucket, Key, Indexes, KVMod, KVState) ->
+    KVMod:delete(Bucket, Key, Indexes, KVState).
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -44,7 +44,7 @@
          stop/1,
          get/3,
          put/5,
-         delete/3,
+         delete/4,
          drop/1,
          fold_buckets/4,
          fold_keys/4,
@@ -128,7 +128,7 @@ get(Bucket, Key, State=#state{data_ref=DataRef,
         [{{Bucket, Key}, {{ts, Timestamp}, Val}}] ->
             case exceeds_ttl(Timestamp, TTL) of
                 true ->
-                    delete(Bucket, Key, State),
+                    delete(Bucket, Key, undefined, State),
                     {error, not_found, State};
                 false ->
                     {ok, Val, State}
@@ -181,9 +181,12 @@ put(Bucket, PrimaryKey, _IndexSpecs, Val, State=#state{data_ref=DataRef,
     end.
 
 %% @doc Delete an object from the memory backend
--spec delete(riak_object:bucket(), riak_object:key(), state()) ->
+%% NOTE: The memory backend does not currently
+%% support secondary indexing and the _IndexSpecs
+%% parameter is ignored.
+-spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
                     {ok, state()}.
-delete(Bucket, Key, State=#state{data_ref=DataRef,
+delete(Bucket, Key, _IndexSpecs, State=#state{data_ref=DataRef,
                                  time_ref=TimeRef,
                                  used_memory=UsedMemory}) ->
     case TimeRef of

--- a/src/riak_kv_mrc_pipe.erl
+++ b/src/riak_kv_mrc_pipe.erl
@@ -346,11 +346,11 @@ send_inputs(Pipe, {Bucket, FilterExprs}, _Timeout) ->
         Error       -> Error
     end;
 send_inputs(Pipe, {index, Bucket, Index, Key}, Timeout) ->
-    Query = [{eq, Index, [Key]}],
+    Query = {eq, Index, Key},
     NewInput = {modfun, riak_index, mapred_index, [Bucket, Query]},
     send_inputs(Pipe, NewInput, Timeout);
 send_inputs(Pipe, {index, Bucket, Index, StartKey, EndKey}, Timeout) ->
-    Query = [{range, Index, [StartKey, EndKey]}],
+    Query = {range, Index, StartKey, EndKey},
     NewInput = {modfun, riak_index, mapred_index, [Bucket, Query]},
     send_inputs(Pipe, NewInput, Timeout);
 send_inputs(Pipe, {search, Bucket, Query}, Timeout) ->

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -29,7 +29,7 @@
          stop/1,
          get/3,
          put/5,
-         delete/3,
+         delete/4,
          drop/1,
          fold_buckets/4,
          fold_keys/4,
@@ -185,12 +185,12 @@ put(Bucket, PrimaryKey, IndexSpecs, Value, State) ->
     end.
 
 %% @doc Delete an object from the backend
--spec delete(riak_object:bucket(), riak_object:key(), state()) ->
+-spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
                     {ok, state()} |
                     {error, term(), state()}.
-delete(Bucket, Key, State) ->
+delete(Bucket, Key, IndexSpecs, State) ->
     {Name, Module, SubState} = get_backend(Bucket, State),
-    case Module:delete(Bucket, Key, SubState) of
+    case Module:delete(Bucket, Key, IndexSpecs, SubState) of
         {ok, NewSubState} ->
             NewState = update_backend_state(Name, Module, NewSubState, State),
             {ok, NewState};

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -153,13 +153,13 @@ to_index_query(IndexField, Args) ->
 
         {ok, [{_, Value}]} ->
             %% One argument == exact match query
-            {ok, {eq, IndexField1, [Value]}};
+            {ok, {eq, IndexField1, Value}};
 
         {ok, [{_, Start}, {_, End}]} ->
             %% Two arguments == range query
             case End > Start of
                 true ->
-                    {ok, {range, IndexField1, [Start, End]}};            
+                    {ok, {range, IndexField1, Start, End}};
                 false ->
                     {error, {invalid_range, Args}}
             end;

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -55,8 +55,6 @@
 -type index_value() :: integer() | binary().
 
 -define(MAX_KEY_SIZE, 65536).
--define(BUCKETFIELD, <<"$bucket">>).
--define(KEYFIELD, <<"$key">>).
 
 -export([new/3, new/4, ensure_robject/1, ancestors/1, reconcile/2, equal/2]).
 -export([increment_vclock/2, increment_vclock/3]).

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -352,7 +352,7 @@ diff_index_specs(Obj, OldObj) ->
     AllIndexes = index_data(Obj),
     AllIndexSet = ordsets:from_list(AllIndexes),
     NewIndexSet = ordsets:subtract(AllIndexSet, OldIndexSet),
-    RemoveIndexSet = 
+    RemoveIndexSet =
         ordsets:subtract(OldIndexSet, AllIndexSet),
     NewIndexSpecs =
         assemble_index_specs(ordsets:subtract(NewIndexSet, OldIndexSet),
@@ -365,6 +365,8 @@ diff_index_specs(Obj, OldObj) ->
 %% @doc Get a list of {Index, Value} tuples from the
 %% metadata of an object.
 -spec index_data(riak_object()) -> [{binary(), index_value()}].
+index_data(undefined) ->
+    [];
 index_data(Obj) ->
     MetaDatas = get_metadatas(Obj),
     lists:flatten([dict:fetch(?MD_INDEX, MD)


### PR DESCRIPTION
## Overview
- This change adds 2i support to ELevelDB backend. 
- This required changes to the DELETE operation in `riak_kv_vnode`, which cascaded to changes in other backends. Specifically, the vnode needed to supply index specs to Mod:delete/N.
- Finally, this also includes AZ639, which makes the $bucket and $key fields implicit, rather than automatically generating them and tacking them on to the object metadata. Needed to do this in order to fully test the ELevelDB changes.
## Setup

Make sure that you have set the `storage_backend` config setting to `riak_kv_eleveldb_backend`.
## Tests
### Index some documents...

``` bash
curl -v -X PUT \
-d 'data1' \
-H "x-riak-index-field1_bin: val1" \
-H "x-riak-index-field2_int: 1001" \
http://127.0.0.1:8098/riak/mybucket/mykey1

curl -v -X PUT \
-d 'data2' \
-H "x-riak-index-Field1_bin: val2" \
-H "x-riak-index-Field2_int: 1002" \
http://127.0.0.1:8098/riak/mybucket/mykey2

curl -v -X PUT \
-d 'data3' \
-H "X-RIAK-INDEX-FIELD1_BIN: val3" \
-H "X-RIAK-INDEX-FIELD2_INT: 1003" \
http://127.0.0.1:8098/riak/mybucket/mykey3

curl -v -X PUT \
-d 'data4' \
-H "x-riak-index-field1_bin: val4" \
-H "x-riak-index-field2_int: 1004" \
http://127.0.0.1:8098/riak/mybucket/mykey4
```
### Retrieve the documents...

``` bash
curl -i http://127.0.0.1:8098/riak/mybucket/mykey1
curl -i http://127.0.0.1:8098/riak/mybucket/mykey2
curl -i http://127.0.0.1:8098/riak/mybucket/mykey3
curl -i http://127.0.0.1:8098/riak/mybucket/mykey4
```
### Query against a binary field...

``` bash
curl http://localhost:8098/buckets/mybucket/index/field1_bin/val1
curl http://localhost:8098/buckets/mybucket/index/field1_bin/val2/val4
```
### Query against an integer field...

``` bash
curl http://localhost:8098/buckets/mybucket/index/field2_int/1001
curl http://localhost:8098/buckets/mybucket/index/field2_int/1002/1004
```
### Try some special queries...

``` bash
curl http://localhost:8098/buckets/mybucket/index/\$bucket/mybucket
curl http://localhost:8098/buckets/mybucket/index/\$key/mykey1/mykey3
```
### Should throw errors: too few / too many args...

``` bash
curl http://localhost:8098/buckets/mybucket/index/field2_int
curl http://localhost:8098/buckets/mybucket/index/field2_int/1/2/3
```
### Delete an object, make sure we can't find it...

```
curl -i -X DELETE http://127.0.0.1:8098/riak/mybucket/mykey1
curl -i http://127.0.0.1:8098/riak/mybucket/mykey1
curl http://localhost:8098/buckets/mybucket/index/field1_bin/val1
curl http://localhost:8098/buckets/mybucket/index/field2_int/1001
```
