### PR TITLE
Fix repeated bitcask merge.

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -338,9 +338,11 @@ callback(Ref,
 callback(Ref,
          merge_check,
          #state{ref=Ref,
-                root=BitcaskRoot}=State) when is_reference(Ref) ->
+                data_dir=DataDir,
+                root=DataRoot}=State) when is_reference(Ref) ->
     case bitcask:needs_merge(Ref) of
         {true, Files} ->
+            BitcaskRoot = filename:join(DataRoot, DataDir),
             bitcask_merge_worker:merge(BitcaskRoot, [], Files);
         false ->
             ok


### PR DESCRIPTION
`riak_kv_bitcask_backend` is not passing the correct path to the bitcask
merge worker and as a result the hint and data files are created in
the wrong place. Bitcask then repeatedly tries to merge even though
from the end user perspective it should not need to.  

This change corrects the problem by passing the correct path to merge worker.

See the bugzilla [here](https://issues.basho.com/show_bug.cgi?id=1200) for steps to reproduce the problem and verify that the fix corrects the problem.
