### PR TITLE
Ack-based Listkeys Backpressure

### DIFF
--- a/include/riak_kv_vnode.hrl
+++ b/include/riak_kv_vnode.hrl
@@ -29,6 +29,11 @@
           bucket :: binary() | tuple(),
           item_filter :: function()}).
 
+%% same as _v3, but triggers ack-based backpressure
+-record(riak_kv_listkeys_req_v4, {
+          bucket :: binary() | tuple(),
+          item_filter :: function()}).
+
 -record(riak_kv_listbuckets_req_v1, {
           item_filter :: function()}).
 
@@ -57,7 +62,7 @@
 -define(KV_GET_REQ, #riak_kv_get_req_v1).
 -define(KV_MGET_REQ, #riak_kv_mget_req_v1).
 -define(KV_LISTBUCKETS_REQ, #riak_kv_listbuckets_req_v1).
--define(KV_LISTKEYS_REQ, #riak_kv_listkeys_req_v3).
+-define(KV_LISTKEYS_REQ, #riak_kv_listkeys_req_v4).
 -define(KV_INDEX_REQ, #riak_kv_index_req_v1).
 -define(KV_VNODE_STATUS_REQ, #riak_kv_vnode_status_req_v1).
 -define(KV_DELETE_REQ, #riak_kv_delete_req_v1).

--- a/src/lk.erl
+++ b/src/lk.erl
@@ -34,6 +34,9 @@ fsm(Bucket) ->
 
 gather_fsm_results(ReqId, Count) ->
     receive
+        {ReqId, From, {keys, Keys}} ->
+            riak_kv_keys_fsm:ack_keys(From),
+            gather_fsm_results(ReqId, Count + length(Keys));
         {ReqId, {keys, Keys}} ->
             gather_fsm_results(ReqId, Count + length(Keys));
         {ReqId, done} ->

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -763,6 +763,9 @@ wait_for_listkeys(ReqId, Timeout) ->
 wait_for_listkeys(ReqId,Timeout,Acc) ->
     receive
         {ReqId, done} -> {ok, lists:flatten(Acc)};
+        {ReqId, From, {keys, Res}} ->
+            riak_kv_keys_fsm:ack_keys(From),
+            wait_for_listkeys(ReqId, Timeout, [Res|Acc]);
         {ReqId,{keys,Res}} -> wait_for_listkeys(ReqId,Timeout,[Res|Acc]);
         {ReqId, Error} -> {error, Error}
     after Timeout ->

--- a/src/riak_kv.app.src
+++ b/src/riak_kv.app.src
@@ -33,6 +33,13 @@
          %% listing operations.
          {legacy_keylisting, true},
 
+         %% This option toggles compatibility of keylisting with 1.0
+         %% and earlier versions.  Once a rolling upgrade to a version
+         %% > 1.0 is completed for a cluster, this should be set to
+         %% true for better control of memory usage during key listing
+         %% operations
+         {listkeys_backpressure, false},
+
          %% use the legacy routines for tracking kv stats
          {legacy_stats, true},
 

--- a/src/riak_kv_keys_fsm.erl
+++ b/src/riak_kv_keys_fsm.erl
@@ -42,12 +42,34 @@
 -export([init/2,
          process_results/2,
          finish/2]).
+-export([use_ack_backpressure/0,
+         req/2]).
 
 -type from() :: {atom(), req_id(), pid()}.
 -type req_id() :: non_neg_integer().
 
 -record(state, {client_type :: plain | mapred,
                 from :: from()}).
+
+%% @doc Returns `true' if the new ack-based backpressure listkeys
+%% protocol should be used.  This decision is based on the
+%% `listkeys_backpressure' setting in `riak_kv''s application
+%% environment.
+-spec use_ack_backpressure() -> boolean().
+use_ack_backpressure() ->
+    app_helper:get_env(riak_kv, listkeys_backpressure) == true.
+
+%% @doc Construct the correct listkeys command record.
+-spec req(binary(), term()) -> term().
+req(Bucket, ItemFilter) ->
+    case use_ack_backpressure() of
+        true ->
+            ?KV_LISTKEYS_REQ{bucket=Bucket,
+                             item_filter=ItemFilter};
+        false ->
+            #riak_kv_listkeys_req_v3{bucket=Bucket,
+                                     item_filter=ItemFilter}
+    end.
 
 %% @doc Return a tuple containing the ModFun to call per vnode,
 %% the number of primary preflist vnodes the operation
@@ -65,11 +87,16 @@ init(From={_, _, ClientPid}, [Bucket, ItemFilter, Timeout, ClientType]) ->
     BucketProps = riak_core_bucket:get_bucket(Bucket),
     NVal = proplists:get_value(n_val, BucketProps),
     %% Construct the key listing request
-    Req = ?KV_LISTKEYS_REQ{bucket=Bucket,
-                           item_filter=ItemFilter},
+    Req = req(Bucket, ItemFilter),
     {Req, all, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout,
      #state{client_type=ClientType, from=From}}.
 
+process_results({From, Bucket, Keys},
+                StateData=#state{client_type=ClientType,
+                                 from={raw, ReqId, ClientPid}}) ->
+    process_keys(ClientType, Bucket, Keys, ReqId, ClientPid),
+    riak_kv_vnode:ack_keys(From), % tell that vnode we're ready for more
+    {ok, StateData};
 process_results({Bucket, Keys},
                 StateData=#state{client_type=ClientType,
                                  from={raw, ReqId, ClientPid}}) ->

--- a/src/riak_kv_keys_fsm.erl
+++ b/src/riak_kv_keys_fsm.erl
@@ -152,7 +152,8 @@ process_keys(plain, _Bucket, Keys, ReqId, ClientPid) ->
             Monitor = erlang:monitor(process, ClientPid),
             ClientPid ! {ReqId, {self(), Monitor}, {keys, Keys}},
             receive
-                {Monitor, ok} -> ok;
+                {Monitor, ok} ->
+                    erlang:demonitor(Monitor, [flush]);
                 {'DOWN', Monitor, process, _Pid, _Reason} ->
                     exit(self(), normal)
             end;

--- a/src/riak_kv_pb_socket.erl
+++ b/src/riak_kv_pb_socket.erl
@@ -102,8 +102,14 @@ handle_info({ReqId, done},
     NewState = send_msg(#rpblistkeysresp{done = 1}, State),
     inet:setopts(Socket, [{active, once}]),
     {noreply, NewState#state{req = undefined, req_ctx = undefined}};
+handle_info({ReqId, From, {keys, []}}, State=#state{req=#rpblistkeysreq{}, req_ctx=ReqId}) ->
+    riak_kv_keys_fsm:ack_keys(From),
+    {noreply, State}; % No keys - no need to send a message, will send done soon.
 handle_info({ReqId, {keys, []}}, State=#state{req=#rpblistkeysreq{}, req_ctx=ReqId}) ->
     {noreply, State}; % No keys - no need to send a message, will send done soon.
+handle_info({ReqId, From, {keys, Keys}}, State=#state{req=#rpblistkeysreq{}, req_ctx=ReqId}) ->
+    riak_kv_keys_fsm:ack_keys(From),
+    {noreply, send_msg(#rpblistkeysresp{keys = Keys}, State)};
 handle_info({ReqId, {keys, Keys}}, State=#state{req=#rpblistkeysreq{}, req_ctx=ReqId}) ->
     {noreply, send_msg(#rpblistkeysresp{keys = Keys}, State)};
 handle_info({ReqId, Error},

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -37,7 +37,8 @@
          list_keys/4,
          fold/3,
          get_vclocks/2,
-         vnode_status/1]).
+         vnode_status/1,
+         ack_keys/1]).
 
 %% riak_core_vnode API
 -export([init/1,
@@ -399,34 +400,20 @@ handle_coverage(?KV_LISTBUCKETS_REQ{item_filter=ItemFilter},
         _ ->
             {noreply, State}
     end;
+handle_coverage(#riak_kv_listkeys_req_v3{bucket=Bucket,
+                                         item_filter=ItemFilter},
+                FilterVNodes, Sender, State) ->
+    %% v3 == no backpressure
+    ResultFun = result_fun(Bucket, Sender),
+    handle_coverage_listkeys(Bucket, ItemFilter, ResultFun,
+                             FilterVNodes, Sender, State);
 handle_coverage(?KV_LISTKEYS_REQ{bucket=Bucket,
                                  item_filter=ItemFilter},
-                FilterVNodes,
-                Sender,
-                State=#state{async_backend=AsyncBackend,
-                             idx=Index,
-                             key_buf_size=BufferSize,
-                             mod=Mod,
-                             modstate=ModState}) ->
-    %% Construct the filter function
-    FilterVNode = proplists:get_value(Index, FilterVNodes),
-    Filter = riak_kv_coverage_filter:build_filter(Bucket, ItemFilter, FilterVNode),
-    BufferMod = riak_kv_fold_buffer,
-    Buffer = BufferMod:new(BufferSize, result_fun(Bucket, Sender)),
-    FoldFun = fold_fun(keys, BufferMod, Filter),
-    FinishFun = finish_fun(BufferMod, Sender),
-    case AsyncBackend of
-        true ->
-            Opts = [async_fold, {bucket, Bucket}];
-        false ->
-            Opts = [{bucket, Bucket}]
-    end,
-    case list(FoldFun, FinishFun, Mod, fold_keys, ModState, Opts, Buffer) of
-        {async, AsyncWork} ->
-            {async, {fold, AsyncWork, FinishFun}, Sender, State};
-        _ ->
-            {noreply, State}
-    end;
+                FilterVNodes, Sender, State) ->
+    %% v4 == ack-based backpressure
+    ResultFun = result_fun_ack(Bucket, Sender),
+    handle_coverage_listkeys(Bucket, ItemFilter, ResultFun,
+                             FilterVNodes, Sender, State);
 handle_coverage(?KV_INDEX_REQ{bucket=Bucket,
                               item_filter=ItemFilter,
                               qry=Query},
@@ -461,6 +448,34 @@ handle_coverage(?KV_INDEX_REQ{bucket=Bucket,
             end;
         false ->
             {reply, {error, {indexes_not_supported, Mod}}, State}
+    end.
+
+%% Convenience for handling both v3 and v4 coverage-based listkeys
+handle_coverage_listkeys(Bucket, ItemFilter, ResultFun,
+                         FilterVNodes, Sender,
+                         State=#state{async_backend=AsyncBackend,
+                             idx=Index,
+                             key_buf_size=BufferSize,
+                             mod=Mod,
+                             modstate=ModState}) ->
+    %% Construct the filter function
+    FilterVNode = proplists:get_value(Index, FilterVNodes),
+    Filter = riak_kv_coverage_filter:build_filter(Bucket, ItemFilter, FilterVNode),
+    BufferMod = riak_kv_fold_buffer,
+    Buffer = BufferMod:new(BufferSize, ResultFun),
+    FoldFun = fold_fun(keys, BufferMod, Filter),
+    FinishFun = finish_fun(BufferMod, Sender),
+    case AsyncBackend of
+        true ->
+            Opts = [async_fold, {bucket, Bucket}];
+        false ->
+            Opts = [{bucket, Bucket}]
+    end,
+    case list(FoldFun, FinishFun, Mod, fold_keys, ModState, Opts, Buffer) of
+        {async, AsyncWork} ->
+            {async, {fold, AsyncWork, FinishFun}, Sender, State};
+        _ ->
+            {noreply, State}
     end.
 
 %% While in handoff, vnodes have the option of returning {forward, State}
@@ -842,6 +857,29 @@ result_fun(Bucket, Sender) ->
     fun(Items) ->
             riak_core_vnode:reply(Sender, {Bucket, Items})
     end.
+
+%% wait for acknowledgement that results were received before
+%% continuing, as a way of providing backpressure for processes that
+%% can't handle results as fast as we can send them
+result_fun_ack(Bucket, Sender) ->
+    fun(Items) ->
+            Monitor = riak_core_vnode:monitor(Sender),
+            riak_core_vnode:reply(Sender, {{self(), Monitor}, Bucket, Items}),
+            receive
+                {Monitor, ok} ->
+                    erlang:demonitor(Monitor, [flush]);
+                {'DOWN', Monitor, process, _Pid, _Reason} ->
+                    throw(receiver_down)
+            end
+    end.
+
+%% @doc If a listkeys request sends a result of `{From, Bucket,
+%% Items}', that means it wants acknowledgement of those items before
+%% it will send more.  Call this function with that `From' to trigger
+%% the next batch.
+-spec ack_keys(From::{pid(), reference()}) -> term().
+ack_keys({Pid, Ref}) ->
+    Pid ! {Ref, ok}.
 
 %% @private
 finish_fun(BufferMod, Sender) ->
@@ -1333,6 +1371,9 @@ result_listener_keys(Acc) ->
         {'$gen_event', {_, done}} ->
             result_listener_done(Acc);
         {'$gen_event', {_, {_Bucket, Results}}} ->
+            result_listener_keys(Results ++ Acc);
+        {'$gen_event', {_, {From, _Bucket, Results}}} ->
+            riak_kv_vnode:ack_keys(From),
             result_listener_keys(Results ++ Acc)
     after 5000 ->
             result_listener_done({timeout, Acc})

--- a/src/riak_kv_wm_keylist.erl
+++ b/src/riak_kv_wm_keylist.erl
@@ -184,6 +184,9 @@ produce_bucket_body(RD, Ctx) ->
 
 stream_keys(ReqId) ->
     receive
+        {ReqId, From, {keys, Keys}} ->
+            riak_kv_keys_fsm:ack_keys(From),
+            {mochijson2:encode({struct, [{<<"keys">>, Keys}]}), fun() -> stream_keys(ReqId) end};
         {ReqId, {keys, Keys}} ->
             {mochijson2:encode({struct, [{<<"keys">>, Keys}]}), fun() -> stream_keys(ReqId) end};
         {ReqId, done} -> {mochijson2:encode({struct, [{<<"keys">>, []}]}), done}

--- a/src/riak_kv_worker.erl
+++ b/src/riak_kv_worker.erl
@@ -44,5 +44,9 @@ init_worker(VNodeIndex, _Args, _Props) ->
 
 %% @doc Perform the asynchronous fold operation.
 handle_work({fold, FoldFun, FinishFun}, _Sender, State) ->
-    FinishFun(FoldFun()),
+    try
+        FinishFun(FoldFun())
+    catch
+        receiver_down -> ok
+    end,
     {noreply, State}.


### PR DESCRIPTION
To prevent keylist results from piling up in a requester's mailbox, this patch changes the protocol between the pieces to require acknowledgements of each batch before the next batch is sent.  It depends on new code in riak_core: https://github.com/basho/riak_core/pull/123

Specifically, each vnode (or async vnode worker) requires that its keylist batch messages to the keylist fsm or pipe worker be acknowledged before the next batch is sent.  In addition, the keylist fsm also requires that its consumers (the PB socket and WM resource) acknowledge batch deliveries before continuing as well.  These acks are invisible to the outside, handled internally by all user interfaces.
## Notes
- this probably could have been done without a new `listkeys_req` vnode command, but the separation of code that it allowed made things a bit clearer, imo
- performance testing on a 4-node VM dev box showed this to increase latency slightly, but with the benefit of never triggering the memory high watermark or other warnings
- the latency/memory usage tradeoff can be tweaked by the `key_buffer_size` appenv setting in riak_kv (a higher value will mean fewer messages to ack, but also larger messages waiting in mailboxes)
- this is specifically meant to solve https://issues.basho.com/show_bug.cgi?id=1286
## Testing

Set the riak_kv environment variable `liskeys_backpressure` to `true`.

Load a large number of keys into a Riak bucket.  Request the keys as a stream.  Over HTTP, this looks like:

```
curl http://localhost:8098/riak/bucket?keys=stream
```

All listkeys requests over PB are streamed.  Using non-streamed keylist requests will confuse the results, as the keylist will still accumulate in memory, just not in a process mailbox.

Watch the console for memory errors.  To reproduce the exact case of BZ1286, you'll need a keyspace large enough to trick the Erlang VM into attempting to allocate all of it.  With slightly smaller, yet still large keyspaces you'll be watching for `long_gc` and `memory_high_watermark`.
