### PR TITLE
Jdm vnodeq stats

### DIFF
--- a/src/riak_kv_wm_stats.erl
+++ b/src/riak_kv_wm_stats.erl
@@ -87,6 +87,7 @@ pretty_print(RD1, C1=#ctx{}) ->
     {json_pp:print(binary_to_list(list_to_binary(Json))), RD2, C2}.
 
 get_stats() ->
-    proplists:delete(disk, riak_kv_stat:get_stats()).
+    proplists:delete(disk, riak_kv_stat:get_stats()) ++
+        riak_core_stat:get_stats().
 
 


### PR DESCRIPTION
The stats webmachine resource will now include riak_core_stat:get_stats() which includes vnode queue stats and gossip/ring convergence stats.
