### PR TITLE
bz://1215 fsm crash on timeout

### DIFF
--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -228,9 +228,10 @@ waiting_vnode_r({r, VnodeResult, Idx, _ReqId}, StateData = #state{get_core = Get
             {next_state, waiting_vnode_r, StateData#state{get_core = UpdGetCore}}
     end;
 waiting_vnode_r(request_timeout, StateData) ->
-    update_stats(StateData),
-    client_reply({error,timeout}, StateData),
-    finalize(StateData).
+    S2 = update_timing(StateData),
+    update_stats(S2),
+    client_reply({error,timeout}, S2),
+    finalize(S2).
 
 %% @private
 waiting_read_repair({r, VnodeResult, Idx, _ReqId},

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -165,6 +165,7 @@ validate(timeout, StateData=#state{from = {raw, ReqId, _Pid}, options = Options,
     PR0 = get_option(pr, Options, ?DEFAULT_PR),
     R = riak_kv_util:expand_rw_value(r, R0, BucketProps, N),
     PR = riak_kv_util:expand_rw_value(pr, PR0, BucketProps, N),
+    NumVnodes = length(PL2),
     NumPrimaries = length([x || {_,primary} <- PL2]),
     if
         R =:= error ->
@@ -181,6 +182,9 @@ validate(timeout, StateData=#state{from = {raw, ReqId, _Pid}, options = Options,
             {stop, normal, StateData};
         PR > NumPrimaries ->
             client_reply({error, {pr_val_unsatisfied, PR, NumPrimaries}}, StateData),
+            {stop, normal, StateData};
+        R > NumVnodes ->
+            client_reply({error, {insufficient_vnodes, NumVnodes, need, R}}, StateData),
             {stop, normal, StateData};
         true ->
             BQ0 = get_option(basic_quorum, Options, default),

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -378,13 +378,16 @@ update(_, _, State) ->
 tick(Field, State) ->
     basho_metrics_nifs:meter_tick(element(2, element(Field, State))).
 
-update_metric(Field, Value, State) ->
+update_metric(Field, Value, State) when is_integer(Value) ->
     case element(Field, State) of
         {meter, M} ->
             basho_metrics_nifs:meter_update(M, Value);
         {histogram, H} ->
             basho_metrics_nifs:histogram_update(H, Value)
     end,
+    State;
+update_metric(Field, Value, State) ->
+    lager:error("Ignoring non-integer stats update for field ~p, value ~p", [Field, Value]),
     State.
 
 %% @spec update(Stat::term(), integer(), state()) -> state()


### PR DESCRIPTION
Fixes get FSM crash on timeout and as a bonus fixed bz://475.  If all vnodes are down you should now get errrors for get or put FSMs.

To reproduce put issue

```
O = riak_object:new(<<"b">>, <<"k">>, <<"eggs">>),
riak_core_node_watcher:node_down(),
{ok, C} = riak:local_client(), C:put(O, [{timeout, 100}]).
```

And get

```
riak_core_node_watcher:node_down().
{ok,C}=riak:local_client().
C:get(<<"b">>,<<"k">>,[{timeout, 100}]).
```
