### PR TITLE
wait for riak_pipe and _kv node services, and unload apps on fullstop (AZ1033 … related)

### DIFF
--- a/test/mapred_test.erl
+++ b/test/mapred_test.erl
@@ -99,7 +99,6 @@ dep_apps() ->
      inets,
      mochiweb,
      fun(start) ->
-             riak_core_ring:fresh(16, node()),
              _ = application:load(riak_kv),
              [begin
                   put({?MODULE,AppKey}, app_helper:get_env(riak_kv, AppKey)),


### PR DESCRIPTION
Not waiting for the node watcher to declare riak_pipe and riak_kv
services as up before running the test was causing preflist exhaustion
errors. Not unloading apps after stopping them was causing re-starting
them for the next test to fail.
