### PR TITLE
Correct keyfilter evaluation in non-legacy keylister.

### DIFF
--- a/src/riak_kv_coverage_filter.erl
+++ b/src/riak_kv_coverage_filter.erl
@@ -122,10 +122,11 @@ compose(Filters) ->
     compose(Filters, []).
 
 compose([], RevFilterFuns) ->
+    FilterFuns = lists:reverse(RevFilterFuns),
     fun(Val) ->
             true =:= lists:foldl(fun(Fun, Acc) -> Fun(Acc) end,
                                  Val,
-                                 lists:reverse(RevFilterFuns))
+                                 FilterFuns)
     end;
 compose([Filter | RestFilters], FilterFuns) ->
     {FilterMod, FilterFun, Args} = Filter,

--- a/src/riak_kv_coverage_filter.erl
+++ b/src/riak_kv_coverage_filter.erl
@@ -121,13 +121,11 @@ compose([]) ->
 compose(Filters) ->
     compose(Filters, []).
 
-compose([], FilterFuns) ->
-    TruthFun =
-        fun(X) ->
-                X =:= true
-        end,
+compose([], RevFilterFuns) ->
     fun(Val) ->
-            lists:all(TruthFun, [FilterFun(Val) || FilterFun <- FilterFuns])
+            true =:= lists:foldl(fun(Fun, Acc) -> Fun(Acc) end,
+                                 Val,
+                                 lists:reverse(RevFilterFuns))
     end;
 compose([Filter | RestFilters], FilterFuns) ->
     {FilterMod, FilterFun, Args} = Filter,


### PR DESCRIPTION
In the legacy keylisting system, keyfilters were defined as chains of
filters, where the output of one was in the input to the next.  This
patch restores that behavior for the new keylisting system.

This bug was found via the Java client integration tests.

This patch should be merged to both 1.0 and master.
