### PR TITLE
1.0

### DIFF
--- a/ebin/riak_kv.app
+++ b/ebin/riak_kv.app
@@ -110,6 +110,13 @@
          %% Secondary code paths
          {add_paths, []},
 
+         %% This option enables compatability of bucket and key listing
+         %% with 0.14 and earlier versions. Once a rolling upgrade to
+         %% a version > 0.14 is completed for a cluster, this should be
+         %% set to false for improved performance for bucket and key
+         %% listing operations.
+         {legacy_keylisting, true},
+
          %% Allow Erlang MapReduce functions to be specified as
          %% strings.
          %%

--- a/ebin/riak_kv.app
+++ b/ebin/riak_kv.app
@@ -3,7 +3,7 @@
 {application, riak_kv,
  [
   {description, "Riak Key/Value Store"},
-  {vsn, "0.14.0"},
+  {vsn, "1.0.0"},
   {modules, [
              lk,
              raw_link_walker,

--- a/rebar.config
+++ b/rebar.config
@@ -8,26 +8,28 @@
                   ]}.
 
 {deps, [
-        {riak_core, "0.14.0", {git, "git://github.com/basho/riak_core",
-                                    {branch, "master"}}},
-        {riakc, "1.1.0", {git, "git://github.com/basho/riak-erlang-client",
+        {riak_core, "1.0.0", {git, "git://github.com/basho/riak_core",
+                                    {branch, "1.0"}}},
+        {riakc, "1.2.0", {git, "git://github.com/basho/riak-erlang-client",
                                {branch, "master"}}},
         {luke, "0.2.4", {git, "git://github.com/basho/luke",
-                              {branch, "master"}}},
-        {erlang_js, "0.6.1", {git, "git://github.com/basho/erlang_js",
-                             {branch, "master"}}},
-        {bitcask, "1.1.6", {git, "git://github.com/basho/bitcask",
-                                 {branch, "master"}}},
-        {merge_index, "0.14.*", {git, "git://github.com/basho/merge_index",
-                                 {branch, "master"}}},
-        {ebloom, "1.0.2", {git, "git://github.com/basho/ebloom",
-                                {branch, "master"}}},
+                              {tag, "luke-0.2.4"}}},
+        {erlang_js, "1.0.0", {git, "git://github.com/basho/erlang_js",
+                             {tag, "1.0.0"}}},
+        {bitcask, "1.2.0", {git, "git://github.com/basho/bitcask",
+                                 {tag, "1.2.0"}}},
+        {merge_index, "1.0.0", {git, "git://github.com/basho/merge_index",
+                                 {branch, "1.0"}}},
+        {ebloom, "1.1.0", {git, "git://github.com/basho/ebloom",
+                                {tag, "1.1.0"}}},
+        %% TODO Fix eper version when we know it
         {eper, ".*", {git, "git://github.com/basho/eper.git",
                         {branch, "master"}}},
-        {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", "HEAD"}},
+        {eleveldb, "1.0.0", {git, "git://github.com/basho/eleveldb.git", {tag, "1.0.0"}}},
+        %% TODO Fix this to a commit revision        
         {sext, ".*", {git, "git://github.com/esl/sext", "HEAD"}},
-        {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git",
-                                {branch, "master"}}},
-        {basho_metrics, ".*", {git, "git://github.com/basho/basho_metrics.git",
-                                {branch, "master"}}}
+        {riak_pipe, "1.0.0", {git, "git://github.com/basho/riak_pipe.git",
+                                {branch, "1.0"}}},
+        {basho_metrics, "1.0.0", {git, "git://github.com/basho/basho_metrics.git",
+                                {tag, "1.0.0"}}}
        ]}.

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -479,12 +479,12 @@ list_keys(Bucket, Timeout, ErrorTolerance) when is_integer(Timeout) ->
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
 list_keys(Bucket, Filter, Timeout) -> 
-    case app_helper:get_env(riak_kv, legacy_keylisting, false) of
+    case app_helper:get_env(riak_kv, legacy_keylisting) of
         true ->
             %% @TODO This code is only here to support
             %% rolling upgrades and will be removed.
             list_keys(Bucket, Timeout, ?DEFAULT_ERRTOL);
-        false ->
+        _ ->
             Me = self(),
             ReqId = mk_reqid(),
             riak_kv_keys_fsm_sup:start_keys_fsm(Node, [{raw, ReqId, Me}, [Bucket, Filter, Timeout, plain]]),
@@ -531,12 +531,12 @@ stream_list_keys(Bucket0, Timeout, ErrorTolerance, Client, ClientType) ->
 %%      If ClientType is set to 'mapred' instead of 'plain', then the
 %%      messages will be sent in the form of a MR input stream.
 stream_list_keys(Input, Timeout, Client, ClientType) when is_pid(Client) ->
-    case app_helper:get_env(riak_kv, legacy_keylisting, false) of
+    case app_helper:get_env(riak_kv, legacy_keylisting) of
         true ->
             %% @TODO This code is only here to support
             %% rolling upgrades and will be removed.
             stream_list_keys(Input, Timeout, ?DEFAULT_ERRTOL, Client, ClientType);
-        false ->
+        _ ->
             ReqId = mk_reqid(),
             case Input of
                 {Bucket, FilterInput} ->
@@ -578,12 +578,12 @@ stream_list_keys(Bucket, Timeout, ErrorTolerance, Client) ->
 %%      out of date if called immediately after a put or delete.
 %% @equiv filter_keys(Bucket, Fun, default_timeout())
 filter_keys(Bucket, Fun) ->
-    case app_helper:get_env(riak_kv, legacy_keylisting, false) of
+    case app_helper:get_env(riak_kv, legacy_keylisting) of
         true ->
             %% @TODO This code is only here to support
             %% rolling upgrades and will be removed.
             list_keys({filter, Bucket, Fun}, ?DEFAULT_TIMEOUT*8);
-        false ->
+        _ ->
             list_keys(Bucket, Fun, ?DEFAULT_TIMEOUT)
     end.
 
@@ -596,12 +596,12 @@ filter_keys(Bucket, Fun) ->
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
 filter_keys(Bucket, Fun, Timeout) ->
-    case app_helper:get_env(riak_kv, legacy_keylisting, false) of
+    case app_helper:get_env(riak_kv, legacy_keylisting) of
         true ->
             %% @TODO This code is only here to support
             %% rolling upgrades and will be removed.
             list_keys({filter, Bucket, Fun}, Timeout);
-        false ->
+        _ ->
             list_keys(Bucket, Fun, Timeout)
     end.
 
@@ -628,12 +628,12 @@ list_buckets() ->
 %%      either adds the first key or removes the last remaining key from
 %%      a bucket.
 list_buckets(Filter, Timeout) ->
-    case app_helper:get_env(riak_kv, legacy_keylisting, false) of
+    case app_helper:get_env(riak_kv, legacy_keylisting) of
         true ->
             %% @TODO This code is only here to support
             %% rolling upgrades and will be removed.
             list_keys('_', Timeout);
-        false ->
+        _ ->
             Me = self(),
             ReqId = mk_reqid(),
             riak_kv_buckets_fsm_sup:start_buckets_fsm(Node, [{raw, ReqId, Me}, [Filter, Timeout, plain]]),
@@ -646,12 +646,12 @@ list_buckets(Filter, Timeout) ->
 %%       {error, Err :: term()}
 %% @doc Return a list of filtered buckets.
 filter_buckets(Fun) ->
-    case app_helper:get_env(riak_kv, legacy_keylisting, false) of
+    case app_helper:get_env(riak_kv, legacy_keylisting) of
         true ->
             %% @TODO This code is only here to support
             %% rolling upgrades and will be removed.
             list_keys('_', ?DEFAULT_TIMEOUT);
-        false ->
+        _ ->
             list_buckets(Fun, ?DEFAULT_TIMEOUT)
     end.
 

--- a/src/riak_kv_coverage_filter.erl
+++ b/src/riak_kv_coverage_filter.erl
@@ -122,10 +122,11 @@ compose(Filters) ->
     compose(Filters, []).
 
 compose([], RevFilterFuns) ->
+    FilterFuns = lists:reverse(RevFilterFuns),
     fun(Val) ->
             true =:= lists:foldl(fun(Fun, Acc) -> Fun(Acc) end,
                                  Val,
-                                 lists:reverse(RevFilterFuns))
+                                 FilterFuns)
     end;
 compose([Filter | RestFilters], FilterFuns) ->
     {FilterMod, FilterFun, Args} = Filter,

--- a/src/riak_kv_coverage_filter.erl
+++ b/src/riak_kv_coverage_filter.erl
@@ -121,13 +121,11 @@ compose([]) ->
 compose(Filters) ->
     compose(Filters, []).
 
-compose([], FilterFuns) ->
-    TruthFun =
-        fun(X) ->
-                X =:= true
-        end,
+compose([], RevFilterFuns) ->
     fun(Val) ->
-            lists:all(TruthFun, [FilterFun(Val) || FilterFun <- FilterFuns])
+            true =:= lists:foldl(fun(Fun, Acc) -> Fun(Acc) end,
+                                 Val,
+                                 lists:reverse(RevFilterFuns))
     end;
 compose([Filter | RestFilters], FilterFuns) ->
     {FilterMod, FilterFun, Args} = Filter,

--- a/src/riak_kv_pb_socket.erl
+++ b/src/riak_kv_pb_socket.erl
@@ -234,7 +234,7 @@ process_message(rpbpingreq, State) ->
     send_msg(rpbpingresp, State);
 
 process_message(rpbgetclientidreq, #state{client=C, client_id=CID} = State) ->
-    ClientId = case app_helper:get_env(riak_kv, vnode_vclocks) of
+    ClientId = case app_helper:get_env(riak_kv, vnode_vclocks, false) of
                    true -> CID;
                    false -> C:get_client_id()
                end,
@@ -242,7 +242,7 @@ process_message(rpbgetclientidreq, #state{client=C, client_id=CID} = State) ->
     send_msg(Resp, State);
 
 process_message(#rpbsetclientidreq{client_id = ClientId}, State) ->
-    NewState = case app_helper:get_env(riak_kv, vnode_vclocks) of
+    NewState = case app_helper:get_env(riak_kv, vnode_vclocks, false) of
                    true -> State#state{client_id=ClientId};
                    false ->
                        {ok, C} = riak:local_client(ClientId),

--- a/src/riak_kv_pb_socket.erl
+++ b/src/riak_kv_pb_socket.erl
@@ -40,7 +40,8 @@
 -record(state, {sock,      % protocol buffers socket
                 client,    % local client
                 req,       % current request (for multi-message requests like list keys)
-                req_ctx}). % context to go along with request (partial results, request ids etc)
+                req_ctx,   % context to go along with request (partial results, request ids etc)
+                client_id = <<0,0,0,0>> }). % emulate legacy API when vnode_vclocks is true
 
 -record(pipe_ctx, {pipe,     % pipe handling mapred request
                    ref,      % easier-access ref/reqid
@@ -232,13 +233,22 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 process_message(rpbpingreq, State) ->
     send_msg(rpbpingresp, State);
 
-process_message(rpbgetclientidreq, #state{client=C} = State) ->
-    Resp = #rpbgetclientidresp{client_id = C:get_client_id()},
+process_message(rpbgetclientidreq, #state{client=C, client_id=CID} = State) ->
+    ClientId = case app_helper:get_env(riak_kv, vnode_vclocks) of
+                   true -> CID;
+                   false -> C:get_client_id()
+               end,
+    Resp = #rpbgetclientidresp{client_id = ClientId},
     send_msg(Resp, State);
 
 process_message(#rpbsetclientidreq{client_id = ClientId}, State) ->
-    {ok, C} = riak:local_client(ClientId),
-    send_msg(rpbsetclientidresp, State#state{client = C});
+    NewState = case app_helper:get_env(riak_kv, vnode_vclocks) of
+                   true -> State#state{client_id=ClientId};
+                   false ->
+                       {ok, C} = riak:local_client(ClientId),
+                       State#state{client = C}
+               end,
+    send_msg(rpbsetclientidresp, NewState);
 
 process_message(rpbgetserverinforeq, State) ->
     Resp = #rpbgetserverinforesp{node = riakc_pb:to_binary(node()), 

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -988,7 +988,9 @@ update_vnode_status2(F, Status, VnodeFile) ->
     end.
  
 vnode_status_filename(Index) ->
-    VnodeStatusDir = app_helper:get_env(riak_kv, vnode_status, "data/kv_vnode"),
+    DataDir = app_helper:get_env(riak_core, platform_data_dir, "data"),
+    Default_KV_VnodeDir = filename:join(DataDir, "kv_vnode"),
+    VnodeStatusDir = app_helper:get_env(riak_kv, vnode_status, Default_KV_VnodeDir),
     filename:join(VnodeStatusDir, integer_to_list(Index)).
     
 read_vnode_status(File) ->


### PR DESCRIPTION
1.0 doesn't have a riak_kv vnode_status parameter in app.config, which would default to "./data/kv_vnode". This fixes that by first checking to see if platform_data_dir is declared in riak_core, uses that, and then bounces back to "./data" if not.
