### PR TITLE
Fix bitcask backend to delete pre-1.0 data directories

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -553,7 +553,8 @@ drop_data_cleanup(DataRoot, Partition, DataDir) ->
                     [data_directory_cleanup(filename:join(DataRoot, Dir)) ||
                         Dir <- Dirs,
                         Dir /= lists:flatten(DataDir),
-                        string:left(Dir, length(PartitionStr) + 1) =:= (PartitionStr ++ "-")];
+                        (Dir =:= PartitionStr) or
+                        (string:left(Dir, length(PartitionStr) + 1) =:= (PartitionStr ++ "-"))];
                 {error, _} ->
                     ignore
             end


### PR DESCRIPTION
Upgrading 0.14.2 cluster to 1.0 cluster would result in two naming conventions for bitcask data directories: <index> and <index>-<timestamp> for 0.14.2 and 1.0 respectively. The bitcask backend would not clean-up the older <index> named directories, and therefore data would remain around after handoff. This pull-request fixes that.

Fixes bz1250
