### PR TITLE
Fix BZ 1176: bad assumptions about cwd writablility

### DIFF
--- a/src/riak_kv_map_master.erl
+++ b/src/riak_kv_map_master.erl
@@ -242,22 +242,21 @@ ensure_dir(Dir) ->
 
 init_data_dir() ->
     %% There are some upgrade situations where the mapred_queue_dir, is not
-    %% specified and as such we'll wind up using the default data/mr_queue,
-    %% relative to current working dir. This causes problems in a packaged env
-    %% (such as rpm/deb) where the current working dir is NOT writable. To
-    %% accomodate these situations, we fallback to creating the mr_queue in
-    %% /tmp.
-    {ok, Cwd} = file:get_cwd(),
+    %% specified and as such we'll wind up using the mr_queue dir,
+    %% relative to platform_data_dir.
+    %% We fallback to creating the mr_queue in /tmp.
+    P_DataDir = app_helper:get_env(riak_core, platform_data_dir),
     DataDir0 = app_helper:get_env(riak_kv, mapred_queue_dir,
-                                  filename:join(Cwd, "data/mr_queue")),
+                                  filename:join(P_DataDir, "mr_queue")),
     case ensure_dir(DataDir0) of
         ok ->
             DataDir0;
         {error, Reason} ->
+            TmpDir = "/tmp/mr_queue",
             lager:warning("Failed to create ~p for mapred_queue_dir "
-                                     "defaulting to /tmp/mr_queue : ~p",
-                                     [DataDir0, Reason]),
-            ok = ensure_dir("/tmp/mr_queue"),
-            "/tmp/mr_queue"
+                                     "defaulting to %s: ~p",
+                                     [DataDir0, TmpDir, Reason]),
+            ok = ensure_dir(TmpDir),
+            TmpDir
     end.
 

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -988,7 +988,9 @@ update_vnode_status2(F, Status, VnodeFile) ->
     end.
  
 vnode_status_filename(Index) ->
-    VnodeStatusDir = app_helper:get_env(riak_kv, vnode_status, "data/kv_vnode"),
+    P_DataDir = app_helper:get_env(riak_core, platform_data_dir),
+    VnodeStatusDir = app_helper:get_env(riak_kv, vnode_status,
+                                        filename:join(P_DataDir, "kv_vnode")),
     filename:join(VnodeStatusDir, integer_to_list(Index)).
     
 read_vnode_status(File) ->


### PR DESCRIPTION
Use app.config's 'platform_data_dir' variable (in the 'riak_core' app section)
for figuring out where a platform's data dir really is.  Assuming that
the current working directory is writable is not a good choice for Riak
Linux packages, at the very least.
