### PR TITLE
Get FSM defaults 

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -60,9 +60,8 @@ start(_Type, _StartArgs) ->
        {pw, 0},
        {dw, quorum},
        {rw, quorum},
-       {pr, 0},
-       {basic_quorum, true},
-       {notfound_ok, false}
+       {basic_quorum, false},
+       {notfound_ok, true}
    ]),
 
     %% Check the storage backend


### PR DESCRIPTION
Update default bprops for basic_quorum=false, notfound_ok=true and removes duplicate pr entry.
