### PR TITLE
Add native 2I queries to PBC protocol

### DIFF
--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -228,7 +228,7 @@ timestamp() ->
     {MegaSeconds,Seconds,MilliSeconds}=erlang:now(),
     (MegaSeconds * 1000000000000) + (Seconds * 1000000) + MilliSeconds.
 
-%% @spec to_index_op_query(binary(), [binary()]) ->
+%% @spec to_index_query(binary(), [binary()]) ->
 %%         {ok, {atom(), binary(), list(binary())}} | {error, Reasons}.
 %% @doc Given an IndexOp, IndexName, and Args, construct and return a
 %%      valid query, or a list of errors if the query is malformed.

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -132,7 +132,9 @@ start(_Type, _StartArgs) ->
             ok = riak_api_pb_service:register([{riak_kv_pb_object, 3, 6}, %% ClientID stuff
                                                {riak_kv_pb_object, 9, 14}, %% Object requests
                                                {riak_kv_pb_bucket, 15, 22}, %% Bucket requests
-                                               {riak_kv_pb_mapred, 23, 24}]), %% MapReduce requests
+                                               {riak_kv_pb_mapred, 23, 24}, %% MapReduce requests
+                                               {riak_kv_pb_index, 25, 26} %% Secondary index requests
+                                               ]),
 
             %% Add routes to webmachine
             [ webmachine_router:add_route(R)

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -1,0 +1,103 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_pb_object: Expose KV functionality to Protocol Buffers
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc <p>The Secondary Index PB service for Riak KV. This covers the
+%% following request messages:</p>
+%%
+%% <pre>
+%%  25 - RpbIndexReq
+%% </pre>
+%%
+%% <p>This service produces the following responses:</p>
+%%
+%% <pre>
+%%  26 - RpbIndexResp
+%% </pre>
+%% @end
+
+-module(riak_kv_pb_index).
+
+-include_lib("riak_pb/include/riak_kv_pb.hrl").
+
+-behaviour(riak_api_pb_service).
+
+-export([init/0,
+         decode/2,
+         encode/1,
+         process/2,
+         process_stream/3]).
+
+-record(?MODULE, {client}).
+-define(state, #?MODULE).
+
+%% @doc init/0 callback. Returns the service internal start
+%% state.
+-spec init() -> any().
+init() ->
+    {ok, C} = riak:local_client(),
+    ?state{client=C}.
+
+%% @doc decode/2 callback. Decodes an incoming message.
+decode(Code, Bin) ->
+    {ok, riak_pb_codec:decode(Code, Bin)}.
+
+%% @doc encode/1 callback. Encodes an outgoing response message.
+encode(Message) ->
+    {ok, riak_pb_codec:encode(Message)}.
+
+%% @doc process/2 callback. Handles an incoming request message.
+process(#rpbindexreq{qtype=eq, key=SKey}, State)
+  when not is_binary(SKey) ->
+    {error, {format, "Invalid equality query ~p", [SKey]}, State};
+process(#rpbindexreq{qtype=range, range_min=Min, range_max=Max}, State)
+  when not (is_binary(Min) andalso is_binary(Max)) ->
+    {error, {format, "Invalid range query: ~p -> ~p", [Min, Max]}, State};
+process(#rpbindexreq{bucket=Bucket, index=Index, qtype=eq, key=SKey}, ?state{client=Client}=State) ->
+    case riak_index:to_index_query(Index, [SKey]) of
+        {ok, Query} ->
+            case Client:get_index(Bucket, Query) of
+                {ok, Results} ->
+                    {reply, #rpbindexresp{keys=Results}, State};
+                {error, QReason} ->
+                    {error, {format, QReason}, State}
+            end;
+        {error, Reason} ->
+            {error, {format, Reason}, State}
+    end;
+process(#rpbindexreq{bucket=Bucket, index=Index, qtype=range,
+                     range_min=Min, range_max=Max}, ?state{client=Client}=State) ->
+    case riak_index:to_index_query(Index, [Min, Max]) of
+        {ok, Query} ->
+            case Client:get_index(Bucket, Query) of
+                {ok, Results} ->
+                    {reply, #rpbindexresp{keys=Results}, State};
+                {error, QReason} ->
+                    {error, {format, QReason}, State}
+            end;
+        {error, Reason} ->
+            {error, {format, Reason}, State}
+    end.
+
+%% @doc process_stream/3 callback. This service does not create any
+%% streaming responses and so ignores all incoming messages.
+process_stream(_,_,State) ->
+    {ignore, State}.


### PR DESCRIPTION
This is part of a series of pull-requests that adds native 2I queries to the Protocol Buffers interface.  In my unscientific tests, the native query shows a 50-80% improvement over the emulation via MapReduce. (See https://gist.github.com/f5d4599cff9e2f9f9c91)

Related: basho/riak_pb#1

**NOTE**: This requires the PBC refactoring (#321) to be present first.
