### PR TITLE
Register routes after sup start

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -88,6 +88,10 @@ start(_Type, _StartArgs) ->
             riak_core:register(riak_kv, [
                 {vnode_module, riak_kv_vnode}
             ]),
+
+            %% Add routes to webmachine
+            [ webmachine_router:add_route(R)
+              || R <- lists:reverse(riak_kv_web:dispatch_table()) ],
             {ok, Pid};
         {error, Reason} ->
             {error, Reason}

--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -41,8 +41,6 @@ start_link() ->
 %% @spec init([]) -> SupervisorTree
 %% @doc supervisor callback.
 init([]) ->
-    [ webmachine_router:add_route(R)
-      || R <- lists:reverse(riak_kv_web:dispatch_table()) ],
     VMaster = {riak_kv_vnode_master,
                {riak_core_vnode_master, start_link,
                 [riak_kv_vnode, riak_kv_legacy_vnode]},


### PR DESCRIPTION
The `riak_kv` webmachine resources require parts of the `riak_kv`
application to be started (`riak_kv_*_fsm_sup`).  Before the change,
a node starting under load would fail requests until the supervisors
were started.

Now the webmachine routes are registered after the sup has started.
This has the side effect that routes will not be re-registered
when the `riak_kv_sup` is restarted, however there is no code
to remove the routes from webmachine when the application stops
so the change should not have any unintended consequences.
