### PR TITLE
Corrected host token order during referer validation.

### DIFF
--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -250,7 +250,7 @@ is_null_origin(RD) ->
 %% @doc Validate that the Referer matches up with scheme, host and port of the
 %%      machine that received the request.
 is_valid_referer(RD) ->
-    OriginTuple = {wrq:scheme(RD), string:join(wrq:host_tokens(RD), "."), wrq:port(RD)},
+    OriginTuple = {wrq:scheme(RD), string:join(lists:reverse(wrq:host_tokens(RD)), "."), wrq:port(RD)},
     case referer_tuple(RD) of
         undefined ->
             true;


### PR DESCRIPTION
The host token order of 'OriginTuple' within 'is_valid_referer(RD)' was backwards. It was checking '1.0.0.127' against '127.0.0.1', or 'com.basho.www' against 'www.basho.com', and thus always failing.
