### PR TITLE
Set `small_vclock` equal to `big_vclock`

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -53,7 +53,7 @@ start(_Type, _StartArgs) ->
        {old_vclock, 86400},
        {young_vclock, 20},
        {big_vclock, 50},
-       {small_vclock, 10},
+       {small_vclock, 50},
        {pr, 0},
        {r, quorum},
        {w, quorum},

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -523,7 +523,7 @@ bucket_props(Bucket, Nval) -> % riak_core_bucket:get_bucket(Bucket).
      {precommit,[]},
      {r,quorum},
      {rw,quorum},
-     {small_vclock,10},
+     {small_vclock,50},
      {w,quorum},
      {young_vclock,20}].
  


### PR DESCRIPTION
The default value of `small_vclock` has been changed to be equal to
`big_vclock` in order to delay or even prevent unnecessary sibling
creation in a Riak deployment with bidirectional cluster replication.
When you replicate a pruned vector clock the other cluster will think
it isn't a descendent, even though it is, and create a sibling.  By
raising `small_vclock` to match `big_vclock` we reduce the frequency
of pruning and thus siblings.  Combined with vnode vclocks, sibling
creation, for this particular reason, may be entirely avoided since
the number of entries will almost always stay below the threshold in a
well behaved cluster (i.e. one not under constant node membership
change or network partitions).

See also: https://issues.basho.com/show_bug.cgi?id=1310
