### PR TITLE
Apply backpressure from the MR sink

### DIFF
--- a/include/riak_kv_mrc_sink.hrl
+++ b/include/riak_kv_mrc_sink.hrl
@@ -7,3 +7,14 @@
           logs :: [{PhaseId::integer(), Message::term()}],
           done :: boolean()
         }).
+
+%% used by riak_kv_mrc_sink:mapred_stream_sink
+-record(mrc_ctx,
+        {
+          ref :: reference(), % the pipe ref (so we don't have to dig)
+          pipe :: riak_pipe:pipe(),
+          sink :: {pid(), reference()}, % sink and monitor
+          sender :: {pid(), reference()}, % async sender and monitor
+          timer :: {reference(), reference()}, % timeout timer and pipe ref
+          keeps :: integer()
+         }).

--- a/src/riak_kv_mrc_pipe.erl
+++ b/src/riak_kv_mrc_pipe.erl
@@ -257,7 +257,7 @@ mapred_stream(Query, Options) when is_list(Options) ->
 mapred_stream_sink(Inputs, Query, Timeout) ->
     {ok, Sink} = riak_kv_mrc_sink:start(self(), []),
     Options = [{sink, #fitting{pid=Sink}},
-               {sink_type, {fsm_sync, sink_sync_period(), infinity}}],
+               {sink_type, {fsm, sink_sync_period(), infinity}}],
     try mapred_stream(Query, Options) of
         {{ok, Pipe}, NumKeeps} ->
             %% catch just in case the pipe or sink has already died

--- a/src/riak_kv_mrc_sink.erl
+++ b/src/riak_kv_mrc_sink.erl
@@ -25,11 +25,11 @@
 %% messages received from the pipe, until it is asked to send them to
 %% its owner. The owner is whatever process started this FSM.
 
-%% This FSM will speak both `raw' and `fsm_sync' sink types (it
+%% This FSM will speak both `raw' and `fsm' sink types (it
 %% answers appropriately to each, without parameterization).
 
 %% The FSM enforces a soft cap on the number of results and logs
-%% accumulated when receiving `fsm_sync' sink type messages. When the
+%% accumulated when receiving `fsm' sink type messages. When the
 %% number of results+logs that have been delivered exceeds the cap
 %% between calls to {@link next/1}, the sink stops delivering result
 %% acks to workers. The value of this cap can be specified by

