### PR TITLE
Improve MR Error Messages (AZ935)

### DIFF
--- a/src/riak_kv_js_vm.erl
+++ b/src/riak_kv_js_vm.erl
@@ -233,10 +233,14 @@ code_change(_OldVsn, State, _Extra) ->
 
 %% Internal functions
 define_invoke_anon_js(JS, Args, #state{ctx=Ctx}=State) ->
-    JSFun =  define_anon_js(JS, Args),
-    case invoke_js(Ctx, JSFun) of
-        {ok, R} ->
-            {{ok, R}, State};
+    case define_anon_js(JS, Args) of
+        {ok, JSFun} ->
+            case invoke_js(Ctx, JSFun) of
+                {ok, R} ->
+                    {{ok, R}, State};
+                Error ->
+                    {Error, State}
+            end;
         Error ->
             {Error, State}
     end.
@@ -280,7 +284,7 @@ invoke_js(Ctx, Js, Args) ->
 define_anon_js(JS, Args) ->
     try
         ArgList = build_arg_list(Args, []),
-        iolist_to_binary([JS, <<"(">>, ArgList, <<");">>])
+        {ok, iolist_to_binary([JS, <<"(">>, ArgList, <<");">>])}
     catch
         exit: {ucs, {bad_utf8_character_code}} ->
             lager:error("Error JSON encoding arguments: ~p", [Args]),

--- a/src/riak_kv_js_vm.erl
+++ b/src/riak_kv_js_vm.erl
@@ -274,11 +274,11 @@ invoke_js(Ctx, Js, Args) ->
     catch
         exit: {ucs, {bad_utf8_character_code}} ->
             lager:error("Error JSON encoding arguments: ~p", [Args]),
-            {error, bad_encoding};
+            {error, bad_utf8_character_code};
         exit: {json_encode, _} ->
             {error, bad_json};
         throw:invalid_utf8 ->
-            {error, bad_encoding}
+            {error, bad_utf8_character_code}
     end.
 
 define_anon_js(JS, Args) ->
@@ -288,11 +288,11 @@ define_anon_js(JS, Args) ->
     catch
         exit: {ucs, {bad_utf8_character_code}} ->
             lager:error("Error JSON encoding arguments: ~p", [Args]),
-            {error, bad_encoding};
+            {error, bad_utf8_character_code};
         exit: {json_encode, _} ->
             {error, bad_json};
         throw:invalid_utf8 ->
-            {error, bad_encoding}
+            {error, bad_utf8_character_code}
     end.
 
 new_context(ThreadStack, HeapSize) ->

--- a/src/riak_kv_mapred_json.erl
+++ b/src/riak_kv_mapred_json.erl
@@ -30,6 +30,7 @@
 
 -export([parse_request/1, parse_inputs/1, parse_query/1]).
 -export([jsonify_not_found/1, dejsonify_not_found/1]).
+-export([jsonify_pipe_error/2]).
 
 -define(QUERY_TOKEN, <<"query">>).
 -define(INPUTS_TOKEN, <<"inputs">>).
@@ -447,6 +448,77 @@ erl_phase_error(StepDef) ->
              "   - \"bucket\" and \"key\" fields,"
              " specifying a Riak object containing"
              " Erlang function source\n"]}.
