### PR TITLE
prevent connection reuse after pipe mapred error (BZ1222)

### DIFF
--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -286,6 +286,12 @@ pipe_stream_mapred_results(RD, Pipe,
 %% This is used to workaround an issue in mochiweb, where the loop
 %% waiting for new TCP data receives a latent pipe message instead,
 %% and blows up, sending a 400 to the requester.
+%%
+%% WARNING: This uses an undocumented feature of mochiweb that exists
+%% in 1.5.1 (the version planned to ship with Riak 1.0).  The feature
+%% appears to still exist in mochiweb 2.2.1, but it may go away in
+%% future mochiweb releases.
+%%
 %% See [https://issues.basho.com/1222] for more details.
 prevent_keepalive() ->
     erlang:put(mochiweb_request_force_close, true).

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -183,14 +183,17 @@ pipe_mapred_nonchunked(RD, State, Pipe, NumKeeps, Sender) ->
         {error, {sender_error, Error}} ->
             %% the sender links to the builder, so the builder has
             %% already been torn down
+            prevent_keepalive(),
             {{halt, 500}, send_error(Error, RD), State};
         {error, timeout} ->
             %% destroying the pipe will tear down the linked sender
             riak_pipe:destroy(Pipe),
+            prevent_keepalive(),
             {{halt, 500}, send_error({error, timeout}, RD), State};
         {error, {Error, _Input}} ->
             %% TODO: jsonify Input for error message
             riak_pipe:destroy(Pipe),
+            prevent_keepalive(),
             {{halt, 500}, send_error({error, Error}, RD), State}
     end.
 
@@ -268,13 +271,24 @@ pipe_stream_mapred_results(RD, Pipe,
             {iolist_to_binary(["\r\n--", Boundary, "--\r\n"]), done};
         {error, timeout} ->
             riak_pipe:destroy(Pipe),
+            prevent_keepalive(),
             {format_error({error, timeout}), done};
         {error, {sender_error, Error}} ->
+            prevent_keepalive(),
             {format_error(Error), done};
         {error, {Error, _Input}} ->
             riak_pipe:destroy(Pipe),
+            prevent_keepalive(),
             {format_error({error, Error}), done}
     end.
+
+%% @doc Prevent this socket from being used for another HTTP request.
+%% This is used to workaround an issue in mochiweb, where the loop
+%% waiting for new TCP data receives a latent pipe message instead,
+%% and blows up, sending a 400 to the requester.
+%% See [https://issues.basho.com/1222] for more details.
+prevent_keepalive() ->
+    erlang:put(mochiweb_request_force_close, true).
 
 %% LEGACY MAPRED
 


### PR DESCRIPTION
Because of the way pipe sends results, sending the response to the client
before eoi means that the request process may still have messages in its
mailbox.  If mochiweb tries to keep the connection alive, its next loop will
receive one of these messages instead of HTTP/TCP data, which will cause it
to send a 400 to the client.  The interim fix here is to just tear down the
connection, unconditionally, after the initial mapred error is sent, forcing
the client to reconnect for its next request.

I think there may still be one corner case where a similar receive->400 might happen after a successful mapred, but we haven't yet seen that in testing, and that fix will be much more invasive.