--- a/src/riak_kv_mrc_sink.erl
+++ b/src/riak_kv_mrc_sink.erl
@@ -198,8 +198,7 @@ collect_output(#pipe_result{ref=Ref, from=PhaseId, result=Res},
 collect_output(#pipe_log{ref=Ref, from=PhaseId, msg=Msg},
                From,
                #state{ref=Ref, logs=Acc}=State) ->
-    NewAcc = add_result(PhaseId, Msg, Acc),
-    maybe_ack(From, State#state{logs=NewAcc});
+    maybe_ack(From, State#state{logs=[{PhaseId, Msg}|Acc]});
 collect_output(#pipe_eoi{ref=Ref}, _From, #state{ref=Ref}=State) ->
     {reply, ok, collect_output, State#state{done=true}};
 collect_output(_, _, State) ->
@@ -227,8 +226,7 @@ send_output(#pipe_result{ref=Ref, from=PhaseId, result=Res},
     {reply, ok, collect_output, NewState};
 send_output(#pipe_log{ref=Ref, from=PhaseId, msg=Msg},
             _From, #state{ref=Ref, logs=Acc}=State) ->
-    NewAcc = add_result(PhaseId, Msg, Acc),
-    NewState = send_to_owner(State#state{logs=NewAcc}),
+    NewState = send_to_owner(State#state{logs=[{PhaseId, Msg}|Acc]}),
     {reply, ok, collect_output, NewState};
 send_output(#pipe_eoi{ref=Ref}, _From, #state{ref=Ref}=State) ->
     NewState = send_to_owner(State#state{done=true}),

--- a/src/riak_kv_mrc_sink_sup.erl
+++ b/src/riak_kv_mrc_sink_sup.erl
@@ -26,7 +26,7 @@
 
 %% API
 -export([start_link/0]).
--export([start_sink/1,
+-export([start_sink/2,
          terminate_sink/1]).
 
 %% Supervisor callbacks
@@ -42,9 +42,9 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 %% @doc Start a new worker under the supervisor.
--spec start_sink(pid()) -> {ok, pid()}.
-start_sink(Owner) ->
-    supervisor:start_child(?MODULE, [Owner]).
+-spec start_sink(pid(), list()) -> {ok, pid()}.
+start_sink(Owner, Options) ->
+    supervisor:start_child(?MODULE, [Owner, Options]).
 
 %% @doc Stop a worker immediately
 -spec terminate_sink(pid()) -> ok | {error, term()}.

--- a/src/riak_kv_pb_mapred.erl
+++ b/src/riak_kv_pb_mapred.erl
@@ -231,7 +231,8 @@ destroy_pipe(#pipe_ctx{pipe=Pipe}=PipeCtx) ->
 
 pipe_mapreduce(Req, State, Inputs, Query, Timeout) ->
     {ok, Sink} = riak_kv_mrc_sink:start(self()),
-    try riak_kv_mrc_pipe:mapred_stream(Query, Sink) of
+    Opts = [{sink_type, {fsm_sync, infinity}}],
+    try riak_kv_mrc_pipe:mapred_stream(Query, Sink, Opts) of
         {{ok, Pipe}, _NumKeeps} ->
             SinkMon = erlang:monitor(process, Sink),
             %% catch just in case the pipe or sink has already died

--- a/src/riak_kv_pb_mapred.erl
+++ b/src/riak_kv_pb_mapred.erl
@@ -230,7 +230,7 @@ destroy_pipe(#pipe_ctx{pipe=Pipe}=PipeCtx) ->
     cleanup_sender(PipeCtx).
 
 pipe_mapreduce(Req, State, Inputs, Query, Timeout) ->
-    {ok, Sink} = riak_kv_mrc_sink:start(self()),
+    {ok, Sink} = riak_kv_mrc_sink:start(self(), []),
     Opts = [{sink_type, {fsm_sync, infinity}}],
     try riak_kv_mrc_pipe:mapred_stream(Query, Sink, Opts) of
         {{ok, Pipe}, _NumKeeps} ->

--- a/src/riak_kv_pb_mapred.erl
+++ b/src/riak_kv_pb_mapred.erl
@@ -230,14 +230,9 @@ destroy_pipe(#pipe_ctx{pipe=Pipe}=PipeCtx) ->
     cleanup_sender(PipeCtx).
 
 pipe_mapreduce(Req, State, Inputs, Query, Timeout) ->
-    {ok, Sink} = riak_kv_mrc_sink:start(self(), []),
-    Opts = [{sink_type, {fsm_sync, infinity}}],
-    try riak_kv_mrc_pipe:mapred_stream(Query, Sink, Opts) of
-        {{ok, Pipe}, _NumKeeps} ->
+    case riak_kv_mrc_pipe:mapred_stream(Query) of
+        {ok, Pipe, Sink, _NumKeeps} ->
             SinkMon = erlang:monitor(process, Sink),
-            %% catch just in case the pipe or sink has already died
-            %% for any reason - we'll get the DOWN later
-            catch riak_kv_mrc_sink:use_pipe(Sink, Pipe),
             PipeRef = (Pipe#pipe.sink)#fitting.ref,
             Timer = erlang:send_after(Timeout, self(),
                                       {pipe_timeout, PipeRef}),
@@ -250,9 +245,8 @@ pipe_mapreduce(Req, State, Inputs, Query, Timeout) ->
                             timer=Timer,
                             sender={InputSender, SenderMonitor},
                             has_mr_query = (Query /= [])},
-            {reply, {stream, PipeRef}, State#state{req=Req, req_ctx=Ctx}}
-    catch throw:{badarg, Fitting, Reason} ->
-            riak_kv_mrc_sink:stop(Sink),
+            {reply, {stream, PipeRef}, State#state{req=Req, req_ctx=Ctx}};
+        {error, {Fitting, Reason}} ->
             {error, {format, "Phase ~p: ~s", [Fitting, Reason]}, State}
     end.
 

--- a/src/riak_kv_pipe_index.erl
+++ b/src/riak_kv_pipe_index.erl
@@ -140,13 +140,14 @@ done(_State) ->
 queue_existing_pipe(Pipe, Bucket, Query, Timeout) ->
     %% make our tiny pipe
     [{_Name, Head}|_] = Pipe#pipe.fittings,
+    Period = riak_kv_mrc_pipe:sink_sync_period(),
     {ok, LKP} = riak_pipe:exec([#fitting_spec{name=index,
                                               module=?MODULE,
                                               nval=1}],
                                [{sink, Head},
                                 {trace, [error]},
                                 {log, {sink, Pipe#pipe.sink}},
-                                {sink_type, {fsm_sync, infinity}}]),
+                                {sink_type, {fsm_sync, Period, infinity}}]),
 
     %% setup the cover operation
     ReqId = erlang:phash2({self(), os:timestamp()}), %% stolen from riak_client

--- a/src/riak_kv_pipe_index.erl
+++ b/src/riak_kv_pipe_index.erl
@@ -127,6 +127,9 @@ done(_State) ->
 %%      to trigger querying on the appropriate vnodes.  The `eoi'
 %%      message is sent to the pipe as soon as it is confirmed that
 %%      all querying processes have started.
+%%
+%%      Note that log/trace messages are sent to the sink of the
+%%      original pipe. It is expected that that sink is an `fsm_sync' type.
 -spec queue_existing_pipe(riak_pipe:pipe(),
                           bucket_or_filter(),
                           {eq, Index::binary(), Value::term()}
@@ -142,7 +145,8 @@ queue_existing_pipe(Pipe, Bucket, Query, Timeout) ->
                                               nval=1}],
                                [{sink, Head},
                                 {trace, [error]},
-                                {log, {sink, Pipe#pipe.sink}}]),
+                                {log, {sink, Pipe#pipe.sink}},
+                                {sink_type, {fsm_sync, infinity}}]),
 
     %% setup the cover operation
     ReqId = erlang:phash2({self(), os:timestamp()}), %% stolen from riak_client

--- a/src/riak_kv_pipe_index.erl
+++ b/src/riak_kv_pipe_index.erl
@@ -129,7 +129,7 @@ done(_State) ->
 %%      all querying processes have started.
 %%
 %%      Note that log/trace messages are sent to the sink of the
-%%      original pipe. It is expected that that sink is an `fsm_sync' type.
+%%      original pipe. It is expected that that sink is an `fsm' type.
 -spec queue_existing_pipe(riak_pipe:pipe(),
                           bucket_or_filter(),
                           {eq, Index::binary(), Value::term()}
@@ -147,7 +147,7 @@ queue_existing_pipe(Pipe, Bucket, Query, Timeout) ->
                                [{sink, Head},
                                 {trace, [error]},
                                 {log, {sink, Pipe#pipe.sink}},
-                                {sink_type, {fsm_sync, Period, infinity}}]),
+                                {sink_type, {fsm, Period, infinity}}]),
 
     %% setup the cover operation
     ReqId = erlang:phash2({self(), os:timestamp()}), %% stolen from riak_client

--- a/src/riak_kv_pipe_listkeys.erl
+++ b/src/riak_kv_pipe_listkeys.erl
@@ -143,13 +143,14 @@ done(_State) ->
 queue_existing_pipe(Pipe, Bucket, Timeout) ->
     %% make our tiny pipe
     [{_Name, Head}|_] = Pipe#pipe.fittings,
+    Period = riak_kv_mrc_pipe:sink_sync_period(),
     {ok, LKP} = riak_pipe:exec([#fitting_spec{name=listkeys,
                                               module=?MODULE,
                                               nval=1}],
                                [{sink, Head},
                                 {trace, [error]},
                                 {log, {sink, Pipe#pipe.sink}},
-                                {sink_type, {fsm_sync, infinity}}]),
+                                {sink_type, {fsm_sync, Period, infinity}}]),
 
     %% setup the cover operation
     ReqId = erlang:phash2({self(), os:timestamp()}), %% stolen from riak_client

--- a/src/riak_kv_pipe_listkeys.erl
+++ b/src/riak_kv_pipe_listkeys.erl
@@ -135,7 +135,7 @@ done(_State) ->
 %%      all keylisting processes have started.
 %%
 %%      Note that log/trace messages are sent to the sink of the
-%%      original pipe. It is expected that that sink is an `fsm_sync' type.
+%%      original pipe. It is expected that that sink is an `fsm' type.
 -spec queue_existing_pipe(riak_pipe:pipe(),
                           bucket_or_filter(),
                           timeout()) ->
@@ -150,7 +150,7 @@ queue_existing_pipe(Pipe, Bucket, Timeout) ->
                                [{sink, Head},
                                 {trace, [error]},
                                 {log, {sink, Pipe#pipe.sink}},
-                                {sink_type, {fsm_sync, Period, infinity}}]),
+                                {sink_type, {fsm, Period, infinity}}]),
 
     %% setup the cover operation
     ReqId = erlang:phash2({self(), os:timestamp()}), %% stolen from riak_client

--- a/src/riak_kv_pipe_listkeys.erl
+++ b/src/riak_kv_pipe_listkeys.erl
@@ -133,6 +133,9 @@ done(_State) ->
 %%      to trigger keylisting on the appropriate vnodes.  The `eoi'
 %%      message is sent to the pipe as soon as it is confirmed that
 %%      all keylisting processes have started.
+%%
+%%      Note that log/trace messages are sent to the sink of the
+%%      original pipe. It is expected that that sink is an `fsm_sync' type.
 -spec queue_existing_pipe(riak_pipe:pipe(),
                           bucket_or_filter(),
                           timeout()) ->
@@ -145,7 +148,8 @@ queue_existing_pipe(Pipe, Bucket, Timeout) ->
                                               nval=1}],
                                [{sink, Head},
                                 {trace, [error]},
-                                {log, {sink, Pipe#pipe.sink}}]),
+                                {log, {sink, Pipe#pipe.sink}},
+                                {sink_type, {fsm_sync, infinity}}]),
 
     %% setup the cover operation
     ReqId = erlang:phash2({self(), os:timestamp()}), %% stolen from riak_client

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -291,10 +291,10 @@ pipe_stream_mapred_results(RD,
     end.
 
 result_part({PhaseId, Results}, HasMRQuery, Boundary) ->
-    Data = [ riak_kv_mapred_json:jsonify_bkeys(
-               riak_kv_mapred_json:jsonify_not_found(R),
-               HasMRQuery)
-             || R <- Results ],
+    Data = riak_kv_mapred_json:jsonify_bkeys(
+             [riak_kv_mapred_json:jsonify_not_found(R)
+              || R <- Results ],
+             HasMRQuery),
     JSON = {struct, [{phase, PhaseId},
                      {data, Data}]},
     ["\r\n--", Boundary, "\r\n",

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -181,7 +181,8 @@ pipe_mapred(RD,
                    mrquery=Query,
                    timeout=Timeout}=State) ->
     {ok, Sink} = riak_kv_mrc_sink:start(self()),
-    try riak_kv_mrc_pipe:mapred_stream(Query, Sink) of
+    Opts = [{sink_type, {fsm_sync, infinity}}],
+    try riak_kv_mrc_pipe:mapred_stream(Query, Sink, Opts) of
         {{ok, Pipe}, NumKeeps} ->
             SinkMon = erlang:monitor(process, Sink),
             %% catch just in case the pipe or sink has already died

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -180,7 +180,7 @@ pipe_mapred(RD,
             #state{inputs=Inputs,
                    mrquery=Query,
                    timeout=Timeout}=State) ->
-    {ok, Sink} = riak_kv_mrc_sink:start(self()),
+    {ok, Sink} = riak_kv_mrc_sink:start(self(), []),
     Opts = [{sink_type, {fsm_sync, infinity}}],
     try riak_kv_mrc_pipe:mapred_stream(Query, Sink, Opts) of
         {{ok, Pipe}, NumKeeps} ->

--- a/test/mapred_test.erl
+++ b/test/mapred_test.erl
@@ -483,7 +483,7 @@ dead_pipe_test_() ->
                  Spec = 
                      [{map, {modfun, riak_kv_mapreduce, map_object_value},
                        none, true}],
-                 {ok, Pipe, _Sink, _NumKeeps} =
+                 {{ok, Pipe}, _NumKeeps} =
                      riak_kv_mrc_pipe:mapred_stream(Spec),
                  riak_pipe:destroy(Pipe),
                  {error, Reason} = riak_kv_mrc_pipe:send_inputs(
@@ -501,7 +501,7 @@ dead_pipe_test_() ->
                  Spec = 
                      [{map, {modfun, riak_kv_mapreduce, map_object_value},
                        none, true}],
-                 {ok, Pipe, _Sink, _NumKeeps} =
+                 {{ok, Pipe}, _NumKeeps} =
                      riak_kv_mrc_pipe:mapred_stream(Spec),
                  riak_pipe:destroy(Pipe),
                  %% this is a hack to make sure that the async sender

--- a/test/mapred_test.erl
+++ b/test/mapred_test.erl
@@ -483,7 +483,7 @@ dead_pipe_test_() ->
                  Spec = 
                      [{map, {modfun, riak_kv_mapreduce, map_object_value},
                        none, true}],
-                 {{ok, Pipe}, _NumKeeps} =
+                 {ok, Pipe, _Sink, _NumKeeps} =
                      riak_kv_mrc_pipe:mapred_stream(Spec),
                  riak_pipe:destroy(Pipe),
                  {error, Reason} = riak_kv_mrc_pipe:send_inputs(
@@ -501,7 +501,7 @@ dead_pipe_test_() ->
                  Spec = 
                      [{map, {modfun, riak_kv_mapreduce, map_object_value},
                        none, true}],
-                 {{ok, Pipe}, _NumKeeps} =
+                 {ok, Pipe, _Sink, _NumKeeps} =
                      riak_kv_mrc_pipe:mapred_stream(Spec),
                  riak_pipe:destroy(Pipe),
                  %% this is a hack to make sure that the async sender


### PR DESCRIPTION
This is a re-opening of #425. That PR closed when I deleted the branch for #416, which 425 targeted. This now targets master.

This PR uses the new ability of basho/riak_pipe#59 to provide backpressure to the MR pipe in the new MR sink introduced by #416. This PR is targeted at the bwf-sep-sink-2 branch to more clearly demonstrate the changes made here until #416 is merged to master.

In addition to using the fsm_sync sink type to synchronously receive pipe results/logs, the sink now has a capped-size buffer. Once that buffer is full, the sink delays acks to result/log senders until the sink's owner empties its buffer. This is to keep the problem of the expanding mailbox from becoming the problem of the expanding heap. The size of this buffer is configurable globally as the riak_kv app env mrc_sink_buffer or as a startup option for the FSM, buffer.

The changes to src/riak_kv_mrc_pipe.erl look more dramatic than they really are because enforcing the use of riak_kv_mrc_sink in all MR pipelines has cleaned up the logic of output collection and sorting.

This branch has not yet been tested for performance changes. It is likely that latency will take a hit, due to the extra synchronicity. The safety of not blowing up memory consumption in a sink process is likely desirable enough to counter worries. There is also work underway (in the bwf-pmi branch) to enable delivery of multiple outputs in a single message.

There are no "capabilities" or other "upgrade" facilities included here. Nodes running earlier versions of Riak will simply ignore the sink_type option, and send regular messages, as they do now, to the MR sink. This is fine - the sink will accept them, even though it cannot provide backpressure to those senders. Nodes running the new version will similarly send regular messages if they are working for a Pipe that was started by an older node (and therefore had not set sink_type).
