### PR TITLE
Expose vnode status via riak_kv_console.

### DIFF
--- a/include/riak_kv_vnode.hrl
+++ b/include/riak_kv_vnode.hrl
@@ -37,6 +37,8 @@
           item_filter :: function(),
           qry :: riak_index:query_def()}).
 
+-record(riak_kv_vnode_status_req_v1, {}).
+
 -record(riak_kv_delete_req_v1, {
           bkey :: {binary(), binary()},
           req_id :: non_neg_integer()}).
@@ -57,6 +59,7 @@
 -define(KV_LISTBUCKETS_REQ, #riak_kv_listbuckets_req_v1).
 -define(KV_LISTKEYS_REQ, #riak_kv_listkeys_req_v3).
 -define(KV_INDEX_REQ, #riak_kv_index_req_v1).
+-define(KV_VNODE_STATUS_REQ, #riak_kv_vnode_status_req_v1).
 -define(KV_DELETE_REQ, #riak_kv_delete_req_v1).
 -define(KV_MAP_REQ, #riak_kv_map_req_v1).
 -define(KV_VCLOCK_REQ, #riak_kv_vclock_req_v1).

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -293,8 +293,7 @@ is_empty(#state{ref=Ref}) ->
 %% @doc Get the status information for this eleveldb backend
 -spec status(state()) -> [{atom(), term()}].
 status(#state{data_root=DataRoot} = State) ->
-    [{Dir, get_status(filename:join(DataRoot, Dir), State)} ||
-        Dir <- element(2, file:list_dir(DataRoot))].
+    get_status(DataRoot, State).
 
 %% @doc Register an asynchronous callback
 -spec callback(reference(), any(), state()) -> {ok, state()}.

--- a/src/riak_kv_status.erl
+++ b/src/riak_kv_status.erl
@@ -23,7 +23,10 @@
 
 -export([statistics/0,
          ringready/0,
-         transfers/0]).
+         transfers/0,
+         vnode_status/0]).
+
+-include("riak_kv_vnode.hrl").
 
 %% ===================================================================
 %% Public API
@@ -43,3 +46,10 @@ ringready() ->
 
 transfers() ->
     riak_core_status:transfers().
+
+%% @doc Get status information about the node local vnodes.
+-spec vnode_status() -> [{atom(), term()}].
+vnode_status() ->
+    %% Get the kv vnode indexes and the associated pids for the node.
+    PrefLists = riak_core_vnode_master:all_index_pid(riak_kv_vnode),
+    riak_kv_vnode:vnode_status(PrefLists).


### PR DESCRIPTION
This change adds a `vnode_status` function to `riak_kv_console`. It also adds code to `riak_kv_vnode` to handle a request for vnode status information. Finally, a `vnode_status` function is added to `riak_kv_status` to determine the local vnodes, send status requests to each one, and accumulate the results. 

Currently the only piece of vnode status information that is available is the backend status.
