### PR TITLE
Better error messages from Pipe-based MapReduce

### DIFF
--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -141,19 +141,25 @@ pipe_mapred(RD,
             #state{inputs=Inputs,
                    mrquery=Query,
                    timeout=Timeout}=State) ->
-    {{ok, Pipe}, NumKeeps} =
-        riak_kv_mrc_pipe:mapred_stream(Query),
-    PipeRef = (Pipe#pipe.sink)#fitting.ref,
-    erlang:send_after(Timeout, self(), {pipe_timeout, PipeRef}),
-    {InputSender, SenderMonitor} =
-        riak_kv_mrc_pipe:send_inputs_async(Pipe, Inputs),
-    case wrq:get_qs_value("chunked", "false", RD) of
-        "true" ->
-            pipe_mapred_chunked(RD, State, Pipe,
-                                {InputSender, SenderMonitor});
-        _ ->
-            pipe_mapred_nonchunked(RD, State, Pipe, NumKeeps,
-                                   {InputSender, SenderMonitor})
+    try riak_kv_mrc_pipe:mapred_stream(Query) of
+        {{ok, Pipe}, NumKeeps} ->
+            PipeRef = (Pipe#pipe.sink)#fitting.ref,
+            erlang:send_after(Timeout, self(), {pipe_timeout, PipeRef}),
+            {InputSender, SenderMonitor} =
+                riak_kv_mrc_pipe:send_inputs_async(Pipe, Inputs),
+            case wrq:get_qs_value("chunked", "false", RD) of
+                "true" ->
+                    pipe_mapred_chunked(RD, State, Pipe,
+                                        {InputSender, SenderMonitor});
+                _ ->
+                    pipe_mapred_nonchunked(RD, State, Pipe, NumKeeps,
+                                           {InputSender, SenderMonitor})
+            end
+    catch throw:{badarg, Fitting, Reason} ->
+            {{halt, 400}, 
+             send_error({error, [{phase, Fitting},
+                                 {error, iolist_to_binary(Reason)}]}, RD),
+             State}
     end.
 
 pipe_mapred_nonchunked(RD, State, Pipe, NumKeeps, Sender) ->


### PR DESCRIPTION
Before this commit, when Pipe-based MapReduce failed to validate a phase function specification (for example, when a module or function was undefined), the client would receive a very generic error, possibly including a mostly useless stacktrace.  With this change, and https://github.com/basho/riak_pipe/pull/29, a much more descriptive error message is returned.

``` erlang
> riakc_pb_socket:mapred(S, <<"foo">>, [{map, {modfun, doesnot, exist}, none, true}]).                      
{error,<<"Phase 0: invalid module named in PhaseSpec function:\n must be a valid module name (failed to load doesnot: n"...>>}
```

``` bash
$ curl -i -X POST -H "content-type:application/json" http://localhost:8098/mapred?chunked=true --data @-
{"inputs":"foo","query":[{"map":{"language":"erlang","module":"does_not","function":"exist"}}]}
^D
HTTP/1.1 400 Bad Request

{"phase":0,"error":"invalid module named in PhaseSpec function:\n must be a valid module name (failed to load does_not: nofile)"}
```
