### PR TITLE
Do not call riak_client:get in ensure_doc if key is undefined.

### DIFF
--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -807,6 +807,8 @@ decode_vclock_header(RD) ->
 %%      convenience for memoizing the result of a get so it can be
 %%      used in multiple places in this resource, without having to
 %%      worry about the order of executing of those places.
+ensure_doc(Ctx=#ctx{doc=undefined, key=undefined}) ->
+    Ctx#ctx{doc={error, notfound}};
 ensure_doc(Ctx=#ctx{doc=undefined, bucket=B, key=K, client=C, r=R,
         pr=PR, basic_quorum=Quorum, notfound_ok=NotFoundOK}) ->
     Ctx#ctx{doc=C:get(B, K, [deletedvclock, {r, R}, {pr, PR},


### PR DESCRIPTION
When posting an object without a key, the value of the key starts as the atom `undefined` and `riak_kv_wm_object:ensure_doc` calls `riak:client:get` and uses `undefined` as the value for the key. Atoms are not acceptable as key input to `riak_client:get`. The problem mainly manifests when using the Innostore backend. Innostore assumes that the key is a binary and calls `erlang:size/1` on the key value. When the key is `undefined` this results in an exception being thrown by Innostore. The POST to create the object will succeed, but not until after the call to riak_client:get times out and this can be a significant delay.

This change adds another function clause to riak_kv_wm_object:ensure_doc to set the doc member of the context record to `{error, notfound}` in the case where the key is `undefined`.
