### PR TITLE
Az603 backend refactoring phase3

### DIFF
--- a/ebin/riak_kv.app
+++ b/ebin/riak_kv.app
@@ -26,6 +26,7 @@
              riak_kv_eleveldb_backend,
              riak_kv_fold_buffer,
              riak_kv_fold_worker,
+             riak_kv_fold_util,
              riak_kv_get_core,
              riak_kv_get_fsm,
              riak_kv_get_fsm_sup,

--- a/ebin/riak_kv.app
+++ b/ebin/riak_kv.app
@@ -25,6 +25,7 @@
              riak_kv_delete_sup,
              riak_kv_eleveldb_backend,
              riak_kv_fold_buffer,
+             riak_kv_fold_worker,
              riak_kv_get_core,
              riak_kv_get_fsm,
              riak_kv_get_fsm_sup,

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -52,12 +52,14 @@
 
 -define(MERGE_CHECK_INTERVAL, timer:minutes(3)).
 -define(API_VERSION, 1).
--define(CAPABILITIES, []).
+-define(CAPABILITIES, [async_fold]).
 
 -record(state, {ref :: reference(),
                 link_file :: string(),
+                data_file :: string(),
                 opts :: [{atom(), term()}],
-                root :: string()}).
+                root :: string(),
+                async_folds :: boolean()}).
 
 -type state() :: #state{}.
 -type config() :: [{atom(), term()}].
@@ -91,10 +93,13 @@ start(Partition, Config) ->
                         Ref when is_reference(Ref) ->
                             schedule_merge(Ref),
                             maybe_schedule_sync(Ref),
+                            AsyncFolds = config_value(async_folds, Config, true),
                             {ok, #state{ref=Ref,
+                                        data_file=DataFile,
                                         link_file=LinkFile,
                                         root=DataRoot,
-                                        opts=BitcaskOpts}};
+                                        opts=BitcaskOpts,
+                                        async_folds=AsyncFolds}};
                         {error, Reason1} ->
                             lager:error("Failed to start bitcask backend: ~p\n",
                                         [Reason1]),
