### PR TITLE
Improper match on w_val_unsatisfied error in HTTP

### DIFF
--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -1032,12 +1032,12 @@ handle_common_error(Reason, RD, Ctx) ->
                             [Returned, Requested]),
                         RD)),
                 Ctx};
-        {error, {w_val_unsatisfied, Requested, Returned}} ->
+        {error, {w_val_unsatisfied, NumW, NumDW, W, DW}} ->
             {{halt, 503},
                 wrq:set_resp_header("Content-Type", "text/plain",
                     wrq:append_to_response_body(
-                        io_lib:format("W-value unsatisfied: ~p/~p~n",
-                            [Returned, Requested]),
+                        io_lib:format("W/DW-value unsatisfied: w=~p/~p dw=~p/~p~n",
+                            [NumW, W, NumDW, DW]),
                         RD)),
                 Ctx};
         {error, {pr_val_unsatisfied, Requested, Returned}} ->


### PR DESCRIPTION
On put requests, the `riak_kv_put_core` responds to the client layer with `{error, {w_val_unsatisfied, NumW, NumDW, W, DW}}` if either W or DW is not met. In `riak_kv_wm_object`, the error is attempted to be matched as `{error, {w_val_unsatisfied, Requested, Returned}}`, which causes the response to be 500 instead of 503.
