### PR TITLE
get put stats -> 1.2-perf

### DIFF
--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -129,6 +129,7 @@ init([From, Bucket, Key, Options]) ->
                        options = Options,
                        bkey = {Bucket, Key},
                        startnow = StartNow},
+    riak_kv_get_put_monitor:get_fsm_spawned(self()),
     riak_core_dtrace:put_tag(io_lib:format("~p,~p", [Bucket, Key])),
     ?DTRACE(?C_GET_FSM_INIT, [], ["init"]),
     {ok, prepare, StateData, 0};

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -170,7 +170,11 @@ prepare(timeout, StateData=#state{bkey=BKey={Bucket,_Key}}) ->
 validate(timeout, StateData=#state{from = {raw, ReqId, _Pid}, options = Options,
                                    n = N, bucket_props = BucketProps, preflist2 = PL2}) ->
     ?DTRACE(?C_GET_FSM_VALIDATE, [], ["validate"]),
-    Timeout = get_option(timeout, Options, ?DEFAULT_TIMEOUT),
+    AppEnvTimeout = app_helper:get_env(riak_kv, timeout),
+    Timeout = case AppEnvTimeout of
+                  undefined -> get_option(timeout, Options, ?DEFAULT_TIMEOUT);
+                  _ -> AppEnvTimeout
+              end,
     R0 = get_option(r, Options, ?DEFAULT_R),
     PR0 = get_option(pr, Options, ?DEFAULT_PR),
     R = riak_kv_util:expand_rw_value(r, R0, BucketProps, N),

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -353,6 +353,7 @@ maybe_read_repair(Indices, RepairObj, UpdStateData) ->
         Dorr ->
             read_repair(Indices, RepairObj, UpdStateData);
         true ->
+            riak_kv_stat:update(skipped_read_repairs),
             skipping
     end.
 

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -359,7 +359,7 @@ maybe_read_repair(Indices, RepairObj, UpdStateData) ->
 determine_do_read_repair(SoftCap, HardCap) when SoftCap == undefined; HardCap == undefined ->
     true;
 determine_do_read_repair(SoftCap, HardCap) ->
