### PR TITLE
Allow empty M/R queries in HTTP and PB interfaces. (AZ990)

### DIFF
--- a/src/riak_kv_mapred_json.erl
+++ b/src/riak_kv_mapred_json.erl
@@ -221,6 +221,8 @@ parse_index_input(Inputs) ->
             end;
         StartKey /= undefined andalso EndKey /= undefined ->
             case riak_index:parse_fields([{Index, StartKey}, {Index, EndKey}]) of
+                {ok, [{Index1, Key1}]} ->
+                    {ok, {index, Bucket, Index1, Key1}};
                 {ok, [{Index1, StartKey1}, {Index1, EndKey1}]} ->
                     {ok, {index, Bucket, Index1, StartKey1, EndKey1}};
                 {error, Reasons} ->

--- a/src/riak_kv_mapred_term.erl
+++ b/src/riak_kv_mapred_term.erl
@@ -82,6 +82,8 @@ parse_inputs({index, Bucket, Index, Key}) ->
     end;
 parse_inputs({index, Bucket, Index, StartKey, EndKey}) ->
     case riak_index:parse_fields([{Index, StartKey}, {Index, EndKey}]) of
+        {ok, [{Index1, Key1}]} ->
+            {ok, {index, Bucket, Index1, Key1}};
         {ok, [{Index1, StartKey1}, {Index1, EndKey1}]} ->
             {ok, {index, Bucket, Index1, StartKey1, EndKey1}};
         {error, Reasons} ->

--- a/src/riak_kv_mrc_pipe.erl
+++ b/src/riak_kv_mrc_pipe.erl
@@ -249,7 +249,7 @@ mapred_plan(BucketOrList, Query) ->
 %% @doc Convert a MapReduce query into a list of Pipe fitting specs.
 -spec mr2pipe_phases([query_part()]) -> [ riak_pipe:fitting_spec() ].
 mr2pipe_phases([]) ->
-    [#fitting_spec{name=empty_pass,
+    [#fitting_spec{name=0,
                    module=riak_pipe_w_pass,
                    chashfun=follow}];
 mr2pipe_phases(Query) ->


### PR DESCRIPTION
Currently, providing an empty M/R query will throw errors as the system tries to convert a `{Bucket, Key}` tuple to JSON. As a workaround, any code that needs to simply pull back the inputs from a Map/Reduce job inserts a reduce phase that calls `riak_kv_mapreduce:reduce_identity/N` which converts the tuple to an array. This is inefficient because all results must eventually stream through a single reduce process.

This change updates the system to encode the `{Bucket, Key}` tuples as an array directly without the need for a reduce phase. This change is only applied when the user specifies an empty map/reduce query to preserve the existing behavior as much as possible.
## Testing

Install Riak, configure to use `riak_kv_eleveldb_backend`.

The tests below are structured so that first we run the MapReduce operation with a `reduce_identity` phase, then we run the same operation with an empty query. The results should be the same in both cases.
### Load Data

``` bash
curl -v -X PUT \
-d 'data1' \
-H "x-riak-index-field1_bin: val1" \
-H "x-riak-index-field2_int: 1001" \
http://127.0.0.1:8098/riak/mybucket/mykey1

curl -v -X PUT \
-d 'data2' \
-H "x-riak-index-Field1_bin: val2" \
-H "x-riak-index-Field2_int: 1002" \
http://127.0.0.1:8098/riak/mybucket/mykey2

curl -v -X PUT \
-d 'data3' \
-H "X-RIAK-INDEX-FIELD1_BIN: val3" \
-H "X-RIAK-INDEX-FIELD2_INT: 1003" \
http://127.0.0.1:8098/riak/mybucket/mykey3

curl -v -X PUT \
-d 'data4' \
-H "x-riak-index-field1_bin: val4" \
-H "x-riak-index-field2_int: 1004" \
http://127.0.0.1:8098/riak/mybucket/mykey4
```
### Run A MapReduce Query

``` bash
curl -X POST \
-H "content-type: application/json" \
-d @- \
http://localhost:8098/mapred \
<<EOF
{
   "inputs":{
       "bucket":"mybucket",
       "index":"field1_bin",
       "start":"val2",
       "end":"val4"
   },
   "query":[
      {
         "reduce":{
            "language":"erlang",
            "module":"riak_kv_mapreduce",
            "function":"reduce_identity",
            "keep":true
         }
      }
   ]
}
EOF
```

``` bash
curl -X POST \
-H "content-type: application/json" \
-d @- \
http://localhost:8098/mapred \
<<EOF
{
   "inputs":{
       "bucket":"mybucket",
       "index":"field1_bin",
       "start":"val2",
       "end":"val4"
   },
   "query":[]
}
EOF
```
### Run a Chunked MapReduce Query

``` bash
curl -X POST \
-H "content-type: application/json" \
-d @- \
http://localhost:8098/mapred?chunked=true \
<<EOF
{
   "inputs":{
       "bucket":"mybucket",
       "index":"field1_bin",
       "start":"val2",
       "end":"val4"
   },
   "query":[
      {
         "reduce":{
            "language":"erlang",
            "module":"riak_kv_mapreduce",
            "function":"reduce_identity",
            "keep":true
         }
      }
   ]
}
EOF
```

``` bash
curl -X POST \
-H "content-type: application/json" \
-d @- \
http://localhost:8098/mapred?chunked=true \
<<EOF
{
   "inputs":{
       "bucket":"mybucket",
       "index":"field1_bin",
       "start":"val2",
       "end":"val4"
   },
   "query":[]
}
EOF
```
### Run an Erlang Protocol Buffers Query

``` erlang
Input = {index, <<"mybucket">>, <<"field1_bin">>, <<"val2">>, <<"val4">>},
IdentityQuery = [
    {reduce,
        {modfun, riak_kv_mapreduce, reduce_identity},
        [{reduce_phase_only_1, true}],
        true
    }
],
Query = [],
{ok, Pid} = riakc_pb_socket:start("127.0.0.1", 8087),
riakc_pb_socket:mapred(Pid, Input, Query).
```

``` erlang
Input = {index, <<"mybucket">>, <<"field1_bin">>, <<"val2">>, <<"val4">>},
Query = [],
{ok, Pid} = riakc_pb_socket:start("127.0.0.1", 8087),
riakc_pb_socket:mapred(Pid, Input, Query).
```
### Run a Python Protocol Buffers Query

Note, the Python client automatically adds the empty `reduce_identity` phase. You will need to comment out two lines of code in `mapreduce.py` to test:

``` python
        # FILE: riak/mapreduce.py

        # If there are no phases, then just echo the inputs back to the user.
        if (num_phases == 0):
            # COMMENT OUT THESE TWO LINES (around line 200)
            # self.reduce(["riak_kv_mapreduce", "reduce_identity"])
            # num_phases = 1
            link_results_flag = True
        else:
            link_results_flag = False
```

Now, run `python` to start the interpreter and paste the following:

``` python
# Create a PB client...
import riak
client = riak.RiakClient(port=8087, transport_class=riak.RiakPbcTransport)

# Perform a range query...
mr = riak.RiakMapReduce(client)
mr._inputs = {
    'bucket': "mybucket",
    'index' : "field1_bin",
    'start' : "val2",
    'end'   : "val4"}

results = mr.run()
print "Range: "
for i in results:
    print i.get_bucket() + " : " + i.get_key()
```
