### PR TITLE
Sort directory listings in eunit assert to fix tests

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -707,7 +707,7 @@ startup_data_dir_test() ->
     [_ | RemovalPartitionDirs] = lists:reverse(TSPartitionDirs),
     os:cmd("rm -rf test/bitcask-backend/*"),
     ?assertEqual(["42", "manual_cleanup"], lists:sort(DataDirs)),
-    ?assertEqual(RemovalPartitionDirs, RemovalDirs).
+    ?assertEqual(lists:sort(RemovalPartitionDirs), lists:sort(RemovalDirs)).
 
 drop_test() ->
     os:cmd("rm -rf test/bitcask-backend/*"),


### PR DESCRIPTION
Fixes: az1008

This test was passing on my OSX box, but was failing on some build machines because the list order was random so it failed the match.
