### PR TITLE
When converting riak_object to JSON, treat usermeta as a struct even if it's empty.

### DIFF
--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -418,10 +418,13 @@ from_json(Obj) ->
 
 jsonify_metadata(MD) ->
     MDJS = fun({LastMod, Now={_,_,_}}) ->
-                                                % convert Now to JS-readable time string
+                   %% convert Now to JS-readable time string
                    {LastMod, list_to_binary(
                                httpd_util:rfc1123_date(
                                  calendar:now_to_local_time(Now)))};
+              %% When the user metadata is empty, it should still be a struct
+              ({?MD_USERMETA, []}) ->
+                   {?MD_USERMETA, {struct, []}};
               ({<<"Links">>, Links}) ->
                    {<<"Links">>, [ [B, K, T] || {{B, K}, T} <- Links ]};
               ({Name, List=[_|_]}) ->


### PR DESCRIPTION
This prevents the case in the Java client where a "map" is expected for the usermeta, but instead the JSON form contains an empty list. Along with basho/riak_pb#10, this resolves the regression in the Java client integration suite.
