### PR TITLE
AZ721 - 2i - Fail Loudly on 2I Errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ priv/*
 *.beam
 doc
 test.*-temp-data
+ebin

--- a/src/riak_kv_index_fsm.erl
+++ b/src/riak_kv_index_fsm.erl
@@ -71,15 +71,15 @@ init(From={_, _, ClientPid}, [Bucket, ItemFilter, Query, Timeout, ClientType]) -
     {Req, all, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout,
      #state{client_type=ClientType, from=From}}.
 
+process_results({error, Reason}, _State) ->
+    {error, Reason};
 process_results({Bucket, Results},
                 StateData=#state{client_type=ClientType,
                                  from={raw, ReqId, ClientPid}}) ->
     process_query_results(ClientType, Bucket, Results, ReqId, ClientPid),
     {ok, StateData};
 process_results(done, StateData) ->
-    {done, StateData};
-process_results({error, Reason}, _State) ->
-    {error, Reason}.
+    {done, StateData}.
 
 finish({error, Error},
        StateData=#state{from={raw, ReqId, ClientPid},
@@ -93,7 +93,7 @@ finish({error, Error},
         plain ->
             %% Notify the requesting client that an error
             %% occurred or the timeout has elapsed.
-            ClientPid ! {ReqId, Error}
+            ClientPid ! {ReqId, {error, Error}}
     end,
     {stop, normal, StateData};
 finish(clean,

--- a/src/riak_kv_mrc_pipe.erl
+++ b/src/riak_kv_mrc_pipe.erl
@@ -610,6 +610,9 @@ send_key_list(Pipe, Bucket, ReqId) ->
             [F(X) || X <- Results],
             send_key_list(Pipe, Bucket, ReqId);
 
+        {ReqId, {error, Reason}} ->
+            {error, Reason};
+
         {ReqId, done} ->
             %% Operation has finished.
             riak_pipe:eoi(Pipe),

--- a/src/riak_kv_pb_socket.erl
+++ b/src/riak_kv_pb_socket.erl
@@ -162,7 +162,7 @@ handle_info({'DOWN', Ref, process, Pid, Reason},
             erlang:cancel_timer(PipeCtx#pipe_ctx.timer),
             riak_pipe:destroy(PipeCtx#pipe_ctx.pipe),
             lager:error("Error sending inputs: ~p", [Reason]),
-            NewState = send_error("~p", [bad_mapred_inputs], State),
+            NewState = send_error("Error sending inputs: ~p", [Reason], State),
             {noreply, NewState#state{req=undefined, req_ctx=undefined}}
     end;
 handle_info({pipe_timeout, Ref},

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -103,10 +103,12 @@ verify_body(Body, State) ->
             {true, [], State#state{inputs=ParsedInputs,
                                    mrquery=ParsedQuery,
                                    timeout=Timeout}};
-        {error, {'query', Message}} ->
+        {error, {'query', Reason}} ->
+            Message = lists:flatten(io_lib:format("~p", [Reason])),
             {false, ["An error occurred parsing the \"query\" field.\n",
                      Message], State};
-        {error, {inputs, Message}} ->
+        {error, {inputs, Reason}} ->
+            Message = lists:flatten(io_lib:format("~p", [Reason])),
             {false, ["An error occurred parsing the \"inputs\" field.\n",
                      Message], State};
         {error, missing_field} ->
@@ -159,7 +161,7 @@ pipe_mapred(RD,
 pipe_mapred_nonchunked(RD, State, Pipe, NumKeeps, Sender) ->
     case pipe_collect_outputs(Pipe, NumKeeps, Sender) of
         {ok, Results} ->
-            JSONResults = 
+            JSONResults =
                 case NumKeeps < 2 of
                     true ->
                         [riak_kv_mapred_json:jsonify_not_found(R)


### PR DESCRIPTION
**NOTE: Make sure to test with https://github.com/basho/riak_core/pull/86**

This pull request makes 2i fail loudly and descriptively in the following cases:
- The user queries a system running a non-2i-capable backend.
- The user runs a 2i query through MapReduce with an invalid field suffix
- The user runs a 2i query through MapReduce with an invalid field type (ie: integer field w/ binary value)

There were two major changes to support this:
1. Error messages weren't properly threaded through the system, causing cryptic responses when running 2i queries against an unsupported backend. 
2. MapReduce was not parsing/validating the incoming inputspec for 2i queries. Instead, it just relied on the user providing the correct field suffix and type. If the user provided the incorrect type, then the system simply wouldn't find results.

To test, set up Riak using a non-2i-capable backend such as `riak_kv_bitcask_backend`.
## Testing With Python Client

Install the python client:

``` bash
git clone git://github.com/basho/riak-python-client.git
cd riak-python-client
sudo python setup.py install
```

For the tests below, you should see descriptive errors.

Fire up a `python` console and test for HTTP:

``` python
import riak
client = riak.RiakClient()
client.index('mybucket', 'valid_field_bin', 'foo').run()
client.index('mybucket', 'invalid_field_zzz', 'foo').run()
client.index('mybucket', 'field1_int', 'not_an_int').run()
client.index('mybucket', 'field1_int', 5, 'not_an_int').run()
```

And again with Protocol Buffers:

``` python
import riak
client = riak.RiakClient(port=8087, transport_class=riak.RiakPbcTransport)
client.index('mybucket', 'valid_field_bin', 'foo').run()
client.index('mybucket', 'invalid_field_zzz', 'foo').run()
client.index('mybucket', 'field1_int', 'not_an_int').run()
client.index('mybucket', 'field1_int', 5, 'not_an_int').run()
```
## Testing With Riak PB Client

In the Riak console, run this. Again, you should see descriptive errors:

``` erlang
f().
{ok, Pid} = riakc_pb_socket:start_link("127.0.0.1", 8087).
riakc_pb_socket:get_index(Pid, <<"mybucket">>, <<"valid_field_bin">>, <<"foo">>).
riakc_pb_socket:get_index(Pid, <<"mybucket">>, <<"invalid_field_zzz">>, <<"foo">>).
riakc_pb_socket:get_index(Pid, <<"mybucket">>, <<"field1_int">>, <<"not_an_int">>).
riakc_pb_socket:get_index(Pid, <<"mybucket">>, <<"field1_int">>, 5, <<"not_an_int">>).
```
## Testing From Shell Via Curl

``` bash
curl -i -X POST \
-H "content-type: application/json" \
-d @- \
http://localhost:8098/mapred \
<<EOF
{
   "inputs":{
       "bucket":"mybucket",
       "index":"valid_field_bin",
       "key":"foo"
   },
   "query":[
      {
         "reduce":{
            "language":"erlang",
            "module":"riak_kv_mapreduce",
            "function":"reduce_identity",
            "keep":true
         }
      }
   ]
}
EOF

curl -i -X POST \
-H "content-type: application/json" \
-d @- \
http://localhost:8098/mapred \
<<EOF
{
   "inputs":{
       "bucket":"mybucket",
       "index":"invalid_field_zzz",
       "key":"foo"
   },
   "query":[
      {
         "reduce":{
            "language":"erlang",
            "module":"riak_kv_mapreduce",
            "function":"reduce_identity",
            "keep":true
         }
      }
   ]
}
EOF

curl -i -X POST \
-H "content-type: application/json" \
-d @- \
http://localhost:8098/mapred \
<<EOF
{
   "inputs":{
       "bucket":"mybucket",
       "index":"field1_int",
       "key":"not_an_int"
   },
   "query":[
      {
         "reduce":{
            "language":"erlang",
            "module":"riak_kv_mapreduce",
            "function":"reduce_identity",
            "keep":true
         }
      }
   ]
}
EOF

curl -i -X POST \
-H "content-type: application/json" \
-d @- \
http://localhost:8098/mapred \
<<EOF
{
   "inputs":{
       "bucket":"mybucket",
       "index":"field1_int",
       "start": 5,
       "end":"not_an_int"
   },
   "query":[
      {
         "reduce":{
            "language":"erlang",
            "module":"riak_kv_mapreduce",
            "function":"reduce_identity",
            "keep":true
         }
      }
   ]
}
EOF
```
