### PR TITLE
Add dimensions to read repair stats

### DIFF
--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -361,13 +361,13 @@ read_repair(Indices, RepairObj,
             #state{req_id = ReqId, starttime = StartTime,
                    preflist2 = Sent, bkey = BKey, bucket_props = BucketProps}) ->
     RepairPreflist = [{Idx, Node} || {{Idx, Node}, _Type} <- Sent,
-                                     lists:member(Idx, Indices)],
+                                     proplists:get_value(Idx, Indices) /= undefined],
     Ps = preflist_for_tracing(RepairPreflist),
     ?DTRACE(?C_GET_FSM_RR, [], Ps),
     riak_kv_vnode:readrepair(RepairPreflist, BKey, RepairObj, ReqId,
                              StartTime, [{returnbody, false},
                                          {bucket_props, BucketProps}]),
-    riak_kv_stat:update(read_repairs).
+    riak_kv_stat:update({read_repairs, Indices, Sent}).
 
 
 get_option(Name, Options, Default) ->

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -362,8 +362,7 @@ read_repair(Indices, RepairObj,
                    preflist2 = Sent, bkey = BKey, bucket_props = BucketProps}) ->
     RepairPreflist = [{Idx, Node} || {{Idx, Node}, _Type} <- Sent,
                                      lists:member(Idx, Indices)],
