### PR TITLE
Fix 2i Stats (AZ1038)

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -591,7 +591,7 @@ do_put(Sender, {Bucket,_Key}=BKey, RObj, ReqID, StartTime, Options, State) ->
     {Reply, UpdState} = perform_put(PrepPutRes, State, UpdPutArgs),
     riak_core_vnode:reply(Sender, Reply),
 
-    update_index_write_stats(PutArgs#putargs.index_specs),
+    update_index_write_stats(UpdPutArgs#putargs.index_specs),
     riak_kv_stat:update(vnode_put),
     UpdState.
 
@@ -716,7 +716,6 @@ perform_put({true, Obj},
     Val = term_to_binary(Obj),
     case Mod:put(Bucket, Key, IndexSpecs, Val, ModState) of
         {ok, UpdModState} ->
-            update_index_write_stats(IndexSpecs),
             case RB of
                 true ->
                     Reply = {dw, Idx, Obj, ReqID};

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -445,6 +445,9 @@ handle_coverage(?KV_INDEX_REQ{bucket=Bucket,
     AsyncBackend = lists:member(async_fold, Capabilities),
     case IndexBackend of
         true ->
+            %% Update stats...
+            riak_kv_stat:update(vnode_index_read),
+
             %% Construct the filter function
             FilterVNode = proplists:get_value(Index, FilterVNodes),
             Filter = riak_kv_coverage_filter:build_filter(Bucket, ItemFilter, FilterVNode),
@@ -587,6 +590,8 @@ do_put(Sender, {Bucket,_Key}=BKey, RObj, ReqID, StartTime, Options, State) ->
     {PrepPutRes, UpdPutArgs} = prepare_put(State, PutArgs),
     {Reply, UpdState} = perform_put(PrepPutRes, State, UpdPutArgs),
     riak_core_vnode:reply(Sender, Reply),
+
+    update_index_write_stats(PutArgs#putargs.index_specs),
     riak_kv_stat:update(vnode_put),
     UpdState.
 
@@ -598,11 +603,12 @@ do_backend_delete(BKey, RObj, State = #state{mod = Mod, modstate = ModState}) ->
     %% JDM: This should just be a tombstone by this point, but better
     %% safe than sorry.
     IndexSpecs = riak_object:diff_index_specs(undefined, RObj),
-    
+
     %% Do the delete...
     {Bucket, Key} = BKey,
     case Mod:delete(Bucket, Key, IndexSpecs, ModState) of
         {ok, UpdModState} ->
+            update_index_delete_stats(IndexSpecs),
             State#state{modstate = UpdModState};
         {error, _Reason, UpdModState} ->
             State#state{modstate = UpdModState}
@@ -710,6 +716,7 @@ perform_put({true, Obj},
     Val = term_to_binary(Obj),
     case Mod:put(Bucket, Key, IndexSpecs, Val, ModState) of
         {ok, UpdModState} ->
+            update_index_write_stats(IndexSpecs),
             case RB of
                 true ->
                     Reply = {dw, Idx, Obj, ReqID};
@@ -992,7 +999,9 @@ do_diffobj_put({Bucket, Key}, DiffObj,
             Val = term_to_binary(DiffObj),
             Res = Mod:put(Bucket, Key, IndexSpecs, Val, ModState),
             case Res of
-                {ok, _UpdModState} -> riak_kv_stat:update(vnode_put);
+                {ok, _UpdModState} ->
+                    update_index_write_stats(IndexSpecs),
+                    riak_kv_stat:update(vnode_put);
                 _ -> nop
             end,
             Res;
@@ -1015,8 +1024,11 @@ do_diffobj_put({Bucket, Key}, DiffObj,
                     Val = term_to_binary(AMObj),
                     Res = Mod:put(Bucket, Key, IndexSpecs, Val, ModState),
                     case Res of
-                        {ok, _UpdModState} -> riak_kv_stat:update(vnode_put);
-                        _ -> nop
+                        {ok, _UpdModState} ->
+                            update_index_write_stats(IndexSpecs),
+                            riak_kv_stat:update(vnode_put);
+                        _ ->
+                            nop
                     end,
                     Res
             end
@@ -1120,6 +1132,30 @@ wait_for_vnode_status_results(PrefLists, ReqId, Acc) ->
          _ ->
             wait_for_vnode_status_results(PrefLists, ReqId, Acc)
     end.
+
+
+%% @private
+update_index_write_stats(IndexSpecs) ->
+    {Added, Removed} = count_index_specs(IndexSpecs),
+    riak_kv_stat:update({vnode_index_write, Added, Removed}).
+
+%% @private
+update_index_delete_stats(IndexSpecs) ->
+    {_Added, Removed} = count_index_specs(IndexSpecs),
+    riak_kv_stat:update({vnode_index_delete, Removed}).
+
+%% @private
+%% @doc Given a list of index specs, return the number to add and
+%% remove.
+count_index_specs(IndexSpecs) ->
+    %% Count index specs...
+    F = fun({add, _, _}, {AddAcc, RemoveAcc}) ->
+                {AddAcc + 1, RemoveAcc};
+           ({remove, _, _}, {AddAcc, RemoveAcc}) ->
+                {AddAcc, RemoveAcc + 1}
+        end,
+    lists:foldl(F, {0, 0}, IndexSpecs).
+
 
 -ifdef(TEST).
 


### PR DESCRIPTION
When we moved the responsibilities of `riak_index_backend` into `riak_kv_vnode` and `riak_kv_eleveldb_backend`, the 2i stats code got lost. This pull request adds it back.
## Testing

Make sure you have configured the system to use `riak_kv_eleveldb_backend`.

Remember to test with `legacy_stats` set to `true` and `false`.

Verify the stats using http://localhost:8098/stats.
### Step 1

Write some objects:

``` bash
curl -v -X PUT \
-d 'data1' \
-H "x-riak-index-field1_bin: val1" \
-H "x-riak-index-field2_int: 1001" \
http://127.0.0.1:8098/riak/mybucket/mykey1

curl -v -X PUT \
-d 'data2' \
-H "x-riak-index-Field1_bin: val2" \
-H "x-riak-index-Field2_int: 1002" \
http://127.0.0.1:8098/riak/mybucket/mykey2

curl -v -X PUT \
-d 'data3' \
-H "X-RIAK-INDEX-FIELD1_BIN: val3" \
-H "X-RIAK-INDEX-FIELD2_INT: 1003" \
http://127.0.0.1:8098/riak/mybucket/mykey3
```

Verify that `vnode_index_writes` stat is 9. The system wrote 3 copies of each object.

Verify that `vnode_index_writes_postings` stat is 18. The system wrote 3 objects \* 3 copies of each object \* 2 index entries per object.
### Step 2

Update an object:

``` bash
curl -v -X PUT \
-d 'data1' \
-H "x-riak-index-field1_bin: val0" \
-H "x-riak-index-field2_int: 1000" \
http://127.0.0.1:8098/riak/mybucket/mykey1
```

Verify that `vnode_index_writes` stat is 12. It was 9, then the system wrote to 3 vnodes.

Verify that `vnode_index_writes_postings` stat is 24. It was 18, then the system wrote 2 postings each to 3 vnodes.

Verify that `vnoed_index_deletes_postings` stat is 6. It was 0, then the system removed 2 old postings from each of 3 vnodes.
### Step 3

Run a query:

``` bash
curl http://localhost:8098/buckets/mybucket/index/field1_bin/val2/val3
```

Verify that `vnode_index_reads` stat is 22. We performed a covering read on the system, which hits 1/3 of all nodes.
### Step 4

Delete an object:

``` bash
curl -X DELETE http://127.0.0.1:8098/riak/mybucket/mykey1
```

Verify that `vnode_index_deletes` stat is 3. The system removed an object from 3 vnodes. Note that due to the tombstone reaping process, this stat may take a few seconds to fully update. Keep refreshing.

Verify that `vnode_index_deletes_postings` stat is 6. The system removed 2 old postings from each of 3 vnodes.
