### PR TITLE
Az655 osync warning

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -319,7 +319,7 @@ check_fcntl() ->
 	{undefined,{ok,o_sync}} ->
 	    case riak_core_util:is_arch(linux) of
 		true ->
-		    lager:warning("fcntl(f,F_SETFL,O_SYNC) fails on Linux."),
+		    lager:warning("{sync_strategy,o_sync} fails on Linux"),
 		    application:set_env(riak_kv,o_sync_warning_logged,true);
 		_ ->
 		    ok

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -89,7 +89,7 @@ start(Partition, Config) ->
                     BitcaskOpts = [{read_write, true} | Config],
                     case bitcask:open(filename:join(DataRoot, DataFile), BitcaskOpts) of
                         Ref when is_reference(Ref) ->
-			    check_fcntl(),
+                            check_fcntl(),
                             schedule_merge(Ref),
                             maybe_schedule_sync(Ref),
                             {ok, #state{ref=Ref,
@@ -316,16 +316,16 @@ check_fcntl() ->
     Logged=application:get_env(riak_kv,o_sync_warning_logged),
     Strategy=application:get_env(bitcask,sync_strategy),
     case {Logged,Strategy} of
-	{undefined,{ok,o_sync}} ->
-	    case riak_core_util:is_arch(linux) of
-		true ->
-		    lager:warning("{sync_strategy,o_sync} not implemented on Linux"),
-		    application:set_env(riak_kv,o_sync_warning_logged,true);
-		_ ->
-		    ok
-	    end;
-	_ ->
-	    ok
+        {undefined,{ok,o_sync}} ->
+            case riak_core_util:is_arch(linux) of
+                true ->
+                    lager:warning("{sync_strategy,o_sync} not implemented on Linux"),
+                    application:set_env(riak_kv,o_sync_warning_logged,true);
+                _ ->
+                    ok
+            end;
+        _ ->
+            ok
     end.
 
 %% @private

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -319,7 +319,7 @@ check_fcntl() ->
 	{undefined,{ok,o_sync}} ->
 	    case riak_core_util:is_arch(linux) of
 		true ->
-		    lager:warning("{sync_strategy,o_sync} fails on Linux"),
+		    lager:warning("{sync_strategy,o_sync} not implemented on Linux"),
 		    application:set_env(riak_kv,o_sync_warning_logged,true);
 		_ ->
 		    ok


### PR DESCRIPTION
Requires branch az655-osync-warning from riak_core as well. On linux, checks for bitcask config {sync_strategy,o_sync} and warns (if on Linux) that it will fail.
