### PR TITLE
1.0.3 eunit fixes

### DIFF
--- a/test/mapred_test.erl
+++ b/test/mapred_test.erl
@@ -105,7 +105,8 @@ dep_apps() ->
                   put({?MODULE,AppKey}, app_helper:get_env(riak_kv, AppKey)),
                   ok = application:set_env(riak_kv, AppKey, Val)
               end || {AppKey, Val} <- KV_Settings],
-             ok = application:start(riak_kv);
+             ok = application:start(riak_kv),
+	     riak_core:wait_for_service(riak_kv);
         (stop) ->
              ok = application:stop(riak_kv),
              net_kernel:stop(),


### PR DESCRIPTION
Make the mapred test wait for the riak_kv service to be up.  1.0.3 changed riak_kv service to be marked up after primary vnodes are initialized and running, not after application was started.
