### PR TITLE
add 2i capability to multi_backend

### DIFF
--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -230,13 +230,24 @@ delete(Bucket, Key, IndexSpecs, State) ->
 fold_buckets(FoldBucketsFun, Acc, Opts, State) ->
     fold(undefined, fold_buckets, FoldBucketsFun, Acc, Opts, State).
 
+%% @doc Given `FoldOptions', determine bucket (if any) that it is constrained to.
+get_fold_bucket([]) ->
+    undefined;
+get_fold_bucket([{bucket, Bucket}|_]) ->
+    Bucket;
+get_fold_bucket([{index, Bucket, _}|_]) ->
+    Bucket;
+get_fold_bucket([_|T]) ->
+    get_fold_bucket(T).
+
+
 %% @doc Fold over all the keys for one or all buckets.
 -spec fold_keys(riak_kv_backend:fold_keys_fun(),
                 any(),
                 [{atom(), term()}],
                 state()) -> {ok, any()} | {async, fun()} | {error, term()}.
 fold_keys(FoldKeysFun, Acc, Opts, State) ->
-    Bucket = proplists:get_value(bucket, Opts),
+    Bucket = get_fold_bucket(Opts),
     fold(Bucket, fold_keys, FoldKeysFun, Acc, Opts, State).
 
 %% @doc Fold over all the objects for one or all buckets.
@@ -245,7 +256,7 @@ fold_keys(FoldKeysFun, Acc, Opts, State) ->
                    [{atom(), term()}],
                    state()) -> {ok, any()} | {async, fun()} | {error, term()}.
 fold_objects(FoldObjectsFun, Acc, Opts, State) ->
-    Bucket = proplists:get_value(bucket, Opts),
+    Bucket = get_fold_bucket(Opts),
     fold(Bucket, fold_objects, FoldObjectsFun, Acc, Opts, State).
 
 %% @doc Delete all objects from the different backends

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -38,6 +38,9 @@
          status/1,
          callback/3]).
 
+%% Special multi_backend API
+-export([is_index_backend/2]).
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
@@ -412,6 +415,15 @@ error_filter({error, _, _}) ->
     true;
 error_filter(_) ->
     false.
+
+%% 
+%% Say if the backend with given Bucket/State is an index backend
+%%
+is_index_backend(Bucket,State) ->
+    {_, Module, _} = get_backend(Bucket,State),
+    {_, Capabilities} = Module:api_version(),
+    lists:member(indexes, Capabilities).
+    
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -449,9 +449,9 @@ handle_coverage(?KV_INDEX_REQ{bucket=Bucket,
             FinishFun = finish_fun(BufferMod, Sender),
             case AsyncBackend of
                 true ->
-                    Opts = [async_fold, {bucket, Bucket}, {index, Bucket, Query}];
+                    Opts = [async_fold, {index, Bucket, Query}];
                 false ->
-                    Opts = [{bucket, Bucket}, {index, Bucket, Query}]
+                    Opts = [{index, Bucket, Query}]
             end,
             case list(FoldFun, FinishFun, Mod, fold_keys, ModState, Opts, Buffer) of
                 {async, AsyncWork} ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -449,9 +449,9 @@ handle_coverage(?KV_INDEX_REQ{bucket=Bucket,
             FinishFun = finish_fun(BufferMod, Sender),
             case AsyncBackend of
                 true ->
-                    Opts = [async_fold, {index, Bucket, Query}];
+                    Opts = [async_fold, {bucket, Bucket}, {index, Bucket, Query}];
                 false ->
-                    Opts = [{index, Bucket, Query}]
+                    Opts = [{bucket, Bucket}, {index, Bucket, Query}]
             end,
             case list(FoldFun, FinishFun, Mod, fold_keys, ModState, Opts, Buffer) of
                 {async, AsyncWork} ->


### PR DESCRIPTION
Here is a basic patch to make multi backend work with secondary indexing.  

I have only tested with this simple positive case:

```
        {storage_backend, riak_kv_multi_backend},                                                                                                                                                     
        {multi_backend_default, <<"leveldb">>},                                                                                                                                                       
        {multi_backend, [                                                                                                                                                                             
           {<<"leveldb">>, riak_kv_eleveldb_backend, [                                                                                                                                                
             {data_root, "data/leveldb"}                                                                                                                                                              
           ]},                                                                                                                                                                                        
           {<<"bitcask">>, riak_kv_bitcask_backend, [                                                                                                                                                 
             {data_root, "data/bitcask"}                                                                                                                                                              
           ]}                                                                                                                                                                                         
        ]},       

krab$ curl -v -X PUT -d 'payload' -H 'X-Riak-Index-num_int: 2' http://127.0.0.1:8091/riak/test/doc2
krab$ curl -v http://127.0.0.1:8091/buckets/test/index/num_int/1


krab$ curl -v http://127.0.0.1:809/buckets/test/index/num_int/2
{"keys":["doc2"]}
```

Obviously, this would need to go through your rigorous testing procedures; ... consider it a suggestion.
