### PR TITLE
separate the socket handler and sink processes in MR endpoints

### DIFF
--- a/include/riak_kv_mrc_sink.hrl
+++ b/include/riak_kv_mrc_sink.hrl
@@ -1,0 +1,9 @@
+%% used to communicate from riak_kv_mrc_sink to riak_kv_wm_mapred and
+%% riak_kv_pb_mapred
+-record(kv_mrc_sink,
+        {
+          ref :: reference(), % the pipe ref
+          results :: [{PhaseId::integer(), Result::term()}],
+          logs :: [{PhaseId::integer(), Message::term()}],
+          done :: boolean()
+        }).

--- a/src/riak_kv_mrc_pipe.erl
+++ b/src/riak_kv_mrc_pipe.erl
@@ -111,6 +111,7 @@
          mapred/2,
          mapred/3,
          mapred_stream/1,
+         mapred_stream/2,
          send_inputs/2,
          send_inputs/3,
          send_inputs_async/2,
@@ -118,6 +119,7 @@
          collect_outputs/2,
          collect_outputs/3,
          group_outputs/2,
+         error_exists/1,
          mapred_plan/1,
          mapred_plan/2,
          compile_string/1,
@@ -206,6 +208,12 @@ mapred(Inputs, Query, Timeout) ->
             {error, Error, collect_outputs(Pipe, NumKeeps, Timeout)}
     end.
 
+%% @equiv mapred_stream(Query, self())
+-spec mapred_stream([query_part()]) ->
+         {{ok, riak_pipe:pipe()}, NumKeeps :: integer()}.
+mapred_stream(Query) ->
+    mapred_stream(Query, self()).
+
 %% @doc Setup the MapReduce plumbing, preparted to receive inputs.
 %% The caller should then use {@link send_inputs/2} or {@link
 %% send_inputs/3} to give the query inputs to process.
@@ -214,11 +222,13 @@ mapred(Inputs, Query, Timeout) ->
 %% requested to keep their inputs, and will need to be passed to
 %% {@link collect_outputs/3} or {@link group_outputs/2} to get labels
 %% compatible with HTTP and PB interface results.
--spec mapred_stream([query_part()]) ->
+-spec mapred_stream([query_part()], pid()) ->
          {{ok, riak_pipe:pipe()}, NumKeeps :: integer()}.
-mapred_stream(Query) ->
+mapred_stream(Query, Target) when is_pid(Target) ->
     NumKeeps = count_keeps_in_query(Query),
