### PR TITLE
Resolve 2I timeout error from case clause

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -791,7 +791,7 @@ wait_for_query_results(ReqId, Timeout, Acc) ->
         {ReqId,{results, Res}} -> wait_for_query_results(ReqId, Timeout, [Res | Acc]);
         {ReqId, Error} -> {error, Error}
     after Timeout ->
-            {error, timeout, Acc}
+            {error, timeout}
     end.
 
 add_inputs(_FlowPid, []) ->


### PR DESCRIPTION
Neither the HTTP nor the PB interfaces match the `{error, timeout, Acc}` return value of `riak_client:wait_for_query_results/3` that results from a receive timeout. This case is difficult to reach except in the case of a heavily loaded cluster, which is why it has not been hit before.

This changes the return value on timeout to be simply `{error, timeout}`. Partial results from a timed out request could be of dubious value and correctness, so the simplest solution is not to return them.
