### PR TITLE
AZ650: Java client mapred queries vs. Pipe

### DIFF
--- a/src/riak_kv_mrc_map.erl
+++ b/src/riak_kv_mrc_map.erl
@@ -125,7 +125,10 @@ process(Input, _Last,
             {ok, State};
         {forward_preflist, Reason} ->
             ?T(_FittingDetails, [map], {forward_preflist, Reason}),
-            {forward_preflist, State}
+            {forward_preflist, State};
+        {error, Error} ->
+            ?T(_FittingDetails, [map, error], {error, {Error, Input}}),
+            {ok, State}
     end.
         
 %% @doc Evaluate the map function.
@@ -164,7 +167,8 @@ map_js(JS, Arg, {ok, Input, KeyData}) ->
     case riak_kv_js_manager:blocking_dispatch(
            ?JSPOOL_MAP, JSCall, ?DEFAULT_JS_RESERVE_ATTEMPTS) of
         {ok, Results}   -> {ok, Results};
-        {error, no_vms} -> {forward_preflist, no_js_vms}
+        {error, no_vms} -> {forward_preflist, no_js_vms};
+        {error, Error}  -> {error, Error}
     end.
 
 %% @doc Send results to the next fitting.

--- a/src/riak_kv_mrc_pipe.erl
+++ b/src/riak_kv_mrc_pipe.erl
@@ -136,7 +136,8 @@ mapred(Inputs, Query, Timeout) ->
 
 mapred_stream(Query) ->
     NumKeeps = count_keeps_in_query(Query),
-    {riak_pipe:exec(mr2pipe_phases(Query), []), NumKeeps}.
+    {riak_pipe:exec(mr2pipe_phases(Query), [{log, sink},{trace,[error]}]),
+     NumKeeps}.
 
 %% The plan functions are useful for seeing equivalent (we hope) pipeline.
 

--- a/src/riak_kv_mrc_pipe.erl
+++ b/src/riak_kv_mrc_pipe.erl
@@ -134,8 +134,7 @@ mapred(Inputs, Query, Timeout) ->
             {error, Error, collect_outputs(Pipe, NumKeeps, Timeout)}
     end.
 
-mapred_stream(Query0) ->
-    Query = correct_keeps(Query0),
+mapred_stream(Query) ->
     NumKeeps = count_keeps_in_query(Query),
     {riak_pipe:exec(mr2pipe_phases(Query), []), NumKeeps}.
 
@@ -310,19 +309,6 @@ bucket_linkfun(Bucket) ->
     BucketProps = riak_core_bucket:get_bucket(Bucket),
     {_, {modfun, Module, Function}} = lists:keyfind(linkfun, 1, BucketProps),
     erlang:make_fun(Module, Function, 3).
-
-correct_keeps([]) ->
-    [];
-correct_keeps(Query) ->
-    case lists:all(fun({_, _, _, false}) -> true;
-                      (_)                -> false
-                   end, Query) of
-        true ->
-            {AllBut, [{A, B, C, _}]} = lists:split(length(Query) - 1, Query),
-            AllBut ++ [{A, B, C, true}];
-        false ->
-            Query
-    end.
 
 count_keeps_in_query(Query) ->
     lists:foldl(fun({_, _, _, true}, Acc) -> Acc + 1;

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -179,7 +179,11 @@ pipe_mapred_nonchunked(RD, State, Pipe, NumKeeps, Sender) ->
         {error, timeout} ->
             %% destroying the pipe will tear down the linked sender
             riak_pipe:destroy(Pipe),
-            {{halt, 500}, send_error({error, timeout}, RD), State}
+            {{halt, 500}, send_error({error, timeout}, RD), State};
+        {error, {Error, _Input}} ->
+            %% TODO: jsonify Input for error message
+            riak_pipe:destroy(Pipe),
+            {{halt, 500}, send_error({error, Error}, RD), State}
     end.
 
 pipe_collect_outputs(Pipe, NumKeeps, Sender) ->
@@ -204,6 +208,14 @@ pipe_receive_output(Ref, {SenderPid, SenderRef}) ->
             eoi;
         #pipe_result{ref=Ref, from=From, result=Result} ->
             {ok, {From, Result}};
+        #pipe_log{ref=Ref, msg=Msg} ->
+            case Msg of
+                {trace, [error], {error, {Error, Input}}} ->
+                    {error, {Error, Input}};
+                _ ->
+                    %% not a log message we're interested in
+                    pipe_receive_output(Ref, {SenderPid, SenderRef})
+            end;
         {'DOWN', SenderRef, process, SenderPid, Reason} ->
             if Reason == normal ->
                     %% just done sending inputs, nothing to worry about
@@ -250,7 +262,10 @@ pipe_stream_mapred_results(RD, Pipe,
             riak_pipe:destroy(Pipe),
             {format_error({error, timeout}), done};
         {error, {sender_error, Error}} ->
-            {format_error(Error), done}
+            {format_error(Error), done};
+        {error, {Error, _Input}} ->
+            riak_pipe:destroy(Pipe),
+            {format_error({error, Error}), done}
     end.
 
 %% LEGACY MAPRED

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -194,7 +194,7 @@ pipe_collect_outputs(Pipe, NumKeeps, Sender) ->
 pipe_collect_outputs1(Ref, Sender, Acc) ->
     case pipe_receive_output(Ref, Sender) of
         {ok, Output} -> pipe_collect_outputs1(Ref, Sender, [Output|Acc]);
-        eoi          -> {ok, Acc};
+        eoi          -> {ok, lists:reverse(Acc)};
         Error        -> Error
     end.
 

--- a/test/mapred_test.erl
+++ b/test/mapred_test.erl
@@ -233,7 +233,7 @@ compat_basic1_test_() ->
                  5 = length(MapRs)
              end),
           ?_test(
-             %% Basic compat: keep neither stages -> force keep last stage
+             %% Basic compat: keep neither stages -> no output
              begin
                  Spec = 
                      [{map, {modfun, riak_kv_mapreduce, map_object_value},
@@ -242,7 +242,7 @@ compat_basic1_test_() ->
                        none, false}],
                  %% "Crazy" semantics: if only 1 keeper stage, then
                  %% return List instead of [List].
-                 {ok, [15]} = riak_kv_mrc_pipe:mapred(IntsBucket, Spec)
+                 {ok, []} = riak_kv_mrc_pipe:mapred(IntsBucket, Spec)
              end),
           ?_test(
              %% Basic compat: keep first stage only, want 'crazy' result",
@@ -289,7 +289,7 @@ compat_basic1_test_() ->
                      [{map, {modfun, riak_kv_mapreduce, map_object_value},
                        {struct,[{<<"sub">>,[<<"0">>]}]}, false},
                       {reduce, {modfun, riak_kv_mapreduce,
-                                reduce_string_to_integer},none,false}],
+                                reduce_string_to_integer},none,true}],
                  {ok, [0]} =
                      riak_kv_mrc_pipe:mapred(Inputs, Spec)
              end),
@@ -350,7 +350,7 @@ compat_basic1_test_() ->
              %% modfun for inputs generator
              begin
                  Inputs = {modfun, ?MODULE, inputs_gen_seq, 6},
-                 Spec = [{reduce, {qfun, ReduceSumFun},none,false}],
+                 Spec = [{reduce, {qfun, ReduceSumFun},none,true}],
                  {ok, [21]} = riak_kv_mrc_pipe:mapred(Inputs, Spec)
              end),
           ?_test(


### PR DESCRIPTION
Just one fix in this branch so far: returning non-streamed HTTP results in the order they were received.  They're returned in reverse order, otherwise.
