### PR TITLE
Properly sort results for comparison in bitcask startup_dir_test.

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -720,7 +720,7 @@ startup_data_dir_test() ->
     [_ | RemovalPartitionDirs] = lists:reverse(TSPartitionDirs),
     os:cmd("rm -rf test/bitcask-backend/*"),
     ?assertEqual(["42", "manual_cleanup"], lists:sort(DataDirs)),
-    ?assertEqual(RemovalPartitionDirs, RemovalDirs).
+    ?assertEqual(RemovalPartitionDirs, lists:reverse(lists:sort(RemovalDirs))).
 
 drop_test() ->
     os:cmd("rm -rf test/bitcask-backend/*"),


### PR DESCRIPTION
For the test to behave properly the results from the call to `file:list_dir` must be sorted and reversed.
