### PR TITLE
Location header returned on object creation updated to new URL format.

### DIFF
--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -554,11 +554,11 @@ post_is_create(RD, Ctx) ->
 %% @doc Choose the Key for the document created during a bucket-level POST.
 %%      This function also sets the Location header to generate a
 %%      201 Created response.
-create_path(RD, Ctx=#ctx{prefix=P, bucket=B}) ->
+create_path(RD, Ctx=#ctx{bucket=B}) ->
     K = riak_core_util:unique_id_62(),
     {K,
      wrq:set_resp_header("Location",
-                         lists:append(["/",P,"/",binary_to_list(B),"/",K]),
+                         lists:append(["/buckets/",binary_to_list(B),"/keys/",K]),
                          RD),
      Ctx#ctx{key=list_to_binary(K)}}.
 


### PR DESCRIPTION
On POST creation of new object, the header 'Location:' was returning /riak/Bucket/Key and now returns /buckets/Bucket/keys/Key.
