### PR TITLE
bz1175 add client_id to state of pb socket to emulate legacy API

### DIFF
--- a/ebin/riak_kv.app
+++ b/ebin/riak_kv.app
@@ -3,7 +3,7 @@
 {application, riak_kv,
  [
   {description, "Riak Key/Value Store"},
-  {vsn, "0.14.0"},
+  {vsn, "1.0.0"},
   {modules, [
              lk,
              raw_link_walker,

--- a/rebar.config
+++ b/rebar.config
@@ -8,26 +8,28 @@
                   ]}.
 
 {deps, [
-        {riak_core, "0.14.0", {git, "git://github.com/basho/riak_core",
-                                    {branch, "master"}}},
-        {riakc, "1.1.0", {git, "git://github.com/basho/riak-erlang-client",
+        {riak_core, "1.0.0", {git, "git://github.com/basho/riak_core",
+                                    {branch, "1.0"}}},
+        {riakc, "1.2.0", {git, "git://github.com/basho/riak-erlang-client",
                                {branch, "master"}}},
         {luke, "0.2.4", {git, "git://github.com/basho/luke",
-                              {branch, "master"}}},
-        {erlang_js, "0.6.1", {git, "git://github.com/basho/erlang_js",
-                             {branch, "master"}}},
-        {bitcask, "1.1.6", {git, "git://github.com/basho/bitcask",
-                                 {branch, "master"}}},
-        {merge_index, "0.14.*", {git, "git://github.com/basho/merge_index",
-                                 {branch, "master"}}},
-        {ebloom, "1.0.2", {git, "git://github.com/basho/ebloom",
-                                {branch, "master"}}},
+                              {tag, "luke-0.2.4"}}},
+        {erlang_js, "1.0.0", {git, "git://github.com/basho/erlang_js",
+                             {tag, "1.0.0"}}},
+        {bitcask, "1.2.0", {git, "git://github.com/basho/bitcask",
+                                 {tag, "1.2.0"}}},
+        {merge_index, "1.0.0", {git, "git://github.com/basho/merge_index",
+                                 {branch, "1.0"}}},
+        {ebloom, "1.1.0", {git, "git://github.com/basho/ebloom",
+                                {tag, "1.1.0"}}},
+        %% TODO Fix eper version when we know it
         {eper, ".*", {git, "git://github.com/basho/eper.git",
                         {branch, "master"}}},
-        {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", "HEAD"}},
+        {eleveldb, "1.0.0", {git, "git://github.com/basho/eleveldb.git", {tag, "1.0.0"}}},
+        %% TODO Fix this to a commit revision        
         {sext, ".*", {git, "git://github.com/esl/sext", "HEAD"}},
-        {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git",
-                                {branch, "master"}}},
-        {basho_metrics, ".*", {git, "git://github.com/basho/basho_metrics.git",
-                                {branch, "master"}}}
+        {riak_pipe, "1.0.0", {git, "git://github.com/basho/riak_pipe.git",
+                                {branch, "1.0"}}},
+        {basho_metrics, "1.0.0", {git, "git://github.com/basho/basho_metrics.git",
+                                {tag, "1.0.0"}}}
        ]}.

--- a/src/riak_kv_mrc_map.erl
+++ b/src/riak_kv_mrc_map.erl
@@ -125,7 +125,10 @@ process(Input, _Last,
             {ok, State};
         {forward_preflist, Reason} ->
             ?T(_FittingDetails, [map], {forward_preflist, Reason}),
-            {forward_preflist, State}
+            {forward_preflist, State};
+        {error, Error} ->
+            ?T(_FittingDetails, [map, error], {error, {Error, Input}}),
+            {ok, State}
     end.
         
 %% @doc Evaluate the map function.
@@ -164,7 +167,8 @@ map_js(JS, Arg, {ok, Input, KeyData}) ->
     case riak_kv_js_manager:blocking_dispatch(
            ?JSPOOL_MAP, JSCall, ?DEFAULT_JS_RESERVE_ATTEMPTS) of
         {ok, Results}   -> {ok, Results};
-        {error, no_vms} -> {forward_preflist, no_js_vms}
+        {error, no_vms} -> {forward_preflist, no_js_vms};
+        {error, Error}  -> {error, Error}
     end.
 
 %% @doc Send results to the next fitting.

--- a/src/riak_kv_mrc_pipe.erl
+++ b/src/riak_kv_mrc_pipe.erl
@@ -134,10 +134,10 @@ mapred(Inputs, Query, Timeout) ->
             {error, Error, collect_outputs(Pipe, NumKeeps, Timeout)}
     end.
 
-mapred_stream(Query0) ->
-    Query = correct_keeps(Query0),
+mapred_stream(Query) ->
     NumKeeps = count_keeps_in_query(Query),
-    {riak_pipe:exec(mr2pipe_phases(Query), []), NumKeeps}.
+    {riak_pipe:exec(mr2pipe_phases(Query), [{log, sink},{trace,[error]}]),
+     NumKeeps}.
 
 %% The plan functions are useful for seeing equivalent (we hope) pipeline.
 
@@ -310,19 +310,6 @@ bucket_linkfun(Bucket) ->
     BucketProps = riak_core_bucket:get_bucket(Bucket),
     {_, {modfun, Module, Function}} = lists:keyfind(linkfun, 1, BucketProps),
     erlang:make_fun(Module, Function, 3).
-
-correct_keeps([]) ->
-    [];
-correct_keeps(Query) ->
-    case lists:all(fun({_, _, _, false}) -> true;
-                      (_)                -> false
-                   end, Query) of
-        true ->
-            {AllBut, [{A, B, C, _}]} = lists:split(length(Query) - 1, Query),
-            AllBut ++ [{A, B, C, true}];
-        false ->
-            Query
-    end.
 
 count_keeps_in_query(Query) ->
     lists:foldl(fun({_, _, _, true}, Acc) -> Acc + 1;

--- a/test/mapred_test.erl
+++ b/test/mapred_test.erl
@@ -236,7 +236,7 @@ compat_basic1_test_() ->
                  5 = length(MapRs)
              end),
           ?_test(
-             %% Basic compat: keep neither stages -> force keep last stage
+             %% Basic compat: keep neither stages -> no output
              begin
                  Spec = 
                      [{map, {modfun, riak_kv_mapreduce, map_object_value},
@@ -245,7 +245,7 @@ compat_basic1_test_() ->
                        none, false}],
                  %% "Crazy" semantics: if only 1 keeper stage, then
                  %% return List instead of [List].
-                 {ok, [15]} = riak_kv_mrc_pipe:mapred(IntsBucket, Spec)
+                 {ok, []} = riak_kv_mrc_pipe:mapred(IntsBucket, Spec)
              end),
           ?_test(
              %% Basic compat: keep first stage only, want 'crazy' result",
@@ -292,7 +292,7 @@ compat_basic1_test_() ->
                      [{map, {modfun, riak_kv_mapreduce, map_object_value},
                        {struct,[{<<"sub">>,[<<"0">>]}]}, false},
                       {reduce, {modfun, riak_kv_mapreduce,
-                                reduce_string_to_integer},none,false}],
+                                reduce_string_to_integer},none,true}],
                  {ok, [0]} =
                      riak_kv_mrc_pipe:mapred(Inputs, Spec)
              end),
@@ -353,7 +353,7 @@ compat_basic1_test_() ->
              %% modfun for inputs generator
              begin
                  Inputs = {modfun, ?MODULE, inputs_gen_seq, 6},
-                 Spec = [{reduce, {qfun, ReduceSumFun},none,false}],
+                 Spec = [{reduce, {qfun, ReduceSumFun},none,true}],
                  {ok, [21]} = riak_kv_mrc_pipe:mapred(Inputs, Spec)
              end),
           ?_test(


### PR DESCRIPTION
Get client Id requests to the PB interface resulted in crash if the local client's id was undefined. This change adds a client_id value to the pb socket's state so that it can behave as before for legacy clients.
