### PR TITLE
erlang:now() -> os:timestamp() in all the places it is safe

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -746,7 +746,8 @@ for_dialyzer_only_ignore(X, Y) ->
     ?MODULE:new(X, Y).
 
 %% @private
-mk_reqid() -> erlang:phash2(erlang:now()). % only has to be unique per-pid
+mk_reqid() ->
+    erlang:phash2({self(), os:timestamp()}). % only has to be unique per-pid
 
 %% @private
 wait_for_reqid(ReqId, Timeout) ->

--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -225,7 +225,7 @@ format_failure_reason(FailureReason) ->
 %% @doc Get a timestamp, the number of milliseconds returned by
 %%      erlang:now().
 timestamp() ->
-    {MegaSeconds,Seconds,MilliSeconds}=erlang:now(),
+    {MegaSeconds,Seconds,MilliSeconds}=os:timestamp(),
     (MegaSeconds * 1000000000000) + (Seconds * 1000000) + MilliSeconds.
 
 %% @spec to_index_query(binary(), [binary()]) ->

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -157,7 +157,7 @@ check_epoch() ->
     %% doc for erlang:now/0 says return value is platform-dependent
     %% -> let's emit an error if this platform doesn't think the epoch
     %%    is Jan 1, 1970
-    {MSec, Sec, _} = erlang:now(),
+    {MSec, Sec, _} = os:timestamp(),
     GSec = calendar:datetime_to_gregorian_seconds(
              calendar:universal_time()),
     case GSec - ((MSec*1000000)+Sec) of

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -420,7 +420,7 @@ print_vnode_status([StatusItem | RestStatusItems]) ->
 
 print_v2_status(Type, Mod, {SrcPartition, TargetPartition}, StartTS) ->
     StartTSStr = datetime_str(StartTS),
-    Running = timer:now_diff(now(), StartTS),
+    Running = timer:now_diff(os:timestamp(), StartTS),
     RunningStr = riak_core_format:human_time_fmt("~.2f", Running),
 
     io:format("transfer type: ~s~n", [Type]),
@@ -453,7 +453,7 @@ print_stats(SrcNode, TargetNode, Stats) ->
     ObjsS = proplists:get_value(objs_per_s, Stats),
     BytesS = proplists:get_value(bytes_per_s, Stats),
     LastUpdate = proplists:get_value(last_update, Stats),
-    Diff = timer:now_diff(now(), LastUpdate),
+    Diff = timer:now_diff(os:timestamp(), LastUpdate),
     DiffStr = riak_core_format:human_time_fmt("~.2f", Diff),
     Objs = proplists:get_value(objs_total, Stats),
     ObjsSStr = riak_core_format:fmt("~p Objs/s", [ObjsS]),

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -124,7 +124,7 @@ test_link(From, Bucket, Key, GetOptions, StateProps) ->
 
 %% @private
 init([From, Bucket, Key, Options]) ->
-    StartNow = now(),
+    StartNow = os:timestamp(),
     StateData = #state{from = From,
                        options = Options,
                        bkey = {Bucket, Key},
