### PR TITLE
Instrument KV get latency in the worker

### DIFF
--- a/src/riak_kv_pipe_get.erl
+++ b/src/riak_kv_pipe_get.erl
@@ -90,7 +90,7 @@ process(Input, Last, #state{partition=Partition, fd=FittingDetails}=State) ->
       riak_kv_vnode_master),
     receive
         {ReqId, {r, {ok, Obj}, _, _}} ->
-            ?T(FittingDetails, [kv_get], [{ok, timer:now_diff(erlang:now(), Start)}]),
+            ?T(FittingDetails, [kv_get], [{kv_get_latency, {r, timer:now_diff(erlang:now(), Start)}}]),
             case riak_pipe_vnode_worker:send_output(
                    {ok, Obj, keydata(Input)}, Partition, FittingDetails) of
                 ok ->
@@ -99,7 +99,7 @@ process(Input, Last, #state{partition=Partition, fd=FittingDetails}=State) ->
                     {ER, State}
             end;
         {ReqId, {r, {error, _} = Error, _, _}} ->
-            ?T(FittingDetails, [kv_get], [{Error, timer:now_diff(erlang:now(), Start)}]),
+            ?T(FittingDetails, [kv_get], [{kv_get_latency, {Error, timer:now_diff(erlang:now(), Start)}}]),
             if Last ->
                     case riak_pipe_vnode_worker:send_output(
                            {Error, bkey(Input), keydata(Input)},

--- a/src/riak_kv_pipe_get.erl
+++ b/src/riak_kv_pipe_get.erl
@@ -82,6 +82,7 @@ init(Partition, FittingDetails) ->
          -> {ok | forward_preflist | {error, term()}, state()}.
 process(Input, Last, #state{partition=Partition, fd=FittingDetails}=State) ->
     ReqId = make_req_id(),
+    Start = erlang:now(),
     riak_core_vnode_master:command(
       {Partition, node()}, %% assume local chashfun was used
       ?KV_GET_REQ{bkey=bkey(Input), req_id=ReqId},
@@ -89,6 +90,7 @@ process(Input, Last, #state{partition=Partition, fd=FittingDetails}=State) ->
       riak_kv_vnode_master),
     receive
         {ReqId, {r, {ok, Obj}, _, _}} ->
+            ?T(FittingDetails, [kv_get], [{ok, timer:now_diff(erlang:now(), Start)}]),
             case riak_pipe_vnode_worker:send_output(
                    {ok, Obj, keydata(Input)}, Partition, FittingDetails) of
                 ok ->
@@ -97,6 +99,7 @@ process(Input, Last, #state{partition=Partition, fd=FittingDetails}=State) ->
                     {ER, State}
             end;
         {ReqId, {r, {error, _} = Error, _, _}} ->
+            ?T(FittingDetails, [kv_get], [{Error, timer:now_diff(erlang:now(), Start)}]),
             if Last ->
                     case riak_pipe_vnode_worker:send_output(
                            {Error, bkey(Input), keydata(Input)},


### PR DESCRIPTION
This adds some latency timing traces to the `riak_kv_pipe_get` vnode worker so that pipes that have large workloads can detect when fetching the KV object is the bottleneck. Errors (like `notfound`) are instrumented as well as successful fetches.
