### PR TITLE
AZ754 - Execute 2i PreCommit Hook Last 

### DIFF
--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -262,7 +262,7 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                 if Disable -> [];
                    true ->
                         L = get_hooks(precommit, BucketProps),
-                        [?PARSE_INDEX_PRECOMMIT|L]
+                        L ++ [?PARSE_INDEX_PRECOMMIT]
                 end,
             Postcommit =
                 if Disable -> [];


### PR DESCRIPTION
Move index precommit hook to the end of all precommit hooks. 

This makes sure that the system correctly parses and validates any index entries that a user has added in a custom Pre-Commit hook.
