### PR TITLE
Use regular logging on Travis for now so we can actually read the output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: erlang
+script: (rebar compile && rebar eunit skip_deps=true) || (find . -name "*.log" -print -exec cat \{\} \; && sh -c "exit 1")
 notifications:
   webhooks: http://basho-engbot.herokuapp.com/travis?key=ad9a6e51d706903e1fd0963c7b8e064b93e85b56
   email: eng@basho.com

--- a/src/riak_kv_test_util.erl
+++ b/src/riak_kv_test_util.erl
@@ -236,15 +236,10 @@ dep_apps(Test, Extra) ->
                 application:set_env(riak_core, ring_state_dir, Test ++ "/ring"),
                 application:set_env(riak_core, platform_data_dir, Test ++ "/data"),
                 application:set_env(riak_core, handoff_port, 0), %% pick a random handoff port
-                case os:getenv("TRAVIS") of
-                    false ->
-                        application:set_env(lager, handlers, [{lager_file_backend,
-                                                               [
-                                                                {Test ++ "/log/debug.log", debug, 10485760, "$D0", 5}]}]),
-                        application:set_env(lager, crash_log, Test ++ "/log/crash.log");
-                    _ ->
-                        application:set_env(lager, handlers, [{lager_console_backend, debug}])
-                end;
+                application:set_env(lager, handlers, [{lager_file_backend,
+                                                       [
+                                                        {Test ++ "/log/debug.log", debug, 10485760, "$D0", 5}]}]),
+                application:set_env(lager, crash_log, Test ++ "/log/crash.log");
            (stop) ->
                 %% TODO: Remove this when the deregistration PR gets
                 %% merged. The list of codes being erased from the


### PR DESCRIPTION
At a later date we can automate uploading the logs on failure.
