### PR TITLE
Add siblings and objsize stats (AZ895)

### DIFF
--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -357,7 +357,7 @@ update_stats({ok, Obj}, #state{get_usecs = GetUsecs}) ->
         lists:sum([size(term_to_binary(MD)) + size(Value) || {MD, Value} <- Contents]),
     riak_kv_stat:update({get_fsm, undefined, GetUsecs, NumSiblings, ObjSize});
 update_stats(_, #state{get_usecs = GetUsecs}) ->
-    riak_kv_stat:update({get_fsm, undefined, GetUsecs, 0, 0}).
+    riak_kv_stat:update({get_fsm, undefined, GetUsecs, undefined, undefined}).
 
 client_info(true, StateData, Acc) ->
     client_info(details(), StateData, Acc);

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -226,14 +226,14 @@ waiting_vnode_r({r, VnodeResult, Idx, _ReqId}, StateData = #state{get_core = Get
             {Reply, UpdGetCore2} = riak_kv_get_core:response(UpdGetCore),
             NewStateData2 = update_timing(StateData#state{get_core = UpdGetCore2}),
             client_reply(Reply, NewStateData2),
-            update_stats(NewStateData2),
+            update_stats(Reply, NewStateData2),
             maybe_finalize(NewStateData2);
         false ->
             {next_state, waiting_vnode_r, StateData#state{get_core = UpdGetCore}}
     end;
 waiting_vnode_r(request_timeout, StateData) ->
     S2 = update_timing(StateData),
-    update_stats(S2),
+    update_stats(timeout, S2),
     client_reply({error,timeout}, S2),
     finalize(S2).
 
@@ -342,8 +342,22 @@ update_timing(StateData = #state{startnow = StartNow}) ->
     EndNow = now(),
     StateData#state{get_usecs = timer:now_diff(EndNow, StartNow)}.
 
-update_stats(#state{get_usecs = GetUsecs}) ->
-    riak_kv_stat:update({get_fsm_time, GetUsecs}).    
+update_stats({ok, Obj}, #state{get_usecs = GetUsecs}) ->
+    %% Get the number of siblings and the object size. For object
+    %% size, get an approximation by adding together the bucket, key,
+    %% vectorclock, and all of the siblings. This is more complex than
+    %% calling term_to_binary/1, but it should be easier on memory,
+    %% especially for objects with large values.
+    NumSiblings = riak_object:value_count(Obj),
+    Contents = riak_object:get_contents(Obj),
+    ObjSize =
+        size(riak_object:bucket(Obj)) +
+        size(riak_object:key(Obj)) +
+        size(term_to_binary(riak_object:vclock(Obj))) +
+        lists:sum([size(term_to_binary(MD)) + size(Value) || {MD, Value} <- Contents]),
+    riak_kv_stat:update({get_fsm, undefined, GetUsecs, NumSiblings, ObjSize});
+update_stats(_, #state{get_usecs = GetUsecs}) ->
+    riak_kv_stat:update({get_fsm, undefined, GetUsecs, 0, 0}).
 
 client_info(true, StateData, Acc) ->
     client_info(details(), StateData, Acc);

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -177,10 +177,6 @@
 
 -behaviour(gen_server2).
 
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
--endif.
-
 %% API
 -export([start_link/0, get_stats/0, get_stats/1, update/1]).
 
@@ -747,58 +743,3 @@ pbc_stats(_, State=#state{pbc_connects_total=NCT,
 
 remove_slide_private_dirs() ->
     os:cmd("rm -rf " ++ slide:private_dir()).
-
--ifdef(TEST).
-
-%% Test that we can change from current state to old state and back
-%% without any problems.
-code_change_test() ->
-    State = #state{
-      vnode_gets=1,
-      vnode_puts=2,
-      vnode_gets_total=3,
-      vnode_puts_total=4,
-      vnode_index_reads=5,
-      vnode_index_reads_total=6,
-      vnode_index_writes=7,
-      vnode_index_writes_total=8,
-      vnode_index_writes_postings=9,
-      vnode_index_writes_postings_total=10,
-      vnode_index_deletes=11,
-      vnode_index_deletes_total=12,
-      vnode_index_deletes_postings=13,
-      vnode_index_deletes_postings_total=14,
-      node_gets_total=15,
-      node_puts_total=16,
-      node_get_fsm_siblings=slide:fresh(),
-      node_get_fsm_objsize=slide:fresh(),
-      get_fsm_time=19,
-      put_fsm_time=20,
-      pbc_connects=21,
-      pbc_connects_total=22,
-      pbc_active=23,
-      read_repairs=24,
-      read_repairs_total=25,
-      coord_redirs=26,
-      coord_redirs_total=27,
-      mapper_count=28,
-      get_meter=29,
-      put_meter=30,
-      legacy=31},
-
-    %% Check that we can upgrade and downgrade the State multiple
-    %% times and still get the same result.
-    {ok, NewState1} = code_change({down, foo}, State, ignored),
-    {ok, NewState2} = code_change(foo, NewState1, ignore),
-    {ok, NewState3} = code_change({down, foo}, NewState2, ignored),
-    {ok, NewState4} = code_change(foo, NewState3, ignore),
-
-    %% The `fsm_siblings` and `fsm_objsize` fields are reset to
-    %% `slide:fresh()` when we upgrade, so ignore those because they
-    %% will be different.
-    ?assertEqual(
-       State#state     { node_get_fsm_siblings=undefined, node_get_fsm_objsize=undefined },
-       NewState4#state { node_get_fsm_siblings=undefined, node_get_fsm_objsize=undefined }),
-    ok.
-
--endif.

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -68,15 +68,18 @@
 %%</dd><dt> node_gets
 %%</dt><dd> Number of gets coordinated by this node in the last
 %%          minute.
-%%</dd><dd> update({get_fsm_time, Microseconds})
+%%</dd><dd> update({get_fsm, _Bucket, Microseconds, NumSiblings, ObjSize})
 %%
 %%</dd><dt> node_get_fsm_siblings
 %%</dt><dd> Stats about number of siblings per object in the last minute.
-%%</dd><dd> update({node_get_fsm_siblings, NumSiblings})
+%%</dd><dd> Updated via node_gets.
 %%
 %%</dd><dt> node_get_fsm_objsize
-%%</dt><dd> Stats about object size over the last minute.
-%%</dd><dd> update({node_get_fsm_objsize, ObjSize)
+%%</dt><dd> Stats about object size over the last minute. The object
+%%          size is an estimate calculated by summing the size of the
+%%          bucket name, key name, and serialized vector clock, plus
+%%          the value and serialized metadata of each sibling.
+%%</dd><dd> Updated via node_gets.
 %%
 %%</dd><dt> node_get_fsm_time_mean
 %%</dt><dd> Mean time, in microseconds, between when a riak_kv_get_fsm is

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -371,6 +371,10 @@ update({vnode_index_write, Postings}, Moment, State=#state{vnode_index_writes_to
 update({vnode_index_delete, Postings}, Moment, State=#state{vnode_index_deletes_total=VID, vnode_index_deletes_postings_total=VIDP}) ->
     NewState = spiral_incr(#state.vnode_index_deletes, Moment, State#state{vnode_index_deletes_total=VID+1}),
     spiral_incr(#state.vnode_index_deletes_postings, Postings, Moment, NewState#state{vnode_index_deletes_postings_total=VIDP+Postings});
+update({get_fsm, _Bucket, Microsecs, undefined, undefined}, Moment, State) ->
+    NGT = State#state.node_gets_total,
+    NewState = State#state { node_gets_total=NGT+1 },
+    slide_incr(#state.get_fsm_time, Microsecs, Moment, NewState);
 update({get_fsm, _Bucket, Microsecs, NumSiblings, ObjSize}, Moment, State) ->
     NGT = State#state.node_gets_total,
     NewState1 = State#state { node_gets_total=NGT+1 },
@@ -378,8 +382,8 @@ update({get_fsm, _Bucket, Microsecs, NumSiblings, ObjSize}, Moment, State) ->
     NewState3 = slide_incr(#state.node_get_fsm_siblings, NumSiblings, Moment, NewState2),
     NewState4 = slide_incr(#state.node_get_fsm_objsize, ObjSize, Moment, NewState3),
     NewState4;
-update({get_fsm_time, Microsecs}, Moment, State=#state{node_gets_total=NGT}) ->
-    slide_incr(#state.get_fsm_time, Microsecs, Moment, State#state{node_gets_total=NGT+1});
+update({get_fsm_time, Microsecs}, Moment, State) ->
+    update({get_fsm, undefined, Microsecs, undefined, undefined}, Moment, State);
 update({put_fsm_time, Microsecs}, Moment, State=#state{node_puts_total=NPT}) ->
     slide_incr(#state.put_fsm_time, Microsecs, Moment, State#state{node_puts_total=NPT+1});
 update(pbc_connect, Moment, State=#state{pbc_connects_total=NCT, pbc_active=Active}) ->


### PR DESCRIPTION
## Overview

This code adds Riak stats for `node_get_fsm_siblings` and
`node_get_fsm_objsize`, and supports hot upgrades (no need to restart
the node.)

**IMPORTANT**: Relies on https://github.com/basho/riak_core/pull/104
## Hot Upgrade

On a running Riak node:
1. Back up the following files:
   - `/usr/lib/riak/lib/riak_kv-1.0.1/ebin/riak_kv_stat.beam`
   - `/usr/lib/riak/lib/riak_kv-1.0.1/ebin/riak_kv_get_fsm.beam`
   - `/usr/lib/riak/lib/riak_core-1.0.1/ebin/slide.beam`
2. Replace old beam files with new beam files:
   - Copy `riak_kv_stat.beam` to `/usr/lib/riak/lib/riak_kv-1.0.1/ebin/riak_kv_stat.beam`
   - Copy `riak_kv_get_fsm.beam` to `/usr/lib/riak/lib/riak_kv-1.0.1/ebin/riak_kv_get_fsm.beam`
   - Copy `slide.beam` to `/usr/lib/riak/lib/riak_core-1.0.1/ebin/slide.beam`
3. Run `riak attach` to connect to the Erlang shell and paste the
   following commands. After running the commands, you will see an
   error message `[error] Supervisor riak_kv_sup had child
   riak_kv_stat... killed in context child_terminated`. This is
   expected and can be ignored.

``` erlang
c:l(slide).
sys:suspend(riak_kv_stat).
c:l(riak_kv_stat).
erlang:exit(erlang:whereis(riak_kv_stat), kill).
sys:resume(riak_kv_stat).
c:l(riak_kv_get_fsm).
```
1. Press Control-D to disconnect from the Erlang shell.
2. To verify installation, run `curl localhost:8098/stats` and look
   for a stat named `node_get_fsm_siblings_total`.
## Hot Downgrade

On a running Riak node:
1. Restore the files you backed up in Step #1 of  **Hot Upgrade**.
2. Run `riak attach` to connect to the Erlang shell and paste the
   following commands. After running the commands, you will see an
   error message `[error] Supervisor riak_kv_sup had child
   riak_kv_stat... killed in context child_terminated`. This is
   expected and can be ignored.

``` erlang
c:l(riak_kv_get_fsm).
sys:suspend(riak_kv_stat).
c:l(riak_kv_stat).
erlang:exit(erlang:whereis(riak_kv_stat), kill).
sys:resume(riak_kv_stat).
c:l(slide).
```
1. Press Control-D to disconnect from the Erlang shell.
2. To verify, run `curl localhost:8098/stats` and ensure that the stat
   named `node_get_fsm_siblings_total` does not exist.
## Rolling Upgrade / Downgrade

On a running Riak node:
1. Back up the following files:
   - `/usr/lib/riak/lib/riak_kv-1.0.1/ebin/riak_kv_stat.beam`
   - `/usr/lib/riak/lib/riak_kv-1.0.1/ebin/riak_kv_get_fsm.beam`
   - `/usr/lib/riak/lib/riak_core-1.0.1/ebin/slide.beam`
2. Replace old beam files with new beam files:
   - Copy `riak_kv_stat.beam` to `/usr/lib/riak/lib/riak_kv-1.0.1/ebin/riak_kv_stat.beam`
   - Copy `riak_kv_get_fsm.beam` to `/usr/lib/riak/lib/riak_kv-1.0.1/ebin/riak_kv_get_fsm.beam`
   - Copy `slide.beam` to `/usr/lib/riak/lib/riak_core-1.0.1/ebin/slide.beam`
3. Restart the Riak node.

To downgrade, restore the previously backed up .beam files.
## Notes
- Updated the `riak_kv_stat` module to support `node_get_fsm_siblings` and
  `node_get_fsm_objsize` stats, tracking number of siblings and object
  size, respectively. Also updated stats module `code_changed/N`
  function to enable hot upgrades. (No need to take down the VM if
  upgrading from Riak 1.0.1.)
- Updated the `riak_kv_get_fsm` module to send stats about # of siblings
  and object size to the stats module.
- Noticed that sometimes 99% stats are larger than 100% stats. Assuming
  that this is due to a small sample size plus the fact that 99% stats
  being estimated while 100% stats are the actual max.
- Calculating object size by summing the bucket size, key size, using
  `term_to_binary/1` on the vector clock, and the metadata and value
  sibling. This isn't as exact of a calculation because it doesn't
  capture some of the overhead (ie: it doesn't count the size of the
  tuple that wraps the metadata and value.) But from what I've seen it's
  within 10% of the object size.
- Tested performance of old and new code via basho_bench. Adding the new
  stats had no discernible affect on performance.
## Test Code

``` erlang
%% Some rough smoke-testing code. Just copy this code and paste into
%% an Erlang shell. Creates siblings of different sizes, prints out
%% the stats, then pauses for 5 seconds.

%% The CreateSiblings/1 function creates creates an object with the
%% specified number of siblings.
CreateSiblings = fun(N) ->
    {ok, Client} = riak:local_client(),
    Client:set_bucket(<<"mybucket">>, [{allow_mult, true}]),
    Key = erlang:md5(term_to_binary(now())),
    Obj = riak_object:new(<<"mybucket">>, Key, <<"1">>),
    [Client:put(Obj) || _X <- lists:seq(1, N)],
    Client:get(<<"mybucket">>, Key),
    ok
end.

%% Print `fsm_siblings` and `fsm_objsize` stats.
PrintStats = fun() ->
    %% Use apply so that we don't hold a reference to old code.
    Stats = erlang:apply(riak_kv_stat, get_stats, []),
    io:format("---~n"),
    io:format("~p~n", [lists:keyfind(node_get_fsm_siblings_mean,   1, Stats)]),
    io:format("~p~n", [lists:keyfind(node_get_fsm_siblings_median, 1, Stats)]),
    io:format("~p~n", [lists:keyfind(node_get_fsm_siblings_95,     1, Stats)]),
    io:format("~p~n", [lists:keyfind(node_get_fsm_siblings_99,     1, Stats)]),
    io:format("~p~n", [lists:keyfind(node_get_fsm_siblings_100,    1, Stats)]),
    io:format("~p~n", [lists:keyfind(node_get_fsm_objsize_mean,    1, Stats)]),
    io:format("~p~n", [lists:keyfind(node_get_fsm_objsize_median,  1, Stats)]),
    io:format("~p~n", [lists:keyfind(node_get_fsm_objsize_95,      1, Stats)]),
    io:format("~p~n", [lists:keyfind(node_get_fsm_objsize_99,      1, Stats)]),
    io:format("~p~n", [lists:keyfind(node_get_fsm_objsize_100,     1, Stats)]),
    ok
end.

CreateSiblings(1).
PrintStats().
timer:sleep(5 * 1000).

CreateSiblings(10).
PrintStats().
timer:sleep(5 * 1000).

CreateSiblings(100).
PrintStats().
timer:sleep(5 * 1000).

CreateSiblings(2).
PrintStats().
timer:sleep(5 * 1000).

CreateSiblings(20).
PrintStats().
timer:sleep(5 * 1000).

CreateSiblings(200).
PrintStats().
timer:sleep(5 * 1000).

CreateSiblings(3).
PrintStats().
timer:sleep(5 * 1000).

CreateSiblings(30).
PrintStats().
timer:sleep(5 * 1000).

CreateSiblings(300).
PrintStats().
```