@@ -164,7 +169,30 @@ delete(Bucket, Key, #state{ref=Ref}=State) ->
 -spec fold_buckets(riak_kv_backend:fold_buckets_fun(),
                    any(),
                    [],
-                   state()) -> {ok, any()} | {error, term()}.
+                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+fold_buckets(FoldBucketsFun, Acc, _Opts, #state{opts=BitcaskOpts,
+                                                data_file=DataFile,
+                                                root=DataRoot,
+                                                async_folds=true}) ->
+    FoldFun = fold_buckets_fun(FoldBucketsFun),
+    case BitcaskOpts of
+        [{read_write, _} | Config] ->
+            ok;
+        Config ->
+            ok
+    end,
+    ReadOpts = [{read_only, true} | Config],
+    BucketFolder =
+        fun() ->
+                case bitcask:open(filename:join(DataRoot, DataFile),
+                                  ReadOpts) of
+                    Ref when is_reference(Ref) ->
+                        bitcask:fold_keys(Ref, FoldFun, {Acc, ordsets:new()});
+                    {error, Reason} ->
+                        {error, Reason}
+                end
+        end,
+    {async, BucketFolder};
 fold_buckets(FoldBucketsFun, Acc, _Opts, #state{ref=Ref}) ->
     FoldFun = fold_buckets_fun(FoldBucketsFun),
     {FoldResult, _Bucketset} =
@@ -180,7 +208,32 @@ fold_buckets(FoldBucketsFun, Acc, _Opts, #state{ref=Ref}) ->
 -spec fold_keys(riak_kv_backend:fold_keys_fun(),
                 any(),
                 [{atom(), term()}],
-                state()) -> {ok, term()} | {error, term()}.
+                state()) -> {ok, term()} | {async, fun()} | {error, term()}.
+fold_keys(FoldKeysFun, Acc, Opts, #state{opts=BitcaskOpts,
+                                         data_file=DataFile,
+                                         root=DataRoot,
+                                         async_folds=true}) ->
+    Bucket =  proplists:get_value(bucket, Opts),
+    FoldFun = fold_keys_fun(FoldKeysFun, Bucket),
+    case BitcaskOpts of
+        [{read_write, _} | Config] ->
+            ok;
+        Config ->
+            ok
+    end,
+    ReadOpts = [{read_only, true} | Config],
+    KeyFolder =
+        fun() ->
+                ?debugFmt("DataFile: ~p~n", [DataFile]),
+                case bitcask:open(filename:join(DataRoot, DataFile),
+                                  ReadOpts) of
+                    Ref when is_reference(Ref) ->
+                        bitcask:fold_keys(Ref, FoldFun, Acc);
+                    {error, Reason} ->
+                        {error, Reason}
+                end
+        end,
+    {async, KeyFolder};
 fold_keys(FoldKeysFun, Acc, Opts, #state{ref=Ref}) ->
     Bucket =  proplists:get_value(bucket, Opts),
     FoldFun = fold_keys_fun(FoldKeysFun, Bucket),
@@ -233,9 +286,10 @@ drop(#state{ref=Ref,
             %% so this backend can continue processing.
             case bitcask:open(filename:join(DataRoot, DataFile), BitcaskOpts) of
                 Ref1 when is_reference(Ref1) ->
-                    {ok, State#state{ref=Ref1}};
+                    {ok, State#state{data_file=DataFile,
+                                     ref=Ref1}};
                 {error, Reason} ->
-                    {error, Reason, State}
+                    {error, Reason, State#state{data_file=DataFile}}
             end;
         {error, Reason1} ->
             {error, Reason1, State}
@@ -382,9 +436,13 @@ schedule_merge(Ref) when is_reference(Ref) ->
 
 %% @private
 config_value(Key, Config) ->
+    config_value(Key, Config, undefined).
+
+%% @private
+config_value(Key, Config, Default) ->
     case proplists:get_value(Key, Config) of
         undefined ->
-            app_helper:get_env(bitcask, Key);
+            app_helper:get_env(bitcask, Key, Default);
         Value ->
             Value
     end.
@@ -393,10 +451,13 @@ config_value(Key, Config) ->
 check_symlink(LinkFile, DeleteExisting) ->
     case file:read_link(LinkFile) of
         {ok, DataFile} ->
+            ?debugFmt("Check syn datafile: ~p~n", [DataFile]),
             case DeleteExisting of
                 true ->
                     file:delete(LinkFile),
-                    make_symlink(LinkFile);
+                    R = make_symlink(LinkFile),
+                    ?debugFmt("New link file: ~p~n", [file:read_link(LinkFile)]),
+                    R;
                 false ->
                     {ok, DataFile}
             end;
@@ -491,6 +552,11 @@ eqc_test_() ->
          [
           {timeout, 60000,
            [?_assertEqual(true,
+                          backend_eqc:test(?MODULE, false,
+                                           [{data_root,
+                                             "test/bitcask-backend"},
+                                            {async_folds, false}])),
+            ?_assertEqual(true,
                           backend_eqc:test(?MODULE, false,
                                            [{data_root,
                                              "test/bitcask-backend"}]))]}

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -224,7 +224,6 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{opts=BitcaskOpts,
     ReadOpts = [{read_only, true} | Config],
     KeyFolder =
         fun() ->
-                ?debugFmt("DataFile: ~p~n", [DataFile]),
                 case bitcask:open(filename:join(DataRoot, DataFile),
                                   ReadOpts) of
                     Ref when is_reference(Ref) ->
@@ -451,13 +450,10 @@ config_value(Key, Config, Default) ->
 check_symlink(LinkFile, DeleteExisting) ->
     case file:read_link(LinkFile) of
         {ok, DataFile} ->
-            ?debugFmt("Check syn datafile: ~p~n", [DataFile]),
             case DeleteExisting of
                 true ->
                     file:delete(LinkFile),
-                    R = make_symlink(LinkFile),
-                    ?debugFmt("New link file: ~p~n", [file:read_link(LinkFile)]),
-                    R;
+                    make_symlink(LinkFile);
                 false ->
                     {ok, DataFile}
             end;

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -57,7 +57,7 @@
 %% ===================================================================
 %% Public API
 %% ===================================================================
-
+n
 %% @doc Return the major version of the
 %% current API and a capabilities list.
 -spec api_version() -> {integer(), [atom()]}.
@@ -143,9 +143,8 @@ delete(Bucket, Key, #state{ref=Ref,
 fold_buckets(FoldBucketsFun, Acc, _Opts, #state{fold_opts=FoldOpts,
                                                 ref=Ref}) ->
     FoldFun = fold_buckets_fun(FoldBucketsFun),
-    {Acc0, _LastBucket} =
-        eleveldb:fold_keys(Ref, FoldFun, {Acc, []}, FoldOpts),
-    {ok, Acc0}.
+    BucketFolder = eleveldb:key_folder(Ref, FoldFun, {Acc, []}, FoldOpts),
+    {async, BucketFolder}.
 
 %% @doc Fold over all the keys for one or all buckets.
 -spec fold_keys(riak_kv_backend:fold_keys_fun(),
@@ -157,17 +156,8 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{fold_opts=FoldOpts1,
     Bucket =  proplists:get_value(bucket, Opts),
     FoldOpts = fold_opts(Bucket, FoldOpts1),
     FoldFun = fold_keys_fun(FoldKeysFun, Bucket),
-
-    %% try
-    %%     Acc0 = eleveldb:fold_keys(Ref, FoldFun, Acc, FoldOpts),
-    %%     {ok, Acc0}
-    %% catch
-    %%     {break, AccFinal} ->
-    %%         {ok, AccFinal}
-    %% end.
     KeyFolder = eleveldb:key_folder(Ref, FoldFun, Acc, FoldOpts),
     {async, KeyFolder}.
-
 
 %% @doc Fold over all the objects for one or all buckets.
 -spec fold_objects(riak_kv_backend:fold_objects_fun(),

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -174,12 +174,11 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{fold_opts=FoldOpts1,
     Bucket =  proplists:get_value(bucket, Opts),
     FoldOpts = fold_opts(Bucket, FoldOpts1),
     FoldFun = fold_keys_fun(FoldKeysFun, Bucket),
-        try
-            Acc0 = eleveldb:fold_keys(Ref, FoldFun, Acc, FoldOpts),
-                    {ok, Acc0}
+    try
+        Acc0 = eleveldb:fold_keys(Ref, FoldFun, Acc, FoldOpts),
+        {ok, Acc0}
     catch
         {break, AccFinal} ->
-            
             {ok, AccFinal}
     end.
 
@@ -358,7 +357,7 @@ eqc_test_() ->
                                            [{data_root,
                                              "test/eleveldb-backend"},
                                             {async_folds, false}])),
-           ?_assertEqual(true,
+            ?_assertEqual(true,
                           backend_eqc:test(?MODULE, false,
                                            [{data_root,
                                              "test/eleveldb-backend"}]))]}

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -43,7 +43,7 @@
 -endif.
 
 -define(API_VERSION, 1).
--define(CAPABILITIES, []).
+-define(CAPABILITIES, [async_fold]).
 
 -record(state, {ref :: reference(),
                 data_root :: string(),
@@ -157,13 +157,17 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{fold_opts=FoldOpts1,
     Bucket =  proplists:get_value(bucket, Opts),
     FoldOpts = fold_opts(Bucket, FoldOpts1),
     FoldFun = fold_keys_fun(FoldKeysFun, Bucket),
-    try
-        Acc0 = eleveldb:fold_keys(Ref, FoldFun, Acc, FoldOpts),
-        {ok, Acc0}
-    catch
-        {break, AccFinal} ->
-            {ok, AccFinal}
-    end.
+
+    %% try
+    %%     Acc0 = eleveldb:fold_keys(Ref, FoldFun, Acc, FoldOpts),
+    %%     {ok, Acc0}
+    %% catch
+    %%     {break, AccFinal} ->
+    %%         {ok, AccFinal}
+    %% end.
+    KeyFolder = eleveldb:key_folder(Ref, FoldFun, Acc, FoldOpts),
+    {async, KeyFolder}.
+
 
 %% @doc Fold over all the objects for one or all buckets.
 -spec fold_objects(riak_kv_backend:fold_objects_fun(),

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -57,7 +57,7 @@
 %% ===================================================================
 %% Public API
 %% ===================================================================
-n
+
 %% @doc Return the major version of the
 %% current API and a capabilities list.
 -spec api_version() -> {integer(), [atom()]}.

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -187,7 +187,15 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{fold_opts=FoldOpts1,
 -spec fold_objects(riak_kv_backend:fold_objects_fun(),
                    any(),
                    [{atom(), term()}],
-                   state()) -> {ok, any()}.
+                   state()) -> {ok, any()} | {async, fun()}.
+fold_objects(FoldObjectsFun, Acc, Opts, #state{fold_opts=FoldOpts1,
+                                               ref=Ref,
+                                               async_folds=true}) ->
+    Bucket =  proplists:get_value(bucket, Opts),
+    FoldOpts = fold_opts(Bucket, FoldOpts1),
+    FoldFun = fold_objects_fun(FoldObjectsFun, Bucket),
+    ObjectFolder = eleveldb:folder(Ref, FoldFun, Acc, FoldOpts),
+    {async, ObjectFolder};
 fold_objects(FoldObjectsFun, Acc, Opts, #state{fold_opts=FoldOpts1,
                                                ref=Ref}) ->
     Bucket = proplists:get_value(bucket, Opts),
@@ -346,6 +354,11 @@ eqc_test_() ->
          [
           {timeout, 60000,
            [?_assertEqual(true,
+                          backend_eqc:test(?MODULE, false,
+                                           [{data_root,
+                                             "test/eleveldb-backend"},
+                                            {async_folds, false}])),
+           ?_assertEqual(true,
                           backend_eqc:test(?MODULE, false,
                                            [{data_root,
                                              "test/eleveldb-backend"}]))]}

--- a/src/riak_kv_fold_buffer.erl
+++ b/src/riak_kv_fold_buffer.erl
@@ -35,6 +35,8 @@
          flush/2,
          size/1]).
 
+-export_type([buffer/0]).
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
@@ -43,7 +45,7 @@
                  buffer_fun :: function(),
                  max_size :: pos_integer(),
                  size=0 :: non_neg_integer()}).
--opaque buffer() :: #buffer{}.
+-type buffer() :: #buffer{}.
 
 %% ===================================================================
 %% Public API

--- a/src/riak_kv_fold_util.erl
+++ b/src/riak_kv_fold_util.erl
@@ -28,7 +28,6 @@
          fold_buffer/3,
          finish_fold/2,
          finish_fold/3,
-         finish_handoff_fold/2,
          flush_buffer/2,
          flush_buffer/3]).
 
@@ -117,27 +116,6 @@ finish_fold(FoldResult, Bucket, Sender) ->
                                       get_buffer_fun({true, Bucket}, Sender));
         {async, FoldFun} ->
             {async, {Bucket, FoldFun}};
-        {error, Reason} ->
-            riak_core_vnode:reply(Sender, {error, Reason})
-    end.
-
-%% @doc Take the appropriate action to finalize a fold operation for
-%% handoff. Handoff folding currently requires some special handling
-%% and does not use any intermediate buffering.
--spec finish_handoff_fold(fold_result(), from()) -> term().
-finish_handoff_fold(FoldResult, Sender) ->   
-    case FoldResult of
-        {{sync, SyncResults}, {async, []}} ->
-            [riak_core_vnode:reply(Sender, SyncBuf)
-                || SyncBuf <- SyncResults];                       
-        {{sync, SyncResults}, {async, AsyncWork}} ->
-            [riak_core_vnode:reply(Sender, SyncBuf)
-                || SyncBuf <- SyncResults],
-            {async, AsyncWork};
-        {ok, Buffer} ->
-            riak_core_vnode:reply(Sender, Buffer);
-        {async, FoldFun} ->
-            {async, FoldFun};
         {error, Reason} ->
             riak_core_vnode:reply(Sender, {error, Reason})
     end.

--- a/src/riak_kv_fold_util.erl
+++ b/src/riak_kv_fold_util.erl
@@ -1,0 +1,172 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc This module provides utility functions related to riak_kv
+%% backend folds.
+
+-module(riak_kv_fold_util).
+-author('Kelly McLaughlin <kelly@basho.com>').
+
+-export([fold_buffer/2,
+         fold_buffer/3,
+         finish_fold/2,
+         finish_fold/3,
+         flush_buffer/2,
+         flush_buffer/3]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-type from() :: {atom(), req_id(), pid()}.
+-type req_id() :: non_neg_integer().
+-type fold_result() :: {ok, term()} |
+                       {async, fun()} |
+                       mb_fold_result() |
+                       {error, term()}.
+-type mb_fold_result() :: {{sync, [term()]}, {async, [fun()]}}.
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+%% @doc Create a new fold buffer of the specified size that will
+%% return any intermediate results to the specified sender using
+%% riak_core_vnode:reply. The finish_fold function must be called
+%% after the fold operation is completed to ensure all results have
+%% been flushed from the buffer and returned to the sender.
+-spec fold_buffer(pos_integer(), from()) -> riak_kv_fold_buffer:buffer().
+fold_buffer(Size, Sender) ->
+    riak_kv_fold_buffer:new(Size,
+                            get_buffer_fun(false, Sender)).
+
+%% @doc Create a new fold buffer of the specified size that will
+%% return any intermediate results to the specified sender using
+%% riak_core_vnode:reply. Each set of buffered results will be
+%% returned to the sender as a two tuple with the Bucket parameter
+%% being the first element and the result set as the second. The
+%% finish_fold function must be called after the fold operation is
+%% completed to ensure all results have been flushed from the buffer
+%% and returned to the sender.
+-spec fold_buffer(pos_integer(), binary(), from()) ->
+                         riak_kv_fold_buffer:buffer().
+fold_buffer(Size, Bucket, Sender) ->
+    riak_kv_fold_buffer:new(Size,
+                            get_buffer_fun({false, Bucket}, Sender)).
+
+%% @doc Take the appropriate action to finalize a fold operation based
+%% on the result from a call to a riak_kv backend fold function such
+%% as fold_buckets.
+-spec finish_fold(fold_result(), from()) -> term().
+finish_fold(FoldResult, Sender) ->
+    case FoldResult of
+        {{sync, [FirstSyncResult | RestSyncResults]}, {async, []}} ->
+            [riak_kv_fold_buffer:flush(SyncBuf, get_buffer_fun(false, Sender))
+             || SyncBuf <- RestSyncResults],
+            riak_kv_fold_buffer:flush(FirstSyncResult,
+                                      get_buffer_fun(true, Sender));
+        {{sync, SyncResults}, {async, AsyncWork}} ->
+            [riak_kv_fold_buffer:flush(SyncBuf, get_buffer_fun(false, Sender))
+             || SyncBuf <- SyncResults],
+            {async, AsyncWork};
+        {ok, Buffer1} ->
+            riak_kv_fold_buffer:flush(Buffer1, get_buffer_fun(true, Sender));
+        {async, FoldFun} ->
+            {async, FoldFun};
+        {error, Reason} ->
+            riak_core_vnode:reply(Sender, {error, Reason})
+    end.
+
+%% @doc Take the appropriate action to finalize a fold operation based
+%% on the result from a call to a riak_kv backend fold function such
+%% as fold_keys.
+-spec finish_fold(fold_result(), binary(), from()) -> term().
+finish_fold(FoldResult, Bucket, Sender) ->
+    case FoldResult of
+        {{sync, [FirstSyncResult | RestSyncResults]}, {async, []}} ->
+            [riak_kv_fold_buffer:flush(SyncBuf,
+                                       get_buffer_fun({false, Bucket}, Sender))
+             || SyncBuf <- RestSyncResults],
+            riak_kv_fold_buffer:flush(FirstSyncResult,
+                                      get_buffer_fun({true, Bucket}, Sender));
+        {{sync, SyncResults}, {async, AsyncWork}} ->
+            [riak_kv_fold_buffer:flush(SyncBuf,
+                                       get_buffer_fun({false, Bucket}, Sender))
+             || SyncBuf <- SyncResults],
+            {async, {Bucket, AsyncWork}};
+        {ok, Buffer1} ->
+            riak_kv_fold_buffer:flush(Buffer1,
+                                      get_buffer_fun({true, Bucket}, Sender));
+        {async, FoldFun} ->
+            {async, {Bucket, FoldFun}};
+        {error, Reason} ->
+            riak_core_vnode:reply(Sender, {error, Reason})
+    end.
+
+%% @doc This function flushes a buffer, but does not send information
+%% to Sender that the fold operation has completed. This is useful for
+%% handling asynchronous folds on backends that use multiple other
+%% backends such as riak_kv_multi_backend.
+-spec flush_buffer(riak_kv_fold_buffer:buffer(), from()) ->
+                          riak_kv_fold_buffer:buffer().
+flush_buffer(Buffer, Sender) ->
+    riak_kv_fold_buffer:flush(Buffer,
+                              get_buffer_fun(false, Sender)).
+
+%% @doc This function flushes a buffer, but does not send information
+%% to Sender that the fold operation has completed. This is useful for
+%% handling asynchronous folds on backends that use multiple other
+%% backends such as riak_kv_multi_backend.
+-spec flush_buffer(riak_kv_fold_buffer:buffer(), binary(), from()) ->
+                          riak_kv_fold_buffer:buffer().
+flush_buffer(Buffer, Bucket, Sender) ->
+    riak_kv_fold_buffer:flush(Buffer,
+                              get_buffer_fun({false, Bucket}, Sender)).
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+%% @private
+%% @doc Return a function to be called on a buffer of results
+%% from a backend fold call. Depending on the input the function may
+%% include information to indicate that the fold operation is complete
+%% and all results have been returned or the bucket that produced the
+%% results may be included.
+get_buffer_fun(true, Sender) ->
+    fun(Results) ->
+            riak_core_vnode:reply(Sender,
+                                  {final_results, Results})
+    end;
+get_buffer_fun(false, Sender) ->
+    fun(Results) ->
+            riak_core_vnode:reply(Sender,
+                                  {results, Results})
+    end;
+get_buffer_fun({true, Bucket}, Sender) ->
+    fun(Results) ->
+            riak_core_vnode:reply(Sender,
+                                  {final_results, {Bucket, Results}})
+    end;
+get_buffer_fun({false, Bucket}, Sender) ->
+    fun(Results) ->
+            riak_core_vnode:reply(Sender,
+                                  {results, {Bucket, Results}})
+    end.

--- a/src/riak_kv_fold_worker.erl
+++ b/src/riak_kv_fold_worker.erl
@@ -1,3 +1,28 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc This module uses the riak_core_vnode_worker behavior to perform 
+%% different riak_kv fold tasks asynchronously.
+
+-author('Kelly McLaughlin <kelly@basho.com>').
+
 -module(riak_kv_fold_worker).
 
 -behaviour(riak_core_vnode_worker).
@@ -9,11 +34,18 @@
 
 -record(state, {index :: partition()}).
 
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+%% @doc Initialize the worker. Currently only the VNode index
+%% parameter is used.
 init_worker(VNodeIndex, _Args, _Props) ->
     {ok, #state{index=VNodeIndex}}.
 
+%% @doc Perform the asynchronous fold operation.
 handle_work({Bucket, FoldFun}, From, State) ->
-    io:format("Handling work~n"),
     Acc = try
               FoldFun()
           catch
@@ -25,6 +57,25 @@ handle_work({Bucket, FoldFun}, From, State) ->
                                              {final_results,
                                               {Bucket,
                                                FinalResults}})
+               end,
+    riak_kv_fold_buffer:flush(Acc, FlushFun),
+    {noreply, State};
+handle_work(FoldFun, From, State) ->
+    FoldResults = try
+                      FoldFun()
+                  catch
+                      {break, AccFinal} ->
+                          AccFinal
+                  end,
+    case FoldResults of 
+        {Acc, _} ->
+            ok;
+        Acc ->
+            ok
+    end,
+    FlushFun = fun(FinalResults) ->
+                       riak_core_vnode:reply(From,
+                                             {final_results, FinalResults})
                end,
     riak_kv_fold_buffer:flush(Acc, FlushFun),
     {noreply, State}.

--- a/src/riak_kv_fold_worker.erl
+++ b/src/riak_kv_fold_worker.erl
@@ -43,6 +43,14 @@ init_worker(VNodeIndex, _Args, _Props) ->
     {ok, #state{index=VNodeIndex}}.
 
 %% @doc Perform the asynchronous fold operation.
+handle_work({fold, FoldFun}, _From, State) ->
+    Acc = try
+              FoldFun()
+          catch
+              {break, AccFinal} ->
+                  AccFinal
+          end,
+    {reply, Acc, State};
 handle_work({Bucket, [FoldFun | RestFoldFuns]}, From, State) ->
     FoldResults = try
                       FoldFun()

--- a/src/riak_kv_fold_worker.erl
+++ b/src/riak_kv_fold_worker.erl
@@ -53,42 +53,40 @@ handle_work({fold, FoldFun}, _From, State) ->
     {reply, Acc, State};
 handle_work({fold, SyncResults, []}, _From, State) ->
     SyncFoldFun = 
-        fun(SyncResult, Acc0) ->
-                Acc0 ++ SyncResult
+        fun(SyncResult, _) ->
+                SyncResult
         end,
     Acc = lists:foldl(SyncFoldFun, [], SyncResults),
     {reply, Acc, State};
 handle_work({fold, [], AsyncWork}, _From, State) ->
     AsyncFoldFun =
-        fun(FoldFun, Acc0) ->
-                FoldResults = try
-                                  FoldFun()
-                              catch
-                                  {break, AccFinal} ->
-                                      AccFinal
-                              end,
-                Acc0 ++ FoldResults
+        fun(FoldFun, _) ->
+                try
+                    FoldFun()
+                catch
+                    {break, AccFinal} ->
+                        AccFinal
+                end
         end,
     Acc = lists:foldl(AsyncFoldFun, [], AsyncWork),
     {reply, Acc, State};
 handle_work({fold, SyncResults, AsyncWork}, _From, State) ->
     SyncFoldFun = 
-        fun(SyncResult, Acc0) ->
-                Acc0 ++ SyncResult
+        fun(SyncResult,_) ->
+                SyncResult
         end,
     AsyncFoldFun =
-        fun(FoldFun, Acc0) ->
-                FoldResults = try
-                                  FoldFun()
-                              catch
-                                  {break, AccFinal} ->
-                                      AccFinal
-                              end,
-                Acc0 ++ FoldResults
+        fun(FoldFun, _) ->
+                try
+                    FoldFun()
+                catch
+                    {break, AccFinal} ->
+                        AccFinal
+                end
         end,
     Acc1 = lists:foldl(SyncFoldFun, [], SyncResults),
-    Acc = lists:foldl(AsyncFoldFun, Acc1, AsyncWork),
-    {reply, Acc, State};
+    lists:foldl(AsyncFoldFun, [], AsyncWork),
+    {reply, Acc1, State};
 handle_work({Bucket, [FoldFun | RestFoldFuns]}, From, State) ->
     FoldResults = try
                       FoldFun()

--- a/src/riak_kv_fold_worker.erl
+++ b/src/riak_kv_fold_worker.erl
@@ -21,9 +21,8 @@
 %% @doc This module uses the riak_core_vnode_worker behavior to perform 
 %% different riak_kv fold tasks asynchronously.
 
--author('Kelly McLaughlin <kelly@basho.com>').
-
 -module(riak_kv_fold_worker).
+-author('Kelly McLaughlin <kelly@basho.com>').
 
 -behaviour(riak_core_vnode_worker).
 
@@ -33,7 +32,6 @@
 -include_lib("riak_kv_vnode.hrl").
 
 -record(state, {index :: partition()}).
-
 
 %% ===================================================================
 %% Public API

--- a/src/riak_kv_fold_worker.erl
+++ b/src/riak_kv_fold_worker.erl
@@ -1,0 +1,31 @@
+-module(riak_kv_fold_worker).
+
+-behaviour(riak_core_vnode_worker).
+
+-export([init_worker/3,
+         handle_work/3]).
+
+-include_lib("riak_kv_vnode.hrl").
+
+-record(state, {index :: partition()}).
+
+init_worker(VNodeIndex, _Args, _Props) ->
+    {ok, #state{index=VNodeIndex}}.
+
+handle_work({Bucket, FoldFun}, From, State) ->
+    io:format("Handling work~n"),
+    Acc = try
+              FoldFun()
+          catch
+              {break, AccFinal} ->
+                  AccFinal
+          end,
+    FlushFun = fun(FinalResults) ->
+                       riak_core_vnode:reply(From,
+                                             {final_results,
+                                              {Bucket,
+                                               FinalResults}})
+               end,
+    riak_kv_fold_buffer:flush(Acc, FlushFun),
+    {noreply, State}.
+    

--- a/src/riak_kv_fold_worker.erl
+++ b/src/riak_kv_fold_worker.erl
@@ -43,6 +43,29 @@ init_worker(VNodeIndex, _Args, _Props) ->
     {ok, #state{index=VNodeIndex}}.
 
 %% @doc Perform the asynchronous fold operation.
+handle_work({Bucket, [FoldFun | RestFoldFuns]}, From, State) ->
+    FoldResults = try
+                      FoldFun()
+                  catch
+                      {break, AccFinal} ->
+                          AccFinal
+                  end,
+    case FoldResults of 
+        {Acc, _} ->
+            ok;
+        Acc ->
+            ok
+    end,
+    case RestFoldFuns of
+        [] ->
+            riak_kv_fold_buffer:flush(Acc,
+                                      get_buffer_fun({true, Bucket}, From)),
+            {noreply, State};
+        _ ->
+            riak_kv_fold_buffer:flush(Acc,
+                                      get_buffer_fun({false, Bucket}, From)),
+            handle_work({Bucket, RestFoldFuns}, From, State)
+    end;
 handle_work({Bucket, FoldFun}, From, State) ->
     Acc = try
               FoldFun()
@@ -50,14 +73,30 @@ handle_work({Bucket, FoldFun}, From, State) ->
               {break, AccFinal} ->
                   AccFinal
           end,
-    FlushFun = fun(FinalResults) ->
-                       riak_core_vnode:reply(From,
-                                             {final_results,
-                                              {Bucket,
-                                               FinalResults}})
-               end,
-    riak_kv_fold_buffer:flush(Acc, FlushFun),
+    riak_kv_fold_buffer:flush(Acc,
+                              get_buffer_fun({true, Bucket}, From)),
     {noreply, State};
+handle_work([FoldFun | RestFoldFuns], From, State) ->
+    FoldResults = try
+                      FoldFun()
+                  catch
+                      {break, AccFinal} ->
+                          AccFinal
+                  end,
+    case FoldResults of 
+        {Acc, _} ->
+            ok;
+        Acc ->
+            ok
+    end,
+    case RestFoldFuns of
+        [] ->
+            riak_kv_fold_buffer:flush(Acc, get_buffer_fun(true, From)),
+            {noreply, State};
+        _ ->
+            riak_kv_fold_buffer:flush(Acc, get_buffer_fun(false, From)),
+            handle_work(RestFoldFuns, From, State)
+    end;
 handle_work(FoldFun, From, State) ->
     FoldResults = try
                       FoldFun()
@@ -71,10 +110,31 @@ handle_work(FoldFun, From, State) ->
         Acc ->
             ok
     end,
-    FlushFun = fun(FinalResults) ->
-                       riak_core_vnode:reply(From,
-                                             {final_results, FinalResults})
-               end,
-    riak_kv_fold_buffer:flush(Acc, FlushFun),
+    riak_kv_fold_buffer:flush(Acc, get_buffer_fun(true, From)),
     {noreply, State}.
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
     
+%% @private
+get_buffer_fun(true, Sender) ->
+    fun(Results) ->
+            riak_core_vnode:reply(Sender,
+                                  {final_results, Results})
+    end;
+get_buffer_fun(false, Sender) ->
+    fun(Results) ->
+            riak_core_vnode:reply(Sender,
+                                  {results, Results})
+    end;
+get_buffer_fun({true, Bucket}, Sender) ->
+    fun(Results) ->
+            riak_core_vnode:reply(Sender,
+                                  {final_results, {Bucket, Results}})
+    end;
+get_buffer_fun({false, Bucket}, Sender) ->
+    fun(Results) ->
+            riak_core_vnode:reply(Sender,
+                                  {results, {Bucket, Results}})
+    end.

--- a/src/riak_kv_legacy_vnode.erl
+++ b/src/riak_kv_legacy_vnode.erl
@@ -125,6 +125,7 @@ start_servers() ->
     %% dbgh:trace(riak_kv_vnode),
     %% dbgh:trace(?MODULE),
     application:set_env(riak_kv, storage_backend, riak_kv_memory_backend),
+    application:set_env(riak_kv, async_folds, false),
     application:set_env(riak_core, default_bucket_props, []),
     Ring = riak_core_ring:fresh(16, node()),
     mochiglobal:put(?RING_KEY, Ring),

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -110,7 +110,7 @@ start(Partition, Config) ->
             {First, _, _} = hd(Defs),
 
             %% Check if async folds have been disabled
-            AsyncFolds = config_value(async_folds, Config, true),
+            AsyncFolds = false,
             %% Get the default
             DefaultBackend = config_value(multi_backend_default, Config, First),
             case lists:keymember(DefaultBackend, 1, Defs) of

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -43,7 +43,7 @@
 -endif.
 
 -define(API_VERSION, 1).
--define(CAPABILITIES, []).
+-define(CAPABILITIES, [async_fold]).
 
 -record (state, {backends :: [{atom(), atom(), term()}],
                  default_backend :: atom()}).

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -182,8 +182,10 @@ init([Index]) ->
     BucketBufSize = app_helper:get_env(riak_kv, bucket_buffer_size, 1000),
     IndexBufSize = app_helper:get_env(riak_kv, index_buffer_size, 100),
     KeyBufSize = app_helper:get_env(riak_kv, key_buffer_size, 100),
-    AsyncFolding = app_helper:get_env(riak_kv, async_folds, true),
-
+    LegacyKeyListing = app_helper:get_env(riak_kv, legacy_keylisting, false),
+    AsyncFolding = app_helper:get_env(riak_kv, async_folds, true)
+        andalso
+        not LegacyKeyListing,   
     case catch Mod:start(Index, [{async_folds, AsyncFolding},
                                  Configuration]) of
         {ok, ModState} ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -190,7 +190,7 @@ init([Index]) ->
             IndexBackend = lists:member(indexes, Capabilities),
             AsyncBackend = lists:member(async_fold, Capabilities),
             %% Create worker pool initialization tuple
-            KeyFoldWorkerPool = {pool, riak_kv_fold_worker, 10, []},
+            FoldWorkerPool = {pool, riak_kv_fold_worker, 10, []},
             {ok, #state{idx=Index,
                         async_backend=AsyncBackend,
                         index_backend=IndexBackend,
@@ -199,7 +199,7 @@ init([Index]) ->
                         bucket_buf_size=BucketBufSize,
                         index_buf_size=IndexBufSize,
                         key_buf_size=KeyBufSize,
-                        mrjobs=dict:new()}, [KeyFoldWorkerPool]};
+                        mrjobs=dict:new()}, [FoldWorkerPool]};
         {error, Reason} ->
             lager:error("Failed to start ~p Reason: ~p",
                         [Mod, Reason]),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -802,6 +802,8 @@ do_fold(Fun, Acc0, Sender, State = #state{mod=Mod, modstate=ModState}) ->
             {reply, Acc, State};
         {async, Work} ->
             {async, {fold, Work}, Sender, State};
+        {{sync, SyncResults}, {async, Work}} ->
+            {async, {fold, SyncResults, Work}, Sender, State};
         ER ->
             {reply, ER, State}
     end.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -638,7 +638,7 @@ list_buckets(Sender, Filter, Mod, ModState, BufferSize) ->
         {ok, Buffer1} ->
             riak_kv_fold_buffer:flush(Buffer1, get_buffer_fun(true, Sender));
         {async, FoldFun} ->
-            FoldFun;
+            {async, FoldFun};
         {error, Reason} ->
             riak_core_vnode:reply(Sender, {error, Reason})
     end.

--- a/test/backend_eqc.erl
+++ b/test/backend_eqc.erl
@@ -60,6 +60,7 @@
                c,  % Backend config
                s,  % Module state returned by Backend:start
                olds=sets:new(), % Old states after a stop
+               worker_pool, % PID of worker pool for async folds
                d=[]}).% Orddict of values stored
 
 %% ====================================================================
@@ -136,12 +137,12 @@ val() ->
 
 fold_buckets_fun() ->
     fun(Bucket, Acc) ->
-            [Bucket | Acc]
+            riak_kv_fold_buffer:add(Bucket, Acc)
     end.
 
 fold_keys_fun() ->
     fun(Bucket, Key, Acc) ->
-            [{Bucket, Key} | Acc]
+            riak_kv_fold_buffer:add({Bucket, Key}, Acc)
     end.
 
 fold_objects_fun() ->
@@ -168,6 +169,37 @@ drop(Backend, State) ->
             NewState
     end.
 
+get_fold_buffer() ->    
+    riak_kv_fold_buffer:new(100, 
+                            get_fold_buffer_fun({raw, foldid, self()})).
+
+get_fold_buffer_fun(From) ->
+    fun(Results) ->
+            riak_core_vnode:reply(From,
+                                  {results, Results})
+    end.
+
+get_flush_buffer_fun(From) ->
+    fun(Results) ->
+            riak_core_vnode:reply(From,
+                                  {final_results, Results})
+    end.
+
+receive_fold_results(Acc) ->
+    receive
+        %% {results, {_, Results}} ->
+        %%     receive_fold_results(Acc++Results);
+        {_, {results, Results}} ->
+            receive_fold_results(Acc++Results);
+        %% {final_results, {_, Results}} ->
+        %%     Acc++Results;
+        {_, {final_results, Results}} ->
+            Acc++Results;
+        {_, Error} ->
+            ?debugFmt("Error occurred: ~p~n", [Error]),
+            []
+    end.
+
 %%====================================================================
 %% eqc_fsm callbacks
 %%====================================================================
@@ -179,10 +211,17 @@ initial_state_data() ->
     #qcst{d = orddict:new()}.
 
 initial_state_data(Backend, Volatile, Config) ->
+    {ok, PoolPid} =
+        riak_core_vnode_worker_pool:start_link(riak_kv_fold_worker,
+                                               2,
+                                               42,
+                                               [],
+                                               worker_props),
     #qcst{backend=Backend,
           c=Config,
           d=orddict:new(),
-          volatile=Volatile}.
+          volatile=Volatile,
+          worker_pool=PoolPid}.
 
 next_state_data(running, stopped, S, _R,
                 {call, _M, stop, _}) ->