+
+%% @doc Produce a list of mochjson2 props from a pipe error log
+jsonify_pipe_error(From, {Error, Input}) ->
+    %% map function returned error tuple
+    [{phase, pipe_phase_index(From)},
+     {error, trunc_print(Error)},
+     {input, trunc_print(Input)}];
+jsonify_pipe_error(_From, Elist) when is_list(Elist) ->
+    %% generic pipe fitting error
+
+    %% phase pulled from Elist should be the same as From,
+    %% but just to dig into that info more, we use Elist here
+    [{phase, pipe_error_phase(Elist)},
+     {error, pipe_error_error(Elist)},
+     {input, pipe_error_input(Elist)},
+     {type, pipe_error_type(Elist)},
+     {stack, pipe_error_stack(Elist)}];
+jsonify_pipe_error(From, Other) ->
+    %% some other error
+    [{phase, pipe_phase_index(From)},
+     {error, trunc_print(Other)}].
+
+%% @doc Turn the pipe fitting name into a MapReduce phase index.
+-spec pipe_phase_index(integer()|{term(),integer()}) -> integer().
+pipe_phase_index({_Type, I}) -> I;
+pipe_phase_index(I)          -> I.
+
+%% @doc convenience for formatting ~500chars of a term as a
+%% human-readable string
+-spec trunc_print(term()) -> binary().
+trunc_print(Term) ->
+    {Msg, _Len} = lager_trunc_io:print(Term, 500),
+    iolist_to_binary(Msg).
+
+%% @doc Pull a field out of a proplist, and possibly transform it.
+pipe_error_field(Field, Proplist) ->
+    pipe_error_field(Field, Proplist, fun(X) -> X end).
+pipe_error_field(Field, Proplist, TrueFun) ->
+    pipe_error_field(Field, Proplist, TrueFun, null).
+pipe_error_field(Field, Proplist, TrueFun, FalseVal) ->
+    case lists:keyfind(Field, 1, Proplist) of
+        {Field, Value} -> TrueFun(Value);
+        false          -> FalseVal
+    end.
+
+%% @doc Pull a field out of a proplist, and format it as a reasonably
+%% short binary if available.
+pipe_error_trunc_print(Field, Elist) ->
+    pipe_error_field(Field, Elist, fun trunc_print/1).
+
+%% @doc Determine the phase that this error came from.
+pipe_error_phase(Elist) ->
+    Details = pipe_error_field(details, Elist, fun(X) -> X end, []),
+    pipe_error_field(name, Details, fun pipe_phase_index/1).
+
+pipe_error_type(Elist) ->
+    %% is this really useful?
+    pipe_error_field(type, Elist).
+
+pipe_error_error(Elist) ->
+    pipe_error_field(error, Elist, fun trunc_print/1,
+                     pipe_error_trunc_print(reason, Elist)).
+
+pipe_error_input(Elist) ->
+    %% translate common inputs?
+    %% e.g. strip 'ok' tuple from map input
+    pipe_error_trunc_print(input, Elist).
+
+pipe_error_stack(Elist) ->
+    %% truncate stacks to "important" part?
+    pipe_error_trunc_print(stack, Elist).
 
 -ifdef(TEST).
 

