### PR TITLE
check json ctype on mr query

### DIFF
--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -92,7 +92,14 @@ handle_ctype_ok(true, RD, State) ->
     check_body(RD, State).
 
 ctype_ok(RD) ->
-    valid_ctype(wrq:get_req_header("content-type", RD)).
+    valid_ctype(get_base_ctype(RD)).
+
+%% Return the "base" content-type, that
+%% is, not including the subtype parameters
+get_base_ctype(RD) ->
+    CType = wrq:get_req_header("content-type", RD),
+    {BaseType, _SubTypeParameters} = mochiweb_util:parse_header(CType),
+    BaseType.
 
 valid_ctype(?MAPRED_CTYPE) -> true;
 valid_ctype(_Ctype) -> false.


### PR DESCRIPTION
Verify that map reduce POST requests are sent with content-type of `application/json` (possible including a subtype parameter). So far I've successfully tested the Java and Ruby clients with this patch. I'm working to get my python environment back ready for testing that client...