-    Ps = [[atom2list(Nd), $,, integer_to_list(Idx)] ||
-             {Idx, Nd} <- lists:sublist(RepairPreflist, 4)],
+    Ps = preflist_for_tracing(RepairPreflist),
     ?DTRACE(?C_GET_FSM_RR, [], Ps),
     riak_kv_vnode:readrepair(RepairPreflist, BKey, RepairObj, ReqId,
                              StartTime, [{returnbody, false},

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -152,17 +152,16 @@ do_per_index(Op, Idx, USecs) ->
 do_get_bucket(false, _) ->
     ok;
 do_get_bucket(true, {Bucket, Microsecs, Stages, NumSiblings, ObjSize}=Args) ->
-    BucketAtom = binary_to_atom(Bucket, latin1),
-    case (catch folsom_metrics:notify_existing_metric({?APP, node, gets, BucketAtom}, 1, spiral)) of
+    case (catch folsom_metrics:notify_existing_metric({?APP, node, gets, Bucket}, 1, spiral)) of
         ok ->
-            [folsom_metrics:notify_existing_metric({?APP, node, gets, Dimension, BucketAtom}, Arg, histogram)
+            [folsom_metrics:notify_existing_metric({?APP, node, gets, Dimension, Bucket}, Arg, histogram)
              || {Dimension, Arg} <- [{time, Microsecs},
                                      {siblings, NumSiblings},
                                      {objsize, ObjSize}], Arg /= undefined],
-            do_stages([?APP, node, gets, time, BucketAtom], Stages);
+            do_stages([?APP, node, gets, time, Bucket], Stages);
         {'EXIT', _} ->
-            folsom_metrics:new_spiral({?APP, node, gets, BucketAtom}),
-            [register_stat({?APP, node, gets, Dimension, BucketAtom}, histogram) || Dimension <- [time,
+            folsom_metrics:new_spiral({?APP, node, gets, Bucket}),
+            [register_stat({?APP, node, gets, Dimension, Bucket}, histogram) || Dimension <- [time,
                                                                                   siblings,
                                                                                   objsize]],
             do_get_bucket(true, Args)
@@ -172,14 +171,13 @@ do_get_bucket(true, {Bucket, Microsecs, Stages, NumSiblings, ObjSize}=Args) ->
 do_put_bucket(false, _) ->
     ok;
 do_put_bucket(true, {Bucket, Microsecs, Stages}=Args) ->
-    BucketAtom = binary_to_atom(Bucket, latin1),
-    case (catch folsom_metrics:notify_existing_metric({?APP, node, puts, BucketAtom}, 1, spiral)) of
+    case (catch folsom_metrics:notify_existing_metric({?APP, node, puts, Bucket}, 1, spiral)) of
         ok ->
-            folsom_metrics:notify_existing_metric({?APP, node, puts, time, BucketAtom}, Microsecs, histogram),
-            do_stages([?APP, node, puts, time, BucketAtom], Stages);
+            folsom_metrics:notify_existing_metric({?APP, node, puts, time, Bucket}, Microsecs, histogram),
+            do_stages([?APP, node, puts, time, Bucket], Stages);
         {'EXIT', _} ->
-            register_stat({?APP, node, puts, BucketAtom}, spiral),
-            register_stat({?APP, node, puts, time, BucketAtom}, histogram),
+            register_stat({?APP, node, puts, Bucket}, spiral),
+            register_stat({?APP, node, puts, time, Bucket}, histogram),
             do_put_bucket(true, Args)
     end.
 

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -28,151 +28,10 @@
 %%      folsom.
 %%
 %%      Get the latest aggregation of stats with the exported function
-%%      get_stats/0. Or use folsom_metrics:get_metric_value/1
+%%      get_stats/0. Or use folsom_metrics:get_metric_value/1,
+%%      or riak_core_stat_q:get_stats/1.
 %%
-%%      Current stats:
-%%<dl><dt>  vnode_gets
-%%</dt><dd> Total number of gets handled by all vnodes on this node
-%%          in the last minute.
-%%</dd><dd> update(vnode_get)
-%%
-%%</dd><dt> vnode_puts
-%%</dt><dd> Total number of puts handled by all vnodes on this node
-%%          in the last minute.
-%%</dd><dd> update(vnode_put)
-%%
-%%</dd><dt> vnode_index_reads
-%%</dt><dd> The number of index reads handled by all vnodes on this node.
-%%          Each query counts as an index read.
-%%</dd><dd> update(vnode_index_read)
-%%
-%%</dd><dt> vnode_index_writes
-%%</dt><dd> The number of batched writes handled by all vnodes on this node.
-%%</dd><dd> update({vnode_index_write, PostingsAdded, PostingsRemoved})
-%%
-%%</dd><dt> vnode_index_writes_postings
-%%</dt><dd> The number of postings written to all vnodes on this node.
-%%</dd><dd> update({vnode_index_write, PostingsAdded, PostingsRemoved})
-%%
-%%</dd><dt> vnode_index_deletes
-%%</dt><dd> The number of batched writes handled by all vnodes on this node.
-%%</dd><dd> update({vnode_index_delete, PostingsRemoved})
-%%
-%%</dd><dt> vnode_index_deletes_postings
-%%</dt><dd> The number of postings written to all vnodes on this node.
-%%</dd><dd> update({vnode_index_delete, PostingsRemoved})
-%%
-%%</dd><dt> node_gets
-%%</dt><dd> Number of gets coordinated by this node in the last
-%%          minute.
-%%</dd><dd> update({get_fsm, _Bucket, Microseconds, NumSiblings, ObjSize})
-%%
-%%</dd><dt> node_get_fsm_siblings
-%%</dt><dd> Stats about number of siblings per object in the last minute.
-%%</dd><dd> Updated via node_gets.
-%%
-%%</dd><dt> node_get_fsm_objsize
-%%</dt><dd> Stats about object size over the last minute. The object
-%%          size is an estimate calculated by summing the size of the
-%%          bucket name, key name, and serialized vector clock, plus
-%%          the value and serialized metadata of each sibling.
-%%</dd><dd> Updated via node_gets.
-%%
-%%</dd><dt> node_get_fsm_time_mean
-%%</dt><dd> Mean time, in microseconds, between when a riak_kv_get_fsm is
-%%          started and when it sends a reply to the client, for the
-%%          last minute.
-%%</dd><dd> update({get_fsm_time, Microseconds})
-%%
-%%</dd><dt> node_get_fsm_time_median
-%%</dt><dd> Median time, in microseconds, between when a riak_kv_get_fsm
-%%          is started and when it sends a reply to the client, for
-%%          the last minute.
-%%</dd><dd> update({get_fsm_time, Microseconds})
-%%
-%%</dd><dt> node_get_fsm_time_95
-%%</dt><dd> Response time, in microseconds, met or beaten by 95% of
-%%          riak_kv_get_fsm executions.
-%%</dd><dd> update({get_fsm_time, Microseconds})
-%%
-%%</dd><dt> node_get_fsm_time_99
-%%</dt><dd> Response time, in microseconds, met or beaten by 99% of
-%%          riak_kv_get_fsm executions.
-%%</dd><dd> update({get_fsm_time, Microseconds})
-%%
-%%</dd><dt> node_get_fsm_time_100
-%%</dt><dd> Response time, in microseconds, met or beaten by 100% of
-%%          riak_kv_get_fsm executions.
-%%</dd><dd> update({get_fsm_time, Microseconds})
-%%
-%%</dd><dt> node_puts
-%%</dt><dd> Number of puts coordinated by this node in the last
-%%          minute.
-%%</dd><dd> update({put_fsm_time, Microseconds})
-%%
-%%</dd><dt> node_put_fsm_time_mean
-%%</dt><dd> Mean time, in microseconds, between when a riak_kv_put_fsm is
-%%          started and when it sends a reply to the client, for the
-%%          last minute.
-%%</dd><dd> update({put_fsm_time, Microseconds})
-%%
-%%</dd><dt> node_put_fsm_time_median
-%%</dt><dd> Median time, in microseconds, between when a riak_kv_put_fsm
-%%          is started and when it sends a reply to the client, for
-%%          the last minute.
-%%</dd><dd> update({put_fsm_time, Microseconds})
-%%
-%%</dd><dt> node_put_fsm_time_95
-%%</dt><dd> Response time, in microseconds, met or beaten by 95% of
-%%          riak_kv_put_fsm executions.
-%%</dd><dd> update({put_fsm_time, Microseconds})
-%%
-%%</dd><dt> node_put_fsm_time_99
-%%</dt><dd> Response time, in microseconds, met or beaten by 99% of
-%%          riak_kv_put_fsm executions.
-%%</dd><dd> update({put_fsm_time, Microseconds})
-%%
-%%</dd><dt> node_put_fsm_time_100
-%%</dt><dd> Response time, in microseconds, met or beaten by 100% of
-%%          riak_kv_put_fsm executions.
-%%</dd><dd> update({put_fsm_time, Microseconds})
-%%
-%%</dd><dt> cpu_nprocs
-%%</dt><dd> Value returned by {@link cpu_sup:nprocs/0}.
-%%
-%%</dd><dt> cpu_avg1
-%%</dt><dd> Value returned by {@link cpu_sup:avg1/0}.
-%%
-%%</dd><dt> cpu_avg5
-%%</dt><dd> Value returned by {@link cpu_sup:avg5/0}.
-%%
-%%</dd><dt> cpu_avg15
-%%</dt><dd> Value returned by {@link cpu_sup:avg15/0}.
-%%
-%%</dd><dt> mem_total
-%%</dt><dd> The first element of the tuple returned by
-%%          {@link memsup:get_memory_data/0}.
-%%
-%%</dd><dt> mem_allocated
-%%</dt><dd> The second element of the tuple returned by
-%%          {@link memsup:get_memory_data/0}.
-%%
-%%</dd><dt> disk
-%%</dt><dd> Value returned by {@link disksup:get_disk_data/0}.
-%%
-%%</dd><dt> pbc_connects_total
-%%</dt><dd> Total number of pb socket connections since start
-%%
-%%</dd><dt> pbc_active
-%%</dt><dd> Number of active pb socket connections
-%%
-%%</dd><dt> coord_redirs_total
-%%</dt><dd> Number of puts forwarded to be coordinated on a node
-%%          in the preflist.
-%%
-%%</dd></dl>
-%%
-%%
+
 -module(riak_kv_stat).
 
 -behaviour(gen_server).
@@ -219,7 +78,7 @@ handle_call(_Req, _From, State) ->
     {reply, ok, State}.
 
 handle_cast({update, Arg}, State) ->
-    update1(Arg),
+    do_update(Arg),
     {noreply, State};
 handle_cast(_Req, State) ->
     {noreply, State}.
@@ -234,52 +93,52 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 %% @doc Update the given stat
-update1({vnode_get, Idx, USecs}) ->
+do_update({vnode_get, Idx, USecs}) ->
     folsom_metrics:notify_existing_metric({?APP, vnode, gets}, 1, spiral),
     create_or_update({?APP, vnode, gets, time}, USecs, histogram),
     do_per_index(gets, Idx, USecs);
-update1({vnode_put, Idx, USecs}) ->
+do_update({vnode_put, Idx, USecs}) ->
     folsom_metrics:notify_existing_metric({?APP, vnode, puts}, 1, spiral),
     create_or_update({?APP, vnode, puts, time}, USecs, histogram),
     do_per_index(puts, Idx, USecs);
-update1(vnode_index_read) ->
+do_update(vnode_index_read) ->
     folsom_metrics:notify_existing_metric({?APP, vnode, index, reads}, 1, spiral);
-update1({vnode_index_write, PostingsAdded, PostingsRemoved}) ->
+do_update({vnode_index_write, PostingsAdded, PostingsRemoved}) ->
     folsom_metrics:notify_existing_metric({?APP, vnode, index, writes}, 1, spiral),
     folsom_metrics:notify_existing_metric({?APP, vnode, index, writes, postings}, PostingsAdded, spiral),
     folsom_metrics:notify_existing_metric({?APP, vnode, index, deletes, postings}, PostingsRemoved, spiral);
-update1({vnode_index_delete, Postings}) ->
+do_update({vnode_index_delete, Postings}) ->
     folsom_metrics:notify_existing_metric({?APP, vnode, index, deletes}, Postings, spiral),
     folsom_metrics:notify_existing_metric({?APP, vnode, index, deletes, postings}, Postings, spiral);
-update1({get_fsm, Bucket, Microsecs, Stages, undefined, undefined, PerBucket}) ->
+do_update({get_fsm, Bucket, Microsecs, Stages, undefined, undefined, PerBucket}) ->
     folsom_metrics:notify_existing_metric({?APP, node, gets}, 1, spiral),
     folsom_metrics:notify_existing_metric({?APP, node, gets, time}, Microsecs, histogram),
     do_stages([?APP, node, gets, time], Stages),
     do_get_bucket(PerBucket, {Bucket, Microsecs, Stages, undefined, undefined});
-update1({get_fsm, Bucket, Microsecs, Stages, NumSiblings, ObjSize, PerBucket}) ->
+do_update({get_fsm, Bucket, Microsecs, Stages, NumSiblings, ObjSize, PerBucket}) ->
     folsom_metrics:notify_existing_metric({?APP, node, gets}, 1, spiral),
     folsom_metrics:notify_existing_metric({?APP, node, gets, time}, Microsecs, histogram),
     folsom_metrics:notify_existing_metric({?APP, node, gets, siblings}, NumSiblings, histogram),
     folsom_metrics:notify_existing_metric({?APP, node, gets, objsize}, ObjSize, histogram),
     do_stages([?APP, node, gets, time], Stages),
     do_get_bucket(PerBucket, {Bucket, Microsecs, Stages, NumSiblings, ObjSize});
-update1({put_fsm_time, Bucket,  Microsecs, Stages, PerBucket}) ->
+do_update({put_fsm_time, Bucket,  Microsecs, Stages, PerBucket}) ->
     folsom_metrics:notify_existing_metric({?APP, node, puts}, 1, spiral),
     folsom_metrics:notify_existing_metric({?APP, node, puts, time}, Microsecs, histogram),
     do_stages([?APP, node, puts, time], Stages),
     do_put_bucket(PerBucket, {Bucket, Microsecs, Stages});
-update1({read_repairs, Indices, Preflist}) ->
+do_update({read_repairs, Indices, Preflist}) ->
     folsom_metrics:notify_existing_metric({?APP, node, gets, read_repairs}, 1, spiral),
     do_repairs(Indices, Preflist);
-update1(coord_redir) ->
+do_update(coord_redir) ->
     folsom_metrics:notify_existing_metric({?APP, node, puts, coord_redirs}, {inc, 1}, counter);
-update1(mapper_start) ->
+do_update(mapper_start) ->
     folsom_metrics:notify_existing_metric({?APP, mapper_count}, {inc, 1}, counter);
-update1(mapper_end) ->
+do_update(mapper_end) ->
     folsom_metrics:notify_existing_metric({?APP, mapper_count}, {dec, 1}, counter);
-update1(precommit_fail) ->
+do_update(precommit_fail) ->
     folsom_metrics:notify_existing_metric({?APP, precommit_fail}, {inc, 1}, counter);
-update1(postcommit_fail) ->
+do_update(postcommit_fail) ->
     folsom_metrics:notify_existing_metric({?APP, postcommit_fail}, {inc, 1}, counter).
 
 %% private
@@ -362,12 +221,16 @@ create_or_update(Name, UpdateVal, Type) ->
             create_or_update(Name, UpdateVal, Type)
     end.
 
-
+%% Stats are namespaced by APP in folsom
+%% so that we don't need to co-ordinate on naming
+%% between apps.
 stat_name(Name) when is_list(Name) ->
     list_to_tuple([?APP] ++ Name);
 stat_name(Name) when is_atom(Name) ->
     {?APP, Name}.
 
+%% @doc list of {Name, Type} for static
+%% stats that we can register at start up
 stats() ->
     [{[vnode, gets], spiral},
      {[vnode, gets, time], histogram},
@@ -390,6 +253,7 @@ stats() ->
      {precommit_fail, counter},
      {postcommit_fail, counter}].
 
+%% @doc register a stat with folsom
 register_stat(Name, spiral) ->
     folsom_metrics:new_spiral(Name);
 register_stat(Name, counter) ->
@@ -399,9 +263,16 @@ register_stat(Name, histogram) ->
     {SampleType, SampleArgs} = get_sample_type(Name),
     folsom_metrics:new_histogram(Name, SampleType, SampleArgs).
 
+%% @doc the histogram sample type may be set in app.config
+%% use key `stat_sample_type` in the `riak_kv` section. Or the
+%% name of an `histogram` stat.
+%% Check the folsom homepage for available types.
+%% Defaults to `{slide_uniform, {60, 1028}}` (a uniform sliding window
+%% of 60 seconds, with a uniform sample of at most 1028 entries)
 get_sample_type(Name) ->
     SampleType0 = app_helper:get_env(riak_kv, stat_sample_type, {slide_uniform, {60, 1028}}),
     app_helper:get_env(riak_kv, Name, SampleType0).
 
+%% @doc produce the legacy blob of stats for display.
 produce_stats() ->
     riak_kv_stat_bc:produce_stats().

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -262,10 +262,10 @@ register_stat(Name, histogram) ->
     folsom_metrics:new_histogram(Name, SampleType, SampleArgs).
 
 %% @doc the histogram sample type may be set in app.config
-%% use key `stat_sample_type` in the `riak_kv` section. Or the
-%% name of an `histogram` stat.
+%% use key `stat_sample_type' in the `riak_kv' section. Or the
+%% name of an `histogram' stat.
 %% Check the folsom homepage for available types.
-%% Defaults to `{slide_uniform, {60, 1028}}` (a uniform sliding window
+%% Defaults to `{slide_uniform, {60, 1028}}' (a uniform sliding window
 %% of 60 seconds, with a uniform sample of at most 1028 entries)
 get_sample_type(Name) ->
     SampleType0 = app_helper:get_env(riak_kv, stat_sample_type, {slide_uniform, {60, 1028}}),

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -194,7 +194,7 @@ start_link() ->
 register_stats() ->
     [(catch folsom_metrics:delete_metric(Stat)) || Stat <- folsom_metrics:get_metrics(),
                                                            is_tuple(Stat), element(1, Stat) == ?APP],
-    [register_stat({?APP, Name}, Type) || {Name, Type} <- stats()],
+    [register_stat(stat_name(Name), Type) || {Name, Type} <- stats()],
     riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
 
 %% @spec get_stats() -> proplist()
@@ -235,44 +235,44 @@ code_change(_OldVsn, State, _Extra) ->
 
 %% @doc Update the given stat
 update1({vnode_get, Idx, USecs}) ->
-    folsom_metrics:notify_existing_metric({?APP, vnode_gets}, 1, spiral),
-    create_or_update({?APP, vnode_gets, time}, USecs, histogram),
-    do_per_index(vnode_gets, Idx, USecs);
+    folsom_metrics:notify_existing_metric({?APP, vnode, gets}, 1, spiral),
+    create_or_update({?APP, vnode, gets, time}, USecs, histogram),
+    do_per_index(gets, Idx, USecs);
 update1({vnode_put, Idx, USecs}) ->
-    folsom_metrics:notify_existing_metric({?APP, vnode_puts}, 1, spiral),
-    create_or_update({?APP, vnode_puts, time}, USecs, histogram),
-    do_per_index(vnode_puts, Idx, USecs);
+    folsom_metrics:notify_existing_metric({?APP, vnode, puts}, 1, spiral),
+    create_or_update({?APP, vnode, puts, time}, USecs, histogram),
+    do_per_index(puts, Idx, USecs);
 update1(vnode_index_read) ->
-    folsom_metrics:notify_existing_metric({?APP, vnode_index_reads}, 1, spiral);
+    folsom_metrics:notify_existing_metric({?APP, vnode, index, reads}, 1, spiral);
 update1({vnode_index_write, PostingsAdded, PostingsRemoved}) ->
-    folsom_metrics:notify_existing_metric({?APP, vnode_index_writes}, 1, spiral),
-    folsom_metrics:notify_existing_metric({?APP, vnode_index_writes_postings}, PostingsAdded, spiral),
-    folsom_metrics:notify_existing_metric({?APP, vnode_index_deletes_postings}, PostingsRemoved, spiral);
+    folsom_metrics:notify_existing_metric({?APP, vnode, index, writes}, 1, spiral),
+    folsom_metrics:notify_existing_metric({?APP, vnode, index, writes, postings}, PostingsAdded, spiral),
+    folsom_metrics:notify_existing_metric({?APP, vnode, index, deletes, postings}, PostingsRemoved, spiral);
 update1({vnode_index_delete, Postings}) ->
-    folsom_metrics:notify_existing_metric({?APP, vnode_index_deletes}, Postings, spiral),
-    folsom_metrics:notify_existing_metric({?APP, vnode_index_deletes_postings}, Postings, spiral);
+    folsom_metrics:notify_existing_metric({?APP, vnode, index, deletes}, Postings, spiral),
+    folsom_metrics:notify_existing_metric({?APP, vnode, index, deletes, postings}, Postings, spiral);
 update1({get_fsm, Bucket, Microsecs, Stages, undefined, undefined, PerBucket}) ->
-    folsom_metrics:notify_existing_metric({?APP, node_gets}, 1, spiral),
-    folsom_metrics:notify_existing_metric({?APP, node_get_fsm_time}, Microsecs, histogram),
-    do_stages([?APP, node_get_fsm, time], Stages),
+    folsom_metrics:notify_existing_metric({?APP, node, gets}, 1, spiral),
+    folsom_metrics:notify_existing_metric({?APP, node, gets, time}, Microsecs, histogram),
+    do_stages([?APP, node, gets, time], Stages),
     do_get_bucket(PerBucket, {Bucket, Microsecs, Stages, undefined, undefined});
 update1({get_fsm, Bucket, Microsecs, Stages, NumSiblings, ObjSize, PerBucket}) ->
-    folsom_metrics:notify_existing_metric({?APP, node_gets}, 1, spiral),
-    folsom_metrics:notify_existing_metric({?APP, node_get_fsm_time}, Microsecs, histogram),
-    folsom_metrics:notify_existing_metric({?APP, node_get_fsm_siblings}, NumSiblings, histogram),
-    folsom_metrics:notify_existing_metric({?APP, node_get_fsm_objsize}, ObjSize, histogram),
-    do_stages([?APP, node_get_fsm, time], Stages),
+    folsom_metrics:notify_existing_metric({?APP, node, gets}, 1, spiral),
+    folsom_metrics:notify_existing_metric({?APP, node, gets, time}, Microsecs, histogram),
+    folsom_metrics:notify_existing_metric({?APP, node, gets, siblings}, NumSiblings, histogram),
+    folsom_metrics:notify_existing_metric({?APP, node, gets, objsize}, ObjSize, histogram),
+    do_stages([?APP, node, gets, time], Stages),
     do_get_bucket(PerBucket, {Bucket, Microsecs, Stages, NumSiblings, ObjSize});
 update1({put_fsm_time, Bucket,  Microsecs, Stages, PerBucket}) ->
-    folsom_metrics:notify_existing_metric({?APP, node_puts}, 1, spiral),
-    folsom_metrics:notify_existing_metric({?APP, node_put_fsm_time}, Microsecs, histogram),
-    do_stages([?APP, node_put_fsm, time], Stages),
+    folsom_metrics:notify_existing_metric({?APP, node, puts}, 1, spiral),
+    folsom_metrics:notify_existing_metric({?APP, node, puts, time}, Microsecs, histogram),
+    do_stages([?APP, node, puts, time], Stages),
     do_put_bucket(PerBucket, {Bucket, Microsecs, Stages});
 update1({read_repairs, Indices, Preflist}) ->
-    folsom_metrics:notify_existing_metric({?APP, read_repairs}, 1, spiral),
+    folsom_metrics:notify_existing_metric({?APP, node, gets, read_repairs}, 1, spiral),
     do_repairs(Indices, Preflist);
 update1(coord_redir) ->
-    folsom_metrics:notify_existing_metric({?APP, coord_redirs_total}, {inc, 1}, counter);
+    folsom_metrics:notify_existing_metric({?APP, node, puts, coord_redirs}, {inc, 1}, counter);
 update1(mapper_start) ->
     folsom_metrics:notify_existing_metric({?APP, mapper_count}, {inc, 1}, counter);
 update1(mapper_end) ->
@@ -286,24 +286,24 @@ update1(postcommit_fail) ->
 %% Per index stats (by op)
 do_per_index(Op, Idx, USecs) ->
     IdxAtom = list_to_atom(integer_to_list(Idx)),
-    create_or_update({?APP, Op, IdxAtom}, 1, spiral),
-    create_or_update({?APP, Op, time, IdxAtom}, USecs, histogram).
+    create_or_update({?APP, vnode, Op, IdxAtom}, 1, spiral),
+    create_or_update({?APP, vnode, Op, time, IdxAtom}, USecs, histogram).
 
 %%  per bucket get_fsm stats
 do_get_bucket(false, _) ->
     ok;
 do_get_bucket(true, {Bucket, Microsecs, Stages, NumSiblings, ObjSize}=Args) ->
     BucketAtom = binary_to_atom(Bucket, latin1),
-    case (catch folsom_metrics:notify_existing_metric({?APP, node_get_fsm, total, BucketAtom}, 1, spiral)) of
+    case (catch folsom_metrics:notify_existing_metric({?APP, node, gets, BucketAtom}, 1, spiral)) of
         ok ->
-            [folsom_metrics:notify_existing_metric({?APP, node_get_fsm, Dimension, BucketAtom}, Arg, histogram)
+            [folsom_metrics:notify_existing_metric({?APP, node, gets, Dimension, BucketAtom}, Arg, histogram)
              || {Dimension, Arg} <- [{time, Microsecs},
                                      {siblings, NumSiblings},
                                      {objsize, ObjSize}], Arg /= undefined],
-            do_stages([?APP, node_get_fsm, time, BucketAtom], Stages);
+            do_stages([?APP, node, gets, time, BucketAtom], Stages);
         {'EXIT', _} ->
-            folsom_metrics:new_spiral({?APP, node_get_fsm, total, BucketAtom}),
-            [register_stat({?APP, node_get_fsm, Dimension, BucketAtom}, histogram) || Dimension <- [time,
+            folsom_metrics:new_spiral({?APP, node, gets, BucketAtom}),
+            [register_stat({?APP, node, gets, Dimension, BucketAtom}, histogram) || Dimension <- [time,
                                                                                   siblings,
                                                                                   objsize]],
             do_get_bucket(true, Args)
@@ -314,13 +314,13 @@ do_put_bucket(false, _) ->
     ok;
 do_put_bucket(true, {Bucket, Microsecs, Stages}=Args) ->
     BucketAtom = binary_to_atom(Bucket, latin1),
-    case (catch folsom_metrics:notify_existing_metric({?APP, node_put_fsm, total, BucketAtom}, 1, spiral)) of
+    case (catch folsom_metrics:notify_existing_metric({?APP, node, puts, BucketAtom}, 1, spiral)) of
         ok ->
-            folsom_metrics:notify_existing_metric({?APP, node_put_fsm, time, BucketAtom}, Microsecs, histogram),
-            do_stages([?APP, node_put_fsm, time, BucketAtom], Stages);
+            folsom_metrics:notify_existing_metric({?APP, node, puts, time, BucketAtom}, Microsecs, histogram),
+            do_stages([?APP, node, puts, time, BucketAtom], Stages);
         {'EXIT', _} ->
-            register_stat({?APP, node_put_fsm, total, BucketAtom}, spiral),
-            register_stat({?APP, node_put_fsm, time, BucketAtom}, histogram),
+            register_stat({?APP, node, puts, BucketAtom}, spiral),
+            register_stat({?APP, node, puts, time, BucketAtom}, histogram),
             do_put_bucket(true, Args)
     end.
 
@@ -346,7 +346,7 @@ do_repairs(Indices, Preflist) ->
                               undefined ->
                                   ok;
                               Reason ->
-                                  create_or_update({?APP, read_repairs, Node, Type, Reason}, 1, spiral)
+                                  create_or_update({?APP, node, gets,  read_repairs, Node, Type, Reason}, 1, spiral)
                           end
                   end,
                   Preflist).
@@ -363,73 +363,29 @@ create_or_update(Name, UpdateVal, Type) ->
     end.
 
 
-%% @spec produce_stats(state(), integer()) -> proplist()
-%% @doc Produce a proplist-formatted view of the current aggregation
-%%      of stats.
-produce_stats() ->
-    lists:append(
-      [lists:flatten([backwards_compat(Name, Type, get_stat({?APP, Name}, Type)) || {Name, Type} <- stats()]),
-       backwards_compat_pb(riak_api_stat:produce_stats()),
-       cpu_stats(),
-       mem_stats(),
-       disk_stats(),
-       system_stats(),
-       ring_stats(),
-       config_stats(),
-       app_stats(),
-       memory_stats()
-      ]).
-
-get_stat(Name, histogram) ->
-    folsom_metrics:get_histogram_statistics(Name);
-get_stat(Name, _Type) ->
-    folsom_metrics:get_metric_value(Name).
-
-backwards_compat_pb({riak_api, Stats}) ->
-    [{pbc_active, proplists:get_value(pbc_connects_active, Stats)} |
-     backwards_compat(pbc_connects, spiral, proplists:get_value(pbc_connects, Stats))].
-
-backwards_compat(Name, spiral, Stats) ->
-    [{Name, trunc(proplists:get_value(one, Stats))},
-     {join(Name, total), proplists:get_value(count, Stats)}];
-backwards_compat(mapper_count, counter, Stats) ->
-    {executing_mappers, Stats};
-backwards_compat(pbc_connects_active, counter, Stats) ->
-    {pbc_active, Stats};
-backwards_compat(Name, counter, Stats) ->
-    {Name, Stats};
-backwards_compat(Name, histogram, Stats) ->
-    backwards_compat_histo(Name, Stats).
-
-backwards_compat_histo(Name, Stats) ->
-    Percentiles = proplists:get_value(percentile, Stats),
-    [{join(Name, mean), trunc(proplists:get_value(arithmetic_mean, Stats))},
-     {join(Name, median), trunc(proplists:get_value(median, Stats))},
-     {join(Name, '95'), trunc(proplists:get_value(95, Percentiles))},
-     {join(Name, '99'), trunc(proplists:get_value(99, Percentiles))},
-     {join(Name, '100'), trunc(proplists:get_value(max, Stats))}].
-
-join(Atom1, Atom2) ->
-    Bin1 = atom_to_binary(Atom1, latin1),
-    Bin2 = atom_to_binary(Atom2, latin1),
-    binary_to_atom(<<Bin1/binary, $_, Bin2/binary>>, latin1).
+stat_name(Name) when is_list(Name) ->
+    list_to_tuple([?APP] ++ Name);
+stat_name(Name) when is_atom(Name) ->
+    {?APP, Name}.
 
 stats() ->
-    [{vnode_gets, spiral},
-     {vnode_puts, spiral},
-     {vnode_index_reads, spiral},
-     {vnode_index_writes, spiral},
-     {vnode_index_writes_postings, spiral},
-     {vnode_index_deletes, spiral},
-     {vnode_index_deletes_postings, spiral},
-     {node_gets, spiral},
-     {node_get_fsm_siblings, histogram},
-     {node_get_fsm_objsize, histogram},
-     {node_get_fsm_time, histogram},
-     {node_puts, spiral},
-     {node_put_fsm_time, histogram},
-     {read_repairs, spiral},
-     {coord_redirs_total, counter},
+    [{[vnode, gets], spiral},
+     {[vnode, gets, time], histogram},
+     {[vnode, puts], spiral},
+     {[vnode, puts, time], histogram},
+     {[vnode, index, reads], spiral},
+     {[vnode, index ,writes], spiral},
+     {[vnode, index, writes, postings], spiral},
+     {[vnode, index, deletes], spiral},
+     {[vnode, index, deletes, postings], spiral},
+     {[node, gets], spiral},
+     {[node, gets, siblings], histogram},
+     {[node, gets, objsize], histogram},
+     {[node, gets, time], histogram},
+     {[node, puts], spiral},
+     {[node, puts, time], histogram},
+     {[node, gets, read_repairs], spiral},
+     {[node, puts, coord_redirs], counter},
      {mapper_count, counter},
      {precommit_fail, counter},
      {postcommit_fail, counter}].
@@ -447,67 +403,5 @@ get_sample_type(Name) ->
     SampleType0 = app_helper:get_env(riak_kv, stat_sample_type, {slide_uniform, {60, 1028}}),
     app_helper:get_env(riak_kv, Name, SampleType0).
 
-%% @spec cpu_stats() -> proplist()
-%% @doc Get stats on the cpu, as given by the cpu_sup module
-%%      of the os_mon application.
-cpu_stats() ->
-    [{cpu_nprocs, cpu_sup:nprocs()},
-     {cpu_avg1, cpu_sup:avg1()},
-     {cpu_avg5, cpu_sup:avg5()},
-     {cpu_avg15, cpu_sup:avg15()}].
-
-%% @spec mem_stats() -> proplist()
-%% @doc Get stats on the memory, as given by the memsup module
-%%      of the os_mon application.
-mem_stats() ->
-    {Total, Alloc, _} = memsup:get_memory_data(),
-    [{mem_total, Total},
-     {mem_allocated, Alloc}].
-
-%% @spec disk_stats() -> proplist()
-%% @doc Get stats on the disk, as given by the disksup module
-%%      of the os_mon application.
-disk_stats() ->
-    [{disk, disksup:get_disk_data()}].
-
-system_stats() ->
-    [{nodename, node()},
-     {connected_nodes, nodes()},
-     {sys_driver_version, list_to_binary(erlang:system_info(driver_version))},
-     {sys_global_heaps_size, erlang:system_info(global_heaps_size)},
-     {sys_heap_type, erlang:system_info(heap_type)},
-     {sys_logical_processors, erlang:system_info(logical_processors)},
-     {sys_otp_release, list_to_binary(erlang:system_info(otp_release))},
-     {sys_process_count, erlang:system_info(process_count)},
-     {sys_smp_support, erlang:system_info(smp_support)},
-     {sys_system_version, list_to_binary(string:strip(erlang:system_info(system_version), right, $\n))},
-     {sys_system_architecture, list_to_binary(erlang:system_info(system_architecture))},
-     {sys_threads_enabled, erlang:system_info(threads)},
-     {sys_thread_pool_size, erlang:system_info(thread_pool_size)},
-     {sys_wordsize, erlang:system_info(wordsize)}].
-
-app_stats() ->
-    [{list_to_atom(atom_to_list(A) ++ "_version"), list_to_binary(V)}
-     || {A,_,V} <- application:which_applications()].
-
-memory_stats() ->
-    [{list_to_atom("memory_" ++ atom_to_list(K)), V} || {K,V} <- erlang:memory()].
-
-ring_stats() ->
-    {ok, R} = riak_core_ring_manager:get_my_ring(),
-    [{ring_members, riak_core_ring:all_members(R)},
-     {ring_num_partitions, riak_core_ring:num_partitions(R)},
-     {ring_ownership, list_to_binary(lists:flatten(io_lib:format("~p", [dict:to_list(
-                        lists:foldl(fun({_P, N}, Acc) ->
-                                            case dict:find(N, Acc) of
-                                                {ok, V} ->
-                                                    dict:store(N, V+1, Acc);
-                                                error ->
-                                                    dict:store(N, 1, Acc)
-                                            end
-                                    end, dict:new(), riak_core_ring:all_owners(R)))])))}].
-
-
-config_stats() ->
-    [{ring_creation_size, app_helper:get_env(riak_core, ring_creation_size)},
-     {storage_backend, app_helper:get_env(riak_kv, storage_backend)}].
+produce_stats() ->
+    riak_kv_stat_bc:produce_stats().

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -1,0 +1,331 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_stat_bc: backwards compatible stats module. Maps new folsom stats
+%%                  to legacy riak_kv stats.
+%%
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc riak_kv_stat_bc is a module that maps the new riak_kv_stats metrics
+%% to the old set of stats. It exists to maintain backwards compatibility for
+%% those using the `/stats` endpoint and `riak-admin status`. This module
+%% should be considered deprecated and temporary. A new `/metrics` endpoint
+%% and `riak-admin metrics` command should be used from now onwards.
+%%
+%%      Current stats:
+%%<dl><dt>  vnode_gets
+%%</dt><dd> Total number of gets handled by all vnodes on this node
+%%          in the last minute.
+%%</dd><dd> update(vnode_get)
+%%
+%%</dd><dt> vnode_puts
+%%</dt><dd> Total number of puts handled by all vnodes on this node
+%%          in the last minute.
+%%</dd><dd> update(vnode_put)
+%%
+%%</dd><dt> vnode_index_reads
+%%</dt><dd> The number of index reads handled by all vnodes on this node.
+%%          Each query counts as an index read.
+%%</dd><dd> update(vnode_index_read)
+%%
+%%</dd><dt> vnode_index_writes
+%%</dt><dd> The number of batched writes handled by all vnodes on this node.
+%%</dd><dd> update({vnode_index_write, PostingsAdded, PostingsRemoved})
+%%
+%%</dd><dt> vnode_index_writes_postings
+%%</dt><dd> The number of postings written to all vnodes on this node.
+%%</dd><dd> update({vnode_index_write, PostingsAdded, PostingsRemoved})
+%%
+%%</dd><dt> vnode_index_deletes
+%%</dt><dd> The number of batched writes handled by all vnodes on this node.
+%%</dd><dd> update({vnode_index_delete, PostingsRemoved})
+%%
+%%</dd><dt> vnode_index_deletes_postings
+%%</dt><dd> The number of postings written to all vnodes on this node.
+%%</dd><dd> update({vnode_index_delete, PostingsRemoved})
+%%
+%%</dd><dt> node_gets
+%%</dt><dd> Number of gets coordinated by this node in the last
+%%          minute.
+%%</dd><dd> update({get_fsm, _Bucket, Microseconds, NumSiblings, ObjSize})
+%%
+%%</dd><dt> node_get_fsm_siblings
+%%</dt><dd> Stats about number of siblings per object in the last minute.
+%%</dd><dd> Updated via node_gets.
+%%
+%%</dd><dt> node_get_fsm_objsize
+%%</dt><dd> Stats about object size over the last minute. The object
+%%          size is an estimate calculated by summing the size of the
+%%          bucket name, key name, and serialized vector clock, plus
+%%          the value and serialized metadata of each sibling.
+%%</dd><dd> Updated via node_gets.
+%%
+%%</dd><dt> node_get_fsm_time_mean
+%%</dt><dd> Mean time, in microseconds, between when a riak_kv_get_fsm is
+%%          started and when it sends a reply to the client, for the
+%%          last minute.
+%%</dd><dd> update({get_fsm_time, Microseconds})
+%%
+%%</dd><dt> node_get_fsm_time_median
+%%</dt><dd> Median time, in microseconds, between when a riak_kv_get_fsm
+%%          is started and when it sends a reply to the client, for
+%%          the last minute.
+%%</dd><dd> update({get_fsm_time, Microseconds})
+%%
+%%</dd><dt> node_get_fsm_time_95
+%%</dt><dd> Response time, in microseconds, met or beaten by 95% of
+%%          riak_kv_get_fsm executions.
+%%</dd><dd> update({get_fsm_time, Microseconds})
+%%
+%%</dd><dt> node_get_fsm_time_99
+%%</dt><dd> Response time, in microseconds, met or beaten by 99% of
+%%          riak_kv_get_fsm executions.
+%%</dd><dd> update({get_fsm_time, Microseconds})
+%%
+%%</dd><dt> node_get_fsm_time_100
+%%</dt><dd> Response time, in microseconds, met or beaten by 100% of
+%%          riak_kv_get_fsm executions.
+%%</dd><dd> update({get_fsm_time, Microseconds})
+%%
+%%</dd><dt> node_puts
+%%</dt><dd> Number of puts coordinated by this node in the last
+%%          minute.
+%%</dd><dd> update({put_fsm_time, Microseconds})
+%%
+%%</dd><dt> node_put_fsm_time_mean
+%%</dt><dd> Mean time, in microseconds, between when a riak_kv_put_fsm is
+%%          started and when it sends a reply to the client, for the
+%%          last minute.
+%%</dd><dd> update({put_fsm_time, Microseconds})
+%%
+%%</dd><dt> node_put_fsm_time_median
+%%</dt><dd> Median time, in microseconds, between when a riak_kv_put_fsm
+%%          is started and when it sends a reply to the client, for
+%%          the last minute.
+%%</dd><dd> update({put_fsm_time, Microseconds})
+%%
+%%</dd><dt> node_put_fsm_time_95
+%%</dt><dd> Response time, in microseconds, met or beaten by 95% of
+%%          riak_kv_put_fsm executions.
+%%</dd><dd> update({put_fsm_time, Microseconds})
+%%
+%%</dd><dt> node_put_fsm_time_99
+%%</dt><dd> Response time, in microseconds, met or beaten by 99% of
+%%          riak_kv_put_fsm executions.
+%%</dd><dd> update({put_fsm_time, Microseconds})
+%%
+%%</dd><dt> node_put_fsm_time_100
+%%</dt><dd> Response time, in microseconds, met or beaten by 100% of
+%%          riak_kv_put_fsm executions.
+%%</dd><dd> update({put_fsm_time, Microseconds})
+%%
+%%</dd><dt> cpu_nprocs
+%%</dt><dd> Value returned by {@link cpu_sup:nprocs/0}.
+%%
+%%</dd><dt> cpu_avg1
+%%</dt><dd> Value returned by {@link cpu_sup:avg1/0}.
+%%
+%%</dd><dt> cpu_avg5
+%%</dt><dd> Value returned by {@link cpu_sup:avg5/0}.
+%%
+%%</dd><dt> cpu_avg15
+%%</dt><dd> Value returned by {@link cpu_sup:avg15/0}.
+%%
+%%</dd><dt> mem_total
+%%</dt><dd> The first element of the tuple returned by
+%%          {@link memsup:get_memory_data/0}.
+%%
+%%</dd><dt> mem_allocated
+%%</dt><dd> The second element of the tuple returned by
+%%          {@link memsup:get_memory_data/0}.
+%%
+%%</dd><dt> disk
+%%</dt><dd> Value returned by {@link disksup:get_disk_data/0}.
+%%
+%%</dd><dt> pbc_connects_total
+%%</dt><dd> Total number of pb socket connections since start
+%%
+%%</dd><dt> pbc_active
+%%</dt><dd> Number of active pb socket connections
+%%
+%%</dd><dt> coord_redirs_total
+%%</dt><dd> Number of puts forwarded to be coordinated on a node
+%%          in the preflist.
+%%
+%%</dd></dl>
+%%
+%%
+-module(riak_kv_stat_bc).
+
+-compile(export_all).
+
+%% @spec produce_stats(state(), integer()) -> proplist()
+%% @doc Produce a proplist-formatted view of the current aggregation
+%%      of stats.
+produce_stats() ->
+    lists:append(
+      [lists:flatten(backwards_compat(riak_core_stat_q:get_stats([riak_kv]))),
+       backwards_compat_pb(riak_core_stat_q:get_stats([riak_api])),
+       cpu_stats(),
+       mem_stats(),
+       disk_stats(),
+       system_stats(),
+       ring_stats(),
+       config_stats(),
+       app_stats(),
+       memory_stats()
+      ]).
+
+backwards_compat(Stats) ->
+    [bc_stat(Old, New, Type, Stats) || {Old, New, Type} <- legacy_stat_map()].
+
+bc_stat(Old, {New, Field}, histogram_percentile, Stats) ->
+    Stat = proplists:get_value(New, Stats),
+    Percentile = proplists:get_value(percentile, Stat),
+    Val = proplists:get_value(Field, Percentile),
+    {Old, trunc(Val)};
+bc_stat(Old, {New, Field}, histogram, Stats) ->
+    Stat = proplists:get_value(New, Stats),
+    Val = proplists:get_value(Field, Stat),
+    {Old, trunc(Val)};
+bc_stat(Old, {New, Field}, spiral, Stats) ->
+    Stat = proplists:get_value(New, Stats),
+    Val = proplists:get_value(Field, Stat),
+    {Old, Val};
+bc_stat(Old, New, counter, Stats) ->
+    Stat = proplists:get_value(New, Stats),
+    {Old, Stat}.
+
+%% hard coded mapping of stats to legacy format
+legacy_stat_map() ->
+    [{vnode_gets, {{riak_kv, vnode, gets}, one}, spiral},
+     {vnode_gets_total, {{riak_kv, vnode, gets}, count}, spiral},
+     {vnode_puts, {{riak_kv, vnode, puts}, one}, spiral},
+     {vnode_puts_total, {{riak_kv, vnode, puts}, count}, spiral},
+     {vnode_index_reads, {{riak_kv, vnode, index, reads}, one}, spiral},
+     {vnode_index_reads_total, {{riak_kv, vnode, index, reads}, count}, spiral},
+     {vnode_index_writes, {{riak_kv, vnode, index, writes}, one}, spiral},
+     {vnode_index_writes_total, {{riak_kv, vnode, index, writes}, count}, spiral},
+     {vnode_index_writes_postings, {{riak_kv,vnode,index,writes,postings}, one}, spiral},
+     {vnode_index_writes_postings_total, {{riak_kv,vnode,index,writes,postings}, count}, spiral},
+     {vnode_index_deletes, {{riak_kv,vnode,index,deletes}, one}, spiral},
+     {vnode_index_deletes_total, {{riak_kv,vnode,index,deletes}, count}, spiral},
+     {vnode_index_deletes_postings, {{riak_kv,vnode,index,deletes,postings}, one}, spiral},
+     {vnode_index_deletes_postings_total, {{riak_kv,vnode,index,deletes,postings}, count}, spiral},
+     {node_gets, {{riak_kv,node,gets}, one}, spiral},
+     {node_gets_total, {{riak_kv,node,gets}, count}, spiral},
+     {node_get_fsm_siblings_mean, {{riak_kv,node,gets,siblings}, arithmetic_mean}, histogram},
+     {node_get_fsm_siblings_median, {{riak_kv,node,gets,siblings}, median}, histogram},
+     {node_get_fsm_siblings_95, {{riak_kv,node,gets,siblings}, 95}, histogram_percentile},
+     {node_get_fsm_siblings_99, {{riak_kv,node,gets,siblings}, 99}, histogram_percentile},
+     {node_get_fsm_siblings_100, {{riak_kv,node,gets,siblings}, max}, histogram},
+     {node_get_fsm_objsize_mean, {{riak_kv,node,gets,objsize}, arithmetic_mean}, histogram},
+     {node_get_fsm_objsize_median, {{riak_kv,node,gets,objsize}, median}, histogram},
+     {node_get_fsm_objsize_95, {{riak_kv,node,gets,objsize}, 95}, histogram_percentile},
+     {node_get_fsm_objsize_99, {{riak_kv,node,gets,objsize}, 99}, histogram_percentile},
+     {node_get_fsm_objsize_100, {{riak_kv,node,gets,objsize}, max}, histogram},
+     {node_get_fsm_time_mean, {{riak_kv,node,gets,time}, arithmetic_mean}, histogram},
+     {node_get_fsm_time_median, {{riak_kv,node,gets,time}, median}, histogram},
+     {node_get_fsm_time_95, {{riak_kv,node,gets,time}, 95}, histogram_percentile},
+     {node_get_fsm_time_99, {{riak_kv,node,gets,time}, 99}, histogram_percentile},
+     {node_get_fsm_time_100, {{riak_kv,node,gets,time}, max}, histogram},
+     {node_puts, {{riak_kv,node, puts}, one}, spiral},
+     {node_puts_total, {{riak_kv,node, puts}, count}, spiral},
+     {node_put_fsm_time_mean, {{riak_kv,node, puts, time}, arithmetic_mean}, histogram},
+     {node_put_fsm_time_median, {{riak_kv,node, puts, time}, median}, histogram},
+     {node_put_fsm_time_95,  {{riak_kv,node, puts, time}, 95}, histogram_percentile},
+     {node_put_fsm_time_99,  {{riak_kv,node, puts, time}, 99}, histogram_percentile},
+     {node_put_fsm_time_100, {{riak_kv,node, puts, time}, max}, histogram},
+     {read_repairs, {{riak_kv,node,gets,read_repairs}, one}, spiral},
+     {read_repairs_total, {{riak_kv,node,gets,read_repairs}, count}, spiral},
+     {coord_redirs_total, {riak_kv,node,puts,coord_redirs}, counter},
+     {executing_mappers, {riak_kv,mapper_count}, counter},
+     {precommit_fail, {riak_kv, precommit_fail}, counter},
+     {postcommit_fail, {riak_kv, postcommit_fail}, counter}
+    ].
+
+backwards_compat_pb(Stats) ->
+    [bc_stat(Old, New, Type, Stats) || {Old, New, Type} <-
+                                     [{pbc_active, {riak_api, pbc_connects, active}, counter},
+                                      {pbc_connects, {{riak_api, pbc_connects}, one}, spiral},
+                                      {pbc_connects_total, {{riak_api, pbc_connects}, count}, spiral}]].
+
+%% @spec cpu_stats() -> proplist()
+%% @doc Get stats on the cpu, as given by the cpu_sup module
+%%      of the os_mon application.
+cpu_stats() ->
+    [{cpu_nprocs, cpu_sup:nprocs()},
+     {cpu_avg1, cpu_sup:avg1()},
+     {cpu_avg5, cpu_sup:avg5()},
+     {cpu_avg15, cpu_sup:avg15()}].
+
+%% @spec mem_stats() -> proplist()
+%% @doc Get stats on the memory, as given by the memsup module
+%%      of the os_mon application.
+mem_stats() ->
+    {Total, Alloc, _} = memsup:get_memory_data(),
+    [{mem_total, Total},
+     {mem_allocated, Alloc}].
+
+%% @spec disk_stats() -> proplist()
+%% @doc Get stats on the disk, as given by the disksup module
+%%      of the os_mon application.
+disk_stats() ->
+    [{disk, disksup:get_disk_data()}].
+
+system_stats() ->
+    [{nodename, node()},
+     {connected_nodes, nodes()},
+     {sys_driver_version, list_to_binary(erlang:system_info(driver_version))},
+     {sys_global_heaps_size, erlang:system_info(global_heaps_size)},
+     {sys_heap_type, erlang:system_info(heap_type)},
+     {sys_logical_processors, erlang:system_info(logical_processors)},
+     {sys_otp_release, list_to_binary(erlang:system_info(otp_release))},
+     {sys_process_count, erlang:system_info(process_count)},
+     {sys_smp_support, erlang:system_info(smp_support)},
+     {sys_system_version, list_to_binary(string:strip(erlang:system_info(system_version), right, $\n))},
+     {sys_system_architecture, list_to_binary(erlang:system_info(system_architecture))},
+     {sys_threads_enabled, erlang:system_info(threads)},
+     {sys_thread_pool_size, erlang:system_info(thread_pool_size)},
+     {sys_wordsize, erlang:system_info(wordsize)}].
+
+app_stats() ->
+    [{list_to_atom(atom_to_list(A) ++ "_version"), list_to_binary(V)}
+     || {A,_,V} <- application:which_applications()].
+
+memory_stats() ->
+    [{list_to_atom("memory_" ++ atom_to_list(K)), V} || {K,V} <- erlang:memory()].
+
+ring_stats() ->
+    {ok, R} = riak_core_ring_manager:get_my_ring(),
+    [{ring_members, riak_core_ring:all_members(R)},
+     {ring_num_partitions, riak_core_ring:num_partitions(R)},
+     {ring_ownership, list_to_binary(lists:flatten(io_lib:format("~p", [dict:to_list(
+                        lists:foldl(fun({_P, N}, Acc) ->
+                                            case dict:find(N, Acc) of
+                                                {ok, V} ->
+                                                    dict:store(N, V+1, Acc);
+                                                error ->
+                                                    dict:store(N, 1, Acc)
+                                            end
+                                    end, dict:new(), riak_core_ring:all_owners(R)))])))}].
+
+
+config_stats() ->
+    [{ring_creation_size, app_helper:get_env(riak_core, ring_creation_size)},
+     {storage_backend, app_helper:get_env(riak_kv, storage_backend)}].

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -24,116 +24,80 @@
 %% @doc riak_kv_stat_bc is a module that maps the new riak_kv_stats metrics
 %% to the old set of stats. It exists to maintain backwards compatibility for
 %% those using the `/stats` endpoint and `riak-admin status`. This module
-%% should be considered deprecated and temporary. A new `/metrics` endpoint
-%% and `riak-admin metrics` command should be used from now onwards.
+%% should be considered soon to be deprecated and temporary.
 %%
-%%      Current stats:
+%%      Legacy stats:
 %%<dl><dt>  vnode_gets
 %%</dt><dd> Total number of gets handled by all vnodes on this node
 %%          in the last minute.
-%%</dd><dd> update(vnode_get)
-%%
-%%</dd><dt> vnode_puts
+%%</dd>
+%%<dt> vnode_puts
 %%</dt><dd> Total number of puts handled by all vnodes on this node
 %%          in the last minute.
-%%</dd><dd> update(vnode_put)
-%%
-%%</dd><dt> vnode_index_reads
+%%</dd>
+%%<dt> vnode_index_reads
 %%</dt><dd> The number of index reads handled by all vnodes on this node.
 %%          Each query counts as an index read.
-%%</dd><dd> update(vnode_index_read)
-%%
-%%</dd><dt> vnode_index_writes
+%%</dd><
+%%<dt> vnode_index_writes
 %%</dt><dd> The number of batched writes handled by all vnodes on this node.
-%%</dd><dd> update({vnode_index_write, PostingsAdded, PostingsRemoved})
-%%
-%%</dd><dt> vnode_index_writes_postings
+%%</dd>
+%%<dt> vnode_index_writes_postings
 %%</dt><dd> The number of postings written to all vnodes on this node.
-%%</dd><dd> update({vnode_index_write, PostingsAdded, PostingsRemoved})
-%%
-%%</dd><dt> vnode_index_deletes
+%%</dd>
+%%<dt> vnode_index_deletes
 %%</dt><dd> The number of batched writes handled by all vnodes on this node.
 %%</dd><dd> update({vnode_index_delete, PostingsRemoved})
 %%
 %%</dd><dt> vnode_index_deletes_postings
 %%</dt><dd> The number of postings written to all vnodes on this node.
-%%</dd><dd> update({vnode_index_delete, PostingsRemoved})
-%%
 %%</dd><dt> node_gets
 %%</dt><dd> Number of gets coordinated by this node in the last
 %%          minute.
-%%</dd><dd> update({get_fsm, _Bucket, Microseconds, NumSiblings, ObjSize})
-%%
 %%</dd><dt> node_get_fsm_siblings
 %%</dt><dd> Stats about number of siblings per object in the last minute.
-%%</dd><dd> Updated via node_gets.
-%%
 %%</dd><dt> node_get_fsm_objsize
 %%</dt><dd> Stats about object size over the last minute. The object
 %%          size is an estimate calculated by summing the size of the
 %%          bucket name, key name, and serialized vector clock, plus
 %%          the value and serialized metadata of each sibling.
-%%</dd><dd> Updated via node_gets.
-%%
 %%</dd><dt> node_get_fsm_time_mean
 %%</dt><dd> Mean time, in microseconds, between when a riak_kv_get_fsm is
 %%          started and when it sends a reply to the client, for the
 %%          last minute.
-%%</dd><dd> update({get_fsm_time, Microseconds})
-%%
 %%</dd><dt> node_get_fsm_time_median
 %%</dt><dd> Median time, in microseconds, between when a riak_kv_get_fsm
 %%          is started and when it sends a reply to the client, for
 %%          the last minute.
-%%</dd><dd> update({get_fsm_time, Microseconds})
-%%
 %%</dd><dt> node_get_fsm_time_95
 %%</dt><dd> Response time, in microseconds, met or beaten by 95% of
 %%          riak_kv_get_fsm executions.
-%%</dd><dd> update({get_fsm_time, Microseconds})
-%%
 %%</dd><dt> node_get_fsm_time_99
 %%</dt><dd> Response time, in microseconds, met or beaten by 99% of
 %%          riak_kv_get_fsm executions.
-%%</dd><dd> update({get_fsm_time, Microseconds})
-%%
 %%</dd><dt> node_get_fsm_time_100
 %%</dt><dd> Response time, in microseconds, met or beaten by 100% of
 %%          riak_kv_get_fsm executions.
-%%</dd><dd> update({get_fsm_time, Microseconds})
-%%
 %%</dd><dt> node_puts
 %%</dt><dd> Number of puts coordinated by this node in the last
 %%          minute.
-%%</dd><dd> update({put_fsm_time, Microseconds})
-%%
 %%</dd><dt> node_put_fsm_time_mean
 %%</dt><dd> Mean time, in microseconds, between when a riak_kv_put_fsm is
 %%          started and when it sends a reply to the client, for the
 %%          last minute.
-%%</dd><dd> update({put_fsm_time, Microseconds})
-%%
 %%</dd><dt> node_put_fsm_time_median
 %%</dt><dd> Median time, in microseconds, between when a riak_kv_put_fsm
 %%          is started and when it sends a reply to the client, for
 %%          the last minute.
-%%</dd><dd> update({put_fsm_time, Microseconds})
-%%
 %%</dd><dt> node_put_fsm_time_95
 %%</dt><dd> Response time, in microseconds, met or beaten by 95% of
 %%          riak_kv_put_fsm executions.
-%%</dd><dd> update({put_fsm_time, Microseconds})
-%%
 %%</dd><dt> node_put_fsm_time_99
 %%</dt><dd> Response time, in microseconds, met or beaten by 99% of
 %%          riak_kv_put_fsm executions.
-%%</dd><dd> update({put_fsm_time, Microseconds})
-%%
 %%</dd><dt> node_put_fsm_time_100
 %%</dt><dd> Response time, in microseconds, met or beaten by 100% of
 %%          riak_kv_put_fsm executions.
-%%</dd><dd> update({put_fsm_time, Microseconds})
-%%
 %%</dd><dt> cpu_nprocs
 %%</dt><dd> Value returned by {@link cpu_sup:nprocs/0}.
 %%
@@ -181,6 +145,7 @@ produce_stats() ->
     lists:append(
       [lists:flatten(backwards_compat(riak_core_stat_q:get_stats([riak_kv]))),
        backwards_compat_pb(riak_core_stat_q:get_stats([riak_api])),
+       read_repair_stats(),
        cpu_stats(),
        mem_stats(),
        disk_stats(),
@@ -191,6 +156,11 @@ produce_stats() ->
        memory_stats()
       ]).
 
+%% Stats in folsom are stored with tuples as keys, the
+%% tuples mimic an hierarchical structure. To be free of legacy
+%% naming constraints the new names are not simply the old names
+%% with commas for underscores. Uses legacy_stat_map to generate
+%% legacys stats from the new list of stats.
 backwards_compat(Stats) ->
     [bc_stat(Old, New, Type, Stats) || {Old, New, Type} <- legacy_stat_map()].
 
@@ -211,7 +181,11 @@ bc_stat(Old, New, counter, Stats) ->
     Stat = proplists:get_value(New, Stats),
     {Old, Stat}.
 
+
 %% hard coded mapping of stats to legacy format
+%% There was a enough variation in the old names that a simple
+%% concatenation of the elements in the new  stat key would not suffice
+%% applications depend on these exact legacy names.
 legacy_stat_map() ->
     [{vnode_gets, {{riak_kv, vnode, gets}, one}, spiral},
      {vnode_gets_total, {{riak_kv, vnode, gets}, count}, spiral},
@@ -259,6 +233,8 @@ legacy_stat_map() ->
      {postcommit_fail, {riak_kv, postcommit_fail}, counter}
     ].
 
+%% PB stats are now under riak_api. In the past they were part of riak_kv.
+%% This function maps those new values to the old names.
 backwards_compat_pb(Stats) ->
     [bc_stat(Old, New, Type, Stats) || {Old, New, Type} <-
                                      [{pbc_active, {riak_api, pbc_connects, active}, counter},
@@ -329,3 +305,57 @@ ring_stats() ->
 config_stats() ->
     [{ring_creation_size, app_helper:get_env(riak_core, ring_creation_size)},
      {storage_backend, app_helper:get_env(riak_kv, storage_backend)}].
+
+%% Read repair stats are a new edition to the legacy blob.
+%% Added to the blob since the stat query interface was not ready for the 1.3
+%% release.
+%% The read repair stats are stored as dimensions with
+%% the key {riak_kv, node, gets, read_repairs, Node, Type, Reason}.
+%% The CSEs are only interested in aggregations of Type and Reason
+%% which are elements 6 and 7 in the key.
+read_repair_stats() ->
+    aggregate(read_repairs, [riak_kv, node, gets, read_repairs, '_', '_', '_'], [6,7]).
+
+%% TODO generalise for riak_core_stat_q
+aggregate(BaseName, Query, Fields) ->
+    Stats = riak_core_stat_q:get_stats(Query),
+    Aggregates = do_aggregate(Stats, Fields),
+    recursive_join(BaseName, Aggregates).
+
+do_aggregate(Stats, Fields) ->
+    lists:foldl(fun({Name, [{count, C0}, {one, O0}]}, Acc) ->
+                        Key = key_from_fields(Name, Fields),
+                        [{count, C}, {one, O}] = case orddict:find(Key, Acc) of
+                                                     error -> [{count, 0}, {one, 0}];
+                                                     {ok, V} -> V
+                                                 end,
+                        orddict:store(Key, [{count, C+C0}, {one, O+O0}], Acc)
+                end,
+                orddict:new(),
+                Stats).
+
+key_from_fields(Name, Fields) ->
+    Key = [element(N, Name) || N <- Fields],
+    join(Key).
+
+recursive_join(BaseName, Aggregates) ->
+    L = orddict:fold(fun(K, V, Acc) when not is_list(V) ->
+                             [{join([BaseName, K], <<>>), V}|Acc];
+                        (K, V, Acc)  ->
+                             [recursive_join(join([BaseName, K], <<>>), V)|Acc]
+                     end,
+                     [],
+                     Aggregates),
+    lists:flatten(L).
+
+join(L) ->
+    join(L, <<>>).
+
+join([], Bin) ->
+    binary_to_atom(Bin, latin1);
+join([Atom|Rest], <<>>) ->
+    Bin2 = atom_to_binary(Atom, latin1),
+    join(Rest, <<Bin2/binary>>);
+join([Atom|Rest], Bin) ->
+    Bin2 = atom_to_binary(Atom, latin1),
+    join(Rest, <<Bin/binary, $_, Bin2/binary>>).


### PR DESCRIPTION
To test this, force some read repair (I create a devrel, do some writes, then partition the cluster) then issue some reads. Attach to the node and check that read repair stats were created with:

```
[{Stat, folsom_metrics:get_metric_value(Stat)} || 
    Stat <- folsom_metrics:get_metrics(), 
                is_tuple(Stat),
                element(1, Stat) == riak_kv,
                element(2, Stat) == read_repairs].
```
