### PR TITLE
Randoming kv_put forwardee node

### DIFF
--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -209,7 +209,7 @@ prepare(timeout, StateData0 = #state{from = From, robj = RObj,
             %% forward on to a random node
             ListPos = crypto:rand_uniform(1, length(Preflist2)),
             {{_Idx, CoordNode},_Type} = lists:nth(ListPos),
-            Timeout = get_option(timeout, Options, ?DEFAULT_TIMEOUT),
+            _Timeout = get_option(timeout, Options, ?DEFAULT_TIMEOUT),
             ?DTRACE(?C_PUT_FSM_PREPARE, [1],
                     ["prepare", atom2list(CoordNode)]),
             try

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -206,9 +206,10 @@ prepare(timeout, StateData0 = #state{from = From, robj = RObj,
             process_reply({error, all_nodes_down}, StateData0);
         {_, true} ->
             %% This node is not in the preference list
-            %% forward on to the first node
-            [{{_Idx, CoordNode},_Type}|_] = Preflist2,
-            _Timeout = get_option(timeout, Options, ?DEFAULT_TIMEOUT),
+            %% forward on to a random node
+            ListPos = crypto:rand_uniform(1, length(Preflist2)),
+            {{_Idx, CoordNode},_Type} = lists:nth(ListPos),
+            Timeout = get_option(timeout, Options, ?DEFAULT_TIMEOUT),
             ?DTRACE(?C_PUT_FSM_PREPARE, [1],
                     ["prepare", atom2list(CoordNode)]),
             try


### PR DESCRIPTION
Instead of always choosing the first node in the preferred node list, randomly choose a node from that list.
