### PR TITLE
Since "Try again" is not relevant to a self-join, make that error explicit

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -70,6 +70,10 @@ join(NodeStr, JoinFn, SuccessFmt, SuccessArgs) ->
                 io:format("Failed: This node is already a member of a "
                           "cluster~n"),
                 error;
+            {error, self_join} ->
+                io:format("Failed: This node cannot join itself in a "
+                          "cluster~n"),
+                error;
             {error, _} ->
                 io:format("Join failed. Try again in a few moments.~n", []),
                 error


### PR DESCRIPTION
Tiny, tiny patch.  Noticed that when trying to join a node to itself that the error message was unhelpful.
