### PR TITLE
Add 2I to Memory backend

### DIFF
--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -284,7 +284,7 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{data_ref=DataRef,
                      get_index_folder(FoldFun, Acc, Index, DataRef, IndexRef);
                  Bucket /= false ->
                      FoldFun = fold_keys_fun(FoldKeysFun, Bucket),
-                     get_folder(FoldFun, Acc, DataRef);
+                     get_index_folder(FoldFun, Acc, {index, Bucket, {eq, <<"$bucket">>, Bucket}}, DataRef, IndexRef);
                  true ->
                      FoldFun = fold_keys_fun(FoldKeysFun, undefined),
                      get_folder(FoldFun, Acc, DataRef)

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -364,11 +364,7 @@ callback(_Ref, _Msg, State) ->
 reset() ->
     reset(app_helper:get_env(riak_kv, memory_backend), app_helper:get_env(riak_kv, storage_backend)).
 
-reset(undefined, _) ->
-    {error, reset_disabled};
-reset([], _) ->
-    {error, reset_disabled};
-reset(Props, ?MODULE) when is_list(Props) ->
+reset([_|_]=Props, ?MODULE) ->
     case proplists:get_value(test, Props) of
         true ->
             {ok, Ring} = riak_core_ring_manager:get_my_ring(),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -615,7 +615,7 @@ do_backend_delete(BKey, RObj, State = #state{mod = Mod, modstate = ModState}) ->
     %% object is a tombstone or all siblings are tombstones
     riak_kv_mapred_cache:eject(BKey),
 
-    %% Calculate the index specs to remove...  
+    %% Calculate the index specs to remove...
     %% JDM: This should just be a tombstone by this point, but better
     %% safe than sorry.
     IndexSpecs = riak_object:diff_index_specs(undefined, RObj),
@@ -968,7 +968,7 @@ do_delete(BKey, ReqId, State) ->
                             UpdState = do_backend_delete(BKey, RObj, State),
                             {reply, {del, Idx, ReqId}, UpdState};
                         Delay when is_integer(Delay) ->
-                            erlang:send_after(Delay, self(), 
+                            erlang:send_after(Delay, self(),
                                               {final_delete, BKey,
                                                delete_hash(RObj)}),
                             %% Nothing checks these messages - will just reply

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -210,8 +210,7 @@ init([Index]) ->
     {ok, VId} = get_vnodeid(Index),
     DeleteMode = app_helper:get_env(riak_kv, delete_mode, 3000),
     AsyncFolding = app_helper:get_env(riak_kv, async_folds, true) == true,
-    case catch Mod:start(Index, [{async_folds, AsyncFolding},
-                                 Configuration]) of
+    case catch Mod:start(Index, [{async_folds, AsyncFolding}|Configuration]) of
         {ok, ModState} ->
             %% Get the backend capabilities
             State = #state{idx=Index,


### PR DESCRIPTION
As it says, this adds secondary indexes to the memory backend. Why?
- The memory backend is useful when running automated test suites because it is less expensive than creating and deleting LevelDB instances. (A special "test" mode has also been added, with a corresponding `reset()` function.)
- ETS is capable of providing this feature with minimal additional work.

Caveats:
- Index postings are not considered when computing the size of an object, and therefore do not count towards its eviction when used as an LRU. This could be added later but is potentially expensive to compute without introducing a coupling to `riak_object`.
- <del>It is necessary to use `ets:match_delete/2` and `ets:select/1,3` operations to efficiently select items from the index, as ETS has no concept of cursors beyond `ets:first/1` and `ets:next/2` which do not let you specify a starting key. `match` and `select` have been known to be locky in certain scenarios.</del> `ets:match_delete/2` must be used when deleting all postings for a bucket/key from the index table, due to the natural ordering of index keys.  This penalty is only incurred when removing objects in LRU mode.
