### PR TITLE
Extend riak_kv_console to support staged joins

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -25,6 +25,7 @@
 -module(riak_kv_console).
 
 -export([join/1,
+         staged_join/1,
          leave/1,
          remove/1,
          status/1,
@@ -41,8 +42,14 @@
 
 
 join([NodeStr]) ->
+    join(NodeStr, fun riak_core:join/1).
+
+staged_join([NodeStr]) ->
+    join(NodeStr, fun riak_core:staged_join/1).
+
+join(NodeStr, JoinFn) ->
     try
-        case riak_core:join(NodeStr) of
+        case JoinFn(NodeStr) of
             ok ->
                 io:format("Sent join request to ~s~n", [NodeStr]),
                 ok;

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -42,16 +42,19 @@
 
 
 join([NodeStr]) ->
-    join(NodeStr, fun riak_core:join/1).
+    join(NodeStr, fun riak_core:join/1,
+         "Sent join request to ~s~n", [NodeStr]).
 
 staged_join([NodeStr]) ->
-    join(NodeStr, fun riak_core:staged_join/1).
+    Node = list_to_atom(NodeStr),
+    join(NodeStr, fun riak_core:staged_join/1,
+         "Success: staged join request for ~p to ~p~n", [node(), Node]).
 
-join(NodeStr, JoinFn) ->
+join(NodeStr, JoinFn, SuccessFmt, SuccessArgs) ->
     try
         case JoinFn(NodeStr) of
             ok ->
-                io:format("Sent join request to ~s~n", [NodeStr]),
+                io:format(SuccessFmt, SuccessArgs),
                 ok;
             {error, not_reachable} ->
                 io:format("Node ~s is not reachable!~n", [NodeStr]),


### PR DESCRIPTION
Update `riak_kv_console` to support staged joins used by the new staged clustering system discussed in basho/riak_core#177.

Related to pull-request that implements the new system: basho/riak_core#181

See also the pull-request that changes `riak-admin` to call staged join: basho/riak#148
