### PR TITLE
Using platform_data_dir to build the default path to data/kv_vnode.

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -988,7 +988,9 @@ update_vnode_status2(F, Status, VnodeFile) ->
     end.
  
 vnode_status_filename(Index) ->
-    VnodeStatusDir = app_helper:get_env(riak_kv, vnode_status, "data/kv_vnode"),
+    DataDir = app_helper:get_env(riak_core, platform_data_dir, "data"),
+    Default_KV_VnodeDir = filename:join(DataDir, "kv_vnode"),
+    VnodeStatusDir = app_helper:get_env(riak_kv, vnode_status, Default_KV_VnodeDir),
     filename:join(VnodeStatusDir, integer_to_list(Index)).
     
 read_vnode_status(File) ->


### PR DESCRIPTION
If platform_data_dir is not defined in riak_core, then it will default back to ./data.
