### PR TITLE
BZ1306 — get_fsm crashes when riak_object value is not a binary

### DIFF
--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -350,17 +350,17 @@ update_stats({ok, Obj}, #state{get_usecs = GetUsecs}) ->
     %% especially for objects with large values.
     NumSiblings = riak_object:value_count(Obj),
     Contents = riak_object:get_contents(Obj),
-    ValueSize = fun (Value) when is_binary(Value) -> size(Value);
-                    (Value) -> size(term_to_binary(Value))
-                end,
     ObjSize =
         size(riak_object:bucket(Obj)) +
         size(riak_object:key(Obj)) +
         size(term_to_binary(riak_object:vclock(Obj))) +
-        lists:sum([size(term_to_binary(MD)) + ValueSize(Value) || {MD, Value} <- Contents]),
+        lists:sum([size(term_to_binary(MD)) + value_size(Value) || {MD, Value} <- Contents]),
     riak_kv_stat:update({get_fsm, undefined, GetUsecs, NumSiblings, ObjSize});
 update_stats(_, #state{get_usecs = GetUsecs}) ->
     riak_kv_stat:update({get_fsm, undefined, GetUsecs, undefined, undefined}).
+
+value_size(Value) when is_binary(Value) -> size(Value);
+value_size(Value) -> size(term_to_binary(Value)).
 
 client_info(true, StateData, Acc) ->
     client_info(details(), StateData, Acc);

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -350,11 +350,14 @@ update_stats({ok, Obj}, #state{get_usecs = GetUsecs}) ->
     %% especially for objects with large values.
     NumSiblings = riak_object:value_count(Obj),
     Contents = riak_object:get_contents(Obj),
+    ValueSize = fun (Value) when is_binary(Value) -> size(Value);
+                    (Value) -> size(term_to_binary(Value))
+                end,
     ObjSize =
         size(riak_object:bucket(Obj)) +
         size(riak_object:key(Obj)) +
         size(term_to_binary(riak_object:vclock(Obj))) +
-        lists:sum([size(term_to_binary(MD)) + size(Value) || {MD, Value} <- Contents]),
+        lists:sum([size(term_to_binary(MD)) + ValueSize(Value) || {MD, Value} <- Contents]),
     riak_kv_stat:update({get_fsm, undefined, GetUsecs, NumSiblings, ObjSize});
 update_stats(_, #state{get_usecs = GetUsecs}) ->
     riak_kv_stat:update({get_fsm, undefined, GetUsecs, undefined, undefined}).


### PR DESCRIPTION
Fixes issue in `riak_kv_get_fsm:update_stats/2` calling `erlang:size/1` on a `riak_object` value which isn't a binary

https://issues.basho.com/show_bug.cgi?id=1306
