### PR TITLE
Add PB service deregistration on stop.

### DIFF
--- a/src/riak_kv.app.src
+++ b/src/riak_kv.app.src
@@ -9,6 +9,7 @@
                   stdlib,
                   sasl,
                   crypto,
+                  riak_api,
                   riak_core,
                   luke,
                   erlang_js,

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -25,6 +25,13 @@
 -behaviour(application).
 -export([start/2,stop/1]).
 
+-define(SERVICES, [{riak_kv_pb_object, 3, 6}, %% ClientID stuff
+                   {riak_kv_pb_object, 9, 14}, %% Object requests
+                   {riak_kv_pb_bucket, 15, 22}, %% Bucket requests
+                   {riak_kv_pb_mapred, 23, 24}, %% MapReduce requests
+                   {riak_kv_pb_index, 25, 26} %% Secondary index requests
+                  ]).
+
 %% @spec start(Type :: term(), StartArgs :: term()) ->
 %%          {ok,Pid} | ignore | {error,Error}
 %% @doc The application:start callback for riak.
@@ -129,12 +136,7 @@ start(_Type, _StartArgs) ->
                 {bucket_validator, riak_kv_bucket}
             ]),
 
-            ok = riak_api_pb_service:register([{riak_kv_pb_object, 3, 6}, %% ClientID stuff
-                                               {riak_kv_pb_object, 9, 14}, %% Object requests
-                                               {riak_kv_pb_bucket, 15, 22}, %% Bucket requests
-                                               {riak_kv_pb_mapred, 23, 24}, %% MapReduce requests
-                                               {riak_kv_pb_index, 25, 26} %% Secondary index requests
-                                               ]),
+            ok = riak_api_pb_service:register(?SERVICES),
 
             %% Add routes to webmachine
             [ webmachine_router:add_route(R)
@@ -147,6 +149,7 @@ start(_Type, _StartArgs) ->
 %% @spec stop(State :: term()) -> ok
 %% @doc The application:stop callback for riak.
 stop(_State) ->
+    ok = riak_api_pb_service:deregister(?SERVICES),
     ok.
 
 %% 719528 days from Jan 1, 0 to Jan 1, 1970


### PR DESCRIPTION
This helps address the lingering service registration problem in #353 while maintaining correctness. Requires merge of basho/riak_api#10.
