### PR TITLE
do not use forward_preflist in riak_kv_pipe_get

### DIFF
--- a/src/riak_kv_pipe_get.erl
+++ b/src/riak_kv_pipe_get.erl
@@ -34,13 +34,16 @@
 %% partition number as the Pipe vnode owning this worker.  For this
 %% reason, it is important to use a `chashfun' for this fitting that
 %% gives the same answer as the consistent hashing function for the KV
-%% object.
+%% object. If the object is not found at the local KV vnode, each KV
+%% vnode in the remainder of the object's primary preflist is tried in
+%% sequence.
 %%
 %% If the object is found, the tuple `{ok, Object, Keydata}' is sent
 %% as output.  If an error occurs looking up the object, and the
 %% preflist has been exhausted, the tuple `{Error, {Bucket, Key},
-%% KeyData}' is sent as output (where `Error' is usually `not_found').
-%% The atom `undefined' is used as `KeyData' if none is specified.
+%% KeyData}' is sent as output (where `Error' is usually `{error,
+%% notfound}').  The atom `undefined' is used as `KeyData' if none is
+%% specified.
 
 -module(riak_kv_pipe_get).
 -behaviour(riak_pipe_vnode_worker).
@@ -79,39 +82,65 @@ init(Partition, FittingDetails) ->
 %% @doc Lookup the bucket/key pair on the Riak KV vnode, and send it
 %% downstream.
 -spec process(riak_kv_mrc_pipe:key_input(), boolean(), state())
