### PR TITLE
Check send_output return when sending 2I results to a pipe.

### DIFF
--- a/src/riak_kv_pipe_index.erl
+++ b/src/riak_kv_pipe_index.erl
@@ -81,6 +81,8 @@ process(Input, _Last, #state{p=Partition, fd=FittingDetails}=State) ->
 
 keysend_loop(ReqId, Partition, FittingDetails) ->
     receive
+        {ReqId, {error, _Reason} = ER} ->
+            ER;
         {ReqId, {Bucket, Keys}} ->
             case keysend(Bucket, Keys, Partition, FittingDetails) of
                 ok ->
@@ -132,7 +134,9 @@ queue_existing_pipe(Pipe, Bucket, Query, Timeout) ->
     {ok, LKP} = riak_pipe:exec([#fitting_spec{name=index,
                                               module=?MODULE,
                                               nval=1}],
-                               [{sink, Head}]),
+                               [{sink, Head},
+                                {trace, [error]},
+                                {log, {sink, Pipe#pipe.sink}}]),
 
     %% setup the cover operation
     ReqId = erlang:phash2(erlang:now()), %% stolen from riak_client


### PR DESCRIPTION
Propagate error returns from riak_pipe_vnode_worker:send_output.  Pipes will now error rather than returning a result without all entries processed.

Depends on basho/riak_pipe#42 being merged.

Tested with idxh module in systest.

Configure pipe with low worker count

```
[{riak_pipe, [{worker_limit, 2},
              {worker_queue_limit, 1}]},
```

Set up fixtures

```
idxh:fixtures().
```

```
(dev1@127.0.0.1)1> [spawn(fun() -> idxh:searchpbc() end) || I <- lists:seq(1,3)].
[<0.417.0>,<0.418.0>,<0.419.0>]
(dev1@127.0.0.1)2> 09:15:06.859 [error] gen_fsm <0.447.0> in state waiting_results terminated with reason: {error,worker_limit_reached}
09:15:06.859 [error] Error sending inputs: {error,worker_limit_reached}
Search <<"b">> / <<"idx1_bin">> = <<"x">>
 {error,<<"Error sending inputs: {error,worker_limit_reached}">>}
(dev1@127.0.0.1)2> 09:15:06.862 [error] CRASH REPORT Process <0.447.0> with 2 neighbours crashed with reason: {error,worker_limit_reached}
09:15:06.863 [error] Supervisor riak_pipe_qcover_sup had child undefined started with {riak_core_coverage_fsm,start_link,undefined} at <0.447.0> exit with reason {error,worker_limit_reached} in context child_terminated
09:15:06.865 [error] Supervisor riak_pipe_builder_sup had child undefined started with {riak_pipe_builder,start_link,undefined} at <0.435.0> exit with reason {error,worker_limit_reached} in context child_terminated
Search <<"b">> / <<"idx1_bin">> = <<"x">>
 {ok,[[<<"b">>,<<"k1">>],
      [<<"b">>,<<"k2">>],
      [<<"b">>,<<"k3">>],
      [<<"b">>,<<"k4">>],
      [<<"b">>,<<"k5">>],
      [<<"b">>,<<"k6">>]]}
Search <<"b">> / <<"idx1_bin">> = <<"x">>
 {ok,[[<<"b">>,<<"k1">>],
      [<<"b">>,<<"k2">>],
      [<<"b">>,<<"k4">>],
      [<<"b">>,<<"k5">>],
      [<<"b">>,<<"k6">>],
      [<<"b">>,<<"k3">>]]}
(dev1@127.0.0.1)2> 
```
