### PR TITLE
Fix 500 HTTP code on pre commit fail

### DIFF
--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -966,8 +966,8 @@ handle_common_error(Reason, RD, Ctx) ->
     case {error, Reason} of
         {error, precommit_fail} ->
             {{halt, 403}, send_precommit_error(RD, undefined), Ctx};
-        {error, {precommit_fail, Reason}} ->
-            {{halt, 403}, send_precommit_error(RD, Reason), Ctx};
+        {error, {precommit_fail, Message}} ->
+            {{halt, 403}, send_precommit_error(RD, Message), Ctx};
         {error, too_many_fails} ->
             {{halt, 503}, wrq:append_to_response_body("Too Many write failures"
                     " to satisfy W/DW\n", RD), Ctx};


### PR DESCRIPTION
riak_kv_wm_object:handle_common_error case for precommit_fail with message fails to unify with argument because Reason is already bound. The result is that a { precommit_fail, "message" } argument results in a 500 Server error instead of 403.

Simply renaming the second Reason variable to Message fixes the problem.
