### PR TITLE
Fix starting riak_core now lager is a dep and make buildbot happy

### DIFF
--- a/test/keys_fsm_eqc.erl
+++ b/test/keys_fsm_eqc.erl
@@ -243,7 +243,7 @@ dep_apps() ->
         end,
     XX = fun(_) -> error_logger:info_msg("Registered: ~w\n", [lists:sort(registered())]) end,
     [sasl, crypto, riak_sysmon, webmachine, XX, os_mon,
-     riak_core, XX, luke, erlang_js,
+     lager, riak_core, XX, luke, erlang_js,
      inets, mochiweb, riak_pipe, SetupFun, riak_kv, SetupFun].
 
 do_dep_apps(StartStop, Apps) ->

--- a/test/mapred_test.erl
+++ b/test/mapred_test.erl
@@ -74,6 +74,7 @@ dep_apps() ->
      end,
      webmachine,
      os_mon,
+     lager,
      fun(start) ->
              _ = application:load(riak_core),
              %% riak_core_handoff_listener uses {reusaddr, true}, but

--- a/test/put_fsm_eqc.erl
+++ b/test/put_fsm_eqc.erl
@@ -41,9 +41,9 @@
 
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include_lib("riak_kv_vnode.hrl").
--include_lib("riak_kv_js_pools.hrl").
--include_lib("riak_kv/src/riak_kv_wm_raw.hrl").
+-include("riak_kv_vnode.hrl").
+-include("riak_kv_js_pools.hrl").
+-include("../src/riak_kv_wm_raw.hrl").
 
 -compile(export_all).
 -export([postcommit_ok/1]).


### PR DESCRIPTION
The put_fsm_eqc test was including headers in a way that assumed riak_kv
was checked out to a directory called 'riak_kv', which isn't the case
whem buildbot runs a per-repo eunit run. This patch fixes the includes
to always work regardless of the checkout directory.
