### PR TITLE
Track node gets and puts with a spiral stat

### DIFF
--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -245,17 +245,17 @@ update1({vnode_index_delete, Postings}) ->
     folsom_metrics:notify_existing_metric({?APP, vnode_index_deletes}, Postings, spiral),
     folsom_metrics:notify_existing_metric({?APP, vnode_index_deletes_postings}, Postings, spiral);
 update1({get_fsm, Bucket, Microsecs, undefined, undefined, PerBucket}) ->
-    folsom_metrics:notify_existing_metric({?APP, node_gets_total}, {inc, 1}, counter),
+    folsom_metrics:notify_existing_metric({?APP, node_gets}, 1, spiral),
     folsom_metrics:notify_existing_metric({?APP, node_get_fsm_time}, Microsecs, histogram),
     do_get_bucket(PerBucket, {Bucket, Microsecs, undefined, undefined});
 update1({get_fsm, Bucket, Microsecs, NumSiblings, ObjSize, PerBucket}) ->
-    folsom_metrics:notify_existing_metric({?APP, node_gets_total}, {inc, 1}, counter),
+    folsom_metrics:notify_existing_metric({?APP, node_gets}, 1, spiral),
     folsom_metrics:notify_existing_metric({?APP, node_get_fsm_time}, Microsecs, histogram),
     folsom_metrics:notify_existing_metric({?APP, node_get_fsm_siblings}, NumSiblings, histogram),
     folsom_metrics:notify_existing_metric({?APP, node_get_fsm_objsize}, ObjSize, histogram),
     do_get_bucket(PerBucket, {Bucket, Microsecs, NumSiblings, ObjSize});
 update1({put_fsm_time, Bucket,  Microsecs, PerBucket}) ->
-    folsom_metrics:notify_existing_metric({?APP, node_puts_total}, {inc, 1}, counter),
+    folsom_metrics:notify_existing_metric({?APP, node_puts}, 1, spiral),
     folsom_metrics:notify_existing_metric({?APP, node_put_fsm_time}, Microsecs, histogram),
     do_put_bucket(PerBucket, {Bucket, Microsecs});
 update1(pbc_connect) ->
@@ -282,14 +282,14 @@ do_get_bucket(false, _) ->
     ok;
 do_get_bucket(true, {Bucket, Microsecs, NumSiblings, ObjSize}=Args) ->
     BucketAtom = binary_to_atom(Bucket, latin1),
-    case (catch folsom_metrics:notify_existing_metric({?APP, join(node_gets_total, BucketAtom)}, {inc, 1}, counter)) of
+    case (catch folsom_metrics:notify_existing_metric({?APP, join(node_gets, BucketAtom)}, 1, spiral)) of
         ok ->
             [folsom_metrics:notify_existing_metric({?APP, join(Stat, BucketAtom)}, Arg, histogram)
              || {Stat, Arg} <- [{node_get_fsm_time, Microsecs},
                                 {node_get_fsm_siblings, NumSiblings},
                                 {node_get_fsm_objsize, ObjSize}], Arg /= undefined];
         {'EXIT', _} ->
-            folsom_metrics:new_counter({?APP, join(node_gets_total, BucketAtom)}),
+            folsom_metrics:new_spiral({?APP, join(node_gets, BucketAtom)}),
             [register_stat({?APP, join(Stat, BucketAtom)}, histogram) || Stat <- [node_get_fsm_time,
                                                                                   node_get_fsm_siblings,
                                                                                   node_get_fsm_objsize]],
@@ -301,11 +301,11 @@ do_put_bucket(false, _) ->
     ok;
 do_put_bucket(true, {Bucket, Microsecs}=Args) ->
     BucketAtom = binary_to_atom(Bucket, latin1),
-    case (catch folsom_metrics:notify_existing_metric({?APP, join(node_puts_total, BucketAtom)}, {inc, 1}, counter)) of
+    case (catch folsom_metrics:notify_existing_metric({?APP, join(node_puts, BucketAtom)}, 1, spiral)) of
         ok ->
             folsom_metrics:notify_existing_metric({?APP, join(node_put_fsm_time, BucketAtom)}, Microsecs, histogram);
         {'EXIT', _} ->
-            register_stat({?APP, join(node_puts_total, BucketAtom)}, counter),
+            register_stat({?APP, join(node_puts, BucketAtom)}, spiral),
             register_stat({?APP, join(node_put_fsm_time, BucketAtom)}, histogram),
             do_put_bucket(true, Args)
     end.
@@ -340,14 +340,6 @@ backwards_compat(pbc_connects_active, counter, Stats) ->
     {pbc_active, Stats};
 backwards_compat(Name, counter, Stats) ->
     {Name, Stats};
-backwards_compat(node_get_fsm_time, histogram, Stats) ->
-    Histogram = proplists:get_value(histogram, Stats),
-    Cnt = lists:foldl(fun({_Bin, Val}, Sum) -> Sum + Val end, 0, Histogram),
-    [{node_gets, Cnt} | backwards_compat_histo(node_get_fsm_time, Stats)];
-backwards_compat(node_put_fsm_time, histogram, Stats) ->
-    Histogram = proplists:get_value(histogram, Stats),
-    Cnt = lists:foldl(fun({_Bin, Val}, Sum) -> Sum + Val end, 0, Histogram),
-    [{node_puts, Cnt} | backwards_compat_histo(node_put_fsm_time, Stats)];
 backwards_compat(Name, histogram, Stats) ->
     backwards_compat_histo(Name, Stats).
 
@@ -372,11 +364,11 @@ stats() ->
      {vnode_index_writes_postings, spiral},
      {vnode_index_deletes, spiral},
      {vnode_index_deletes_postings, spiral},
-     {node_gets_total, counter},
+     {node_gets, spiral},
      {node_get_fsm_siblings, histogram},
      {node_get_fsm_objsize, histogram},
      {node_get_fsm_time, histogram},
-     {node_puts_total, counter},
+     {node_puts, spiral},
      {node_put_fsm_time, histogram},
      {pbc_connects, spiral},
      {pbc_connects_active, counter},


### PR DESCRIPTION
When using the `slide_uniform` sample type for the node puts / gets
histogram, the one minute count will be inaccurate for very small
and somewhat large numbers of readings. `Folsom` (actually `bear`)
only calculates the histogram when there are 5 or more readings.
The `slide_uniform` sample type holds a maximum number of 1028
readings per second by default, so nodes with greater throughput
than that will show lower than actual one minute counts. Using
`spiral` for the get / put count solves these issues.
