### PR TITLE
BZ1254: Expose tombstones in siblings and link-walking queries over HTTP.

### DIFF
--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -27,6 +27,7 @@
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
+-include("riak_kv_wm_raw.hrl").
 
 -export([start_link/6, start_link/7, start_link/8, delete/8]).
 
@@ -72,7 +73,7 @@ delete(ReqId,Bucket,Key,Options,Timeout,Client,ClientId,VClock) ->
         {error, Reason} ->
             Client ! {ReqId, {error, Reason}};
         {W, PW, DW} ->
-            Obj0 = riak_object:new(Bucket, Key, <<>>, dict:store(<<"X-Riak-Deleted">>,
+            Obj0 = riak_object:new(Bucket, Key, <<>>, dict:store(?MD_DELETED,
                                                                  "true", dict:new())),
             Tombstone = riak_object:set_vclock(Obj0, VClock),
             {ok,C} = riak:local_client(ClientId),

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -23,6 +23,7 @@
 -define(MD_LASTMOD,  <<"X-Riak-Last-Modified">>).
 -define(MD_USERMETA, <<"X-Riak-Meta">>).
 -define(MD_INDEX,    <<"index">>).
+-define(MD_DELETED,  <<"X-Riak-Deleted">>).
 
 %% Names of HTTP header fields
 -define(HEAD_CTYPE,           "Content-Type").
@@ -32,6 +33,7 @@
 -define(HEAD_CLIENT,          "X-Riak-ClientId").
 -define(HEAD_USERMETA_PREFIX, "x-riak-meta-").
 -define(HEAD_INDEX_PREFIX,    "x-riak-index-").
+-define(HEAD_DELETED,         "X-Riak-Deleted").
 
 %% Names of JSON fields in bucket properties
 -define(JSON_PROPS,   <<"props">>).

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -121,6 +121,12 @@ multipart_encode_body(Prefix, Bucket, {MD, V}, APIVersion) ->
              Rfc1123
      end,
      "\r\n",
+     case dict:find(?MD_DELETED, MD) of
+         {ok, "true"} ->
+             [?HEAD_DELETED, ": true\r\n"];
+         error ->
+             []
+     end,
      case dict:find(?MD_USERMETA, MD) of
          {ok, M} ->
             lists:foldl(fun({Hdr,Val},Acc) ->


### PR DESCRIPTION
As discussed in http://issues.basho.com/1254, tombstones that have not been reaped may appear in link-walking queries but only appear to be empty objects with a Content-Type of "application/octet-stream". This adds the X-Riak-Deleted header to multipart bodies emitted by link-walking queries (and consequentially siblings that are tombstones in normal fetches).

Response after this fix:

``` text
HTTP/1.1 200 OK
Server: MochiWeb/1.1 WebMachine/1.9.0 (participate in the frantic)
Expires: Tue, 18 Oct 2011 19:20:14 GMT
Date: Tue, 18 Oct 2011 19:10:14 GMT
Content-Type: multipart/mixed; boundary=ADqgQtdmA5iQgyR5UGzX6V3HZtI
Content-Length: 481


--ADqgQtdmA5iQgyR5UGzX6V3HZtI
Content-Type: multipart/mixed; boundary=Ljz1mP3hZzqPu6DH1Y4L8k7hfxy

--Ljz1mP3hZzqPu6DH1Y4L8k7hfxy
X-Riak-Vclock: a85hYGBgzGDKBVIcypz/fvrNPcuWwZTIlMfKIOotdIIvCwA=
Location: /buckets/links/keys/target
Content-Type: application/octet-stream
Link: </buckets/links>; rel="up"
Etag: 5bUNdzHJhZDdCr7KlWxXq
Last-Modified: Tue, 18 Oct 2011 19:10:13 GMT
X-Riak-Deleted: true


--Ljz1mP3hZzqPu6DH1Y4L8k7hfxy--

--ADqgQtdmA5iQgyR5UGzX6V3HZtI--
```
