### PR TITLE
Start folsom so stat system will work during tests

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1379,7 +1379,9 @@ list_buckets_test_() ->
     {foreach,
      fun() ->
              application:start(sasl),
-             application:get_all_env(riak_kv)
+             application:get_all_env(riak_kv),
+             application:start(folsom),
+             riak_kv_stat:register_stats()
      end,
      fun(Env) ->
              application:stop(sasl),

--- a/test/fsm_eqc_util.erl
+++ b/test/fsm_eqc_util.erl
@@ -182,6 +182,8 @@ start_mock_servers() ->
     {ok, _Pid3} = fsm_eqc_vnode:start_link(),
     application:load(riak_core),
     application:start(crypto),
+    application:start(folsom),
+    riak_kv_stat:register_stats(),
     riak_core_ring_events:start_link(),
     riak_core_node_watcher_events:start_link(),
     riak_core_node_watcher:start_link(),
@@ -189,6 +191,7 @@ start_mock_servers() ->
     ok.
 
 cleanup_mock_servers() ->
+    application:stop(folsom),
     application:stop(riak_core).
 
 make_options([], Options) ->


### PR DESCRIPTION
Now that our underlying stats system is based on folsom we need to
make sure the application is started and the stats are registered.
