### PR TITLE
Update eunit tests to work with basho_expect

### DIFF
--- a/test/rest_url_encoding_test.erl
+++ b/test/rest_url_encoding_test.erl
@@ -35,7 +35,7 @@
 -compile(export_all).
 
 url_encoding_test_() ->
-    Envs = ["RIAK_TEST_HOST", "RIAK_TEST_HTTP_PORT", "RIAK_TEST_NODE",
+    Envs = ["RIAK_TEST_HOST_1", "RIAK_TEST_HTTP_1", "RIAK_TEST_NODE_1",
             "RIAK_TEST_COOKIE", "RIAK_EUNIT_NODE"],
     Vals = [os:getenv(Env) || Env <- Envs],
     case lists:member(false, Vals) of


### PR DESCRIPTION
Minor changes to work with environment variables set by new basho_expect driver.
