### PR TITLE
Kill vnode workers after finishing their fold.

### DIFF
--- a/src/riak_kv_worker.erl
+++ b/src/riak_kv_worker.erl
@@ -49,4 +49,17 @@ handle_work({fold, FoldFun, FinishFun}, _Sender, State) ->
     catch
         receiver_down -> ok
     end,
-    {noreply, State}.
+
+    %% Here we're going to terminate the process instead of
+    %% continuing with the state machine. We do this because
+    %% if there was a lot of memory generated during the fold
+    %% (e.g. list keys) then the memory won't be cleaned up
+    %% immediately. Instead the process will go back to 'sleep'
+    %% in the pool until it's needed again. Once needed it will
+    %% GC, but that means there can potentially be N processes
+    %% running all eating up unused memory. We could issue an
+    %% erlang:collect_garbage() call here instead, but that
+    %% would eat up more processor time than just killing and
+    %% restarting the worker.
+
+    exit(normal).


### PR DESCRIPTION
Terminate the process instead of continuing with the state machine. Do this because if there was a lot of memory generated during the fold (e.g. list keys) then the memory won't be cleaned up immediately. Instead the process will go back to 'sleep' in the pool until it's needed again. Once needed it will GC, but that means there can potentially be N processes running all eating up unused memory. We could issue an erlang:collect_garbage() call here instead, but that would eat up more processor time than just killing and restarting the worker.

Note: when testing, please try and run a LOT of worker requests that will be short-lived. We want to make sure that the restart frequency isn't triggered. Also be sure and test riak_kv async_folds true and false.
