### PR TITLE
separate the socket handler and sink processes in MR endpoints

### DIFF
--- a/include/riak_kv_mrc_sink.hrl
+++ b/include/riak_kv_mrc_sink.hrl
@@ -1,0 +1,9 @@
+%% used to communicate from riak_kv_mrc_sink to riak_kv_wm_mapred and
+%% riak_kv_pb_mapred
+-record(kv_mrc_sink,
+        {
+          ref :: reference(), % the pipe ref
+          results :: [{PhaseId::integer(), Result::term()}],
+          logs :: [{PhaseId::integer(), Message::term()}],
+          done :: boolean()
+        }).

--- a/src/riak_kv_mrc_sink.erl
+++ b/src/riak_kv_mrc_sink.erl
@@ -1,0 +1,234 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_mrc_sink: A simple process to act as a Pipe sink for
+%% MapReduce queries
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc This FSM acts as a Riak Pipe sink, and dumbly accumulates
+%% messages received from the pipe, until it is asked to send them to
+%% its owner. The owner is whatever process started this FSM.
+
+%% Messages are delivered to the owners as an erlang message that is a
+%% `#kv_mrc_pipe{}' record. The `logs' field is a list of log messages
+%% received, ordered oldest to youngest, each having the form
+%% `{PhaseId, Message}'. The `results' field is an orddict keyed by
+%% `PhaseId', with each value being a list of results received from
+%% that phase, ordered oldest to youngest. The `ref' field is the
+%% reference from the `#pipe{}' record. The `done' field is `true' if
+%% the `eoi' message has been received, or `false' otherwise.
+
+%% There should be three states: `which_pipe', `collect_output', and
+%% `send_output'.
+
+%% The FSM starts in `which_pipe', and waits there until it
+%% is told which pipe to expect output from.
+
+%% From `which_pipe', the FSM moves to `collect_output'. While in
+%% `collect_output', the FSM simply collects `#pipe_log{}',
+%% `#pipe_result{}', and `#pipe_eoi{}' messages.
+
+%% If the FSM has received logs, results, or the eoi before it
+%% receives a `next' event, it sends everything it has accumulated to
+%% the owner, wrapped in a `#kv_mrc_sink{}' record, clears its buffers,
+%% and returns to collecting pipe messages.
+
+%% If the FSM has not received any logs, results, or the eoi before it
+%% receives a `next' event, it enters the `send_ouput' state. As soon
+%% as the FSM receives any log, result, or eoi message in the
+%% `send_output' state, it sends that message to the owner process,
+%% and then returns to the `collect_output' state.
+
+%% The FSM only exits on its own in three cases. The first is when its
+%% owner exits. The second is when the builder of the pipe for which
+%% it is consuming messages exits abnormally. The third is after it
+%% delivers the a `#kv_mrc_sink{}' in which it has marked
+%% `done=true'.
+-module(riak_kv_mrc_sink).
+
+-export([
+         start/1,
+         start_link/1,
+         use_pipe/2,
+         next/1,
+         stop/1,
+         init/1,
+         which_pipe/2, which_pipe/3,
+         collect_output/2, collect_output/3,
+         send_output/2, send_output/3,
+         handle_event/3,
+         handle_sync_event/4,
+         handle_info/3,
+         terminate/3,
+         code_change/4
+        ]).
+
+-behaviour(gen_fsm).
+
+-include_lib("riak_pipe/include/riak_pipe.hrl").
+-include("riak_kv_mrc_sink.hrl").
+
+-record(state, {
+          owner :: pid(),
+          builder :: pid(),
+          ref :: reference(),
+          results=[] :: [{PhaseId::term(), Results::list()}],
+          logs=[] :: list(),
+          done=false :: boolean()
+         }).
+
+start(OwnerPid) ->
+    riak_kv_mrc_sink_sup:start_sink(OwnerPid).
+
+start_link(OwnerPid) ->
+    gen_fsm:start_link(?MODULE, [OwnerPid], []).
+
+use_pipe(Sink, Pipe) ->
+    gen_fsm:sync_send_event(Sink, {use_pipe, Pipe}).
+
+%% @doc Trigger the send of the next result/log/eoi batch received.
+next(Sink) ->
+    gen_fsm:send_event(Sink, next).
+
+stop(Sink) ->
+    riak_kv_mrc_sink_sup:terminate_sink(Sink).
+
+%% gen_fsm exports
+
+init([OwnerPid]) ->
+    erlang:monitor(process, OwnerPid),
+    {ok, which_pipe, #state{owner=OwnerPid}}.
+
+%%% which_pipe: waiting to find out what pipe we're listening to
+
+which_pipe(_, State) ->
+    {next_state, which_pipe, State}.
+
+which_pipe({use_pipe, #pipe{builder=Builder, sink=Sink}}, _From, State) ->
+    erlang:monitor(process, Builder),
+    {reply, ok, collect_output,
+     State#state{builder=Builder, ref=Sink#fitting.ref}};
+which_pipe(_, _, State) ->
+    {next_state, which_pipe, State}.
+
+%%% collect_output: buffering results and logs until asked for them
+
+collect_output(next, State) ->
+    case State#state.done of
+        true ->
+            NewState = send_to_owner(State),
+            {stop, normal, NewState};
+        false ->
+            case has_output(State) of
+                true ->
+                    NewState = send_to_owner(State),
+                    {next_state, collect_output, NewState};
+                false ->
+                    %% nothing to send yet, prepare to send as soon as
+                    %% there is something
+                    {next_state, send_output, State}
+            end
+    end;
+collect_output(_, State) ->
+    {next_state, collect_output, State}.
+collect_output(_, _, State) ->
+    {next_state, collect_output, State}.
+
+%% send_output: waiting for output to send, after having been asked
+%% for some while there wasn't any
+
+%% all work for send_output is done in handle_info
+send_output(_, State) ->
+    {next_state, send_output, State}.
+send_output(_, _, State) ->
+    {next_state, send_output, State}.
+
+handle_event(_, StateName, State) ->
+    {next_state, StateName, State}.
+
+handle_sync_event(_, _, StateName, State) ->
+    {next_state, StateName, State}.
+
+handle_info(#pipe_result{ref=Ref, from=PhaseId, result=Res},
+            StateName, #state{ref=Ref, results=Acc}=State) ->
+    NewAcc = add_result(PhaseId, Res, Acc),
+    info_response(StateName, State#state{results=NewAcc});
+handle_info(#pipe_log{ref=Ref, from=PhaseId, msg=Msg},
+            StateName, #state{ref=Ref, logs=Acc}=State) ->
+    info_response(StateName, State#state{logs=[{PhaseId, Msg}|Acc]});
+handle_info(#pipe_eoi{ref=Ref},
+            StateName, #state{ref=Ref}=State) ->
+    info_response(StateName, State#state{done=true});
+handle_info({'DOWN', _, process, Pid, Reason}, _,
+            #state{owner=Pid}=State) ->
+    %% exit as soon as the owner dies
+    {stop, Reason, State};
+handle_info({'DOWN', _, process, Pid, Reason}, _,
+            #state{builder=Pid}=State) when Reason /= normal ->
+    %% don't stop when the builder exits 'normal', because that's
+    %% probably just the pipe shutting down normally - wait for the
+    %% owner to ask for the last outputs
+    {stop, Reason, State};
+handle_info(_, StateName, State) ->
+    {next_state, StateName, State}.
+
+%% continue buffering, unless we've been waiting to reply; stop if we
+%% were waiting to reply and we've received eoi
+info_response(collect_output, State) ->
+    {next_state, collect_output, State};
+info_response(send_output, #state{done=Done}=State) ->
+    NewState = send_to_owner(State),
+    if Done -> {stop, normal, NewState};
+       true -> {next_state, collect_output, NewState}
+    end.
+
+terminate(_, _, _) ->
+    ok.
+
+code_change(_, StateName, State, _) ->
+    {ok, StateName, State}.
+
+%% internal
+
+has_output(#state{results=[], logs=[]}) ->
+    false;
+has_output(_) ->
+    true.
+
+%% also clears buffers
+send_to_owner(#state{owner=Owner, ref=Ref,
+                     results=Results, logs=Logs, done=Done}=State) ->
+    Owner ! #kv_mrc_sink{ref=Ref,
+                         results=finish_results(Results),
+                         logs=lists:reverse(Logs),
+                         done=Done},
+    State#state{results=[], logs=[]}.
+
+%% results are kept as lists in a proplist
+add_result(PhaseId, Result, Acc) ->
+    case lists:keytake(PhaseId, 1, Acc) of
+        {value, {PhaseId, IAcc}, RAcc} ->
+            [{PhaseId,[Result|IAcc]}|RAcc];
+        false ->
+            [{PhaseId,[Result]}|Acc]
+    end.
+
+%% transform the proplist buffers into orddicts time-ordered
+finish_results(Results) ->
+    [{I, lists:reverse(R)} || {I, R} <- lists:keysort(1, Results)].

--- a/src/riak_kv_mrc_sink_sup.erl
+++ b/src/riak_kv_mrc_sink_sup.erl
@@ -1,0 +1,83 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2011 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Supervisor for a sink processes used by {@link
+%% riak_kv_wm_mapred} and {@link riak_kv_pb_mapred}.
+-module(riak_kv_mrc_sink_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+-export([start_sink/1,
+         terminate_sink/1]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+%%%===================================================================
+%%% API functions
+%%%===================================================================
+
+%% @doc Start the supervisor.
+-spec start_link() -> {ok, pid()} | ignore | {error, term()}.
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% @doc Start a new worker under the supervisor.
+-spec start_sink(pid()) -> {ok, pid()}.
+start_sink(Owner) ->
+    supervisor:start_child(?MODULE, [Owner]).
+
+%% @doc Stop a worker immediately
+-spec terminate_sink(pid()) -> ok | {error, term()}.
+terminate_sink(Sink) ->
+    supervisor:terminate_child(?MODULE, Sink).
+
+%%%===================================================================
+%%% Supervisor callbacks
+%%%===================================================================
+
+%% @doc Initialize the supervisor.  This is a `simple_one_for_one',
+%% whose child spec is for starting `riak_kv_mrc_sink' FSMs.
+-spec init([]) -> {ok, {{supervisor:strategy(),
+                         pos_integer(),
+                         pos_integer()},
+                        [ supervisor:child_spec() ]}}.
+init([]) ->
+    RestartStrategy = simple_one_for_one,
+    MaxRestarts = 1000,
+    MaxSecondsBetweenRestarts = 3600,
+
+    SupFlags = {RestartStrategy, MaxRestarts, MaxSecondsBetweenRestarts},
+
+    Restart = temporary,
+    Shutdown = 2000,
+    Type = worker,
+
+    AChild = {undefined, % no registered name
+              {riak_kv_mrc_sink, start_link, []},
+              Restart, Shutdown, Type, [riak_kv_mrc_sink]},
+
+    {ok, {SupFlags, [AChild]}}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -99,6 +99,9 @@ init([]) ->
     IndexFsmSup = {riak_kv_index_fsm_sup,
                    {riak_kv_index_fsm_sup, start_link, []},
                    permanent, infinity, supervisor, [riak_kv_index_fsm_sup]},
+    SinkFsmSup = {riak_kv_mrc_sink_sup,
+                  {riak_kv_mrc_sink_sup, start_link, []},
+                  permanent, infinity, supervisor, [riak_kv_mrc_sink_sup]},
     %% @TODO This code is only here to support
     %% rolling upgrades and will be removed.
     LegacyKeysFsmSup = {riak_kv_keys_fsm_legacy_sup,
@@ -114,6 +117,7 @@ init([]) ->
         GetFsmSup,
         PutFsmSup,
         DeleteSup,
+        SinkFsmSup,
         BucketsFsmSup,
         KeysFsmSup,
         IndexFsmSup,


### PR DESCRIPTION
I think this is the correct fix for #366.

Prior to this commit, the process holding the HTTP/PB socket was also the process acting as the Pipe sink for MapReduce requests. This led to many problems, including overwhelming mailboxes with error logging, and extra unexpected messages that had to be ignored if the socket was kept open to handle other requests.

This commit creates a new process to act as the sink, and sets up a request-response interface between them. The sink process spools pipe output until the socket-handling process asks for them.

This removes our dependence on the undocumented `mochiweb_request_force_close` feature, which was used to forcibly close an HTTP connection after a MapReduce failure to avoid incorrect 400 errors later (introduced in #224)

I've made this PR against 1.2, in case we want to include it in a point release, but the patch should be easily rebase-able onto master.

Some why's (structure):
- _Why start these sinks under a supervisor?_ I agree, it seems like a little bit of overkill. Mostly, we want to make sure they're tied to the app's supervision tree. They could just be linked directly to the processes handling the sockets, but then those processes would have to trap exits in order to be able to provide error messages to their clients. However, the mapred modules are not the only handlers in those processes, so others would have to care about whether exits were trapped as well (or we'd have to be super careful about cleaning up). Putting the sinks under a supervisor also makes it super easy to check for leaks: `supervisor:which_children(riak_kv_mrc_sink_sup)`.
- _What's with the `self()`-messaging `#sink_part{}` in `riak_kv_pb_mapred`?_ The module has to operate asynchronously, in order to be able to watch for a timeout message. The design of `riak_api` only allows one message to be sent to the client per erlang message to the process. The `#rbpmapredresp{}` record only allows one phase's outputs per message. The `riak_kv_mrc_sink` fsm might send results for multiple phases in one message. Thus, we must break them down to allow multiple messages to be sent to the client.
- _If the point was to get rid of extra messages, what's with the speculative receives in the cleanup?_ It is still possible that a reply from `riak_kv_mrc_sink` might arrive after our timeout message arrives, for example. We can't let it slip. The difference between this speculative receiving and other attempts, is that we know that there is at most one message waiting, and that it will have been delivered before we check here, if it will be delivered at all.
- _Why am I still getting "fitting was gone before startup" messages in the log?_ This patch does not target those message. This one is aimed at the "unrecognized message" errors coming out of `riak_api`.

Some what's (testing, mostly):
- _What has been tested already?_ I've been running the Java client unit tests via `riak_test` against this branch, as they're good at finding these kinds of errors. There are loadgen tests in issues attached to #366 that should be tried as well.
- _How does this affect performance?_ I don't know. It does introduce an extra process for results to hop through, so copying them could make things slower. The `basho_bench` tests for mapred should be run.
- _Are there any compatibility concerns?_ Because of the buffering that `riak_kv_mrc_sink` is doing, it's possible that clients will once again see multiple results per streaming message, as they did before the transition to pipe. This _should not_ affect compatibility, but it's something to watch for. (It also might improve performance from some perspectives.)
