### PR TITLE
Fix bitcask fd leak

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -225,7 +225,6 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{opts=BitcaskOpts,
                             Ref1 when is_reference(Ref1) ->
                                 FoldResults =
                                     bitcask:fold_keys(Ref1, FoldFun, Acc),
-                                io:format("Closing Ref1~n"),
                                 bitcask:close(Ref1),
                                 FoldResults;
                             {error, Reason} ->

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -186,6 +186,7 @@ fold_buckets(FoldBucketsFun, Acc, Opts, #state{opts=BitcaskOpts,
                                     bitcask:fold_keys(Ref1,
                                                       FoldFun,
                                                       {Acc, sets:new()}),
+                                bitcask:close(Ref1),
                                 Acc1;
                             {error, Reason} ->
                                 {error, Reason}
@@ -222,7 +223,11 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{opts=BitcaskOpts,
                         case bitcask:open(filename:join(DataRoot, DataFile),
                                           ReadOpts) of
                             Ref1 when is_reference(Ref1) ->
-                                bitcask:fold_keys(Ref1, FoldFun, Acc);
+                                FoldResults =
+                                    bitcask:fold_keys(Ref1, FoldFun, Acc),
+                                io:format("Closing Ref1~n"),
+                                bitcask:close(Ref1),
+                                FoldResults;
                             {error, Reason} ->
                                 {error, Reason}
                         end
@@ -257,7 +262,10 @@ fold_objects(FoldObjectsFun, Acc, Opts, #state{opts=BitcaskOpts,
                         case bitcask:open(filename:join(DataRoot, DataFile),
                                           ReadOpts) of
                             Ref1 when is_reference(Ref1) ->
-                                bitcask:fold(Ref1, FoldFun, Acc);
+                                FoldResults =
+                                    bitcask:fold(Ref1, FoldFun, Acc),
+                                bitcask:close(Ref1),
+                                FoldResults;
                             {error, Reason} ->
                                 {error, Reason}
                         end


### PR DESCRIPTION
Make sure the asynchronous bucket, key, and object folding functions properly close the bitcask reference they open after completing the fold operation to ensure prompt cleanup of the associated system resources.

The bugzilla ticket is [here](https://issues.basho.com/show_bug.cgi?id=1237) and describes a method to reproduce the error as well as a command line script Scott created to spit out file descriptor usage.
