### PR TITLE
Add disk stats to `/stats` output to make consistent

### DIFF
--- a/src/riak_kv_wm_stats.erl
+++ b/src/riak_kv_wm_stats.erl
@@ -85,5 +85,6 @@ pretty_print(RD1, C1=#ctx{}) ->
     {json_pp:print(binary_to_list(list_to_binary(Json))), RD2, C2}.
 
 get_stats() ->
-    proplists:delete(disk, riak_kv_stat:get_stats()) ++
-        riak_core_stat:get_stats().
+    {value, {disk, Disk}, Stats} = lists:keytake(disk, 1, riak_kv_stat:get_stats()),
+    DiskFlat = [{struct, [{id, list_to_binary(Id)}, {size, Size}, {used, Used}]} || {Id, Size, Used} <- Disk],
+    lists:append([Stats, [{disk, DiskFlat}], riak_core_stat:get_stats()]).


### PR DESCRIPTION
As pointed out by @fygrave in #285, `riak-admin status` shows
diak stats, but `/stats` does not. This fixes that.
