### PR TITLE
Repair Command

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -276,12 +276,13 @@ transfers([]) ->
                 %% Display base status
                 Type = proplists:get_value(type, Status),
                 Mod = proplists:get_value(mod, Status),
-                Partition = proplists:get_value(partition, Status),
+                SrcPartition = proplists:get_value(src_partition, Status),
+                TargetPartition = proplists:get_value(target_partition, Status),
                 StartTS = proplists:get_value(start_ts, Status),
                 SrcNode = proplists:get_value(src_node, Status),
                 TargetNode = proplists:get_value(target_node, Status),
 
-                print_v2_status(Type, Mod, Partition, StartTS),
+                print_v2_status(Type, Mod, {SrcPartition, TargetPartition}, StartTS),
 
                 %% Get info about stats if there is any yet
                 Stats = proplists:get_value(stats, Status),
@@ -407,14 +408,20 @@ print_vnode_status([StatusItem | RestStatusItems]) ->
     end,
     print_vnode_status(RestStatusItems).
 
-print_v2_status(Type, Mod, Partition, StartTS) ->
+print_v2_status(Type, Mod, {SrcPartition, TargetPartition}, StartTS) ->
     StartTSStr = datetime_str(StartTS),
     Running = timer:now_diff(now(), StartTS),
     RunningStr = riak_core_format:human_time_fmt("~.2f", Running),
 
     io:format("transfer type: ~s~n", [Type]),
     io:format("vnode type: ~p~n", [Mod]),
-    io:format("partition: ~p~n", [Partition]),
+    case Type of
+        repair ->
+            io:format("source partition: ~p~n", [SrcPartition]),
+            io:format("target partition: ~p~n", [TargetPartition]);
+        _ ->
+            io:format("partition: ~p~n", [TargetPartition])
+    end,
     io:format("started: ~s [~s ago]~n", [StartTSStr, RunningStr]).
 
 print_v1_status(Mod, Partition, Node) ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -222,12 +222,11 @@ repair_status(Partition) ->
 -spec repair_filter(partition()) -> Filter::function().
 repair_filter(Target) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
-    CH = element(4, Ring),
     NValMap = [{riak_core_bucket:name(B), riak_core_bucket:n_val(B)} ||
                   B <- riak_core_bucket:get_buckets(Ring)],
-    RangeMap = riak_core_repair:gen_range_map(Target, CH, NValMap),
+    RangeMap = riak_core_repair:gen_range_map(Target, Ring, NValMap),
     DefaultN = riak_core_bucket:n_val(riak_core_config:default_bucket_props()),
-    Default = riak_core_repair:gen_range(Target, CH, DefaultN),
+    Default = riak_core_repair:gen_range(Target, Ring, DefaultN),
     RangeFun = riak_core_repair:gen_range_fun(RangeMap, Default),
     fun({Bucket, _Key}=BKey) ->
             Hash = riak_core_util:chash_key(BKey),


### PR DESCRIPTION
Add the ability to repair a KV partition.  If a partition's data is
lost or corrupted this command may be used to rebuild it from adjacent
partitions.  This is preferable over a list-keys + read-repair since
it is more targeted, should complete more quickly and should put less
strain on the cluster.

The command can currently only be run by attaching to Riak.

```
riak_kv_vnode:repair(Partition).
```
