### PR TITLE
BZ1189 HTTP/JS-safe reduce batch controls (redo)

### DIFF
--- a/src/riak_kv_w_reduce.erl
+++ b/src/riak_kv_w_reduce.erl
@@ -322,16 +322,14 @@ calc_delay_max(#fitting_details{arg = {rct, _ReduceFun, ReduceArg}}) ->
 %% atoms, since the HTTP interface has no way to send atoms natively
 -spec delay_props_from_json(list()) -> [{atom(), term()}].
 delay_props_from_json(JsonProps) ->
-    Only1 = case lists:keyfind(<<"reduce_phase_only_1">>, 1, JsonProps) of
-                {_, Only1V} ->
-                    [{reduce_phase_only_1, Only1V}];
-                false ->
-                    []
-            end,
-    Batch = case lists:keyfind(<<"reduce_phase_batch_size">>, 1, JsonProps) of
-                {_, BatchV} ->
-                    [{reduce_phase_batch_size, BatchV}];
-                false ->
-                    []
-            end,
+    Only1 = extract_json_prop(reduce_phase_only_1, JsonProps),
+    Batch = extract_json_prop(reduce_phase_batch_size, JsonProps),
     Only1 ++ Batch.
+
+extract_json_prop (Key, JsonProps) ->
+    case lists:keyfind(atom_to_binary(Key, latin1), 1, JsonProps) of
+        {_,Value} ->
+            [{Key,Value}];
+        false ->
+            []
+    end.

--- a/src/riak_kv_w_reduce.erl
+++ b/src/riak_kv_w_reduce.erl
@@ -66,6 +66,24 @@
 %% X = Fun([C,B,A], Arg)
 %% '''
 %%
+%% To use `reduce_phase_only_1' and `reduce_phase_batch_size' over the
+%% HTTP interface, specify a JSON structure as the function's
+%% argument, as in:
+%% ```
+%% {...,"query":[...,{"reduce":{...,"arg":{"reduce_phase_batch_size":100}}}]}
+%% '''
+%% Or:
+%% ```
+%% {...,"query":[...,{"reduce":{...,"arg":{"reduce_phase_only1":true}}}]}
+%% '''
+%% The HTTP interface will translate that argument into a mochijson2
+%% structure (e.g. `{struct, [{<<"reduce_phase_only_1">>, true}]}'),
+%% which this fitting will understand.  This also provides a safe way
+%% to pass these arguments when using a reduce phase implemented in
+%% Javascript over the Protocol Buffer or native interfaces.
+%% Mochijson2 conversion will fail on the bare proplist, but will
+%% succeed at encoding this form.
+%%
 %% The exception to the batching controls is handoff.  Whenever a
 %% worker receives handoff from another worker, it immediately reduces
 %% the concatenation of the two inputs.
@@ -275,6 +293,7 @@ js_runner(JS) ->
 calc_delay_max(#fitting_details{arg = {rct, _ReduceFun, ReduceArg}}) ->
     Props = case ReduceArg of
                 L when is_list(L) -> L;         % May or may not be a proplist
+                {struct, L} -> delay_props_from_json(L);
                 _                 -> []
             end,
     AppMax = app_helper:get_env(riak_kv, mapred_reduce_phase_batch_size, 20),
@@ -285,3 +304,21 @@ calc_delay_max(#fitting_details{arg = {rct, _ReduceFun, ReduceArg}}) ->
             proplists:get_value(reduce_phase_batch_size,
                                 Props, AppMax)
     end.
+
+%% @doc convert JSON struct properties with similar names to Erlang
+%% atoms, since the HTTP interface has no way to send atoms natively
+-spec delay_props_from_json(list()) -> [{atom(), term()}].
+delay_props_from_json(JsonProps) ->
+    Only1 = case lists:keyfind(<<"reduce_phase_only_1">>, 1, JsonProps) of
+                {_, Only1V} ->
+                    [{reduce_phase_only_1, Only1V}];
+                false ->
+                    []
+            end,
+    Batch = case lists:keyfind(<<"reduce_phase_batch_size">>, 1, JsonProps) of
+                {_, BatchV} ->
+                    [{reduce_phase_batch_size, BatchV}];
+                false ->
+                    []
+            end,
+    Only1 ++ Batch.


### PR DESCRIPTION
_This PR is a replacement for https://github.com/basho/riak_kv/pull/206 targetted for 1.0 to make it easier to see changes_

The first patch allows the new reduce batch size controls to be specified as JSON (or mochijson2) structures, to allow them to be controlled over HTTP, as well as safely used with Javascript-implemented phases.

To test, set `{allow_strfun, true}` in the `riak_kv` section of `app.config`, load 1000 objects into bucket `lk', then:

```
$ curl -X POST -H "content-type:application/json" http://localhost:8098/mapred --data @-
{"inputs":"lk","query":[{"reduce":{"language":"erlang","source":"fun(_,_) -> io:format(\"R\"), [] end.","arg":{"reduce_phase_batch_size":100}}}]}
```

This should print 20 `R`s on the Riak console.

```
$ curl -X POST -H "content-type:application/json" http://localhost:8098/mapred --data @-
{"inputs":"lk","query":[{"reduce":{"language":"erlang","source":"fun(_,_) -> io:format(\"R\"), [] end.","arg":{"reduce_phase_only_1":true}}}]}
```

This should print only 1 `R` on the Riak console.

The second patch prevents accidental JS failures caused by using the Erlang reduce batch size knob format, instead of the JSON format.  The atoms or tuples are simply filtered from the `Arg' list prior to evaluating the function.  This can be tested from the Riak console via:

```
 riak_kv_mrc_pipe:mapred(<<"lk">>, [{map, {modfun, riak_kv_mapreduce, map_object_value}, none, true},{reduce, {jsanon, <<"function() { ejsLog('/tmp/reduce_batch_test.log', '1'); return []; }">>}, [{reduce_phase_batch_size, 100}], true}]).
```

This should print ten `1`s to the file `/tmp/reduce_batch_test.log`.

```
 riak_kv_mrc_pipe:mapred(<<"lk">>, [{map, {modfun, riak_kv_mapreduce, map_object_value}, none, true},{reduce, {jsanon, <<"function() { ejsLog('/tmp/reduce_batch_test.log', '2'); return []; }">>}, [reduce_phase_only_1}], true}]).
```

This should print one `2` to the file `/tmp/reduce_batch_test.log`.