-         -> {ok | forward_preflist | {error, term()}, state()}.
+         -> {ok | {error, term()}, state()}.
 process(Input, Last, #state{partition=Partition, fd=FittingDetails}=State) ->
+    %% assume local chashfun was used for initial attempt
+    case try_partition(Input, {Partition, node()}, FittingDetails) of
+        {error, _} when Last == false ->
+            {try_preflist(Input, State), State};
+        Result ->
+            {send_output(Input, Result, State), State}
+    end.
+
+send_output(Input, {ok, Obj}, State) ->
+    send_output({ok, Obj, keydata(Input)}, State);
+send_output(Input, Error, State) ->
+    send_output({Error, bkey(Input), keydata(Input)}, State).
+
+send_output(Output, #state{partition=Partition, fd=FittingDetails}) ->
+    riak_pipe_vnode_worker:send_output(
+      Output, Partition, FittingDetails).
+
+%% @doc Try the other primaries in the Input's preflist (skipping the
+%% local vnode we already tried in {@link process/3}.
+try_preflist(Input, #state{partition=P}=State) ->
+    %% pipe only uses primaries - mimicking that here, both to provide
+    %% continuity, and also to avoid a really long wait for a true
+    %% not-found
+    AnnPreflist = riak_core_apl:get_primary_apl(
+                    bkey_chash(Input), bkey_nval(Input), riak_kv),
+    Preflist = [ V || {V, _A} <- AnnPreflist ],
+    %% remove the one we already tried
+    RestPreflist = Preflist--[{P, node()}],
+    try_preflist(Input, RestPreflist, State).
+
+%% helper function walking the remaining preflist
+try_preflist(Input, [], State) ->
+    %% send not-found if no replicas gave us the value
+    send_output(Input, {error, notfound}, State);
+try_preflist(Input, [NextV|Rest], #state{fd=FittingDetails}=State) ->
+    case try_partition(Input, NextV, FittingDetails) of
+        {ok,_}=Result ->
+            send_output(Input, Result, State);
+        _Error ->
+            try_preflist(Input, Rest, State)
+    end.
+
+try_partition(Input, Vnode, FittingDetails) ->
     ReqId = make_req_id(),
     Start = os:timestamp(),
     riak_core_vnode_master:command(
-      {Partition, node()}, %% assume local chashfun was used
+      Vnode,
       ?KV_GET_REQ{bkey=bkey(Input), req_id=ReqId},
       {raw, ReqId, self()},
       riak_kv_vnode_master),
     receive
         {ReqId, {r, {ok, Obj}, _, _}} ->
             ?T(FittingDetails, [kv_get], [{kv_get_latency, {r, timer:now_diff(os:timestamp(), Start)}}]),
-            case riak_pipe_vnode_worker:send_output(
-                   {ok, Obj, keydata(Input)}, Partition, FittingDetails) of
-                ok ->
-                    {ok, State};
-                ER ->
-                    {ER, State}
-            end;
+            {ok, Obj};
         {ReqId, {r, {error, _} = Error, _, _}} ->
             ?T(FittingDetails, [kv_get], [{kv_get_latency, {Error, timer:now_diff(os:timestamp(), Start)}}]),
-            if Last ->
-                    case riak_pipe_vnode_worker:send_output(
-                           {Error, bkey(Input), keydata(Input)},
-                           Partition, FittingDetails) of
-                        ok ->
-                            {ok, State};
-                        ER ->
-                            {ER, State}
-                    end;
-               true ->
-                    {forward_preflist, State}
-            end
+            Error
     end.
 
 %% @doc Not used.

--- a/test/mapred_test.erl
+++ b/test/mapred_test.erl
@@ -537,6 +537,221 @@ fake_builder(TestProc) ->
             end
     end.
 
+notfound_failover_test_() ->
+    IntsBucket = <<"foonum">>,
+    NumInts = 5,
+
+    {setup,
+     setup(),
+     cleanup(),
+     fun(_) ->
+         [
+          ?_test(
+             %% The data created by this step is used by all/most of the
+             %% following tests.
+             ok = riak_kv_mrc_pipe:example_setup(NumInts)
+            ),
+          ?_test(
+             %% check the condition that used to bring down a pipe in
+             %% https://github.com/basho/riak_kv/issues/290
+             %% this version checks it with an actual not-found
+             begin
+                 QLimit = 3,
+                 WaitRef = make_ref(),
+                 Spec =
+                     [{map,
+                       {modfun, riak_kv_mapreduce, map_object_value},
+                       <<"include_keydata">>, false},
+                      {reduce,
+                       {modfun, ?MODULE, reduce_wait_for_signal},
+                       [{reduce_phase_batch_size, 1},
+                        {wait, {self(), WaitRef}}],
+                       true}],
+                 PipeSpec = riak_kv_mrc_pipe:mapred_plan(Spec),
+                 %% make it easier to fill
+                 SmallPipeSpec = [ S#fitting_spec{q_limit=QLimit}
+                                   || S <- PipeSpec ],
+                 {ok, Pipe} = riak_pipe:exec(SmallPipeSpec,
+                                             [{log, sink},
+                                              {trace, [error, queue_full]}]),
+                 ExistingKey = {IntsBucket, <<"bar1">>},
+                 ChashFun = (hd(SmallPipeSpec))#fitting_spec.chashfun,
+                 MissingKey = find_adjacent_key(ChashFun, ExistingKey),
+                 %% get main workers spun up
+                 ok = riak_pipe:queue_work(Pipe, ExistingKey),
+                 receive {waiting, WaitRef, ReducePid} -> ok end,
+
+                 %% reduce is now blocking, fill its queue
+                 [ ok = riak_pipe:queue_work(Pipe, ExistingKey)
+                   || _ <- lists:seq(1, QLimit) ],
+
+                 {NValMod,NValFun} = (hd(SmallPipeSpec))#fitting_spec.nval,
+                 NVal = NValMod:NValFun(ExistingKey),
+
+                 %% each of N paths through the primary preflist
+                 [ fill_map_queue(Pipe, QLimit, ExistingKey)
+                   || _ <- lists:seq(1, NVal) ],
+
+                 %% check get queue actually full
+                 ExpectedTOs = lists:duplicate(NVal, timeout),
+                 {error, ExpectedTOs} =
+                     riak_pipe:queue_work(Pipe, ExistingKey, noblock),
+
+                 %% now inject a missing key that would need to
+                 %% failover to the full queue
+                 ok = riak_pipe:queue_work(Pipe, {MissingKey, test_passing}),
+                 %% and watch for it to block in the reduce queue
+                 %% *this* is when pre-patched code would fail:
+                 %% we'll receive an [error] trace from the kvget fitting's
+                 %% failure to forward the bkey along its preflist
+                 ok = consume_queue_full(Pipe, 1),
+
+                 %% let the pipe finish
+                 riak_pipe:eoi(Pipe),
+                 ReducePid ! {continue, WaitRef},
+
+                 {eoi, Results, Logs} = riak_pipe:collect_results(Pipe),
+                 %% the object does not exist, but we told the map
+                 %% phase to send on its keydata - check for it
+                 ?assert(lists:member({1, test_passing}, Results)),
+                 %% just to be a little extra cautious, check for
+                 %% other errors
+                 ?assertEqual([], [E || {_,{trace,[error],_}}=E <- Logs])
+             end),
+          ?_test(
+             %% check the condition that used to bring down a pipe in
+             %% https://github.com/basho/riak_kv/issues/290
+             %% this version checks with an object that is missing a replica
+             begin
+                 QLimit = 3,
+                 WaitRef = make_ref(),
+                 Spec =
+                     [{map,
+                       {modfun, riak_kv_mapreduce, map_object_value},
+                       none, false},
+                      {reduce,
+                       {modfun, ?MODULE, reduce_wait_for_signal},
+                       [{reduce_phase_batch_size, 1},
+                        {wait, {self(), WaitRef}}],
+                       true}],
+                 PipeSpec = riak_kv_mrc_pipe:mapred_plan(Spec),
+                 %% make it easier to fill
+                 SmallPipeSpec = [ S#fitting_spec{q_limit=QLimit}
+                                   || S <- PipeSpec ],
+                 {ok, Pipe} = riak_pipe:exec(SmallPipeSpec,
+                                             [{log, sink},
+                                              {trace, [error, queue_full]}]),
+                 ExistingKey = {IntsBucket, <<"bar1">>},
+                 ChashFun = (hd(SmallPipeSpec))#fitting_spec.chashfun,
+                 {MissingBucket, MissingKey} =
+                     find_adjacent_key(ChashFun, ExistingKey),
+
+                 %% create a value for the "missing" key
+                 {ok, C} = riak:local_client(),
+                 ok = C:put(riak_object:new(MissingBucket, MissingKey,
+                                            test_passing),
+                            3),
+                 %% and now kill the first replica;
+                 %% this will make the vnode local to the kvget pipe
+                 %% fitting return an error (because it's the memory
+                 %% backend), so it will have to look at another kv vnode
+                 [{{PrimaryIndex, _},_}] =
+                     riak_core_apl:get_primary_apl(
+                       ChashFun({MissingBucket, MissingKey}), 1, riak_kv),
+                 {ok, VnodePid} = riak_core_vnode_manager:get_vnode_pid(
+                                    PrimaryIndex, riak_kv_vnode),
+                 exit(VnodePid, kill),
+                 
+                 %% get main workers spun up
+                 ok = riak_pipe:queue_work(Pipe, ExistingKey),
+                 receive {waiting, WaitRef, ReducePid} -> ok end,
+
+                 %% reduce is now blocking, fill its queue
+                 [ ok = riak_pipe:queue_work(Pipe, ExistingKey)
+                   || _ <- lists:seq(1, QLimit) ],
+
+                 {NValMod,NValFun} = (hd(SmallPipeSpec))#fitting_spec.nval,
+                 NVal = NValMod:NValFun(ExistingKey),
+
+                 %% each of N paths through the primary preflist
+                 [ fill_map_queue(Pipe, QLimit, ExistingKey)
+                   || _ <- lists:seq(1, NVal) ],
+
+                 %% check get queue actually full
+                 ExpectedTOs = lists:duplicate(NVal, timeout),
+                 {error, ExpectedTOs} =
+                     riak_pipe:queue_work(Pipe, ExistingKey, noblock),
+
+                 %% now inject a missing key that would need to
+                 %% failover to the full queue
+                 ok = riak_pipe:queue_work(Pipe, {MissingBucket, MissingKey}),
+                 %% and watch for it to block in the reduce queue
+                 %% *this* is when pre-patched code would fail:
+                 %% we'll receive an [error] trace from the kvget fitting's
+                 %% failure to forward the bkey along its preflist
+                 ok = consume_queue_full(Pipe, 1),
+
+                 %% let the pipe finish
+                 riak_pipe:eoi(Pipe),
+                 ReducePid ! {continue, WaitRef},
+
+                 {eoi, Results, Logs} = riak_pipe:collect_results(Pipe),
+                 %% the object does not exist, but we told the map
+                 %% phase to send on its keydata - check for it
+                 ?assert(lists:member({1, test_passing}, Results)),
+                 %% just to be a little extra cautious, check for
+                 %% other errors
+                 ?assertEqual([], [E || {_,{trace,[error],_}}=E <- Logs])
+             end)
+         ]
+     end}.
+
+fill_map_queue(Pipe, QLimit, ExistingKey) ->
+    %% give the map worker one more to block on
+    ok = riak_pipe:queue_work(Pipe, ExistingKey, noblock),
+    consume_queue_full(Pipe, 1),
+    %% map is now blocking, fill its queue
+    [ ok = riak_pipe:queue_work(Pipe, ExistingKey, noblock)
+      || _ <- lists:seq(1, QLimit) ],
+    %% give the get worker one more to block on
+    ok = riak_pipe:queue_work(Pipe, ExistingKey, noblock),
+    consume_queue_full(Pipe, {xform_map, 0}),
+    %% get is now blocking, fill its queue
+    [ ok = riak_pipe:queue_work(Pipe, ExistingKey, noblock)
+      || _ <- lists:seq(1, QLimit) ],
+    ok.
+
+find_adjacent_key({Mod, Fun}, ExistingKey) ->
+    [ExistingHead|_] = riak_core_apl:get_primary_apl(
+                         Mod:Fun(ExistingKey), 2, riak_kv),
+    [K|_] = lists:dropwhile(
+              fun(N) ->
+                      K = {<<"foonum_missing">>,
+                           list_to_binary(integer_to_list(N))},
+                      [_,Second] = riak_core_apl:get_primary_apl(
+                                     Mod:Fun(K), 2, riak_kv),
+                      Second /= ExistingHead
+              end,
+              lists:seq(1, 1000)),
+    {<<"foonum_missing">>, list_to_binary(integer_to_list(K))}.
+
+consume_queue_full(Pipe, FittingName) ->
+    {log, {FittingName, {trace, [queue_full], _}}} =
+        riak_pipe:receive_result(Pipe, 5000),
+    ok.
+
+reduce_wait_for_signal(Inputs, Args) ->
+    case get(waited) of
+        true ->
+            Inputs;
+        _ ->
+            {TestProc, WaitRef} = proplists:get_value(wait, Args),
+            TestProc ! {waiting, WaitRef, self()},
+            receive {continue, WaitRef} -> ok end,
+            put(waited, true),
+            Inputs
+    end.
+
 wait_until_dead(Pid) when is_pid(Pid) ->
     Ref = monitor(process, Pid),
     receive


### PR DESCRIPTION
As described in basho/riak_kv#290, using forward_preflist makes a MapReduce
pipeline unnecessarily brittle when map or reduce phases are too slow to
keep up with kvget_map fittings. When kvget_map's queues get full,
forward_preflist fails in a way that the fitting is unable to handle.

This patch instead talks directly to another (non-local) KV vnode in the
object's primary preflist to attempt to find the value (instead of
moving the pipe input to a different pipe worker local to that other KV
vnode).

Talking directly to another non-local KV vnode has the downside of
pulling object data across the cluster's internal network if the object
is found. This should be a temporary situation that will correct itself
when the replica is repaired.

Talking to KV vnodes in series, instead of in parallel as a get_fsm
would do, will adversely effect tail latency, but no worse than waiting
for an opening on a different pipe vnode would have.

Directly using riak_kv_get_fsm would have been another option, but that
would also risk incurring other overhead like read-repair. While
read-repair has been a desired feature of MapReduce requests in the
past, introducing it as a surprising side effect of this fix seems
unwise.
