### PR TITLE
reset bucket props via http

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -43,7 +43,7 @@
 -export([list_buckets/0,list_buckets/2]).
 -export([get_index/3,get_index/2]).
 -export([stream_get_index/3,stream_get_index/2]).
--export([set_bucket/2,get_bucket/1]).
+-export([set_bucket/2,get_bucket/1,reset_bucket/1]).
 -export([reload_all/1]).
 -export([remove_from_cluster/1]).
 -export([get_stats/1]).
@@ -715,6 +715,10 @@ set_bucket(BucketName,BucketProps) ->
 %% See riak_core_bucket for expected useful properties.
 get_bucket(BucketName) ->
     rpc:call(Node,riak_core_bucket,get_bucket,[BucketName]).
+%% @spec reset_bucket(riak_object:bucket()) -> ok
+%% @doc Reset properties for this Bucket to the default values
+reset_bucket(BucketName) ->
+    rpc:call(Node,riak_core_bucket,reset_bucket,[BucketName]).
 %% @spec reload_all(Module :: atom()) -> term()
 %% @doc Force all Riak nodes to reload Module.
 %%      This is used when loading new modules for map/reduce functionality.

--- a/src/riak_kv_wm_props.erl
+++ b/src/riak_kv_wm_props.erl
@@ -47,7 +47,7 @@
 %% 
 %% DELETE /buckets/Bucket/props
 %%   Reset bucket properties back to the default settings
-%%   not supporteed by the OLD API
+%%   not supported by the OLD API
 
 -module(riak_kv_wm_props).
 


### PR DESCRIPTION
This PR exposes the functionality in https://github.com/basho/riak_core/pull/248 over the version 2 HTTP API.

Depends on: https://github.com/basho/riak_core/pull/248
Original Implementation: https://github.com/basho/riak_kv/pull/357
