### PR TITLE
Allow per-phase pre-reduce for JS/HTTP queries

### DIFF
--- a/src/riak_kv_mrc_pipe.erl
+++ b/src/riak_kv_mrc_pipe.erl
@@ -346,12 +346,12 @@ map2pipe(FunSpec, Arg, Keep, I, QueryT) ->
                     chashfun=follow} || Keep]
      ++
      if PrereduceP ->
-             {reduce, R_FunSpec, _R_Arg, _Keep} = element(I+2, QueryT),
+             {reduce, R_FunSpec, R_Arg, _Keep} = element(I+2, QueryT),
              [#fitting_spec{name={prereduce,I},
                             module=riak_kv_w_reduce,
                             arg={rct,
                                  riak_kv_w_reduce:reduce_compat(R_FunSpec),
-                                 Arg},
+                                 R_Arg},
                             chashfun=follow}];
         true ->
              []

--- a/src/riak_kv_mrc_pipe.erl
+++ b/src/riak_kv_mrc_pipe.erl
@@ -365,10 +365,13 @@ want_prereduce_p(Idx, QueryT) ->
     {map, _FuncSpec, Arg, _Keep} = element(Idx, QueryT),
     Props = case Arg of
                 L when is_list(L) -> L;         % May or may not be a proplist
+                {struct, L}       -> L;         % mochijson form
                 _                 -> []
             end,
     AppDefault = app_helper:get_env(riak_kv, mapred_always_prereduce, false),
-    proplists:get_value(do_prereduce, Props, AppDefault).
+    true =:= proplists:get_value(
+               <<"do_prereduce">>, Props,       % mochijson form
+               proplists:get_value(do_prereduce, Props, AppDefault)).
 
 -spec query_type(integer(), tuple()) -> map | reduce | link.
 query_type(Idx, QueryT) ->


### PR DESCRIPTION
https://issues.basho.com/show_bug.cgi?id=1213
https://issues.basho.com/show_bug.cgi?id=1238

This PR does three things:
1. allow enabling/disabling pre-reduce for JS map phases (by filtering out the un-jsonifiable Erlang proplist bit in the static arg) - BZ1213
2. allow enabling/disabling pre-reduce of JS map phases over HTTP (by accepting a mochijson arg with a do_prereduce prop) - BZ1213
3. pass the reduce arg instead of the map arg to the prereduce function (because it's an instance of the subsequent reduce phase, not the map phase) - BZ1238