-    Actual = riak_kv_get_put_monitor:get_in_progress(),
+    Actual = riak_kv_get_put_monitor:gets_active(),
     determine_do_read_repair(SoftCap, HardCap, Actual).
 
 determine_do_read_repair(SoftCap, _HardCap, Actual) when Actual =< SoftCap ->

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -314,7 +314,7 @@ finalize(StateData=#state{get_core = GetCore}) ->
         delete ->
             maybe_delete(UpdStateData);
         {read_repair, Indices, RepairObj} ->
-            read_repair(Indices, RepairObj, UpdStateData);
+            maybe_read_repair(Indices, RepairObj, UpdStateData);
         _Nop ->
             ?DTRACE(?C_GET_FSM_FINALIZE, [], ["finalize"]),
             ok
@@ -338,6 +338,48 @@ maybe_delete(_StateData=#state{n = N, preflist2=Sent,
                     ["maybe_delete", "nop"]),
             nop
     end.
+
+%% based on what the get_put_monitor stats say, and a random roll, potentially
+%% skip read-repriar
+maybe_read_repair(Indices, RepairObj, UpdStateData) ->
+    SoftCap = riak:get_app_env(read_repair_skip_soft_cap),
+    HardCap = riak:get_app_env(read_repair_skip_hard_cap),
+    Dorr = determine_do_read_repair(SoftCap, HardCap),
+    if
+        Dorr ->
+            read_repair(Indices, RepairObj, UpdStateData);
+        true ->
+            skipping
+    end.
+
+determine_do_read_repair(SoftCap, HardCap) when SoftCap == undefined; HardCap == undefined ->
+    true;
+determine_do_read_repair(SoftCap, HardCap) ->
+    Actual = riak_kv_get_put_monitor:get_in_progress(),
+    determine_do_read_repair(SoftCap, HardCap, Actual).
+
+determine_do_read_repair(SoftCap, _HardCap, Actual) when Actual =< SoftCap ->
+    true;
+determine_do_read_repair(_SoftCap, HardCap, Actual) when HardCap =< Actual ->
+    false;
+determine_do_read_repair(SoftCap, HardCap, Actual) ->
+    Roll = roll_d100(),
+    determine_do_read_repair(SoftCap, HardCap, Actual, Roll).
+
+determine_do_read_repair(SoftCap, HardCap, Actual, Roll) ->
+    AdjustedActual = Actual - SoftCap,
+    AdjustedHard = HardCap - SoftCap,
+    Threshold = AdjustedActual / AdjustedHard * 100,
+    Threshold =< Roll.
+
+-ifdef(TEST).
+roll_d100() ->
+    fsm_eqc_util:get_fake_rng(get_fsm_qc).
+-else.
+% technically not a d100 as it has a 0
+roll_d100() ->
+    crypto:rand_uniform(0, 100).
+-endif.
 
 %% Issue read repairs for any vnodes that are out of date
 read_repair(Indices, RepairObj,
@@ -434,6 +476,19 @@ atom2list(P) when is_pid(P)->
 %%      changes: riak_kv_vnode:test_vnode/1 now relies on riak_core to
 %%      be running ... eventually there's a call to
 %%      riak_core_ring_manager:get_raw_ring().
+
+determine_do_read_repair_test_() ->
+    [
+        {"soft cap is undefined", ?_assert(determine_do_read_repair(undefined, 7))},
+        {"hard cap is undefiend", ?_assert(determine_do_read_repair(3000, undefined))},
+        {"actual below soft cap", ?_assert(determine_do_read_repair(3000, 7000, 2000))},
+        {"actual equals soft cap", ?_assert(determine_do_read_repair(3000, 7000, 3000))},
+        {"actual above hard cap", ?_assertNot(determine_do_read_repair(3000, 7000, 9000))},
+        {"actaul equals hard cap", ?_assertNot(determine_do_read_repair(3000, 7000, 7000))},
+        {"roll below threshold", ?_assertNot(determine_do_read_repair(5000, 15000, 10000, 1))},
+        {"roll exactly threshold", ?_assert(determine_do_read_repair(5000, 15000, 10000, 50))},
+        {"roll above threshold", ?_assert(determine_do_read_repair(5000, 15000, 10000, 70))}
+    ].
 
 -ifdef(BROKEN_EUNIT_PURITY_VIOLATION).
 get_fsm_test_() ->

--- a/src/riak_kv_get_put_monitor.erl
+++ b/src/riak_kv_get_put_monitor.erl
@@ -135,10 +135,10 @@ handle_info(_Info, State) ->
 
 %% @private
 terminate(_Reason, _State) ->
-	Counters = [put_fsm_in_progress, get_fsm_in_progress, put_fsm_errors_minute,
-				get_fsm_errors_minute, put_fsm_errors_since_start,
-				get_fsm_errors_since_start],
-	[folsom_metrics:delete_metric(Counter) || Counter <- Counters],
+    Counters = [put_fsm_in_progress, get_fsm_in_progress, put_fsm_errors_minute,
+                get_fsm_errors_minute, put_fsm_errors_since_start,
+                get_fsm_errors_since_start],
+    [folsom_metrics:delete_metric(Counter) || Counter <- Counters],
     ok.
 
 %% @private

--- a/src/riak_kv_get_put_monitor.erl
+++ b/src/riak_kv_get_put_monitor.erl
@@ -85,6 +85,10 @@ handle_info(_Info, State) ->
     {noreply, State}.
 
 terminate(_Reason, _State) ->
+	Counters = [put_fsm_in_progress, get_fsm_in_progress, put_fsm_errors_minute,
+				get_fsm_errors_minute, put_fsm_errors_since_start,
+				get_fsm_errors_since_start],
+	[folsom_metrics:delete_metric(Counter) || Counter <- Counters],
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/riak_kv_get_put_monitor.erl
+++ b/src/riak_kv_get_put_monitor.erl
@@ -1,0 +1,83 @@
+-module(riak_kv_get_put_monitor).
+-behaviour(gen_server).
+-define(SERVER, ?MODULE).
+
+-record(state, {gets = [], puts = []}).
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+
+-export([start_link/0, get_fsm_spawned/1, put_fsm_spawned/1, stop/0]).
+
+%% ------------------------------------------------------------------
+%% gen_server Function Exports
+%% ------------------------------------------------------------------
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+stop() ->
+    gen_server:cast(?SERVER, stop).
+
+get_fsm_spawned(Pid) ->
+    gen_server:cast(?SERVER, {get_fsm_spawned, Pid}).
+
+put_fsm_spawned(Pid) ->
+    gen_server:cast(?SERVER, {put_fsm_spawned, Pid}).
+
+%% ------------------------------------------------------------------
+%% gen_server Function Definitions
+%% ------------------------------------------------------------------
+
+init([]) ->
+    folsom_metrics:new_counter(put_fsm_in_progress),
+    folsom_metrics:new_counter(get_fsm_in_progress),
+    folsom_metrics:new_histogram(put_fsm_errors, slide, 60),
+    folsom_metrics:new_histogram(get_fsm_errors, slide, 60),
+    {ok, #state{}}.
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast({get_fsm_spawned, Pid}, State) ->
+    #state{gets = GetList} = State,
+    GetList2 = insert_pid(Pid, GetList),
+    folsom_metrics:notify({get_fsm_in_progress, {inc, 1}}),
+    {noreply, State#state{gets = GetList2}};
+
+handle_cast({put_fsm_spawned, Pid}, State) ->
+    #state{puts = PutList} = State,
+    PutList2 = insert_pid(Pid, PutList),
+    folsom_metrics:notify({put_fsm_in_process, {inc, 1}}),
+    {noreply, State#state{puts = PutList2}};
+
+handle_cast(stop, State) ->
+    {stop, normal, State};
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+insert_pid(Pid, List) ->
+    MonRef = erlang:monitor(process, Pid),
+    orddict:store(MonRef, Pid, List).

--- a/src/riak_kv_get_put_monitor.erl
+++ b/src/riak_kv_get_put_monitor.erl
@@ -109,12 +109,6 @@ init([]) ->
     [begin
         folsom_metrics:Func(?COUNTER(FsmType, DataPoint))
     end || {Func, FsmType, DataPoint} <- ?STATTYPES],
-%    folsom_metrics:new_counter(put_fsm_in_progress),
-%    folsom_metrics:new_counter(get_fsm_in_progress),
-%    folsom_metrics:new_spiral(put_fsm_errors_minute),
-%    folsom_metrics:new_spiral(get_fsm_errors_minute),
-%    folsom_metrics:new_counter(put_fsm_errors_since_start),
-%    folsom_metrics:new_counter(get_fsm_errors_since_start),
     {ok, #state{}}.
 
 %% @private

--- a/src/riak_kv_get_put_monitor.erl
+++ b/src/riak_kv_get_put_monitor.erl
@@ -110,10 +110,12 @@ tell_folsom_about_exit(get, Cause) when Cause == normal; Cause == shutdown ->
     % normal exit) but increment the errors count as well.
 tell_folsom_about_exit(put, _Cause) ->
     tell_folsom_about_exit(put, normal),
-    folsom_metrics:notify({put_fsm_errors, 1});
+    folsom_metrics:notify({put_fsm_errors_since_start, {inc, 1}}),
+    folsom_metrics:notify({put_fsm_errors_minute, 1});
 tell_folsom_about_exit(get, _Cause) ->
     tell_folsom_about_exit(get, normal),
-    folsom_metrics:notify({get_fsm_errors, 1}).
+    folsom_metrics:notify({get_fsm_errors_since_start, {inc, 1}}),
+    folsom_metrics:notify({get_fsm_errors_minute, 1}).
 
 orddict_get_erase(Key, Orddict) ->
     case orddict:find(Key, Orddict) of

--- a/src/riak_kv_get_put_monitor.erl
+++ b/src/riak_kv_get_put_monitor.erl
@@ -56,7 +56,7 @@
 %% ------------------------------------------------------------------
 
 -export([start_link/0, get_fsm_spawned/1, put_fsm_spawned/1,
-    all_stats/0, stop/0]).
+    all_stats/0, stop/0, get_in_progress/0]).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Exports
@@ -94,6 +94,12 @@ put_fsm_spawned(Pid) ->
 all_stats() ->
     [{Key, folsom_metrics:get_metric_value(Key)} ||
         Key <- ?COUNTERS].
+
+%% Returns the last count for the get fms's in progress.
+-spec get_in_progress() -> non_neg_integer().
+get_in_progress() ->
+    folsom_metrics:get_metric_value(?COUNTER(get, in_progress)).
+
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------

--- a/src/riak_kv_get_put_monitor.erl
+++ b/src/riak_kv_get_put_monitor.erl
@@ -28,9 +28,9 @@
 %% The stat names are all 4 element tuples, the first two elements being
 %% 'riak_kv', then the local node. The third is either 'get' or 'put' depending
 %% on if the fsm reporting in was for a get or a put action.  The final element
-%% is either 'in_progess' or 'errors'.
+%% is either 'in_progress' or 'errors'.
 %%
-%% The 'in_progess' is a simple counter reporting the number of get or put fsm's
+%% The 'in_progress' is a simple counter reporting the number of get or put fsm's
 %% currently alive.  'errors' is a spiral for all fsm's that exited with a
 %% reason other than normal or shutdown.
 -module(riak_kv_get_put_monitor).
@@ -46,7 +46,7 @@
 -define(COUNTERS, [?COUNTER(FsmType, DataPoint) ||
     {_, FsmType, DataPoint} <- ?STATTYPES]).
 
--type metric() :: {'riak_kv', 'node', 'puts' | 'gets', 'in_progess' | 'errors'}.
+-type metric() :: {'riak_kv', 'node', 'puts' | 'gets', 'in_progress' | 'errors'}.
 -type spiral_value() :: [{'counter', non_neg_integer()} | {'one', non_neg_integer()}].
 
 -record(state, {monitor_list = []}).
@@ -170,11 +170,11 @@ insert_pid(Pid, Type, List) ->
     orddict:store(MonRef, {Pid, Type}, List).
 
 tell_folsom_about_spawn(Type) ->
-    folsom_metrics:notify({?COUNTER(Type, in_progess), {inc, 1}}).
+    folsom_metrics:notify({?COUNTER(Type, in_progress), {inc, 1}}).
 
 tell_folsom_about_exit(Type, Cause) when Cause == normal; Cause == shutdown ->
-    folsom_metrics:notify({?COUNTER(Type, in_progess), {dec, 1}});
-% for the abnormal cases, we not only decrmemt the in progess count (like a
+    folsom_metrics:notify({?COUNTER(Type, in_progress), {dec, 1}});
+% for the abnormal cases, we not only decrmemt the in progress count (like a
     % normal exit) but increment the errors count as well.
 tell_folsom_about_exit(Type, _Cause) ->
     tell_folsom_about_exit(Type, normal),

--- a/src/riak_kv_get_put_monitor.erl
+++ b/src/riak_kv_get_put_monitor.erl
@@ -37,16 +37,16 @@
 -behaviour(gen_server).
 -define(SERVER, ?MODULE).
 -define(STATTYPES, [
-    {new_counter, put, in_progess},
-    {new_counter, get, in_progess},
-    {new_spiral, put, errors},
-    {new_spiral, get, errors}
+    {new_counter, puts, in_progess},
+    {new_counter, gets, in_progess},
+    {new_spiral, puts, errors},
+    {new_spiral, gets, errors}
 ]).
 -define(COUNTER(FsmType, DataPoint), {riak_kv, node(), FsmType, DataPoint}).
 -define(COUNTERS, [?COUNTER(FsmType, DataPoint) ||
     {_, FsmType, DataPoint} <- ?STATTYPES]).
 
--type metric() :: {'riak_kv', node(), 'put' | 'get', 'in_progess' | 'errors'}.
+-type metric() :: {'riak_kv', node(), 'puts' | 'gets', 'in_progess' | 'errors'}.
 -type spiral_value() :: [{'counter', non_neg_integer()} | {'one', non_neg_integer()}].
 
 -record(state, {monitor_list = []}).
@@ -98,7 +98,7 @@ all_stats() ->
 %% Returns the last count for the get fms's in progress.
 -spec get_in_progress() -> non_neg_integer().
 get_in_progress() ->
-    folsom_metrics:get_metric_value(?COUNTER(get, in_progress)).
+    folsom_metrics:get_metric_value(?COUNTER(gets, in_progress)).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
@@ -121,14 +121,14 @@ handle_call(_Request, _From, State) ->
 %% @private
 handle_cast({get_fsm_spawned, Pid}, State) ->
     #state{monitor_list = List} = State,
-    List2 = insert_pid(Pid, get, List),
-    tell_folsom_about_spawn(get),
+    List2 = insert_pid(Pid, gets, List),
+    tell_folsom_about_spawn(gets),
     {noreply, State#state{monitor_list = List2}};
 
 handle_cast({put_fsm_spawned, Pid}, State) ->
     #state{monitor_list = List} = State,
-    List2 = insert_pid(Pid, put, List),
-    tell_folsom_about_spawn(put),
+    List2 = insert_pid(Pid, puts, List),
+    tell_folsom_about_spawn(puts),
     {noreply, State#state{monitor_list = List2}};
 
 handle_cast(stop, State) ->

--- a/src/riak_kv_get_put_monitor.erl
+++ b/src/riak_kv_get_put_monitor.erl
@@ -172,7 +172,11 @@ insert_pid(Pid, Type, List) ->
 tell_folsom_about_spawn(Type) ->
     folsom_metrics:notify({?COUNTER(Type, in_progress), {inc, 1}}).
 
-tell_folsom_about_exit(Type, Cause) when Cause == normal; Cause == shutdown ->
+tell_folsom_about_exit(Type, Cause) when Cause == normal; Cause == shutdown; Cause == noproc ->
+    % no proc is considered 'normal' because that indicates the process had exited
+    % before the monitor was able to be applied.  We have no way of knowing why
+    % it exited, and on an underloaded system, it is most likely the request
+    % completed before we got the 'monitor me' message.
     folsom_metrics:notify({?COUNTER(Type, in_progress), {dec, 1}});
 % for the abnormal cases, we not only decrmemt the in progress count (like a
     % normal exit) but increment the errors count as well.

--- a/src/riak_kv_get_put_monitor.erl
+++ b/src/riak_kv_get_put_monitor.erl
@@ -37,8 +37,8 @@
 -behaviour(gen_server).
 -define(SERVER, ?MODULE).
 -define(STATTYPES, [
-    {new_counter, puts, in_progess},
-    {new_counter, gets, in_progess},
+    {new_counter, puts, in_progress},
+    {new_counter, gets, in_progress},
     {new_spiral, puts, errors},
     {new_spiral, gets, errors}
 ]).

--- a/src/riak_kv_get_put_monitor.erl
+++ b/src/riak_kv_get_put_monitor.erl
@@ -42,11 +42,11 @@
     {new_spiral, puts, errors},
     {new_spiral, gets, errors}
 ]).
--define(COUNTER(FsmType, DataPoint), {riak_kv, node(), FsmType, DataPoint}).
+-define(COUNTER(FsmType, DataPoint), {riak_kv, node, FsmType, DataPoint}).
 -define(COUNTERS, [?COUNTER(FsmType, DataPoint) ||
     {_, FsmType, DataPoint} <- ?STATTYPES]).
 
--type metric() :: {'riak_kv', node(), 'puts' | 'gets', 'in_progess' | 'errors'}.
+-type metric() :: {'riak_kv', 'node', 'puts' | 'gets', 'in_progess' | 'errors'}.
 -type spiral_value() :: [{'counter', non_neg_integer()} | {'one', non_neg_integer()}].
 
 -record(state, {monitor_list = []}).

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -156,6 +156,7 @@ init([From, RObj, Options]) ->
                                            robj = RObj,
                                            bkey = BKey,
                                            options = Options}),
+    riak_kv_get_put_monitor:put_fsm_spawned(self()),
     riak_core_dtrace:put_tag(io_lib:format("~p,~p", [Bucket, Key])),
     case riak_kv_util:is_x_deleted(RObj) of
         true  ->

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -262,6 +262,8 @@ update1({put_fsm_time, Bucket,  Microsecs, PerBucket}) ->
     do_put_bucket(PerBucket, {Bucket, Microsecs});
 update1(read_repairs) ->
     folsom_metrics:notify_existing_metric({?APP, read_repairs}, 1, spiral);
+update1(skipped_read_repairs) ->
+    folsom_metrics:notify_existing_metric({?APP, skipped_read_repairs}, 1, spiral);
 update1(coord_redir) ->
     folsom_metrics:notify_existing_metric({?APP, coord_redirs_total}, {inc, 1}, counter);
 update1(mapper_start) ->
@@ -374,6 +376,7 @@ stats() ->
      {node_puts, spiral},
      {node_put_fsm_time, histogram},
      {read_repairs, spiral},
+     {skipped_read_repairs, spiral},
      {coord_redirs_total, counter},
      {mapper_count, counter},
      {precommit_fail, counter},

--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -104,6 +104,9 @@ init([]) ->
     LegacyKeysFsmSup = {riak_kv_keys_fsm_legacy_sup,
                  {riak_kv_keys_fsm_legacy_sup, start_link, []},
                  permanent, infinity, supervisor, [riak_kv_keys_fsm_legacy_sup]},
+    GetPutMonitor = {riak_kv_get_put_monitor,
+                     {riak_kv_get_put_monitor, start_link, []},
+                     permanent, 5000, worker, [riak_kv_get_put_monitor]},
 
     % Figure out which processes we should run...
     HasStorageBackend = (app_helper:get_env(riak_kv, storage_backend) /= undefined),
@@ -120,6 +123,7 @@ init([]) ->
         LegacyKeysFsmSup,
         KLSup,
         KLMaster,
+        GetPutMonitor,
         JSSup,
         MapJSPool,
         ReduceJSPool,

--- a/test/fsm_eqc_util.erl
+++ b/test/fsm_eqc_util.erl
@@ -246,6 +246,14 @@ wait_for_req_id(ReqId, Pid) ->
 
 start_fake_get_put_monitor() ->
     Pid = spawn_link(?MODULE, fake_get_put_monitor, [undefined]),
+    case whereis(riak_kv_get_put_monitor) of
+        undefined ->
+            ok;
+        OldPid ->
+            unlink(OldPid),
+            exit(OldPid, shutdown),
+            riak_kv_test_util:wait_for_pid(OldPid)
+    end,
     register(riak_kv_get_put_monitor, Pid),
     {ok, Pid}.
 

--- a/test/fsm_eqc_util.erl
+++ b/test/fsm_eqc_util.erl
@@ -270,4 +270,24 @@ is_get_put_last_cast(Type, Pid) ->
             false
     end.
 
+start_fake_rng(ProcessName) ->
+    Pid = spawn_link(?MODULE, fake_rng, [1]),
+    register(ProcessName, Pid),
+    {ok, Pid}.
+
+set_fake_rng(ProcessName, Val) ->
+    gen_server:cast(ProcessName, {set, Val}).
+
+get_fake_rng(ProcessName) ->
+    gen_server:call(ProcessName, get).
+
+fake_rng(N) ->
+    receive
+        {'$gen_call', From, get} ->
+            gen_server:reply(From, N),
+            fake_rng(N);
+        {'$gen_cast', {set, NewN}} ->
+            fake_rng(NewN)
+    end.
+
 -endif. % EQC

--- a/test/fsm_eqc_util.erl
+++ b/test/fsm_eqc_util.erl
@@ -254,6 +254,8 @@ fake_get_put_monitor(LastCast) ->
         {'$gen_call', From, last_cast} ->
             gen_server:reply(From, LastCast),
             fake_get_put_monitor(LastCast);
+        {'$gen_cast', stop} ->
+            ok;
         {'$gen_cast', NewCast} ->
             fake_get_put_monitor(NewCast);
         _ ->

--- a/test/get_fsm_qc.erl
+++ b/test/get_fsm_qc.erl
@@ -199,7 +199,7 @@ prop_basic_get() ->
         {SoftCap, HardCap, Actual, Roll} = RRAbort,
         application:set_env(riak, read_repair_skip_soft_cap, SoftCap),
         application:set_env(riak, read_repair_skip_hard_cap, HardCap),
-        FolsomKey = {riak_kv, node(), get, in_progress},
+        FolsomKey = {riak_kv, node(), gets, in_progress},
         % don't really care if the key doesn't exist when we delete it.
         catch folsom_metrics:delete_metric(FolsomKey),
         folsom_metrics:new_counter(FolsomKey),

--- a/test/get_fsm_qc.erl
+++ b/test/get_fsm_qc.erl
@@ -197,8 +197,8 @@ prop_basic_get() ->
         Options = fsm_eqc_util:make_options([{r, R}, {pr, PR}], [{timeout, 200} | Options0]),
 
         {SoftCap, HardCap, Actual, Roll} = RRAbort,
-        application:set_env(riak, read_repair_skip_soft_cap, SoftCap),
-        application:set_env(riak, read_repair_skip_hard_cap, HardCap),
+        application:set_env(riak_kv, read_repair_soft, SoftCap),
+        application:set_env(riak_kv, read_repair_max, HardCap),
         FolsomKey = {riak_kv, node, gets, active},
         % don't really care if the key doesn't exist when we delete it.
         catch folsom_metrics:delete_metric(FolsomKey),

--- a/test/get_fsm_qc.erl
+++ b/test/get_fsm_qc.erl
@@ -199,7 +199,7 @@ prop_basic_get() ->
         {SoftCap, HardCap, Actual, Roll} = RRAbort,
         application:set_env(riak, read_repair_skip_soft_cap, SoftCap),
         application:set_env(riak, read_repair_skip_hard_cap, HardCap),
-        FolsomKey = {riak_kv, node, gets, in_progress},
+        FolsomKey = {riak_kv, node, gets, active},
         % don't really care if the key doesn't exist when we delete it.
         catch folsom_metrics:delete_metric(FolsomKey),
         folsom_metrics:new_counter(FolsomKey),

--- a/test/get_fsm_qc.erl
+++ b/test/get_fsm_qc.erl
@@ -277,7 +277,8 @@ prop_basic_get() ->
                  {n_value, equals(length(History), ExpectedN)},
                  {repair, check_repair(Objects, RepairHistory, History)},
                  {delete,  check_delete(Objects, RepairHistory, History, PerfectPreflist)},
-                 {distinct, all_distinct(Partitions)}
+                 {distinct, all_distinct(Partitions)},
+                 {told_monitor, fsm_eqc_util:is_get_put_last_cast(get, GetPid)}
                 ]))
     end).
 

