### PR TITLE
AZ645 - Dedup Index Fields / Handle Multi-Value Index Fields

### DIFF
--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -146,8 +146,8 @@ parse_fields(IndexFields) ->
 
     %% Return the object, or a list of Reasons.
     case FailureReasons == [] of
-        true  -> {ok, lists:reverse(Results)};
-        false -> {error, lists:reverse(FailureReasons)}
+        true  -> {ok, lists:usort(Results)};
+        false -> {error, lists:usort(FailureReasons)}
     end.
 
 


### PR DESCRIPTION
Mochiweb / Webmachine turn multi-valued index fields into comma separated lists. This pull requests turns those comma separated lists back into multiple fields, and removes any duplicates.

You'll probably need to set `storage_backend` to `riak_kv_index_backend` to test this out.
### Test Multi-Value Fields

``` bash
# Create an object with multi-valued fields...
curl -v -X PUT \
-d 'data1' \
-H "x-riak-index-myfield_bin: a" \
-H "x-riak-index-myfield_bin: b" \
-H "x-riak-index-myfield_bin: c" \
-H "x-riak-index-myfield_bin: d" \
http://127.0.0.1:8098/riak/mybucket/mykey

# Get the value...
curl -i http://127.0.0.1:8098/riak/mybucket/mykey

# Search on a field...
curl http://127.0.0.1:8098/buckets/mybucket/index/myfield_bin/a
curl http://127.0.0.1:8098/buckets/mybucket/index/myfield_bin/b/d
```
### Test Fields wit Duplicate Values

``` bash
# Create an object that has duplicate values...
curl -v -X PUT \
-d 'data1' \
-H "x-riak-index-myfield_bin: a" \
-H "x-riak-index-myfield_bin: a" \
-H "x-riak-index-myfield_bin: a" \
-H "x-riak-index-myfield_bin: a" \
-H "x-riak-index-myfield_bin: a" \
http://127.0.0.1:8098/riak/mybucket/mykey

# Read the object, verify that duplicates are removed...
curl -i http://127.0.0.1:8098/riak/mybucket/mykey
```
