### PR TITLE
correct for proper host token ordering fix in webmachine

### DIFF
--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -250,7 +250,7 @@ is_null_origin(RD) ->
 %% @doc Validate that the Referer matches up with scheme, host and port of the
 %%      machine that received the request.
 is_valid_referer(RD) ->
-    OriginTuple = {wrq:scheme(RD), string:join(lists:reverse(wrq:host_tokens(RD)), "."), wrq:port(RD)},
+    OriginTuple = {wrq:scheme(RD), string:join(wrq:host_tokens(RD), "."), wrq:port(RD)},
     case referer_tuple(RD) of
         undefined ->
             true;


### PR DESCRIPTION
This patch is required after https://github.com/basho/webmachine/pull/87 is accepted.
