### PR TITLE
Klarna extend erlang riak client

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
 
 {deps, [
         {riak_core, "1.1.2", {git, "git://github.com/basho/riak_core", {tag, "1.1.2"}}},
-        {riakc, "1.2.1", {git, "git://github.com/rmeritz/riak-erlang-client",
+        {riakc, "1.2.1", {git, "git@github.com:rmeritz/riak-erlang-client.git",
                                {tag, "1.2.1-klarna-0.0.0"}}},
         {luke, "0.2.5", {git, "git://github.com/basho/luke", {tag, "0.2.5"}}},
         {erlang_js, "1.0.2", {git, "git://github.com/basho/erlang_js", {tag, "1.0.2"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
 
 {deps, [
         {riak_core, "1.1.2", {git, "git://github.com/basho/riak_core", {tag, "1.1.2"}}},
-        {riakc, "1.2.1", {git, "git@github.com:rmeritz/riak-erlang-client.git",
+        {riakc, "1.2.1", {git, "git://github.com/rmeritz/riak-erlang-client.git",
                                {tag, "1.2.1-klarna-0.0.0"}}},
         {luke, "0.2.5", {git, "git://github.com/basho/luke", {tag, "0.2.5"}}},
         {erlang_js, "1.0.2", {git, "git://github.com/basho/erlang_js", {tag, "1.0.2"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -10,8 +10,8 @@
 
 {deps, [
         {riak_core, "1.1.2", {git, "git://github.com/basho/riak_core", {tag, "1.1.2"}}},
-        {riakc, "1.2.1", {git, "git://github.com/basho/riak-erlang-client",
-                               {tag, "1.2.1"}}},
+        {riakc, "1.2.1", {git, "git://github.com/rmeritz/riak-erlang-client",
+                               {tag, "1.2.1-klarna-0.0.0"}}},
         {luke, "0.2.5", {git, "git://github.com/basho/luke", {tag, "0.2.5"}}},
         {erlang_js, "1.0.2", {git, "git://github.com/basho/erlang_js", {tag, "1.0.2"}}},
         {bitcask, "1.5.1", {git, "git://github.com/basho/bitcask", {tag, "1.5.1"}}},

--- a/src/riak_kv_pb_socket.erl
+++ b/src/riak_kv_pb_socket.erl
@@ -264,6 +264,11 @@ process_message(rpbgetserverinforeq, State) ->
                                  server_version = get_riak_version()},
     send_msg(Resp, State);
 
+process_message(rpbstatusreq, State) ->
+    Resp = #rpbstatusresp{status = term_to_binary(
+                                     riak_kv_status:statistics())},
+    send_msg(Resp, State);
+
 process_message(#rpbgetreq{bucket=B, key=K, r=R0, pr=PR0, notfound_ok=NFOk,
                            basic_quorum=BQ, if_modified=VClock,
                            head=Head, deletedvclock=DeletedVClock}, #state{client=C} = State) ->


### PR DESCRIPTION
This change allows allows you to make a status request equivalent to riak-admin status from the the protocall buffer interface.

This change is dependent on this pull request that changes basho/riak-erlang-client.
