### PR TITLE
Add leveldb ReadBlockError counter to riak_kv_stats

### DIFF
--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -300,7 +300,8 @@ is_empty(#state{ref=Ref}) ->
 -spec status(state()) -> [{atom(), term()}].
 status(State) ->
     {ok, Stats} = eleveldb:status(State#state.ref, <<"leveldb.stats">>),
-    [{stats, Stats}].
+    {ok, ReadBlockError} = eleveldb:status(State#state.ref, <<"leveldb.ReadBlockError">>),
+    [{stats, Stats}, {read_block_error, ReadBlockError}].
 
 %% @doc Register an asynchronous callback
 -spec callback(reference(), any(), state()) -> {ok, state()}.
@@ -655,7 +656,7 @@ retry_fail_test() ->
         ok = stop(State2)
     after
         os:cmd("rm -rf " ++ Root),
-        application:unset_env(riak_kv, eleveldb_open_retries), 
+        application:unset_env(riak_kv, eleveldb_open_retries),
         application:unset_env(riak_kv, eleveldb_open_retry_delay)
     end.
 

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -314,7 +314,12 @@ is_empty(#state{backends=Backends}) ->
 -spec status(state()) -> [{atom(), term()}].
 status(#state{backends=Backends}) ->
     %% @TODO Reexamine how this is handled
-    [{N, Mod:status(ModState)} || {N, Mod, ModState} <- Backends].
+    %% all backend mods return a proplist from Mod:status/1
+    %% So as to tag the backend with its mod, without
+    %% breaking this API list of two tuples return,
+    %% add the tuple {mod, Mod} to the status for each
+    %% backend.
+    [{N, [{mod, Mod} | Mod:status(ModState)]} || {N, Mod, ModState} <- Backends].
 
 %% @doc Register an asynchronous callback
 -spec callback(reference(), any(), state()) -> {ok, state()}.

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -38,7 +38,8 @@
 
 %% API
 -export([start_link/0, get_stats/0,
-         update/1, register_stats/0, produce_stats/0]).
+         update/1, register_stats/0, produce_stats/0,
+         leveldb_read_block_errors/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -251,7 +252,9 @@ stats() ->
      {[node, puts, coord_redirs], counter},
      {mapper_count, counter},
      {precommit_fail, counter},
-     {postcommit_fail, counter}].
+     {postcommit_fail, counter},
+     {[vnode, backend, leveldb, read_block_error],
+      {function, fun riak_kv_stat:leveldb_read_block_errors/0}}].
 
 %% @doc register a stat with folsom
 register_stat(Name, spiral) ->
@@ -261,7 +264,11 @@ register_stat(Name, counter) ->
 register_stat(Name, histogram) ->
     %% get the global default histo type
     {SampleType, SampleArgs} = get_sample_type(Name),
-    folsom_metrics:new_histogram(Name, SampleType, SampleArgs).
+    folsom_metrics:new_histogram(Name, SampleType, SampleArgs);
+register_stat(Name, {function, F}) ->
+    %% store the function in a gauge metric
+    folsom_metrics:new_gauge(Name),
+    folsom_metrics:notify({Name, F}).
 
 %% @doc the histogram sample type may be set in app.config
 %% use key `stat_sample_type` in the `riak_kv` section. Or the
@@ -276,3 +283,47 @@ get_sample_type(Name) ->
 %% @doc produce the legacy blob of stats for display.
 produce_stats() ->
     riak_kv_stat_bc:produce_stats().
+
+%% @doc get the leveldb.ReadBlockErrors counter.
+%% non-zero values mean it is time to consider replacing
+%% this nodes disk.
+leveldb_read_block_errors() ->
+    %% level stats are per node
+    %% but the way to get them is
+    %% is with riak_kv_vnode:vnode_status/1
+    %% for that reason just chose a partition
+    %% on this node at random
+    %% and ask for it's stats
+    {ok, R} = riak_core_ring_manager:get_my_ring(),
+    Indices = riak_core_ring:my_indices(R),
+    Nth = crypto:rand_uniform(1, length(Indices)),
+    Idx = lists:nth(Nth, Indices),
+    PList = [{Idx, node()}],
+    [{Idx, [Status]}] = riak_kv_vnode:vnode_status(PList),
+    leveldb_read_block_errors(Status).
+
+leveldb_read_block_errors({backend_status, riak_kv_eleveldb_backend, Status}) ->
+    rbe_val(proplists:get_value(read_block_error, Status));
+leveldb_read_block_errors({backend_status, riak_kv_multi_backend, Statuses}) ->
+    multibackend_read_block_errors(Statuses, undefined);
+leveldb_read_block_errors(_) ->
+    undefined.
+
+multibackend_read_block_errors([], Val) ->
+    rbe_val(Val);
+multibackend_read_block_errors([{_Name, Status}|Rest], undefined) ->
+    RBEVal = case proplists:get_value(mod, Status) of
+                 riak_kv_eleveldb_backend ->
+                     proplists:get_value(read_block_error, Status);
+                 _ -> undefined
+             end,
+    multibackend_read_block_errors(Rest, RBEVal);
+multibackend_read_block_errors(_, Val) ->
+    rbe_val(Val).
+
+rbe_val(undefined) ->
+    undefined;
+rbe_val(Bin) ->
+    list_to_integer(binary_to_list(Bin)).
+
+

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -254,7 +254,7 @@ stats() ->
      {precommit_fail, counter},
      {postcommit_fail, counter},
      {[vnode, backend, leveldb, read_block_error],
-      {function, fun riak_kv_stat:leveldb_read_block_errors/0}}].
+      {function, {function, ?MODULE, leveldb_read_block_errors}}}].
 
 %% @doc register a stat with folsom
 register_stat(Name, spiral) ->

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -146,6 +146,7 @@ produce_stats() ->
       [lists:flatten(backwards_compat(riak_core_stat_q:get_stats([riak_kv]))),
        backwards_compat_pb(riak_core_stat_q:get_stats([riak_api])),
        read_repair_stats(),
+       level_stats(),
        pipe_stats(),
        cpu_stats(),
        mem_stats(),
@@ -328,6 +329,11 @@ bc_stat_val(StatName, Val) when is_list(Val) ->
     [{join([StatName, ValName]), ValVal} || {ValName, ValVal} <- Val];
 bc_stat_val(StatName, Val) ->
     {StatName, Val}.
+
+%% Leveldb stats are a last minute new edition to the blob
+level_stats() ->
+    Stats = riak_core_stat_q:get_stats([riak_kv, vnode, backend, leveldb, read_block_error]),
+    [{join(lists:nthtail(3, tuple_to_list(Name))), Val} || {Name, Val} <- Stats].
 
 %% Read repair stats are a new edition to the legacy blob.
 %% Added to the blob since the stat query interface was not ready for the 1.3


### PR DESCRIPTION
Ad hoc adding of one off leveldb stat for `ReadBlockError` on request of MvM.
