### PR TITLE
Add custom webmachine routes found in app config

### DIFF
--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -43,6 +43,8 @@ start_link() ->
 init([]) ->
     [ webmachine_router:add_route(R)
       || R <- lists:reverse(riak_kv_web:dispatch_table()) ],
+    [ webmachine_router:add_route(R)
+      || R <- lists:reverse(app_helper:get_env(riak_kv, routes, [])) ],
     VMaster = {riak_kv_vnode_master,
                {riak_core_vnode_master, start_link,
                 [riak_kv_vnode, riak_kv_legacy_vnode]},


### PR DESCRIPTION
We are creating a logging and analytics system in Riak. The first new component is a webmachine module that serves an HTTP resource and logs the interactions directly in riak with a local client. The easiest way I found to add routes to webmachine when riak_kv starts is to look for routes in the config. This is a low-cost, back-compat solution.

Previously I added my custom route while starting a custom application after Riak had started. This is far less cumbersome and more timely.