@@ -379,7 +379,7 @@ client_reply(Reply, StateData = #state{from = {raw, ReqId, Pid},
     ?DTRACE(?C_GET_FSM_CLIENT_REPLY, [ShortCode, GetUSecs], ["client_reply"]).
 
 update_timing(StateData = #state{startnow = StartNow}) ->
-    EndNow = now(),
+    EndNow = os:timestamp(),
     StateData#state{get_usecs = timer:now_diff(EndNow, StartNow)}.
 
 update_stats({ok, Obj}, #state{get_usecs = GetUsecs, tracked_bucket = StatTracked}) ->

--- a/src/riak_kv_map_master.erl
+++ b/src/riak_kv_map_master.erl
@@ -135,8 +135,8 @@ code_change(_OldVsn, State, _Extra) ->
 
 %% Internal functions
 make_id() ->
-    {_, _, T3} = erlang:now(),
-    {T3, node()}.
+    ID = erlang:phash2({self(), os:timestamp()}),
+    {ID, node()}.
 
 dequeue_mapper(State) ->
     case are_mappers_waiting(State) of

--- a/src/riak_kv_mapper.erl
+++ b/src/riak_kv_mapper.erl
@@ -63,7 +63,7 @@ init([VNode, Id, QTerm0, MapInputs, PhasePid]) ->
     erlang:link(PhasePid),
     gen_fsm:send_event(PhasePid, {register_mapper, Id, self()}),
     QTermFun = xform_link_walk(QTerm0),
-    {_, _, ReqId} = erlang:now(),
+    ReqId = erlang:phash2({self(), os:timestamp()}),
     riak_kv_stat:update(mapper_start),
     {ok, CacheRef} = riak_kv_mapred_cache:cache_ref(),
     CacheKeyBase = generate_cache_key_base(QTermFun(undefined)),

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -196,7 +196,7 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, State=#state{data_ref=DataRef,
                                                       time_ref=TimeRef,
                                                       ttl=TTL,
                                                       used_memory=UsedMemory}) ->
-    Now = now(),
+    Now = os:timestamp(),
     case TTL of
         undefined ->
             Val1 = Val;
@@ -519,7 +519,7 @@ do_put(Bucket, Key, Val, IndexSpecs, DataRef, IndexRef) ->
 
 %% Check if this timestamp is past the ttl setting.
 exceeds_ttl(Timestamp, TTL) ->
-    Diff = (timer:now_diff(now(), Timestamp) / 1000 / 1000),
+    Diff = (timer:now_diff(os:timestamp(), Timestamp) / 1000 / 1000),
     Diff > TTL.
 
 update_indexes(_Bucket, _Key, undefined, _IndexRef) ->

--- a/src/riak_kv_pipe_get.erl
+++ b/src/riak_kv_pipe_get.erl
@@ -120,7 +120,7 @@ done(_State) ->
     ok.
 
 make_req_id() ->
-    erlang:phash2(erlang:now()). % stolen from riak_client
+    erlang:phash2({self(), os:timestamp()}). % stolen from riak_client
 
 %% useful utilities
 

--- a/src/riak_kv_pipe_index.erl
+++ b/src/riak_kv_pipe_index.erl
@@ -68,7 +68,7 @@ process(Input, _Last, #state{p=Partition, fd=FittingDetails}=State) ->
         {Bucket, Query} ->
             FilterVNodes = []
     end,
-    ReqId = erlang:phash2(erlang:now()), % stolen from riak_client
+    ReqId = erlang:phash2({self(), os:timestamp()}), % stolen from riak_client
     riak_core_vnode_master:coverage(
       ?KV_INDEX_REQ{bucket=Bucket,
                     item_filter=none, %% riak_client uses nothing else?
@@ -139,7 +139,7 @@ queue_existing_pipe(Pipe, Bucket, Query, Timeout) ->
                                 {log, {sink, Pipe#pipe.sink}}]),
 
     %% setup the cover operation
-    ReqId = erlang:phash2(erlang:now()), %% stolen from riak_client
+    ReqId = erlang:phash2({self(), os:timestamp()}), %% stolen from riak_client
     BucketProps = riak_core_bucket:get_bucket(Bucket),
     NVal = proplists:get_value(n_val, BucketProps),
     {ok, Sender} = riak_pipe_qcover_sup:start_qcover_fsm(

--- a/src/riak_kv_pipe_listkeys.erl
+++ b/src/riak_kv_pipe_listkeys.erl
@@ -73,7 +73,7 @@ process(Input, _Last, #state{p=Partition, fd=FittingDetails}=State) ->
             Filters = [],
             FilterVNodes = []
     end,
-    ReqId = erlang:phash2(erlang:now()), % stolen from riak_client
+    ReqId = erlang:phash2({self(), os:timestamp()}), % stolen from riak_client
     riak_core_vnode_master:coverage(
       riak_kv_keys_fsm:req(Bucket, Filters),
       {Partition, node()},
@@ -148,7 +148,7 @@ queue_existing_pipe(Pipe, Bucket, Timeout) ->
                                 {log, {sink, Pipe#pipe.sink}}]),
 
     %% setup the cover operation
-    ReqId = erlang:phash2(erlang:now()), %% stolen from riak_client
+    ReqId = erlang:phash2({self(), os:timestamp()}), %% stolen from riak_client
     BucketProps = riak_core_bucket:get_bucket(Bucket),
     NVal = proplists:get_value(n_val, BucketProps),
     {ok, Sender} = riak_pipe_qcover_sup:start_qcover_fsm(

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -644,7 +644,7 @@ update_last_modified(RObj) ->
     %% which should serve the same purpose.  It was possible to generate two
     %% objects with the same vclock on 0.14.2 if the same clientid was used in
     %% the same second.  It can be revisited post-1.0.0.
-    Now = erlang:now(),
+    Now = os:timestamp(),
     NewMD = dict:store(?MD_VTAG, make_vtag(Now),
                        dict:store(?MD_LASTMOD, Now, MD0)),
     riak_object:update_metadata(RObj, NewMD).

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -194,7 +194,7 @@ get_vclocks(Preflist, BKeyList) ->
 %% @doc Get status information about the node local vnodes.
 -spec vnode_status([{partition(), pid()}]) -> [{atom(), term()}].
 vnode_status(PrefLists) ->
-    ReqId = erlang:phash2(erlang:now()),
+    ReqId = erlang:phash2({self(), os:timestamp()}),
     %% Get the status of each vnode
     riak_core_vnode_master:command(PrefLists,
                                    ?KV_VNODE_STATUS_REQ{},

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -482,7 +482,7 @@ dejsonify_values([{<<"metadata">>, {struct, MD0}},
                             <<"Links">> ->
                                 {Key, [{{B, K}, Tag} || [B, K, Tag] <- Val]};
                             <<"X-Riak-Last-Modified">> ->
-                                {Key, erlang:now()};
+                                {Key, os:timestamp()};
                             _ ->
                                 {Key, if
                                           is_binary(Val) ->


### PR DESCRIPTION
There are 2 holdouts in kv_lru and kv_mrc_pipe that are less clear if
they're safe to change, so I left them.
