### PR TITLE
Put riak_kv_stat under supervision of riak_core

### DIFF
--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -211,6 +211,7 @@ update(Arg) ->
 %% gen_server
 
 init([]) ->
+    register_stats(),
     {ok, ok}.
 
 handle_call(_Req, _From, State) ->

--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -47,9 +47,6 @@ init([]) ->
                {riak_core_vnode_master, start_link,
                 [riak_kv_vnode, riak_kv_legacy_vnode, riak_kv]},
                permanent, 5000, worker, [riak_core_vnode_master]},
-    RiakStat = {riak_kv_stat,
-                {riak_kv_stat, start_link, []},
-                permanent, 5000, worker, [riak_kv_stat]},
     MapJSPool = {?JSPOOL_MAP,
                  {riak_kv_js_manager, start_link,
                   [?JSPOOL_MAP, read_js_pool_size(map_js_vm_count, "map")]},
@@ -114,7 +111,6 @@ init([]) ->
     % Build the process list...
     Processes = lists:flatten([
         ?IF(HasStorageBackend, VMaster, []),
-        RiakStat,
         GetFsmSup,
         PutFsmSup,
         DeleteSup,

--- a/src/riak_kv_wm_stats.erl
+++ b/src/riak_kv_wm_stats.erl
@@ -68,13 +68,7 @@ content_types_provided(ReqData, Context) ->
 
 
 service_available(ReqData, Ctx) ->
-    case app_helper:get_env(riak_kv, riak_kv_stat, false) of
-        false ->
-            {false, wrq:append_to_response_body("riak_kv_stat is disabled on this node.\n", ReqData),
-             Ctx};
-        true ->
-            {true, ReqData, Ctx}
-    end.
+    {true, ReqData, Ctx}.
 
 forbidden(RD, Ctx) ->
     {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx}.
@@ -93,5 +87,3 @@ pretty_print(RD1, C1=#ctx{}) ->
 get_stats() ->
     proplists:delete(disk, riak_kv_stat:get_stats()) ++
         riak_core_stat:get_stats().
-
-


### PR DESCRIPTION
riak_core now supervisior folsom as an included app, stat modules
need to be part of the same supervision tree for consistency.

Remove check of app_env for stats, as stats are always on now
