### PR TITLE
Slf dtrace take1

### DIFF
--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -54,7 +54,7 @@ start_link(ReqId, Bucket, Key, Options, Timeout, Client, ClientId, VClock) ->
 %% @doc Delete the object at Bucket/Key.  Direct return value is uninteresting,
 %%      see riak_client:delete/3 for expected gen_server replies to Client.
 delete(ReqId,Bucket,Key,Options,Timeout,Client,ClientId,undefined) ->
-    riak_core_dtrace:put_tag([Bucket, $,, Key]),
+    riak_core_dtrace:put_tag(io_lib:format("~p,~p", [Bucket, Key])),
     ?DTRACE(?C_DELETE_INIT1, [0], []),
     case get_r_options(Bucket, Options) of
         {error, Reason} ->
@@ -76,7 +76,7 @@ delete(ReqId,Bucket,Key,Options,Timeout,Client,ClientId,undefined) ->
             end
     end;
 delete(ReqId,Bucket,Key,Options,Timeout,Client,ClientId,VClock) ->
-    riak_core_dtrace:put_tag([Bucket, $,, Key]),
+    riak_core_dtrace:put_tag(io_lib:format("~p,~p", [Bucket, Key])),
     ?DTRACE(?C_DELETE_INIT2, [0], []),
     case get_w_options(Bucket, Options) of
         {error, Reason} ->

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -128,7 +128,7 @@ init([From, Bucket, Key, Options]) ->
                        options = Options,
                        bkey = {Bucket, Key},
                        startnow = StartNow},
-    riak_core_dtrace:put_tag([Bucket, $,, Key]),
+    riak_core_dtrace:put_tag(io_lib:format("~p,~p", [Bucket, Key])),
     ?DTRACE(?C_GET_FSM_INIT, [], ["init"]),
     {ok, prepare, StateData, 0};
 init({test, Args, StateProps}) ->

--- a/src/riak_kv_keys_fsm.erl
+++ b/src/riak_kv_keys_fsm.erl
@@ -79,7 +79,7 @@ req(Bucket, ItemFilter) ->
 %% should cover, the service to use to check for available nodes,
 %% and the registered name to use to access the vnode master process.
 init(From={_, _, ClientPid}, [Bucket, ItemFilter, Timeout, ClientType]) ->
-    riak_core_dtrace:put_tag(Bucket),
+    riak_core_dtrace:put_tag(io_lib:format("~p", [Bucket])),
     ClientNode = atom_to_list(node(ClientPid)),
     PidStr = pid_to_list(ClientPid),
     FilterX = if ItemFilter == none -> 0;

--- a/src/riak_kv_keys_fsm.erl
+++ b/src/riak_kv_keys_fsm.erl
@@ -148,7 +148,7 @@ finish(clean,
         plain ->
             ClientPid ! {ReqId, done}
     end,
-    ?DTRACE(?C_KEYS_FINISH, [-1], []),
+    ?DTRACE(?C_KEYS_FINISH, [0], []),
     {stop, normal, StateData}.
 
 %% ===================================================================

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -152,7 +152,7 @@ init([From, RObj, Options]) ->
                                            robj = RObj,
                                            bkey = BKey,
                                            options = Options}),
-    riak_core_dtrace:put_tag([Bucket, $,, Key]),
+    riak_core_dtrace:put_tag(io_lib:format("~p,~p", [Bucket, Key])),
     case riak_kv_util:is_x_deleted(RObj) of
         true  ->
             TombNum = 1,


### PR DESCRIPTION
NOTE: This is a work in progress, to be picked up by someone else while I'm away on vacation.

NOTE: Depends on https://github.com/basho/riak_core/pull/174

All trace messages are funneled first into a function called `dtrace()`
in order to make tracing via Redbug or other Erlang-based tracing tools
a bit easier to use, e.g. `redbug:start({riak_kv_get_fsm, dtrace}).`

However, Erlang tracing syntax (e.g. via Redbug) will be clumsy, but
at least it's doable (I hope).  For example, for the get FSM probe category
numbers between 500 & 512:

```
redbug:start("riak_kv_get_fsm:dtrace('_', X, '_', '_') when 500 =< X, X =< 512", {msgs, 100}).
```

Eventually, I want to see libusdt used for Erlang-triggerable probes, but
we aren't quite there yet, alas.  As a temporary measure, it's likely that
the Erlang virtual machine will have 1024 numbered probes instead of
the current 1.  If/when the 1024 numbered probes arrive, the category
code can be used for the 0-to-1023 probe "name" mapping.  In the long
term, the code can be used to derive a real ASCII string name for a
probe created by libusdt.
