### PR TITLE
Innostore (and others) memory fix

### DIFF
--- a/src/riak_kv_worker.erl
+++ b/src/riak_kv_worker.erl
@@ -45,4 +45,5 @@ init_worker(VNodeIndex, _Args, _Props) ->
 %% @doc Perform the asynchronous fold operation.
 handle_work({fold, FoldFun, FinishFun}, _Sender, State) ->
     FinishFun(FoldFun()),
+    erlang:garbage_collect(),
     {noreply, State}.


### PR DESCRIPTION
Clean up memory at the end of the worker process before it gets put back into the pool, otherwise, the memory sits around in-use until the worker happens to get used again.
