### PR TITLE
do not call riak_api functions removed in riak_api#15

### DIFF
--- a/src/riak_kv_test_util.erl
+++ b/src/riak_kv_test_util.erl
@@ -240,13 +240,7 @@ dep_apps(Test, Extra) ->
                                                        [
                                                         {Test ++ "/log/debug.log", debug, 10485760, "$D0", 5}]}]),
                 application:set_env(lager, crash_log, Test ++ "/log/crash.log");
-           (stop) ->
-                %% TODO: This cleanup is just a quick fix to run the whole test.
-                %% Defining API dispatcher by application:set_env/3 may cause
-                %% race conditions of mis-deregistering and application stop.
-                Services = riak_api_pb_service:dispatch_table(),
-                NewServices = lists:foldl(fun dict:erase/2, Services, lists:seq(1,26)),
-                application:set_env(riak_api, services, NewServices);
+           (stop) -> ok;
            (_) -> ok
         end,
 


### PR DESCRIPTION
Saving/clearing/restoring the riak_api dispatch table is no longer
necessary as of basho/riak_api#15 merging into master. In fact, the
dispatch_table function no longer exists, so calling it is removed here
to fix the tests.