-    {riak_pipe:exec(mr2pipe_phases(Query), [{log, sink},{trace,[error]}]),
+    {riak_pipe:exec(mr2pipe_phases(Query),
+                    [{sink, #fitting{pid=Target}},
+                     {log, sink},{trace,[error]}]),
      NumKeeps}.
 
 %% The plan functions are useful for seeing equivalent (we hope) pipeline.
@@ -661,6 +671,20 @@ group_outputs(Outputs, _NumKeeps) ->
             end,
     Merged = lists:foldl(Group, [], Outputs),
     [ lists:reverse(O) || {_, O} <- lists:keysort(1, Merged) ].
+
+%% @doc Look through the logs the pipe produced, and determine if any
+%% of them signal an error. Return the details about the first error
+%% found.
+%%
+%% Each log should be of the form: `{#pipe_log.from, #pipe_log.msg}'
+-spec error_exists(list()) -> {true, term(), term()} | false.
+error_exists(Logs) ->
+    case [ {F, I} || {F, {trace, [error], {error, I}}} <- Logs ] of
+        [{From, Info}|_] ->
+            {true, From, Info};
+        [] ->
+            false
+    end.
 
 %% @doc Produce an Erlang term from a string containing Erlang code.
 %% This is used by {@link riak_kv_mrc_map} and {@link

--- a/src/riak_kv_mrc_sink.erl
+++ b/src/riak_kv_mrc_sink.erl
@@ -175,10 +175,10 @@ handle_info(#pipe_log{ref=Ref, from=PhaseId, msg=Msg},
 handle_info(#pipe_eoi{ref=Ref},
             StateName, #state{ref=Ref}=State) ->
     info_response(StateName, State#state{done=true});
-handle_info({'DOWN', _, process, Pid, Reason}, _,
+handle_info({'DOWN', _, process, Pid, _Reason}, _,
             #state{owner=Pid}=State) ->
     %% exit as soon as the owner dies
-    {stop, Reason, State};
+    {stop, normal, State};
 handle_info({'DOWN', _, process, Pid, Reason}, _,
             #state{builder=Pid}=State) when Reason /= normal ->
     %% don't stop when the builder exits 'normal', because that's

--- a/src/riak_kv_mrc_sink.erl
+++ b/src/riak_kv_mrc_sink.erl
@@ -1,0 +1,234 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_mrc_sink: A simple process to act as a Pipe sink for
+%% MapReduce queries
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc This FSM acts as a Riak Pipe sink, and dumbly accumulates
+%% messages received from the pipe, until it is asked to send them to
+%% its owner. The owner is whatever process started this FSM.
+
+%% Messages are delivered to the owners as an erlang message that is a
+%% `#kv_mrc_pipe{}' record. The `logs' field is a list of log messages
+%% received, ordered oldest to youngest, each having the form
+%% `{PhaseId, Message}'. The `results' field is an orddict keyed by
+%% `PhaseId', with each value being a list of results received from
+%% that phase, ordered oldest to youngest. The `ref' field is the
+%% reference from the `#pipe{}' record. The `done' field is `true' if
+%% the `eoi' message has been received, or `false' otherwise.
+
+%% There should be three states: `which_pipe', `collect_output', and
+%% `send_output'.
+
+%% The FSM starts in `which_pipe', and waits there until it
+%% is told which pipe to expect output from.
+
+%% From `which_pipe', the FSM moves to `collect_output'. While in
+%% `collect_output', the FSM simply collects `#pipe_log{}',
+%% `#pipe_result{}', and `#pipe_eoi{}' messages.
+
+%% If the FSM has received logs, results, or the eoi before it
+%% receives a `next' event, it sends everything it has accumulated to
+%% the owner, wrapped in a `#kv_mrc_sink{}' record, clears its buffers,
+%% and returns to collecting pipe messages.
+
+%% If the FSM has not received any logs, results, or the eoi before it
+%% receives a `next' event, it enters the `send_ouput' state. As soon
+%% as the FSM receives any log, result, or eoi message in the
+%% `send_output' state, it sends that message to the owner process,
+%% and then returns to the `collect_output' state.
+
+%% The FSM only exits on its own in three cases. The first is when its
+%% owner exits. The second is when the builder of the pipe for which
+%% it is consuming messages exits abnormally. The third is after it
+%% delivers the a `#kv_mrc_sink{}' in which it has marked
+%% `done=true'.
+-module(riak_kv_mrc_sink).
+
+-export([
+         start/1,
+         start_link/1,
+         use_pipe/2,
+         next/1,
+         stop/1,
+         init/1,
+         which_pipe/2, which_pipe/3,
+         collect_output/2, collect_output/3,
+         send_output/2, send_output/3,
+         handle_event/3,
+         handle_sync_event/4,
+         handle_info/3,
+         terminate/3,
+         code_change/4
+        ]).
+
+-behaviour(gen_fsm).
+
+-include_lib("riak_pipe/include/riak_pipe.hrl").
+-include("riak_kv_mrc_sink.hrl").
+
+-record(state, {
+          owner :: pid(),
+          builder :: pid(),
+          ref :: reference(),
+          results=[] :: [{PhaseId::term(), Results::list()}],
+          logs=[] :: list(),
+          done=false :: boolean()
+         }).
+
+start(OwnerPid) ->
+    riak_kv_mrc_sink_sup:start_sink(OwnerPid).
+
+start_link(OwnerPid) ->
+    gen_fsm:start_link(?MODULE, [OwnerPid], []).
+
+use_pipe(Sink, Pipe) ->
+    gen_fsm:sync_send_event(Sink, {use_pipe, Pipe}).
+
+%% @doc Trigger the send of the next result/log/eoi batch received.
+next(Sink) ->
+    gen_fsm:send_event(Sink, next).
+
+stop(Sink) ->
+    riak_kv_mrc_sink_sup:terminate_sink(Sink).
+
+%% gen_fsm exports
+
+init([OwnerPid]) ->
+    erlang:monitor(process, OwnerPid),
+    {ok, which_pipe, #state{owner=OwnerPid}}.
+
+%%% which_pipe: waiting to find out what pipe we're listening to
+
+which_pipe(_, State) ->
+    {next_state, which_pipe, State}.
+
+which_pipe({use_pipe, #pipe{builder=Builder, sink=Sink}}, _From, State) ->
+    erlang:monitor(process, Builder),
+    {reply, ok, collect_output,
+     State#state{builder=Builder, ref=Sink#fitting.ref}};
+which_pipe(_, _, State) ->
+    {next_state, which_pipe, State}.
+
+%%% collect_output: buffering results and logs until asked for them
+
+collect_output(next, State) ->
+    case State#state.done of
+        true ->
+            NewState = send_to_owner(State),
+            {stop, normal, NewState};
+        false ->
+            case has_output(State) of
+                true ->
+                    NewState = send_to_owner(State),
+                    {next_state, collect_output, NewState};
+                false ->
+                    %% nothing to send yet, prepare to send as soon as
+                    %% there is something
+                    {next_state, send_output, State}
+            end
+    end;
+collect_output(_, State) ->
+    {next_state, collect_output, State}.
+collect_output(_, _, State) ->
+    {next_state, collect_output, State}.
+
+%% send_output: waiting for output to send, after having been asked
+%% for some while there wasn't any
+
+%% all work for send_output is done in handle_info
+send_output(_, State) ->
+    {next_state, send_output, State}.
+send_output(_, _, State) ->
+    {next_state, send_output, State}.
+
+handle_event(_, StateName, State) ->
+    {next_state, StateName, State}.
+
+handle_sync_event(_, _, StateName, State) ->
+    {next_state, StateName, State}.
+
+handle_info(#pipe_result{ref=Ref, from=PhaseId, result=Res},
+            StateName, #state{ref=Ref, results=Acc}=State) ->
+    NewAcc = add_result(PhaseId, Res, Acc),
+    info_response(StateName, State#state{results=NewAcc});
+handle_info(#pipe_log{ref=Ref, from=PhaseId, msg=Msg},
+            StateName, #state{ref=Ref, logs=Acc}=State) ->
+    info_response(StateName, State#state{logs=[{PhaseId, Msg}|Acc]});
+handle_info(#pipe_eoi{ref=Ref},
+            StateName, #state{ref=Ref}=State) ->
+    info_response(StateName, State#state{done=true});
+handle_info({'DOWN', _, process, Pid, Reason}, _,
+            #state{owner=Pid}=State) ->
+    %% exit as soon as the owner dies
+    {stop, Reason, State};
+handle_info({'DOWN', _, process, Pid, Reason}, _,
+            #state{builder=Pid}=State) when Reason /= normal ->
+    %% don't stop when the builder exits 'normal', because that's
+    %% probably just the pipe shutting down normally - wait for the
+    %% owner to ask for the last outputs
+    {stop, Reason, State};
+handle_info(_, StateName, State) ->
+    {next_state, StateName, State}.
+
+%% continue buffering, unless we've been waiting to reply; stop if we
+%% were waiting to reply and we've received eoi
+info_response(collect_output, State) ->
+    {next_state, collect_output, State};
+info_response(send_output, #state{done=Done}=State) ->
+    NewState = send_to_owner(State),
+    if Done -> {stop, normal, NewState};
+       true -> {next_state, collect_output, NewState}
+    end.
+
+terminate(_, _, _) ->
+    ok.
+
+code_change(_, StateName, State, _) ->
+    {ok, StateName, State}.
+
+%% internal
+
+has_output(#state{results=[], logs=[]}) ->
+    false;
+has_output(_) ->
+    true.
+
+%% also clears buffers
+send_to_owner(#state{owner=Owner, ref=Ref,
+                     results=Results, logs=Logs, done=Done}=State) ->
+    Owner ! #kv_mrc_sink{ref=Ref,
+                         results=finish_results(Results),
+                         logs=lists:reverse(Logs),
+                         done=Done},
+    State#state{results=[], logs=[]}.
+
+%% results are kept as lists in a proplist
+add_result(PhaseId, Result, Acc) ->
+    case lists:keytake(PhaseId, 1, Acc) of
+        {value, {PhaseId, IAcc}, RAcc} ->
+            [{PhaseId,[Result|IAcc]}|RAcc];
+        false ->
+            [{PhaseId,[Result]}|Acc]
+    end.
+
+%% transform the proplist buffers into orddicts time-ordered
+finish_results(Results) ->
+    [{I, lists:reverse(R)} || {I, R} <- lists:keysort(1, Results)].

--- a/src/riak_kv_mrc_sink.erl
+++ b/src/riak_kv_mrc_sink.erl
@@ -184,7 +184,7 @@ handle_info({'DOWN', _, process, Pid, Reason}, _,
     %% don't stop when the builder exits 'normal', because that's
     %% probably just the pipe shutting down normally - wait for the
     %% owner to ask for the last outputs
-    {stop, Reason, State};
+    {stop, normal, State};
 handle_info(_, StateName, State) ->
     {next_state, StateName, State}.
 

--- a/src/riak_kv_mrc_sink_sup.erl
+++ b/src/riak_kv_mrc_sink_sup.erl
@@ -1,0 +1,83 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2011 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Supervisor for a sink processes used by {@link
+%% riak_kv_wm_mapred} and {@link riak_kv_pb_mapred}.
+-module(riak_kv_mrc_sink_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+-export([start_sink/1,
+         terminate_sink/1]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+%%%===================================================================
+%%% API functions
+%%%===================================================================
+
+%% @doc Start the supervisor.
+-spec start_link() -> {ok, pid()} | ignore | {error, term()}.
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% @doc Start a new worker under the supervisor.
+-spec start_sink(pid()) -> {ok, pid()}.
+start_sink(Owner) ->
+    supervisor:start_child(?MODULE, [Owner]).
+
+%% @doc Stop a worker immediately
+-spec terminate_sink(pid()) -> ok | {error, term()}.
+terminate_sink(Sink) ->
+    supervisor:terminate_child(?MODULE, Sink).
+
+%%%===================================================================
+%%% Supervisor callbacks
+%%%===================================================================
+
+%% @doc Initialize the supervisor.  This is a `simple_one_for_one',
+%% whose child spec is for starting `riak_kv_mrc_sink' FSMs.
+-spec init([]) -> {ok, {{supervisor:strategy(),
+                         pos_integer(),
+                         pos_integer()},
+                        [ supervisor:child_spec() ]}}.
+init([]) ->
+    RestartStrategy = simple_one_for_one,
+    MaxRestarts = 1000,
+    MaxSecondsBetweenRestarts = 3600,
+
+    SupFlags = {RestartStrategy, MaxRestarts, MaxSecondsBetweenRestarts},
+
+    Restart = temporary,
+    Shutdown = 2000,
+    Type = worker,
+
+    AChild = {undefined, % no registered name
+              {riak_kv_mrc_sink, start_link, []},
+              Restart, Shutdown, Type, [riak_kv_mrc_sink]},
+
+    {ok, {SupFlags, [AChild]}}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/src/riak_kv_pb_mapred.erl
+++ b/src/riak_kv_pb_mapred.erl
@@ -143,21 +143,13 @@ process_stream({'DOWN', Ref, process, Pid, Reason}, Ref,
 process_stream({'DOWN', Mon, process, Pid, Reason}, _,
                State=#state{req=#rpbmapredreq{},
                             req_ctx=#pipe_ctx{sink={Pid, Mon}}=PipeCtx}) ->
-    if Reason == normal ->
-            %% the sink exited normally, which means it sent us a
-            %% message with multiple phases in it, and we're chugging
-            %% through them now, but our messages to ourself are
-            %% behind this DOWN message in the mailbox
-            {ignore, State};
-       true ->
-            %% the sink died, which it shouldn't be able to do before
-            %% delivering our final results
-            destroy_pipe(PipeCtx),
-            lager:error("Error receiving outputs: ~p", [Reason]),
-            {error,
-             {format, "Error receiving outputs: ~p", [Reason]},
-             clear_state_req(State)}
-    end;
+    %% the sink died, which it shouldn't be able to do before
+    %% delivering our final results
+    destroy_pipe(PipeCtx),
+    lager:error("Error receiving outputs: ~p", [Reason]),
+    {error,
+     {format, "Error receiving outputs: ~p", [Reason]},
+     clear_state_req(State)};
 process_stream({pipe_timeout, Ref}, Ref,
                State=#state{req=#rpbmapredreq{},
                             req_ctx=#pipe_ctx{ref=Ref}=PipeCtx}) ->

--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -99,6 +99,9 @@ init([]) ->
     IndexFsmSup = {riak_kv_index_fsm_sup,
                    {riak_kv_index_fsm_sup, start_link, []},
                    permanent, infinity, supervisor, [riak_kv_index_fsm_sup]},
+    SinkFsmSup = {riak_kv_mrc_sink_sup,
+                  {riak_kv_mrc_sink_sup, start_link, []},
+                  permanent, infinity, supervisor, [riak_kv_mrc_sink_sup]},
     %% @TODO This code is only here to support
     %% rolling upgrades and will be removed.
     LegacyKeysFsmSup = {riak_kv_keys_fsm_legacy_sup,
@@ -114,6 +117,7 @@ init([]) ->
         GetFsmSup,
         PutFsmSup,
         DeleteSup,
+        SinkFsmSup,
         BucketsFsmSup,
         KeysFsmSup,
         IndexFsmSup,

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -30,6 +30,7 @@
 
 -include_lib("webmachine/include/webmachine.hrl").
 -include_lib("riak_pipe/include/riak_pipe.hrl").
+-include("riak_kv_mrc_sink.hrl").
 
 -define(MAPRED_CTYPE, "application/json").
 -define(DEFAULT_TIMEOUT, 60000).
@@ -179,8 +180,13 @@ pipe_mapred(RD,
             #state{inputs=Inputs,
                    mrquery=Query,
                    timeout=Timeout}=State) ->
-    try riak_kv_mrc_pipe:mapred_stream(Query) of
+    {ok, Sink} = riak_kv_mrc_sink:start(self()),
+    try riak_kv_mrc_pipe:mapred_stream(Query, Sink) of
         {{ok, Pipe}, NumKeeps} ->
+            SinkMon = erlang:monitor(process, Sink),
+            %% catch just in case the pipe or sink has already died
+            %% for any reason - we'll get the DOWN later
+            catch riak_kv_mrc_sink:use_pipe(Sink, Pipe),
             PipeRef = (Pipe#pipe.sink)#fitting.ref,
             Tref = erlang:send_after(Timeout, self(), {pipe_timeout, PipeRef}),
             {InputSender, SenderMonitor} =
@@ -188,12 +194,17 @@ pipe_mapred(RD,
             case wrq:get_qs_value("chunked", "false", RD) of
                 "true" ->
                     pipe_mapred_chunked(RD, State, Pipe,
-                                        {InputSender, SenderMonitor}, {Tref, PipeRef});
+                                        {InputSender, SenderMonitor},
+                                        {Tref, PipeRef},
+                                        {Sink, SinkMon});
                 _ ->
                     pipe_mapred_nonchunked(RD, State, Pipe, NumKeeps,
-                                           {InputSender, SenderMonitor}, {Tref, PipeRef})
+                                           {InputSender, SenderMonitor},
+                                           {Tref, PipeRef},
+                                           {Sink, SinkMon})
             end
     catch throw:{badarg, Fitting, Reason} ->
+            riak_kv_mrc_sink:stop(Sink),
             {{halt, 400}, 
              send_error({error, [{phase, Fitting},
                                  {error, iolist_to_binary(Reason)}]}, RD),
@@ -210,6 +221,14 @@ cleanup_sender({SenderPid, SenderRef}) ->
     erlang:demonitor(SenderRef, [flush]),
     exit(SenderPid, kill).
 
+cleanup_pipe({Sink,SinkMon}, Timer) ->
+    erlang:demonitor(SinkMon, [flush]),
+    %% killing the sink should tear down the pipe
+    riak_kv_mrc_sink:stop(Sink),
+    %% receive just in case the sink had sent us one last response
+    receive #kv_mrc_sink{} -> ok after 0 -> ok end,
+    cleanup_timer(Timer).
+
 cleanup_timer({Tref, PipeRef}) ->
     case erlang:cancel_timer(Tref) of
         false ->
@@ -223,8 +242,8 @@ cleanup_timer({Tref, PipeRef}) ->
             ok
     end.
 
-pipe_mapred_nonchunked(RD, State, Pipe, NumKeeps, Sender, PipeTref) ->
-    case pipe_collect_outputs(Pipe, NumKeeps, Sender) of
+pipe_mapred_nonchunked(RD, State, Pipe, NumKeeps, Sender, PipeTref, Sink) ->
+    case pipe_collect_outputs(Pipe, NumKeeps, Sender, Sink) of
         {ok, Results} ->
             JSONResults =
                 case NumKeeps < 2 of
@@ -238,72 +257,91 @@ pipe_mapred_nonchunked(RD, State, Pipe, NumKeeps, Sender, PipeTref) ->
                 end,
             HasMRQuery = State#state.mrquery /= [],
             JSONResults1 = riak_kv_mapred_json:jsonify_bkeys(JSONResults, HasMRQuery),
-            cleanup_timer(PipeTref),
+            cleanup_pipe(Sink, PipeTref),
             {true,
              wrq:set_resp_body(mochijson2:encode(JSONResults1), RD),
              State};
         {error, {sender_error, Error}} ->
             %% the sender links to the builder, so the builder has
             %% already been torn down
-            cleanup_timer(PipeTref),
-            prevent_keepalive(),
+            cleanup_pipe(Sink, PipeTref),
             {{halt, 500}, send_error(Error, RD), State};
         {error, timeout} ->
+            cleanup_pipe(Sink, PipeTref),
             riak_pipe:destroy(Pipe),
             cleanup_sender(Sender),
-            prevent_keepalive(),
             {{halt, 500}, send_error({error, timeout}, RD), State};
         {error, Error} ->
-            cleanup_timer(PipeTref),
+            cleanup_pipe(Sink, PipeTref),
             riak_pipe:destroy(Pipe),
             cleanup_sender(Sender),
-            prevent_keepalive(),
             {{halt, 500}, send_error({error, Error}, RD), State}
     end.
 
-pipe_collect_outputs(Pipe, NumKeeps, Sender) ->
+pipe_collect_outputs(Pipe, NumKeeps, Sender, Sink) ->
     Ref = (Pipe#pipe.sink)#fitting.ref,
-    case pipe_collect_outputs1(Ref, Sender, []) of
+    case pipe_collect_outputs1(Ref, Sender, Sink, []) of
+        {ok, [{_,Outputs}]} when NumKeeps < 2 ->
+            {ok, Outputs};
         {ok, Outputs} ->
-            {ok, riak_kv_mrc_pipe:group_outputs(Outputs, NumKeeps)};
+            {ok, [ O || {_, O} <- Outputs]};
         Error ->
             Error
     end.
 
-pipe_collect_outputs1(Ref, Sender, Acc) ->
-    case pipe_receive_output(Ref, Sender) of
-        {ok, Output} -> pipe_collect_outputs1(Ref, Sender, [Output|Acc]);
-        eoi          -> {ok, lists:reverse(Acc)};
+pipe_collect_outputs1(Ref, Sender, Sink, Acc) ->
+    case pipe_receive_output(Ref, Sender, Sink) of
+        {ok, false, Output} ->
+            pipe_collect_outputs1(Ref, Sender, Sink, [Output|Acc]);
+        {ok, true, Output} ->
+            {ok, resort_collected_outputs([Output|Acc])};
         Error        -> Error
     end.
 
-pipe_receive_output(Ref, {SenderPid, SenderRef}) ->
+%% Outputs are collected as a list of orddicts, with the first being
+%% the most recently received. What we really want is one orddict.
+%%
+%% That is, for one keep, our input should look like:
+%%    [ [{0, [G,H,I]}], [{0, [D,E,F]}], [{0, [A,B,C]}] ]
+%% And we want it to come out as:
+%%    [{0, [A,B,C,D,E,F,G,H,I]}]
+-spec resort_collected_outputs([ [{integer(), list()}] ]) ->
+          [{integer(), list()}].
+resort_collected_outputs(Acc) ->
+    %% each orddict has its outputs in oldest->newest; since we're
+    %% iterating from newest->oldest overall, we can just tack the
+    %% next list onto the front of the accumulator
+    DM = fun(_K, O, A) -> O++A end,
+    lists:foldl(fun(O, A) -> orddict:merge(DM, O, A) end, [], Acc).
+
+pipe_receive_output(Ref, {SenderPid, SenderRef}, {SinkPid, SinkMon}) ->
+    riak_kv_mrc_sink:next(SinkPid),
     receive
-        #pipe_eoi{ref=Ref} ->
-            eoi;
-        #pipe_result{ref=Ref, from=From, result=Result} ->
-            {ok, {From, Result}};
-        #pipe_log{ref=Ref, from=From, msg=Msg} ->
-            case Msg of
-                {trace, [error], {error, Info}} ->
+        #kv_mrc_sink{ref=Ref, results=Results, logs=Logs, done=Done} ->
+            case riak_kv_mrc_pipe:error_exists(Logs) of
+                {true, From, Info} ->
                     {error, riak_kv_mapred_json:jsonify_pipe_error(
                               From, Info)};
-                _ ->
-                    %% not a log message we're interested in
-                    pipe_receive_output(Ref, {SenderPid, SenderRef})
+                false ->
+                    {ok, Done, Results}
             end;
         {'DOWN', SenderRef, process, SenderPid, Reason} ->
             if Reason == normal ->
                     %% just done sending inputs, nothing to worry about
-                    pipe_receive_output(Ref, {SenderPid, SenderRef});
+                    pipe_receive_output(
+                      Ref, {SenderPid, SenderRef}, {SinkPid, SinkMon});
                true ->
                     {error, {sender_error, Reason}}
             end;
+        {'DOWN', SinkMon, process, SinkPid, Reason} ->
+            %% we should never receive the sink's DOWN before its
+            %% final message to us
+            {error, {sink_error, Reason}};
         {pipe_timeout, Ref} ->
             {error, timeout}
     end.
 
-pipe_mapred_chunked(RD, State, Pipe, Sender, PipeTref) ->
+pipe_mapred_chunked(RD, State, Pipe, Sender, PipeTref, Sink) ->
     Boundary = riak_core_util:unique_id_62(),
     CTypeRD = wrq:set_resp_header(
                 "Content-Type",
@@ -311,62 +349,63 @@ pipe_mapred_chunked(RD, State, Pipe, Sender, PipeTref) ->
                 RD),
     BoundaryState = State#state{boundary=Boundary},
     Streamer = pipe_stream_mapred_results(
-                 CTypeRD, Pipe, BoundaryState, Sender, PipeTref),
+                 CTypeRD, Pipe, BoundaryState, Sender, PipeTref, Sink),
     {true,
      wrq:set_resp_body({stream, Streamer}, CTypeRD),
      BoundaryState}.
 
 pipe_stream_mapred_results(RD, Pipe,
                            #state{boundary=Boundary}=State, 
-                           Sender, PipeTref) ->
-    case pipe_receive_output((Pipe#pipe.sink)#fitting.ref, Sender) of
-        {ok, {PhaseId, Result}} ->
-            %% results come out of pipe one
-            %% at a time but they're supposed to
-            %% be in a list at the client end
-            JSONResults = [riak_kv_mapred_json:jsonify_not_found(Result)],
-            HasMRQuery = State#state.mrquery /= [],
-            JSONResults1 = riak_kv_mapred_json:jsonify_bkeys(JSONResults, HasMRQuery),
-            Data = mochijson2:encode({struct, [{phase, PhaseId},
-                                               {data, JSONResults1}]}),
-            Body = ["\r\n--", Boundary, "\r\n",
-                    "Content-Type: application/json\r\n\r\n",
-                    Data],
-            {iolist_to_binary(Body),
-             fun() -> pipe_stream_mapred_results(RD, Pipe, State, Sender, PipeTref) end};
-        eoi ->
-            cleanup_timer(PipeTref),
-            {iolist_to_binary(["\r\n--", Boundary, "--\r\n"]), done};
+                           Sender, PipeTref, Sink) ->
+    case pipe_receive_output((Pipe#pipe.sink)#fitting.ref, Sender, Sink) of
+        {ok, Done, Outputs} ->
+            BodyA = case Outputs of
+                        [] ->
+                            [];
+                        _ ->
+                            HasMRQuery = State#state.mrquery /= [],
+                            [ result_part(O, HasMRQuery, Boundary)
+                              || O <- Outputs ]
+                    end,
+            {BodyB,Next} = case Done of
+                               true ->
+                                   cleanup_pipe(Sink, PipeTref),
+                                   {iolist_to_binary(
+                                      ["\r\n--", Boundary, "--\r\n"]),
+                                    done};
+                               false ->
+                                   {[],
+                                    fun() -> pipe_stream_mapred_results(
+                                               RD, Pipe, State,
+                                               Sender, PipeTref, Sink)
+                                    end}
+                           end,
+            {iolist_to_binary([BodyA,BodyB]), Next};
         {error, timeout} ->
+            cleanup_pipe(Sink, PipeTref),
             riak_pipe:destroy(Pipe),
             cleanup_sender(Sender),
-            prevent_keepalive(),
             {format_error({error, timeout}), done};
         {error, {sender_error, Error}} ->
-            cleanup_timer(PipeTref),
-            prevent_keepalive(),
+            cleanup_pipe(Sink, PipeTref),
             {format_error(Error), done};
         {error, {Error, _Input}} ->
-            cleanup_timer(PipeTref),
+            cleanup_pipe(Sink, PipeTref),
             riak_pipe:destroy(Pipe),
             cleanup_sender(Sender),
-            prevent_keepalive(),
             {format_error({error, Error}), done}
     end.
 
-%% @doc Prevent this socket from being used for another HTTP request.
-%% This is used to workaround an issue in mochiweb, where the loop
-%% waiting for new TCP data receives a latent pipe message instead,
-%% and blows up, sending a 400 to the requester.
-%%
-%% WARNING: This uses an undocumented feature of mochiweb that exists
-%% in 1.5.1 (the version planned to ship with Riak 1.0).  The feature
-%% appears to still exist in mochiweb 2.2.1, but it may go away in
-%% future mochiweb releases.
-%%
-%% See [https://issues.basho.com/1222] for more details.
-prevent_keepalive() ->
-    erlang:put(mochiweb_request_force_close, true).
+result_part({PhaseId, Results}, HasMRQuery, Boundary) ->
+    Data = [ riak_kv_mapred_json:jsonify_bkeys(
+               riak_kv_mapred_json:jsonify_not_found(R),
+               HasMRQuery)
+             || R <- Results ],
+    JSON = {struct, [{phase, PhaseId},
+                     {data, Data}]},
+    ["\r\n--", Boundary, "\r\n",
+     "Content-Type: application/json\r\n\r\n",
+     mochijson2:encode(JSON)].
 
 %% LEGACY MAPRED
 


### PR DESCRIPTION
I think this is the correct fix for #366.

**Dependencies**: This PR depends on basho/riak_api#14

**History**: This is a rebase of #407 onto master, with rewrites to use new functionality introduced by basho/riak_api#14.

Prior to this commit, the process holding the HTTP/PB socket was also the process acting as the Pipe sink for MapReduce requests. This led to many problems, including overwhelming mailboxes with error logging, and extra unexpected messages that had to be ignored if the socket was kept open to handle other requests.

This commit creates a new process to act as the sink, and sets up a request-response interface between them. The sink process spools pipe output until the socket-handling process asks for them.

This removes our dependence on the undocumented `mochiweb_request_force_close` feature, which was used to forcibly close an HTTP connection after a MapReduce failure to avoid incorrect 400 errors later (introduced in #224)

Some why's (structure):
- _Why start these sinks under a supervisor?_ I agree, it seems like a little bit of overkill. Mostly, we want to make sure they're tied to the app's supervision tree. They could just be linked directly to the processes handling the sockets, but then those processes would have to trap exits in order to be able to provide error messages to their clients. However, the mapred modules are not the only handlers in those processes, so others would have to care about whether exits were trapped as well (or we'd have to be super careful about cleaning up). Putting the sinks under a supervisor also makes it super easy to check for leaks: `supervisor:which_children(riak_kv_mrc_sink_sup)`.
- _If the point was to get rid of extra messages, what's with the speculative receives in the cleanup?_ It is still possible that a reply from `riak_kv_mrc_sink` might arrive after our timeout message arrives, for example. We can't let it slip. The difference between this speculative receiving and other attempts, is that we know that there is at most one message waiting, and that it will have been delivered before we check here, if it will be delivered at all.
- _Why am I still getting "fitting was gone before startup" messages in the log?_ This patch does not target those message. This one is aimed at the "unrecognized message" errors coming out of `riak_api`.

Some what's (testing, mostly):
- _What has been tested already?_ I've been running the Java client unit tests via `riak_test` against this branch, as they're good at finding these kinds of errors. There are loadgen tests in issues attached to #366 that should be tried as well.
- _How does this affect performance?_ I don't know. It does introduce an extra process for results to hop through, so copying them could make things slower. The `basho_bench` tests for mapred should be run.
- _Are there any compatibility concerns?_ Because of the buffering that `riak_kv_mrc_sink` is doing, it's possible that clients will once again see multiple results per streaming message, as they did before the transition to pipe. This _should not_ affect compatibility, but it's something to watch for. (It also might improve performance from some perspectives.)
