### PR TITLE
Changed riak_kv_bitcask_backend to pass Bitcask options to bitcask_merge_worker:merge/3

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -379,11 +379,12 @@ callback(Ref,
          merge_check,
          #state{ref=Ref,
                 data_dir=DataDir,
+                opts=BitcaskOpts,
                 root=DataRoot}=State) when is_reference(Ref) ->
     case bitcask:needs_merge(Ref) of
         {true, Files} ->
             BitcaskRoot = filename:join(DataRoot, DataDir),
-            bitcask_merge_worker:merge(BitcaskRoot, [], Files);
+            bitcask_merge_worker:merge(BitcaskRoot, BitcaskOpts, Files);
         false ->
             ok
     end,


### PR DESCRIPTION
...ker:merge/3.

Problem solved: using multi_backend in riak with a bitcask backend, keys were not expiring after expiry_secs during merges.
