### PR TITLE
Call eleveldb:close on vnode stop for eleveldb backend.

### DIFF
--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -106,8 +106,8 @@ start(Partition, Config) ->
 
 %% @doc Stop the eleveldb backend
 -spec stop(state()) -> ok.
-stop(_State) ->
-    %% No-op; GC handles cleanup
+stop(State) ->
+    eleveldb:close(State#state.ref),
     ok.
 
 %% @doc Retrieve an object from the eleveldb backend


### PR DESCRIPTION
This will have the consequence of failing any running folds
at the point the vnode shuts down rather than allowing them
to complete.

Resolves errors like

```
2012-07-23 22:01:45.831 [error] <0.648.0>@riak_kv_vnode:delete:575 Failed to drop riak_kv_eleveldb_backend. Reason: {error_db_destroy,"IO error: lock ./data/leveldb/114179815416476790484662877555959610910619729920/LOCK: Resource temporarily unavailable"}
2012-07-24 00:01:24.486 [error] <0.1766.0>@riak_kv_vnode:init:265 Failed to start riak_kv_eleveldb_backend Reason: {db_open,"IO error: lock ./data/leveldb/3882113724160210876478537836902626
77096107081728/LOCK: Resource temporarily unavailable"}
```
