### PR TITLE
Fix eleveldb bucket listing with 2I

### DIFF
--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -188,9 +188,14 @@ fold_buckets(FoldBucketsFun, Acc, Opts, #state{fold_opts=FoldOpts,
     FoldOpts1 = [{first_key, FirstKey} | FoldOpts],
     BucketFolder =
         fun() ->
-                {FoldResult, _} =
-                    eleveldb:fold_keys(Ref, FoldFun, {Acc, []}, FoldOpts1),
-                FoldResult
+                try
+                    {FoldResult, _} =
+                        eleveldb:fold_keys(Ref, FoldFun, {Acc, []}, FoldOpts1),
+                    FoldResult
+                catch
+                    {break, AccFinal} ->
+                        AccFinal
+                end
         end,
     case lists:member(async_fold, Opts) of
         true ->


### PR DESCRIPTION
The exception handling to catch when eleveldb exits a fold early was omitted from the fold_buckets function, but with the addition of the secondary index capability to the backend, bucket listing can break out of fold_buckets early. This change adds that exception handling to the fold_buckets function.

See the bugzilla ticket [here](https://issues.basho.com/show_bug.cgi?id=1202) for steps to reproduce the problem and verify the fix.
