### PR TITLE
AZ665 - Add variability to write_buffer_size to reduce concurrent compaction.

### DIFF
--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -86,7 +86,7 @@ start(Partition, Config) ->
     WriteBufferMin = config_value(write_buffer_size_min, Config, 3 * 1024 * 1024),
     WriteBufferMax = config_value(write_buffer_size_max, Config, 6 * 1024 * 1024),
     random:seed(now()),
-    WriteBufferSize = WriteBufferMin + random:uniform(WriteBufferMax - WriteBufferMin),
+    WriteBufferSize = WriteBufferMin + random:uniform(1 + WriteBufferMax - WriteBufferMin),
 
     %% Assemble options...
     Options = [

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -359,7 +359,7 @@ handle_coverage(?KV_INDEX_REQ{bucket=Bucket,
                     {noreply, State}
             end;
         false ->
-            riak_core_vnode:reply(Sender, {error, {indexes_not_supported, Mod}})
+            {reply, {error, {indexes_not_supported, Mod}}, State}
     end.
 
 handle_handoff_command(Req=?FOLD_REQ{foldfun=FoldFun}, Sender, State) ->

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -136,9 +136,6 @@ produce_index_results(RD, Ctx) ->
             JsonKeys2 = mochijson2:encode(JsonKeys1),
             {JsonKeys2, RD, Ctx};
         {error, Reason} ->
-            %% RD1 = wrq:set_response_code(500, RD),
-            %% RD2 = wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD1),
-            %% Msg = io_lib:format("Invalid query: ~p~n", [Reason]),
             {{error, Reason}, RD, Ctx}
     end.
 

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -136,10 +136,10 @@ produce_index_results(RD, Ctx) ->
             JsonKeys2 = mochijson2:encode(JsonKeys1),
             {JsonKeys2, RD, Ctx};
         {error, Reason} ->
-            RD1 = wrq:set_response_code(500, RD),
-            RD2 = wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD1),
-            Msg = io_lib:format("Invalid query: ~p~n", [Reason]),
-            {Msg, RD2, Ctx}
+            %% RD1 = wrq:set_response_code(500, RD),
+            %% RD2 = wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD1),
+            %% Msg = io_lib:format("Invalid query: ~p~n", [Reason]),
+            {{error, Reason}, RD, Ctx}
     end.
 
 


### PR DESCRIPTION
During benchmark tests, adding some variability to the write_buffer_size smoothed out latencies and sped up average write speeds during heavy loads by reducing the probability that all vnodes would kick off a compaction at the same time.
