### PR TITLE
Az666 2i unencoded values

### DIFF
--- a/src/riak_kv_pb_socket.erl
+++ b/src/riak_kv_pb_socket.erl
@@ -234,7 +234,7 @@ process_message(rpbpingreq, State) ->
     send_msg(rpbpingresp, State);
 
 process_message(rpbgetclientidreq, #state{client=C, client_id=CID} = State) ->
-    ClientId = case app_helper:get_env(riak_kv, vnode_vclocks) of
+    ClientId = case app_helper:get_env(riak_kv, vnode_vclocks, false) of
                    true -> CID;
                    false -> C:get_client_id()
                end,
@@ -242,7 +242,7 @@ process_message(rpbgetclientidreq, #state{client=C, client_id=CID} = State) ->
     send_msg(Resp, State);
 
 process_message(#rpbsetclientidreq{client_id = ClientId}, State) ->
-    NewState = case app_helper:get_env(riak_kv, vnode_vclocks) of
+    NewState = case app_helper:get_env(riak_kv, vnode_vclocks, false) of
                    true -> State#state{client_id=ClientId};
                    false ->
                        {ok, C} = riak:local_client(ClientId),

--- a/src/riak_kv_pb_socket.erl
+++ b/src/riak_kv_pb_socket.erl
@@ -40,7 +40,8 @@
 -record(state, {sock,      % protocol buffers socket
                 client,    % local client
                 req,       % current request (for multi-message requests like list keys)
-                req_ctx}). % context to go along with request (partial results, request ids etc)
+                req_ctx,   % context to go along with request (partial results, request ids etc)
+                client_id = <<0,0,0,0>> }). % emulate legacy API when vnode_vclocks is true
 
 -record(pipe_ctx, {pipe,     % pipe handling mapred request
                    ref,      % easier-access ref/reqid
@@ -232,13 +233,22 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 process_message(rpbpingreq, State) ->
     send_msg(rpbpingresp, State);
 
-process_message(rpbgetclientidreq, #state{client=C} = State) ->
-    Resp = #rpbgetclientidresp{client_id = C:get_client_id()},
+process_message(rpbgetclientidreq, #state{client=C, client_id=CID} = State) ->
+    ClientId = case app_helper:get_env(riak_kv, vnode_vclocks) of
+                   true -> CID;
+                   false -> C:get_client_id()
+               end,
+    Resp = #rpbgetclientidresp{client_id = ClientId},
     send_msg(Resp, State);
 
 process_message(#rpbsetclientidreq{client_id = ClientId}, State) ->
-    {ok, C} = riak:local_client(ClientId),
-    send_msg(rpbsetclientidresp, State#state{client = C});
+    NewState = case app_helper:get_env(riak_kv, vnode_vclocks) of
+                   true -> State#state{client_id=ClientId};
+                   false ->
+                       {ok, C} = riak:local_client(ClientId),
+                       State#state{client = C}
+               end,
+    send_msg(rpbsetclientidresp, NewState);
 
 process_message(rpbgetserverinforeq, State) ->
     Resp = #rpbgetserverinforesp{node = riakc_pb:to_binary(node()), 

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -988,7 +988,9 @@ update_vnode_status2(F, Status, VnodeFile) ->
     end.
  
 vnode_status_filename(Index) ->
-    VnodeStatusDir = app_helper:get_env(riak_kv, vnode_status, "data/kv_vnode"),
+    DataDir = app_helper:get_env(riak_core, platform_data_dir, "data"),
+    Default_KV_VnodeDir = filename:join(DataDir, "kv_vnode"),
+    VnodeStatusDir = app_helper:get_env(riak_kv, vnode_status, Default_KV_VnodeDir),
     filename:join(VnodeStatusDir, integer_to_list(Index)).
     
 read_vnode_status(File) ->

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -124,14 +124,14 @@ multipart_encode_body(Prefix, Bucket, {MD, V}, APIVersion) ->
      case dict:find(?MD_USERMETA, MD) of
          {ok, M} ->
             lists:foldl(fun({Hdr,Val},Acc) ->
-                            [Acc|[Hdr,": ",Val,"\r\n"]]
+                            [Acc|[Hdr,": ",encode_value(Val),"\r\n"]]
                         end,
                         [], M);
          error -> []
      end,
      case dict:find(?MD_INDEX, MD) of
          {ok, IF} ->
-             [[?HEAD_INDEX_PREFIX,Key,": ",Val,"\r\n"] || {Key,Val} <- IF];
+             [[?HEAD_INDEX_PREFIX,Key,": ",encode_value(Val),"\r\n"] || {Key,Val} <- IF];
          error -> []
      end,
      "\r\n",

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -124,14 +124,14 @@ multipart_encode_body(Prefix, Bucket, {MD, V}, APIVersion) ->
      case dict:find(?MD_USERMETA, MD) of
          {ok, M} ->
             lists:foldl(fun({Hdr,Val},Acc) ->
-                            [Acc|[Hdr,": ",encode_value(Val),"\r\n"]]
+                            [Acc|[Hdr,": ",encode_2i_value(Val),"\r\n"]]
                         end,
                         [], M);
          error -> []
      end,
      case dict:find(?MD_INDEX, MD) of
          {ok, IF} ->
-             [[?HEAD_INDEX_PREFIX,Key,": ",encode_value(Val),"\r\n"] || {Key,Val} <- IF];
+             [[?HEAD_INDEX_PREFIX,Key,": ",encode_2i_value(Val),"\r\n"] || {Key,Val} <- IF];
          error -> []
      end,
      "\r\n",
@@ -200,6 +200,16 @@ encode_value(V) when is_binary(V) ->
     V;
 encode_value(V) ->
     term_to_binary(V).
+
+%% @spec encode_2i_value(term()) -> binary()
+%% @doc Encode the 2i value as a binary
+encode_2i_value(V) when is_integer(V) ->
+    list_to_binary(erlang:integer_to_list(V));
+encode_2i_value(S) when is_list(S) orelse is_binary(S) ->
+    S;
+encode_2i_value(X) ->
+    throw({unknown_2i_val_type, X}).
+
 
 %% @spec accept_value(string(), binary()) -> term()
 %% @doc Accept the object value as a binary - content type can be used


### PR DESCRIPTION
riak_kv_wm_utils:multipart_encode_body wasn't encoding 2i header values properly. Created a new encode function to encode integers as strings (binary) and use it when creating the response.
