### PR TITLE
Changed semantics of backend:drop - backend must close all handles.

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -124,7 +124,12 @@ start(Partition, Config) ->
 %% @doc Stop the bitcask backend
 -spec stop(state()) -> ok.
 stop(#state{ref=Ref}) ->
-    bitcask:close(Ref).
+    case Ref of
+        undefined ->
+            ok;
+        _ ->
+            bitcask:close(Ref)
+    end.
 
 %% @doc Retrieve an object from the bitcask backend
 -spec get(riak_object:bucket(), riak_object:key(), state()) ->
@@ -304,8 +309,7 @@ fold_objects(FoldObjectsFun, Acc, Opts, #state{opts=BitcaskOpts,
 -spec drop(state()) -> {ok, state()} | {error, term(), state()}.
 drop(#state{ref=Ref,
             partition=Partition,
-            root=DataRoot,
-            opts=BitcaskOpts}=State) ->
+            root=DataRoot}=State) ->
     %% Close the bitcask reference
     bitcask:close(Ref),
 
@@ -321,32 +325,17 @@ drop(#state{ref=Ref,
     CleanupDir = check_for_cleanup_dir(DataRoot, auto),
     move_unused_dirs(CleanupDir, PartitionDirs),
 
+    %% Spawn a process to cleanup the old data files.
+    %% The use of spawn is intentional. We do not
+    %% care if this process dies since any lingering
+    %% files will be cleaned up on the next drop.
+    %% The worst case is that the files hang
+    %% around and take up some disk space.
+    spawn(drop_data_cleanup(PartitionStr, CleanupDir)),
+
     %% Make sure the data directory is now empty
     data_directory_cleanup(PartitionDir),
-
-    case make_data_dir(filename:join([DataRoot,
-                                      PartitionStr])) of
-        {ok, DataDir} ->
-            %% Spawn a process to cleanup the old data files.
-            %% The use of spawn is intentional. We do not
-            %% care if this process dies since any lingering
-            %% files will be cleaned up on the next drop.
-            %% The worst case is that the files hang
-            %% around and take up some disk space.
-            spawn(drop_data_cleanup(PartitionStr, CleanupDir)),
-
-            %% Now open the bitcask and return an updated state
-            %% so this backend can continue processing.
-            case bitcask:open(filename:join(DataRoot, DataDir), BitcaskOpts) of
-                Ref1 when is_reference(Ref1) ->
-                    {ok, State#state{data_dir=DataDir,
-                                     ref=Ref1}};
-                {error, Reason} ->
-                    {error, Reason, State#state{data_dir=DataDir}}
-            end;
-        {error, Reason1} ->
-            {error, Reason1, State}
-    end.
+    {ok, State#state{ref = undefined}}.
 
 %% @doc Returns true if this bitcasks backend contains any
 %% non-tombstone values; otherwise returns false.
@@ -737,7 +726,7 @@ drop_test() ->
     %% Stop the backend
     ok = stop(State1),
     os:cmd("rm -rf test/bitcask-backend/*"),
-    ?assertEqual(["42", "auto_cleanup"], lists:sort(DataDirs)),
+    ?assertEqual(["auto_cleanup"], lists:sort(DataDirs)),
     %% The drop cleanup happens in a separate process so
     %% there is no guarantee it has happened yet when
     %% this test runs.


### PR DESCRIPTION
Resolves issues around eleveldb locking and handoff.

Should fix errors like this with 1.2.0rc2

```
2012-07-23 22:01:45.831 [error] <0.648.0>@riak_kv_vnode:delete:575 Failed to drop riak_kv_eleveldb_backend. Reason: {error_db_destroy,"IO error: lock ./data/leveldb/114179815416476790484662877555959610910619729920/LOCK: Resource temporarily unavailable"}
2012-07-24 00:01:24.486 [error] <0.1766.0>@riak_kv_vnode:init:265 Failed to start riak_kv_eleveldb_backend Reason: {db_open,"IO error: lock ./data/leveldb/3882113724160210876478537836902626
77096107081728/LOCK: Resource temporarily unavailable"}
```
