### PR TITLE
spawn writes to folsom, cache reads via riak core stat cache

### DIFF
--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -176,62 +176,67 @@
 -module(riak_kv_stat).
 
 %% API
--export([get_stats/0, update/1, register_stats/0]).
+-export([get_stats/0, update/1, register_stats/0, produce_stats/0]).
 
 -define(APP, riak_kv).
 
 %% @spec get_stats() -> proplist()
 %% @doc Get the current aggregation of stats.
 get_stats() ->
-    produce_stats().
+    riak_core_stat_cache:get_stats(?APP).
 
 register_stats() ->
-    [register_stat({?APP, Name}, Type) || {Name, Type} <- stats()].
+    [register_stat({?APP, Name}, Type) || {Name, Type} <- stats()],
+    riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
+
+update(Arg) ->
+    spawn(fun() ->
+                  update1(Arg) end).
 
 %% @doc Update the given stat
-update(vnode_get) ->
+update1(vnode_get) ->
     folsom_metrics:notify_existing_metric({?APP, vnode_gets}, 1, meter);
-update(vnode_put) ->
+update1(vnode_put) ->
     folsom_metrics:notify_existing_metric({?APP, vnode_puts}, 1, meter);
-update(vnode_index_read) ->
+update1(vnode_index_read) ->
     folsom_metrics:notify_existing_metric({?APP, vnode_index_reads}, 1, meter);
-update({vnode_index_write, PostingsAdded, PostingsRemoved}) ->
+update1({vnode_index_write, PostingsAdded, PostingsRemoved}) ->
     folsom_metrics:notify_existing_metric({?APP, vnode_index_writes}, 1, meter),
     folsom_metrics:notify_existing_metric({?APP, vnode_index_writes_postings}, PostingsAdded, meter),
     folsom_metrics:notify_existing_metric({?APP, vnode_index_deletes_postings}, PostingsRemoved, meter);
-update({vnode_index_delete, Postings}) ->
+update1({vnode_index_delete, Postings}) ->
     folsom_metrics:notify_existing_metric({?APP, vnode_index_deletes}, Postings, meter),
     folsom_metrics:notify_existing_metric({?APP, vnode_index_deletes_postings}, Postings, meter);
-update({get_fsm, Bucket, Microsecs, undefined, undefined, PerBucket}) ->
+update1({get_fsm, Bucket, Microsecs, undefined, undefined, PerBucket}) ->
     folsom_metrics:notify_existing_metric({?APP, node_gets_total}, {inc, 1}, counter),
     folsom_metrics:notify_existing_metric({?APP, node_get_fsm_time}, Microsecs, histogram),
     do_get_bucket(PerBucket, {Bucket, Microsecs, undefined, undefined});
-update({get_fsm, Bucket, Microsecs, NumSiblings, ObjSize, PerBucket}) ->
+update1({get_fsm, Bucket, Microsecs, NumSiblings, ObjSize, PerBucket}) ->
     folsom_metrics:notify_existing_metric({?APP, node_gets_total}, {inc, 1}, counter),
     folsom_metrics:notify_existing_metric({?APP, node_get_fsm_time}, Microsecs, histogram),
     folsom_metrics:notify_existing_metric({?APP, node_get_fsm_siblings}, NumSiblings, histogram),
     folsom_metrics:notify_existing_metric({?APP, node_get_fsm_objsize}, ObjSize, histogram),
     do_get_bucket(PerBucket, {Bucket, Microsecs, NumSiblings, ObjSize});
-update({put_fsm_time, Bucket,  Microsecs, PerBucket}) ->
+update1({put_fsm_time, Bucket,  Microsecs, PerBucket}) ->
     folsom_metrics:notify_existing_metric({?APP, node_puts_total}, {inc, 1}, counter),
     folsom_metrics:notify_existing_metric({?APP, node_put_fsm_time}, Microsecs, histogram),
     do_put_bucket(PerBucket, {Bucket, Microsecs});
-update(pbc_connect) ->
+update1(pbc_connect) ->
     folsom_metrics:notify_existing_metric({?APP, pbc_connects_active}, {inc, 1}, counter),
     folsom_metrics:notify_existing_metric({?APP, pbc_connects}, 1, meter);
-update(pbc_disconnect) ->
+update1(pbc_disconnect) ->
     folsom_metrics:notify_existing_metric({?APP, pbc_connects_active}, {dec, 1}, counter);
-update(read_repairs) ->
+update1(read_repairs) ->
     folsom_metrics:notify_existing_metric({?APP, read_repairs}, 1, meter);
-update(coord_redir) ->
+update1(coord_redir) ->
     folsom_metrics:notify_existing_metric({?APP, coord_redirs_total}, {inc, 1}, counter);
-update(mapper_start) ->
+update1(mapper_start) ->
     folsom_metrics:notify_existing_metric({?APP, mapper_count}, {inc, 1}, counter);
-update(mapper_end) ->
+update1(mapper_end) ->
     folsom_metrics:notify_existing_metric({?APP, mapper_count}, {dec, 1}, counter);
-update(precommit_fail) ->
+update1(precommit_fail) ->
     folsom_metrics:notify_existing_metric({?APP, precommit_fail}, {inc, 1}, counter);
-update(postcommit_fail) ->
+update1(postcommit_fail) ->
     folsom_metrics:notify_existing_metric({?APP, postcommit_fail}, {inc, 1}, counter).
 
 %% private

--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -47,6 +47,9 @@ init([]) ->
                {riak_core_vnode_master, start_link,
                 [riak_kv_vnode, riak_kv_legacy_vnode, riak_kv]},
                permanent, 5000, worker, [riak_core_vnode_master]},
+    RiakStat = {riak_kv_stat,
+                {riak_kv_stat, start_link, []},
+                permanent, 5000, worker, [riak_kv_stat]},
     MapJSPool = {?JSPOOL_MAP,
                  {riak_kv_js_manager, start_link,
                   [?JSPOOL_MAP, read_js_pool_size(map_js_vm_count, "map")]},
@@ -111,6 +114,7 @@ init([]) ->
     % Build the process list...
     Processes = lists:flatten([
         ?IF(HasStorageBackend, VMaster, []),
+        RiakStat,
         GetFsmSup,
         PutFsmSup,
         DeleteSup,


### PR DESCRIPTION
After testing, reading and writing stats concurrently slowed Riak's general throughput. Short of a process per stat (ideal) or re-introducing the gen_server (possible), spawning for each update seems like a reasonable compromise.

Also, use new stat cache provided by core.
