### PR TITLE
Fix assorted test sadness.

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -129,7 +129,7 @@ start(_Type, _StartArgs) ->
                 {bucket_validator, riak_kv_bucket}
             ]),
 
-            riak_api_pb_service:register([{riak_kv_pb_object, 3, 6}, %% ClientID stuff
+            ok = riak_api_pb_service:register([{riak_kv_pb_object, 3, 6}, %% ClientID stuff
                                                {riak_kv_pb_object, 9, 14}, %% Object requests
                                                {riak_kv_pb_bucket, 15, 22}, %% Bucket requests
                                                {riak_kv_pb_mapred, 23, 24}, %% MapReduce requests

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -129,7 +129,7 @@ start(_Type, _StartArgs) ->
                 {bucket_validator, riak_kv_bucket}
             ]),
 
-            ok = riak_api_pb_service:register([{riak_kv_pb_object, 3, 6}, %% ClientID stuff
+            riak_api_pb_service:register([{riak_kv_pb_object, 3, 6}, %% ClientID stuff
                                                {riak_kv_pb_object, 9, 14}, %% Object requests
                                                {riak_kv_pb_bucket, 15, 22}, %% Bucket requests
                                                {riak_kv_pb_mapred, 23, 24}, %% MapReduce requests

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -472,6 +472,7 @@ multi_backend_test_() ->
              [P1, P2]
      end,
      fun([P1, P2]) ->
+             application:stop(bitcask),
              crypto:stop(),
              ?assertCmd("rm -rf test/bitcask-backend"),
              unlink(P1),

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -879,6 +879,7 @@ dtrace_errstr(Term) ->
 make_vtag_test() ->
     crypto:start(),
     ?assertNot(make_vtag(now()) =:=
-               make_vtag(now())).
+               make_vtag(now())),
+    crypto:stop().
 
 -endif.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1454,6 +1454,9 @@ filter_keys_test() ->
     flush_msgs().
 
 must_be_last_cleanup_stuff_test() ->
+    %% Thess gets started by the tests, so we should stop them.
+    application:stop(bitcask),
+    application:stop(folsom),
     [application:unset_env(riak_kv, K) ||
         {K, _V} <- application:get_all_env(riak_kv)],
     [application:set_env(riak_kv, K, V) || {K, V} <- erlang:get({?MODULE, kv})].

--- a/test/fsm_eqc_util.erl
+++ b/test/fsm_eqc_util.erl
@@ -192,6 +192,7 @@ start_mock_servers() ->
 
 cleanup_mock_servers() ->
     application:stop(folsom),
+    application:stop(crypto),
     application:stop(riak_core).
 
 make_options([], Options) ->

--- a/test/mapred_test.erl
+++ b/test/mapred_test.erl
@@ -72,11 +72,14 @@ dep_apps() ->
              _ = application:stop(riak_sysmon),
              KillDamnFilterProc()
      end,
+     inets,
+     mochiweb,
      webmachine,
      os_mon,
      compiler,
      syntax_tools,
      lager,
+     folsom,
      fun(start) ->
              _ = application:load(riak_core),
              %% riak_core_handoff_listener uses {reusaddr, true}, but
@@ -99,8 +102,6 @@ dep_apps() ->
      riak_pipe,
      luke,
      erlang_js,
-     inets,
-     mochiweb,
      fun(start) ->
              _ = application:load(riak_kv),
              [begin


### PR DESCRIPTION
Most of the fixes are just cleaning up resources created by various tests.
Some stuff in test/mapred_test.erl starts riak_kv_app multiple times, which
causes problems with the return value of the riak_api_pb_service:register()
call. Therefore, this is no longer required to be 'ok'.

I'm not very familiar with the Riak codebase, so I'm not hugely confident that I've done the right thing here, especially in `riak_kv_app:start()`. Also, any comments on style or idiom would be appreciated.