@@ -211,8 +250,8 @@ running(#qcst{backend=Backend,
      {history, {call, Backend, put, [bucket(), key(), [], val(), State]}},
      {history, {call, Backend, get, [bucket(), key(), State]}},
      {history, {call, Backend, delete, [bucket(), key(), State]}},
-     {history, {call, Backend, fold_buckets, [fold_buckets_fun(), [], [], State]}},
-     {history, {call, Backend, fold_keys, [fold_keys_fun(), [], [], State]}},
+     {history, {call, Backend, fold_buckets, [fold_buckets_fun(), get_fold_buffer(), [], State]}},
+     {history, {call, Backend, fold_keys, [fold_keys_fun(), get_fold_buffer(), [], State]}},
      {history, {call, Backend, fold_objects, [fold_objects_fun(), [], [], State]}},
      {history, {call, Backend, is_empty, [State]}},
      {history, {call, ?MODULE, drop, [Backend, State]}},
@@ -237,14 +276,36 @@ postcondition(_From, _To, _S,
               {call, _M, delete,[_Bucket, _Key, _BeState]}, {R, _RState}) ->
     R =:= ok;
 postcondition(_From, _To, S,
-              {call, _M, fold_buckets, [_FoldFun, _Acc, _Opts, _BeState]}, {ok, R}) ->
+              {call, _M, fold_buckets, [_FoldFun, _Acc, _Opts, _BeState]}, {ok, Buf}) ->
     ExpectedEntries = orddict:to_list(S#qcst.d),
     Buckets = [Bucket || {{Bucket, _}, _} <- ExpectedEntries],
+    From = {raw, foldid, self()}, 
+    riak_kv_fold_buffer:flush(Buf, get_flush_buffer_fun(From)),
+    R = receive_fold_results([]),
+    lists:usort(Buckets) =:= lists:sort(R);
+postcondition(_From, _To, S=#qcst{worker_pool=Pool},
+              {call, _M, fold_buckets, [_FoldFun, _Acc, _Opts, _BeState]}, {async, Work}) ->
+    ExpectedEntries = orddict:to_list(S#qcst.d),
+    Buckets = [Bucket || {{Bucket, _}, _} <- ExpectedEntries],
+    From = {raw, foldid, self()}, 
+    riak_core_vnode_worker_pool:handle_work(Pool, Work, From),
+    R = receive_fold_results([]),
     lists:usort(Buckets) =:= lists:sort(R);
 postcondition(_From, _To, S,
-              {call, _M, fold_keys, [_FoldFun, _Acc, _Opts, _BeState]}, {ok, R}) ->
+              {call, _M, fold_keys, [_FoldFun, _Acc, _Opts, _BeState]}, {ok, Buf}) ->
     ExpectedEntries = orddict:to_list(S#qcst.d),
     Keys = [{Bucket, Key} || {{Bucket, Key}, _} <- ExpectedEntries],
+    From = {raw, foldid, self()}, 
+    riak_kv_fold_buffer:flush(Buf, get_flush_buffer_fun(From)),
+    R = receive_fold_results([]),
+    lists:sort(Keys) =:= lists:sort(R);
+postcondition(_From, _To, S=#qcst{worker_pool=Pool},
+              {call, _M, fold_keys, [_FoldFun, _Acc, _Opts, _BeState]}, {async, Work}) ->
+    ExpectedEntries = orddict:to_list(S#qcst.d),
+    Keys = [{Bucket, Key} || {{Bucket, Key}, _} <- ExpectedEntries],
+    From = {raw, foldid, self()}, 
+    riak_core_vnode_worker_pool:handle_work(Pool, Work, From),
+    R = receive_fold_results([]),
     lists:sort(Keys) =:= lists:sort(R);
 postcondition(_From, _To, S,
               {call, _M, fold_objects, [_FoldFun, _Acc, _Opts, _BeState]}, {ok, R}) ->


### PR DESCRIPTION
Adds support for asynchronous folds for the backends. The async behavior is used by default if it is available in the backend (this is the case for bitcask, eleveldb, and memory), but can be disabled using an entry in the `riak_kv` section of `app.config`. Setting `async_folds` to `false` will override the default.

This pull request also updates the `backend_eqc` module to test the async folds and bitcask, eleveldb, and memory backends now run quickcheck tests using both sync and async folds.
