### PR TITLE
Add a coverage fsm and plumbing for getting backend status from all vnodes.

### DIFF
--- a/include/riak_kv_vnode.hrl
+++ b/include/riak_kv_vnode.hrl
@@ -37,6 +37,8 @@
           item_filter :: function(),
           qry :: riak_index:query_def()}).
 
+-record(riak_kv_backend_status_req_v1, {}).
+
 -record(riak_kv_delete_req_v1, {
           bkey :: {binary(), binary()},
           req_id :: non_neg_integer()}).
@@ -57,6 +59,7 @@
 -define(KV_LISTBUCKETS_REQ, #riak_kv_listbuckets_req_v1).
 -define(KV_LISTKEYS_REQ, #riak_kv_listkeys_req_v3).
 -define(KV_INDEX_REQ, #riak_kv_index_req_v1).
+-define(KV_BACKEND_STATUS_REQ, #riak_kv_backend_status_req_v1).
 -define(KV_DELETE_REQ, #riak_kv_delete_req_v1).
 -define(KV_MAP_REQ, #riak_kv_map_req_v1).
 -define(KV_VCLOCK_REQ, #riak_kv_vclock_req_v1).

--- a/src/riak_kv_backend_status_fsm.erl
+++ b/src/riak_kv_backend_status_fsm.erl
@@ -1,0 +1,66 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc The backend status fsm manages the gathering the status of
+%% the backends for each vnode.
+
+-module(riak_kv_backend_status_fsm).
+
+-behaviour(riak_core_coverage_fsm).
+
+-include_lib("riak_kv_vnode.hrl").
+
+-export([init/2,
+         process_results/2,
+         finish/2]).
+
+-type from() :: {atom(), req_id(), pid()}.
+-type req_id() :: non_neg_integer().
+
+-record(state, {from :: from(),
+                statuses=[] :: [{partition(), atom(), term()}]}).
+
+%% @doc Return a tuple containing the ModFun to call per vnode,
+%% the number of primary preflist vnodes the operation
+%% should cover, the service to use to check for available nodes,
+%% and the registered name to use to access the vnode master process.
+init(From, Timeout) ->
+    %% Construct the backend status request
+    Req = ?KV_BACKEND_STATUS_REQ{},
+    {Req, allup, 1, 1, riak_kv, riak_kv_vnode_master, Timeout,
+     #state{from=From}}.
+
+process_results(Status,
+                State=#state{statuses=Statuses}) ->
+    {done, State#state{statuses=[Status | Statuses]}};
+process_results({error, Reason}, _State) ->
+    {error, Reason}.
+
+finish({error, Error},
+       State=#state{from={raw, ReqId, ClientPid}}) ->
+    %% Notify the requesting client that an error
+    %% occurred or the timeout has elapsed.
+    ClientPid ! {ReqId, Error},
+    {stop, normal, State};
+finish(clean,
+       State=#state{from={raw, ReqId, ClientPid},
+                    statuses=Statuses}) ->
+    ClientPid ! {ReqId, {statuses, Statuses}},
+    {stop, normal, State}.

--- a/src/riak_kv_backend_status_fsm_sup.erl
+++ b/src/riak_kv_backend_status_fsm_sup.erl
@@ -1,0 +1,51 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Supervise the riak_kv backend status state machines.
+
+-module(riak_kv_backend_status_fsm_sup).
+
+-behaviour(supervisor).
+
+-export([start_backend_status_fsm/2]).
+-export([start_link/0]).
+-export([init/1]).
+
+start_backend_status_fsm(Node, Args) ->
+    supervisor:start_child({?MODULE, Node}, Args).
+
+%% @spec start_link() -> ServerRet
+%% @doc API for starting the supervisor.
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% @spec init([]) -> SupervisorTree
+%% @doc supervisor callback.
+init([]) ->
+    BackendStatusFsmSpec = {undefined,
+                            {riak_core_coverage_fsm,
+                             start_link,
+                             [riak_kv_backend_status_fsm]
+                            },
+                            temporary,
+                            5000,
+                            worker,
+                            [riak_kv_backend_status_fsm]},
+    {ok, {{simple_one_for_one, 10, 10}, [BackendStatusFsmSpec]}}.

--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -107,6 +107,12 @@ init([]) ->
     IndexFsmSup = {riak_kv_index_fsm_sup,
                    {riak_kv_index_fsm_sup, start_link, []},
                    permanent, infinity, supervisor, [riak_kv_index_fsm_sup]},
+    BackendStatusFsmSup = {riak_kv_backend_status_fsm_sup,
+                           {riak_kv_backend_status_fsm_sup, start_link, []},
+                           permanent,
+                           infinity,
+                           supervisor,
+                           [riak_kv_backend_status_fsm_sup]},
     %% @TODO This code is only here to support
     %% rolling upgrades and will be removed.
     LegacyKeysFsmSup = {riak_kv_keys_fsm_legacy_sup,
@@ -130,6 +136,7 @@ init([]) ->
         BucketsFsmSup,
         KeysFsmSup,
         IndexFsmSup,
+        BackendStatusFsmSup,
         LegacyKeysFsmSup,
         KLSup,
         KLMaster,

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -440,12 +440,11 @@ handle_coverage(?KV_INDEX_REQ{bucket=Bucket,
     end;
 handle_coverage(?KV_BACKEND_STATUS_REQ{},
                 _FilterVNodes,
-                Sender,
+                _Sender,
                 State=#state{mod=Mod,
                              modstate=ModState,
                              idx=Index}) ->
-    backend_status(result_fun(Sender), Index, Mod, ModState),
-    {noreply, State}.
+    {reply, {Index, Mod, Mod:status(ModState)}, State}.
 
 handle_handoff_command(Req=?FOLD_REQ{foldfun=FoldFun}, Sender, State) ->
     %% The function in riak_core used for object folding
@@ -737,13 +736,6 @@ do_get_term(BKey, Mod, ModState) ->
 
 do_get_binary({Bucket, Key}, Mod, ModState) ->
     Mod:get(Bucket, Key, ModState).
-
-%% @private
-%% @doc Get the status of the backend associated with this vnode.
--spec backend_status(fun(), partition(), atom(), term()) -> true.
-backend_status(ResultFun, Index, Mod, ModState) ->
-    Status = Mod:status(ModState),
-    ResultFun({Index, Mod, Status}).
 
 %% @private
 %% @doc This is a generic function for operations that involve


### PR DESCRIPTION
This change adds `riak_kv_backend_status_fsm` and makes other necessary
changes to provide a way to query the backend status for all available
vnodes.  There is also the addition of a `backend_status` function to
`riak_kv_console` so this information can be made available via a
command line tool such as `riak-admin`.
