### PR TITLE
Fix backup/restore bug caused by misuse of fixed-up ring

### DIFF
--- a/src/riak_kv_backup.erl
+++ b/src/riak_kv_backup.erl
@@ -40,7 +40,7 @@ backup(EntryNode, BaseFilename, Mode) ->
     ensure_connected(EntryNode),
 
     % Get a list of nodes...
-    {ok, Ring} = rpc:call(EntryNode, riak_core_ring_manager, get_my_ring, []),
+    {ok, Ring} = rpc:call(EntryNode, riak_core_ring_manager, get_raw_ring, []),
     Members = riak_core_ring:all_members(Ring),
 
     FileName = 
@@ -177,7 +177,7 @@ ensure_connected(Node) ->
 %% throw exception on failure.
 ensure_synchronized(Ring, Members) ->
     F = fun(Node) ->
-        {ok, Ring2} = rpc:call(Node, riak_core_ring_manager, get_my_ring, []),
+        {ok, Ring2} = rpc:call(Node, riak_core_ring_manager, get_raw_ring, []),
         riak_core_ring:equal_rings(Ring, Ring2)
     end,
     case lists:all(F, Members) of


### PR DESCRIPTION
Change riak_kv_backup from using get_my_ring to get_raw_ring so that the rings passed into the equal_rings check don't needlessly fail due to local (fixed-up) ring modifications. Without this change, backup/restore fail on clusters that engage the ring fix-up logic.

Fixes BZ1249