--- a/src/riak_kv_mrc_map.erl
+++ b/src/riak_kv_mrc_map.erl
@@ -138,9 +138,13 @@ process(Input, _Last,
         #state{fd=_FittingDetails, phase=Phase, arg=Arg}=State) ->
     ?T(_FittingDetails, [map], {mapping, Input}),
     case map(Phase, Arg, Input) of
-        {ok, Results} ->
+        {ok, Results} when is_list(Results) ->
             ?T(_FittingDetails, [map], {produced, Results}),
             send_results(Results, State),
+            {ok, State};
+        {ok, _NonListResults} ->
+            ?T(_FittingDetails, [map, error],
+               {error, {non_list_result, Input}}),
             {ok, State};
         {forward_preflist, Reason} ->
             ?T(_FittingDetails, [map], {forward_preflist, Reason}),

--- a/src/riak_kv_w_reduce.erl
+++ b/src/riak_kv_w_reduce.erl
@@ -203,23 +203,11 @@ handoff(HandoffAcc, #state{inacc=OldInAcc}=State) ->
          {ok, [term()]} | {error, {term(), term(), term()}}.
 reduce(Inputs, #state{fd=FittingDetails}, ErrString) ->
     {rct, Fun, Arg} = FittingDetails#fitting_details.arg,
-    try
-        ?T(FittingDetails, [reduce], {reducing, length(Inputs)}),
-        Outputs = Fun(Inputs, Arg),
-        true = is_list(Outputs), %%TODO: nicer error
-        ?T(FittingDetails, [reduce], {reduced, length(Outputs)}),
-        Outputs
-    catch Type:Error ->
-            %% attempting to be helpful here by catching the error and
-            %% preserving the inputs, in case trying the input again
-            %% later (when a new input or eoi arrives) will be
-            %% successful
-            ?T(FittingDetails, [reduce], {reduce_error, Type, Error}),
-            error_logger:error_msg(
-              "~p:~p ~s:~n   ~P~n   ~P",
-              [Type, Error, ErrString, Inputs, 15, erlang:get_stacktrace(), 15]),
-            Inputs
-    end.
+    ?T(FittingDetails, [reduce], {reducing, ErrString, length(Inputs)}),
+    Outputs = Fun(Inputs, Arg),
+    true = is_list(Outputs), %%TODO: nicer error
+    ?T(FittingDetails, [reduce], {reduced, ErrString, length(Outputs)}),
+    Outputs.
 
 %% @doc Check that the arg is a valid arity-2 function.  See {@link
 %%      riak_pipe_v:validate_function/3}.

--- a/src/riak_kv_w_reduce.erl
+++ b/src/riak_kv_w_reduce.erl
@@ -281,9 +281,8 @@ js_runner(JS) ->
                      || R <- Results0];
                 {ok, NonlistResults} ->
                     NonlistResults; %% will blow up in reduce/3
-                {error, no_vms} ->
-                    %% will be caught by process/3, or will blow up done/1
-                    throw(no_js_vms)
+                {error, Error} ->
+                    exit(Error)
             end
     end.
 

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -82,7 +82,6 @@ process_post(RD, State) ->
             legacy_mapred(RD, State)
     end.
 
-
 %% Internal functions
 send_error(Error, RD)  ->
     wrq:set_resp_body(format_error(Error), RD).
@@ -190,8 +189,7 @@ pipe_mapred_nonchunked(RD, State, Pipe, NumKeeps, Sender) ->
             riak_pipe:destroy(Pipe),
             prevent_keepalive(),
             {{halt, 500}, send_error({error, timeout}, RD), State};
-        {error, {Error, _Input}} ->
-            %% TODO: jsonify Input for error message
+        {error, Error} ->
             riak_pipe:destroy(Pipe),
             prevent_keepalive(),
             {{halt, 500}, send_error({error, Error}, RD), State}
@@ -219,10 +217,20 @@ pipe_receive_output(Ref, {SenderPid, SenderRef}) ->
             eoi;
         #pipe_result{ref=Ref, from=From, result=Result} ->
             {ok, {From, Result}};
-        #pipe_log{ref=Ref, msg=Msg} ->
+        #pipe_log{ref=Ref, from=From, msg=Msg} ->
             case Msg of
                 {trace, [error], {error, {Error, Input}}} ->
-                    {error, {Error, Input}};
+                    %% map function returned error tuple
+                    {error, [{phase, pipe_phase_index(From)},
+                             {error, trunc_print(Error)},
+                             {input, trunc_print(Input)}]};
+                {trace, [error], {error, Elist}} when is_list(Elist) ->
+                    %% generic pipe fitting error
+                    {error, [{phase, pipe_error_phase(Elist)},
+                             {error, pipe_error_error(Elist)},
+                             {input, pipe_error_input(Elist)},
+                             {type, pipe_error_type(Elist)},
+                             {stack, pipe_error_stack(Elist)}]};
                 _ ->
                     %% not a log message we're interested in
                     pipe_receive_output(Ref, {SenderPid, SenderRef})
@@ -237,6 +245,57 @@ pipe_receive_output(Ref, {SenderPid, SenderRef}) ->
         {pipe_timeout, Ref} ->
             {error, timeout}
     end.
+
+%% @doc Turn the pipe fitting name into a MapReduce phase index.
+-spec pipe_phase_index(integer()|{term(),integer()}) -> integer().
+pipe_phase_index({_Type, I}) -> I;
+pipe_phase_index(I)          -> I.
+
+%% @doc convenience for formatting ~500chars of a term as a
+%% human-readable string
+-spec trunc_print(term()) -> binary().
+trunc_print(Term) ->
+    {Msg, _Len} = lager_trunc_io:print(Term, 500),
+    iolist_to_binary(Msg).
+
+%% @doc Pull a field out of a proplist, and possibly transform it.
+pipe_error_field(Field, Proplist) ->
+    pipe_error_field(Field, Proplist, fun(X) -> X end).
+pipe_error_field(Field, Proplist, TrueFun) ->
+    pipe_error_field(Field, Proplist, TrueFun, null).
+pipe_error_field(Field, Proplist, TrueFun, FalseVal) ->
+    case lists:keyfind(Field, 1, Proplist) of
+        {Field, Value} -> TrueFun(Value);
+        false          -> FalseVal
+    end.
+
+%% @doc Pull a field out of a proplist, and format it as a reasonably
+%% short binary if available.
+pipe_error_trunc_print(Field, Elist) ->
+    pipe_error_field(Field, Elist, fun trunc_print/1).
+
+%% @doc Determine the phase that this error came from.
+pipe_error_phase(Elist) ->
+    Details = pipe_error_field(details, Elist, fun(X) -> X end, []),
+    pipe_error_field(name, Details, fun pipe_phase_index/1).
+
+pipe_error_type(Elist) ->
+    %% is this really useful?
+    pipe_error_field(type, Elist).
+
+pipe_error_error(Elist) ->
+    %% translate common errors?
+    %% e.g. bad json
+    pipe_error_trunc_print(error, Elist).
+
+pipe_error_input(Elist) ->
+    %% translate common inputs?
+    %% e.g. strip 'ok' tuple from map input
+    pipe_error_trunc_print(input, Elist).
+
+pipe_error_stack(Elist) ->
+    %% truncate stacks to "important" part?
+    pipe_error_trunc_print(stack, Elist).
 
 pipe_mapred_chunked(RD, State, Pipe, Sender) ->
     Boundary = riak_core_util:unique_id_62(),

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -284,9 +284,8 @@ pipe_error_type(Elist) ->
     pipe_error_field(type, Elist).
 
 pipe_error_error(Elist) ->
-    %% translate common errors?
-    %% e.g. bad json
-    pipe_error_trunc_print(error, Elist).
+    pipe_error_field(error, Elist, fun trunc_print/1,
+                     pipe_error_trunc_print(reason, Elist)).
 
 pipe_error_input(Elist) ->
     %% translate common inputs?

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -219,18 +219,9 @@ pipe_receive_output(Ref, {SenderPid, SenderRef}) ->
             {ok, {From, Result}};
         #pipe_log{ref=Ref, from=From, msg=Msg} ->
             case Msg of
-                {trace, [error], {error, {Error, Input}}} ->
-                    %% map function returned error tuple
-                    {error, [{phase, pipe_phase_index(From)},
-                             {error, trunc_print(Error)},
-                             {input, trunc_print(Input)}]};
-                {trace, [error], {error, Elist}} when is_list(Elist) ->
-                    %% generic pipe fitting error
-                    {error, [{phase, pipe_error_phase(Elist)},
-                             {error, pipe_error_error(Elist)},
-                             {input, pipe_error_input(Elist)},
-                             {type, pipe_error_type(Elist)},
-                             {stack, pipe_error_stack(Elist)}]};
+                {trace, [error], {error, Info}} ->
+                    {error, riak_kv_mapred_json:jsonify_pipe_error(
+                              From, Info)};
                 _ ->
                     %% not a log message we're interested in
                     pipe_receive_output(Ref, {SenderPid, SenderRef})
@@ -245,56 +236,6 @@ pipe_receive_output(Ref, {SenderPid, SenderRef}) ->
         {pipe_timeout, Ref} ->
             {error, timeout}
     end.
-
-%% @doc Turn the pipe fitting name into a MapReduce phase index.
--spec pipe_phase_index(integer()|{term(),integer()}) -> integer().
-pipe_phase_index({_Type, I}) -> I;
-pipe_phase_index(I)          -> I.
-
-%% @doc convenience for formatting ~500chars of a term as a
-%% human-readable string
--spec trunc_print(term()) -> binary().
-trunc_print(Term) ->
-    {Msg, _Len} = lager_trunc_io:print(Term, 500),
-    iolist_to_binary(Msg).
-
-%% @doc Pull a field out of a proplist, and possibly transform it.
-pipe_error_field(Field, Proplist) ->
-    pipe_error_field(Field, Proplist, fun(X) -> X end).
-pipe_error_field(Field, Proplist, TrueFun) ->
-    pipe_error_field(Field, Proplist, TrueFun, null).
-pipe_error_field(Field, Proplist, TrueFun, FalseVal) ->
-    case lists:keyfind(Field, 1, Proplist) of
-        {Field, Value} -> TrueFun(Value);
-        false          -> FalseVal
-    end.
-
-%% @doc Pull a field out of a proplist, and format it as a reasonably
-%% short binary if available.
-pipe_error_trunc_print(Field, Elist) ->
-    pipe_error_field(Field, Elist, fun trunc_print/1).
-
-%% @doc Determine the phase that this error came from.
-pipe_error_phase(Elist) ->
-    Details = pipe_error_field(details, Elist, fun(X) -> X end, []),
-    pipe_error_field(name, Details, fun pipe_phase_index/1).
-
-pipe_error_type(Elist) ->
-    %% is this really useful?
-    pipe_error_field(type, Elist).
-
-pipe_error_error(Elist) ->
-    pipe_error_field(error, Elist, fun trunc_print/1,
-                     pipe_error_trunc_print(reason, Elist)).
-
-pipe_error_input(Elist) ->
-    %% translate common inputs?
-    %% e.g. strip 'ok' tuple from map input
-    pipe_error_trunc_print(input, Elist).
-
-pipe_error_stack(Elist) ->
-    %% truncate stacks to "important" part?
-    pipe_error_trunc_print(stack, Elist).
 
 pipe_mapred_chunked(RD, State, Pipe, Sender) ->
     Boundary = riak_core_util:unique_id_62(),


### PR DESCRIPTION
This PR "improves" MapReduce error messages.

At the moment, "improves" means, "gets more information out in the HTTP response."  I'm interested in feedback about whether or not this is the right information to expose, and whether or not it's exposed in a useful format.  If both aspects are +1, similar changes should also be made to the PB response.

Side note: There was early discussion about translating errors like `bad_encoding` to more verbose English like "The input contained bytes that were not valid UTF-8 characters."  This was dropped in favor of just changing the error atom to `bad_utf8_character_code` to keep things simpler.  The new atom should be descriptive, yet unique enough to describe further in other Google-reachable contexts, like the wiki.
