### PR TITLE
Catch noproc exit on pipe listkeys/index link

### DIFF
--- a/src/riak_kv_pipe_listkeys.erl
+++ b/src/riak_kv_pipe_listkeys.erl
@@ -156,7 +156,23 @@ queue_existing_pipe(Pipe, Bucket, Timeout) ->
                       [LKP, Bucket, NVal]]),
 
     %% wait for cover to hit everything
-    erlang:link(Sender),
+    {RealTO, TOReason} =
+        try erlang:link(Sender) of
+            true ->
+                %% Sender was alive - wait as expected
+                {Timeout, timeout}
+        catch error:noproc ->
+                %% Sender finished early; it's always spawned locally,
+                %% so we'll get a noproc exit, instead of an exit signal
+
+                %% messages had better already be in our mailbox,
+                %% don't wait any extra time for them
+                {0,
+                 %% we'll have no idea what its failure was, unless it
+                 %% sent us an error message
+                 listkeys_coverage_failure}
+        end,
+
     receive
         {ReqId, done} ->
             %% this eoi will flow into the other pipe
@@ -166,8 +182,8 @@ queue_existing_pipe(Pipe, Bucket, Timeout) ->
             %% this destroy should not harm the other pipe
             riak_pipe:destroy(LKP),
             Error
-    after Timeout ->
+    after RealTO ->
             %% this destroy should not harm the other pipe
             riak_pipe:destroy(LKP),
-            {error, timeout}
+            {error, TOReason}
     end.


### PR DESCRIPTION
This patch is related to basho/riak_pipe#48.

It is possible that the coverage fsm handling the index query at the head of a pipe
will finish (or otherwise exit) before we try to link to it. This patch wraps the
link in a try-catch to prevent a 'noproc' exit (if the coverage fsm did finish
successfully faster than expected, we want to pick up the 'done' message from our
inbox).

The listkeys pipe coverage fitting had the same potential problem (which this patch also addresses).

This was tested by temporarily adding a sleep before the call to erlang:link/1 in riak_kv_pipe_index, to make sure that the coverage FSM had exited before linking to it.