--- a/test/get_fsm_qc.erl
+++ b/test/get_fsm_qc.erl
@@ -199,7 +199,7 @@ prop_basic_get() ->
         {SoftCap, HardCap, Actual, Roll} = RRAbort,
         application:set_env(riak, read_repair_skip_soft_cap, SoftCap),
         application:set_env(riak, read_repair_skip_hard_cap, HardCap),
-        FolsomKey = {riak_kv, node(), gets, in_progress},
+        FolsomKey = {riak_kv, node, gets, in_progress},
         % don't really care if the key doesn't exist when we delete it.
         catch folsom_metrics:delete_metric(FolsomKey),
         folsom_metrics:new_counter(FolsomKey),

--- a/test/get_fsm_qc.erl
+++ b/test/get_fsm_qc.erl
@@ -61,6 +61,7 @@ setup() ->
 
     %% Start up mock servers and dependencies
     fsm_eqc_util:start_mock_servers(),
+    fsm_eqc_util:start_fake_rng(?MODULE),
     ok.
 
 cleanup(_) ->
@@ -195,6 +196,16 @@ prop_basic_get() ->
         
         Options = fsm_eqc_util:make_options([{r, R}, {pr, PR}], [{timeout, 200} | Options0]),
 
+        {SoftCap, HardCap, Actual, Roll} = RRAbort,
+        application:set_env(riak, read_repair_skip_soft_cap, SoftCap),
+        application:set_env(riak, read_repair_skip_hard_cap, HardCap),
+        FolsomKey = {riak_kv, node(), get, in_progress},
+        % don't really care if the key doesn't exist when we delete it.
+        catch folsom_metrics:delete_metric(FolsomKey),
+        folsom_metrics:new_counter(FolsomKey),
+        folsom_metrics:notify({FolsomKey, {inc, Actual}}),
+        fsm_eqc_util:set_fake_rng(?MODULE, Roll),
+
         {ok, GetPid} = riak_kv_get_fsm:test_link({raw, ReqId, self()},
                             riak_object:bucket(Object),
                             riak_object:key(Object),
@@ -267,6 +278,8 @@ prop_basic_get() ->
                 io:format("Res: ~p\n", [Res]),
                 io:format("Repair: ~p~nHistory: ~p~n",
                           [RepairHistory, History]),
+                io:format("SoftCap: ~p~nHardCap: ~p~nActual: ~p~nRoll: ~p~n",
+                          [SoftCap, HardCap, Actual, Roll]),
                 io:format("RetResult: ~p~nExpResult: ~p~nDeleted objects: ~p~n",
                           [RetResult, ExpResult, Deleted]),
                 io:format("N: ~p  R: ~p  RealR: ~p  PR: ~p  RealPR: ~p~n"

--- a/test/get_put_monitor_eqc.erl
+++ b/test/get_put_monitor_eqc.erl
@@ -58,30 +58,34 @@ initial_state() ->
     unlink(Pid),
     #state{}.
 
-command(#state{put_fsm = [], get_fsm = []}) ->
-    oneof([
-        {call, ?MODULE, get_fsm_started, []},
-        {call, ?MODULE, put_fsm_started, []}
-    ]);
 command(S) ->
-    oneof([
-        {call, ?MODULE, get_fsm_started, []},
-        {call, ?MODULE, get_fsm_exit_normal, [get, S]},
-        {call, ?MODULE, get_fsm_exit_shutdown, [get, S]},
-        {call, ?MODULE, get_fsm_exit_error, [get, S]},
-        {call, ?MODULE, put_fsm_started, []},
-        {call, ?MODULE, put_fsm_exit_normal, [put, S]},
-        {call, ?MODULE, put_fsm_exit_shutdown, [put, S]},
-        {call, ?MODULE, put_fsm_exit_error, [put, S]}
+    frequency([
+        {3, {call, ?MODULE, put_fsm_started, []}},
+        {3, {call, ?MODULE, get_fsm_started, []}},
+        {1, {call, ?MODULE, put_fsm_exit_normal, [put, g_put_pid(S)]}},
+        {1, {call, ?MODULE, put_fsm_exit_shutdown, [put, g_put_pid(S)]}},
+        {1, {call, ?MODULE, put_fsm_exit_error, [put, g_put_pid(S)]}},
+        {1, {call, ?MODULE, get_fsm_exit_normal, [get, g_get_pid(S)]}},
+        {1, {call, ?MODULE, get_fsm_exit_shutdown, [get, g_get_pid(S)]}},
+        {1, {call, ?MODULE, get_fsm_exit_error, [get, g_get_pid(S)]}}
     ]).
 
-precondition(S, {call, _, _Command, [get, S]}) ->
-    [] =/= S#state.get_fsm;
-precondition(S, {call, _, _Command, [put, S]}) ->
-    [] =/= S#state.put_fsm;
+g_put_pid(#state{put_fsm = []}) ->
+    undefined;
+g_put_pid(#state{put_fsm = L}) ->
+    oneof(L).
+
+g_get_pid(#state{get_fsm = []}) ->
+    undefined;
+g_get_pid(#state{get_fsm = L}) ->
+    oneof(L).
+
+precondition(#state{get_fsm = []}, {call, _, _Command, [get, _]}) ->
+    false;
+precondition(#state{put_fsm = []}, {call, _, _Command, [put, _]}) ->
+    false;
 precondition(_,_) ->
     true.
-
 
 next_state(S, Res, {call, _, get_fsm_started, []}) ->
     Gets2 = ordsets:add_element(Res, S#state.get_fsm),
@@ -91,22 +95,22 @@ next_state(S, Res, {call, _, put_fsm_started, []}) ->
     Puts2 = ordsets:add_element(Res, S#state.put_fsm),
     S#state{put_fsm = Puts2};
 
-next_state(S, Res, {call, _, get_fsm_exit_error, [get, _]}) ->
-    Gets2 = ordsets:del_element(Res, S#state.get_fsm),
+next_state(S, _Res, {call, _, get_fsm_exit_error, [get, Pid]}) ->
+    Gets2 = ordsets:del_element(Pid, S#state.get_fsm),
     ErrCount = S#state.get_errors + 1,
     S#state{get_fsm = Gets2, get_errors = ErrCount};
 
-next_state(S, Res, {call, _, _, [get, _]}) ->
-    Gets2 = ordsets:del_element(Res, S#state.get_fsm),
+next_state(S, _Res, {call, _, _, [get, Pid]}) ->
+    Gets2 = ordsets:del_element(Pid, S#state.get_fsm),
     S#state{get_fsm = Gets2};
     
-next_state(S, Res, {call, _, put_fsm_exit_error, [put, _]}) ->
-    Puts2 = ordsets:del_element(Res, S#state.put_fsm),
+next_state(S, _Res, {call, _, put_fsm_exit_error, [put, Pid]}) ->
+    Puts2 = ordsets:del_element(Pid, S#state.put_fsm),
     ErrCount = S#state.put_errors + 1,
     S#state{put_fsm = Puts2, put_errors = ErrCount};
 
-next_state(S, Res, {call, _, _, [put, _]}) ->
-    Puts2 = ordsets:del_element(Res, S#state.put_fsm),
+next_state(S, _Res, {call, _, _, [put, Pid]}) ->
+    Puts2 = ordsets:del_element(Pid, S#state.put_fsm),
     S#state{put_fsm = Puts2}.
 
 
@@ -146,18 +150,23 @@ postcondition(S, {call, _Mod, _NiceShutdown, [get, _]}, Res) ->
 check_state(S) ->
     #state{put_errors = PutErrCount, get_errors = GetErrCount,
         put_fsm = PutList, get_fsm = GetList} = S,
-%    ?debugFmt("state of thing:  ~p", [gen_server:call(riak_kv_get_put_monitor, dump_state)]),
+    % wait for folsom stats to settle; if we check too quick, folsom won't have
+    % finished updating. Timers suck, so maybe something better will come along
+    timer:sleep(10),
+
     % with a timetrap of 60 seconds, the spiral will never have values slide off
     PutCount = length(PutList),
     ?assertEqual(PutCount, folsom_metrics:get_metric_value(put_fsm_in_progress)),
     GetCount = length(GetList),
     ?assertEqual(GetCount, folsom_metrics:get_metric_value(get_fsm_in_progress)),
+
+    ?assertEqual(PutErrCount, folsom_metrics:get_metric_value(put_fsm_errors_since_start)),
+    ?assertEqual(GetErrCount, folsom_metrics:get_metric_value(get_fsm_errors_since_start)),
+
     [{count, GotPutErrCount},_] = folsom_metrics:get_metric_value(put_fsm_errors_minute),
     ?assertEqual(PutErrCount, GotPutErrCount),
     [{count, GotGetErrCount},_] = folsom_metrics:get_metric_value(get_fsm_errors_minute),
     ?assertEqual(GetErrCount, GotGetErrCount),
-    ?assertEqual(PutErrCount, folsom_metrics:get_metric_value(put_fsm_errors_since_start)),
-    ?assertEqual(GetErrCount, folsom_metrics:get_metric_value(get_fsm_errors_since_start)),
     true.
 
 %% ====================================================================
@@ -169,18 +178,15 @@ get_fsm_started() ->
     riak_kv_get_put_monitor:get_fsm_spawned(Pid),
     Pid.
 
-get_fsm_exit_normal(get, S) ->
-    Pid = lists_random(S#state.get_fsm),
+get_fsm_exit_normal(get, Pid) ->
     end_and_wait(Pid, normal),
     Pid.
 
-get_fsm_exit_shutdown(get, S) ->
-    Pid = lists_random(S#state.get_fsm),
+get_fsm_exit_shutdown(get, Pid) ->
     end_and_wait(Pid, shutdown),
     Pid.
 
-get_fsm_exit_error(get, S) ->
-    Pid = lists_random(S#state.get_fsm),
+get_fsm_exit_error(get, Pid) ->
     end_and_wait(Pid, unnatural),
     Pid.
 
@@ -189,18 +195,15 @@ put_fsm_started() ->
     riak_kv_get_put_monitor:put_fsm_spawned(Pid),
     Pid.
 
-put_fsm_exit_normal(put, S) ->
-    Pid = lists_random(S#state.put_fsm),
+put_fsm_exit_normal(put, Pid) ->
     end_and_wait(Pid, normal),
     Pid.
 
-put_fsm_exit_shutdown(put, S) ->
-    Pid = lists_random(S#state.put_fsm),
+put_fsm_exit_shutdown(put, Pid) ->
     end_and_wait(Pid, shutdown),
     Pid.
 
-put_fsm_exit_error(put, S) ->
-    Pid = lists_random(S#state.put_fsm),
+put_fsm_exit_error(put, Pid) ->
     end_and_wait(Pid, unnatural),
     Pid.
 
@@ -212,12 +215,12 @@ fake_fsm() -> proc_lib:spawn(?MODULE, fake_fsm_loop, []).
 
 fake_fsm_loop() ->
     receive
-        _ ->
-            fake_fsm_loop()
+        ExitCause ->
+            exit(ExitCause)
     end.
 
 end_and_wait(Pid, Cause) ->
-    exit(Pid, Cause),
+    Pid ! Cause,
     Monref = erlang:monitor(process, Pid),
     receive
         {'DOWN', Monref, process, Pid, _} ->

--- a/test/get_put_monitor_eqc.erl
+++ b/test/get_put_monitor_eqc.erl
@@ -156,10 +156,10 @@ check_state(S) ->
 
     % with a timetrap of 60 seconds, the spiral will never have values slide off
     MetricExpects = [
-        {{riak_kv, node(), puts, in_progess}, length(PutList)},
-        {{riak_kv, node(), gets, in_progess}, length(GetList)},
-        {{riak_kv, node(), puts, errors}, [{count, PutErrCount}, {one, PutErrCount}]},
-        {{riak_kv, node(), gets, errors}, [{count, GetErrCount}, {one, GetErrCount}]}
+        {{riak_kv, node, puts, in_progess}, length(PutList)},
+        {{riak_kv, node, gets, in_progess}, length(GetList)},
+        {{riak_kv, node, puts, errors}, [{count, PutErrCount}, {one, PutErrCount}]},
+        {{riak_kv, node, gets, errors}, [{count, GetErrCount}, {one, GetErrCount}]}
     ],
 
     [ begin

--- a/test/get_put_monitor_eqc.erl
+++ b/test/get_put_monitor_eqc.erl
@@ -112,7 +112,8 @@ postcondition(S, _Test, _Res) ->
     PutCount = length(PutList),
     ?assertMatch([{count, PutCount},_], folsom_metrics:get_metric_value(put_fsm_in_progress)),
     GetCount = length(GetList),
-    ?assertMatch([{count, GetCount},_], folsom_metrics:get_metric_value(get_fsm_in_progress)).
+    ?assertMatch([{count, GetCount},_], folsom_metrics:get_metric_value(get_fsm_in_progress)),
+    true.
 
 %% ====================================================================
 %% Calls

--- a/test/get_put_monitor_eqc.erl
+++ b/test/get_put_monitor_eqc.erl
@@ -170,8 +170,8 @@ check_state(S) ->
 
     % with a timetrap of 60 seconds, the spiral will never have values slide off
     MetricExpects = [
-        {{riak_kv, node, puts, in_progress}, length(PutList)},
-        {{riak_kv, node, gets, in_progress}, length(GetList)},
+        {{riak_kv, node, puts, active}, length(PutList)},
+        {{riak_kv, node, gets, active}, length(GetList)},
         {{riak_kv, node, puts, errors}, [{count, PutErrCount}, {one, PutErrCount}]},
         {{riak_kv, node, gets, errors}, [{count, GetErrCount}, {one, GetErrCount}]}
     ],

--- a/test/get_put_monitor_eqc.erl
+++ b/test/get_put_monitor_eqc.erl
@@ -156,8 +156,8 @@ check_state(S) ->
 
     % with a timetrap of 60 seconds, the spiral will never have values slide off
     MetricExpects = [
-        {{riak_kv, node, puts, in_progess}, length(PutList)},
-        {{riak_kv, node, gets, in_progess}, length(GetList)},
+        {{riak_kv, node, puts, in_progress}, length(PutList)},
+        {{riak_kv, node, gets, in_progress}, length(GetList)},
         {{riak_kv, node, puts, errors}, [{count, PutErrCount}, {one, PutErrCount}]},
         {{riak_kv, node, gets, errors}, [{count, GetErrCount}, {one, GetErrCount}]}
     ],

--- a/test/get_put_monitor_eqc.erl
+++ b/test/get_put_monitor_eqc.erl
@@ -38,6 +38,7 @@ prop() ->
         {_,_,Res} = run_commands(?MODULE, Cmds),
         unlink(Pid),
         Monref = erlang:monitor(process, Pid),
+        riak_kv_get_put_monitor:stop(),
         receive
             {'DOWN', Monref, process, Pid, _} ->
                 ok
@@ -106,12 +107,12 @@ next_state(S, Res, {call, _, _, [put, _]}) ->
 postcondition(S, _Test, _Res) ->
     #state{put_errors = PutErrCount, get_errors = GetErrCount,
         put_fsm = PutList, get_fsm = GetList} = S,
-    ?assertMatch([{count, PutErrCount},_], folsom:get_metric_value(put_fsm_errors)),
-    ?assertMatch([{count, GetErrCount},_], folsom:get_metric_value(get_fsm_errors)),
+    ?assertMatch([{count, PutErrCount},_], folsom_metrics:get_metric_value(put_fsm_errors)),
+    ?assertMatch([{count, GetErrCount},_], folsom_metrics:get_metric_value(get_fsm_errors)),
     PutCount = length(PutList),
-    ?assertMatch([{count, PutCount},_], folsom:get_metric_value(put_fsm_in_progress)),
+    ?assertMatch([{count, PutCount},_], folsom_metrics:get_metric_value(put_fsm_in_progress)),
     GetCount = length(GetList),
-    ?assertMatch([{count, GetCount},_], folsom:get_metric_value(get_fsm_in_progress)).
+    ?assertMatch([{count, GetCount},_], folsom_metrics:get_metric_value(get_fsm_in_progress)).
 
 %% ====================================================================
 %% Calls
@@ -139,7 +140,7 @@ get_fsm_exit_error(get, S) ->
 
 put_fsm_started() ->
     Pid = fake_fsm(),
-    riak_kv_get_put_monitor:get_fsm_spawned(Pid),
+    riak_kv_get_put_monitor:put_fsm_spawned(Pid),
     Pid.
 
 put_fsm_exit_normal(put, S) ->

--- a/test/get_put_monitor_eqc.erl
+++ b/test/get_put_monitor_eqc.erl
@@ -156,10 +156,10 @@ check_state(S) ->
 
     % with a timetrap of 60 seconds, the spiral will never have values slide off
     MetricExpects = [
-        {{riak_kv, node(), put, in_progess}, length(PutList)},
-        {{riak_kv, node(), get, in_progess}, length(GetList)},
-        {{riak_kv, node(), put, errors}, [{count, PutErrCount}, {one, PutErrCount}]},
-        {{riak_kv, node(), get, errors}, [{count, GetErrCount}, {one, GetErrCount}]}
+        {{riak_kv, node(), puts, in_progess}, length(PutList)},
+        {{riak_kv, node(), gets, in_progess}, length(GetList)},
+        {{riak_kv, node(), puts, errors}, [{count, PutErrCount}, {one, PutErrCount}]},
+        {{riak_kv, node(), gets, errors}, [{count, GetErrCount}, {one, GetErrCount}]}
     ],
 
     [ begin

--- a/test/get_put_monitor_eqc.erl
+++ b/test/get_put_monitor_eqc.erl
@@ -1,0 +1,184 @@
+-module(get_put_monitor_eqc).
+
+-ifdef(EQC).
+
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eqc/include/eqc_statem.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile([export_all]).
+
+-record(state, {
+    get_fsm = [],
+    put_fsm = [],
+    get_errors = 0,
+    put_errors = 0
+}).
+
+-define(QC_OUT(P),
+        eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).
+
+eqc_test_() ->
+    {timeout, 120, ?_assertEqual(true, quickcheck(numtests(100, ?QC_OUT(prop()))))}.
+
+test() ->
+    test(100).
+
+test(N) ->
+    quickcheck(numtests(N, prop())).
+
+check() ->
+    check(prop(), current_counterexample()).
+
+prop() ->
+    ?FORALL(Cmds, commands(?MODULE), begin
+        crypto:start(),
+        application:start(folsom),
+        {ok, Pid} = riak_kv_get_put_monitor:start_link(),
+        {_,_,Res} = run_commands(?MODULE, Cmds),
+        unlink(Pid),
+        Monref = erlang:monitor(process, Pid),
+        receive
+            {'DOWN', Monref, process, Pid, _} ->
+                ok
+        end,
+        case Res of
+            ok -> ok;
+            _ -> io:format(user, "QC result: ~p\n", [Res])
+        end,
+        aggregate(command_names(Cmds), Res == ok)
+    end).
+
+%% ====================================================================
+%% eqc_statem callbacks
+%% ====================================================================
+
+initial_state() ->
+    #state{}.
+
+command(S) ->
+    oneof([
+        {call, ?MODULE, get_fsm_started, []},
+        {call, ?MODULE, get_fsm_exit_normal, [get, S]},
+        {call, ?MODULE, get_fsm_exit_shutdown, [get, S]},
+        {call, ?MODULE, get_fsm_exit_error, [get, S]},
+        {call, ?MODULE, put_fsm_started, []},
+        {call, ?MODULE, put_fsm_exit_normal, [put, S]},
+        {call, ?MODULE, put_fsm_exit_shutdown, [put, S]},
+        {call, ?MODULE, put_fsm_exit_error, [put, S]}
+    ]).
+
+precondition(S, {call, _, _Command, [get, S]}) ->
+    [] =/= S#state.get_fsm;
+precondition(S, {call, _, _Command, [put, S]}) ->
+    [] =/= S#state.put_fsm;
+precondition(_,_) ->
+    true.
+
+
+next_state(S, Res, {call, _, get_fsm_started, []}) ->
+    Gets2 = ordsets:add_element(Res, S#state.get_fsm),
+    S#state{get_fsm = Gets2};
+
+next_state(S, Res, {call, _, put_fsm_started, []}) ->
+    Puts2 = ordsets:add_element(Res, S#state.put_fsm),
+    S#state{put_fsm = Puts2};
+
+next_state(S, Res, {call, _, get_fsm_exit_error, [get, _]}) ->
+    Gets2 = ordsets:del_element(Res, S#state.get_fsm),
+    ErrCount = S#state.get_errors + 1,
+    S#state{get_fsm = Gets2, get_errors = ErrCount};
+
+next_state(S, Res, {call, _, _, [get, _]}) ->
+    Gets2 = ordsets:del_element(Res, S#state.get_fsm),
+    S#state{get_fsm = Gets2};
+    
+next_state(S, Res, {call, _, put_fsm_exit_error, [put, _]}) ->
+    Puts2 = ordsets:del_element(Res, S#state.put_fsm),
+    ErrCount = S#state.put_errors + 1,
+    S#state{put_fsm = Puts2, put_errors = ErrCount};
+
+next_state(S, Res, {call, _, _, [put, _]}) ->
+    Puts2 = ordsets:del_element(Res, S#state.put_fsm),
+    S#state{put_fsm = Puts2}.
+
+
+postcondition(S, _Test, _Res) ->
+    #state{put_errors = PutErrCount, get_errors = GetErrCount,
+        put_fsm = PutList, get_fsm = GetList} = S,
+    ?assertMatch([{count, PutErrCount},_], folsom:get_metric_value(put_fsm_errors)),
+    ?assertMatch([{count, GetErrCount},_], folsom:get_metric_value(get_fsm_errors)),
+    PutCount = length(PutList),
+    ?assertMatch([{count, PutCount},_], folsom:get_metric_value(put_fsm_in_progress)),
+    GetCount = length(GetList),
+    ?assertMatch([{count, GetCount},_], folsom:get_metric_value(get_fsm_in_progress)).
+
+%% ====================================================================
+%% Calls
+%% ====================================================================
+
+get_fsm_started() ->
+    Pid = fake_fsm(),
+    riak_kv_get_put_monitor:get_fsm_spawned(Pid),
+    Pid.
+
+get_fsm_exit_normal(get, S) ->
+    Pid = lists_random(S#state.get_fsm),
+    end_and_wait(Pid, normal),
+    Pid.
+
+get_fsm_exit_shutdown(get, S) ->
+    Pid = lists_random(S#state.get_fsm),
+    end_and_wait(Pid, shutdown),
+    Pid.
+
+get_fsm_exit_error(get, S) ->
+    Pid = lists_random(S#state.get_fsm),
+    end_and_wait(Pid, unnatural),
+    Pid.
+
+put_fsm_started() ->
+    Pid = fake_fsm(),
+    riak_kv_get_put_monitor:get_fsm_spawned(Pid),
+    Pid.
+
+put_fsm_exit_normal(put, S) ->
+    Pid = lists_random(S#state.put_fsm),
+    end_and_wait(Pid, normal),
+    Pid.
+
+put_fsm_exit_shutdown(put, S) ->
+    Pid = lists_random(S#state.put_fsm),
+    end_and_wait(Pid, shutdown),
+    Pid.
+
+put_fsm_exit_error(put, S) ->
+    Pid = lists_random(S#state.put_fsm),
+    end_and_wait(Pid, unnatural),
+    Pid.
+
+%% ====================================================================
+%% Helpers
+%% ====================================================================
+
+fake_fsm() -> proc_lib:spawn(?MODULE, fake_fsm_loop, []).
+
+fake_fsm_loop() ->
+    receive
+        _ ->
+            fake_fsm_loop()
+    end.
+
+end_and_wait(Pid, Cause) ->
+    exit(Pid, Cause),
+    Monref = erlang:monitor(process, Pid),
+    receive
+        {'DOWN', Monref, process, Pid, _} ->
+            ok
+    end.
+
+lists_random(List) ->
+    Max = length(List),
+    Nth = crypto:rand_uniform(1, Max),
+    lists:nth(Nth, List).
+-endif.

--- a/test/put_fsm_eqc.erl
+++ b/test/put_fsm_eqc.erl
@@ -393,7 +393,8 @@ prop_basic_put() ->
            conjunction([{result, equals(RetResult, Expected)},
                         {details, check_details(RetInfo, Options)},
                         {postcommit, equals(PostCommits, ExpectedPostCommits)},
-                        {puts_sent, check_puts_sent(ExpectedVnodePuts, H)}]))
+                        {puts_sent, check_puts_sent(ExpectedVnodePuts, H)},
+                        {told_monitor, fsm_eqc_util:is_get_put_last_cast(put, PutPid)}]))
     end).
 
 make_options([], Options) ->


### PR DESCRIPTION
Addes a get_put monitor and some stat tracking, as well as skipping read-repair on over loaded nodes.
