### PR TITLE
Spawn a monitoring process per get/ put fsm

### DIFF
--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -83,10 +83,6 @@ init([]) ->
     SinkFsmSup = {riak_kv_mrc_sink_sup,
                   {riak_kv_mrc_sink_sup, start_link, []},
                   permanent, infinity, supervisor, [riak_kv_mrc_sink_sup]},
-    GetPutMonitor = {riak_kv_get_put_monitor,
-                     {riak_kv_get_put_monitor, start_link, []},
-                     permanent, 5000, worker, [riak_kv_get_put_monitor]},
-
     EntropyManager = {riak_kv_entropy_manager,
                       {riak_kv_entropy_manager, start_link, []},
                       permanent, 30000, worker, [riak_kv_entropy_manager]},
@@ -105,7 +101,6 @@ init([]) ->
         KeysFsmSup,
         IndexFsmSup,
         EntropyManager,
-        GetPutMonitor,
         JSSup,
         MapJSPool,
         ReduceJSPool,

--- a/test/fsm_eqc_util.erl
+++ b/test/fsm_eqc_util.erl
@@ -246,43 +246,20 @@ wait_for_req_id(ReqId, Pid) ->
     end.
 
 start_fake_get_put_monitor() ->
-    Pid = spawn_link(?MODULE, fake_get_put_monitor, [undefined]),
-    case whereis(riak_kv_get_put_monitor) of
-        undefined ->
-            ok;
-        OldPid ->
-            unlink(OldPid),
-            exit(OldPid, shutdown),
-            riak_kv_test_util:wait_for_pid(OldPid)
-    end,
-    register(riak_kv_get_put_monitor, Pid),
-    {ok, Pid}.
+    meck:new(riak_kv_get_put_monitor),
+    meck:expect(riak_kv_get_put_monitor, get_fsm_spawned,
+                fun(_Pid) ->  ok  end),
+    meck:expect(riak_kv_get_put_monitor, put_fsm_spawned,
+                fun(_Pid) ->  ok  end),
+    meck:expect(riak_kv_get_put_monitor, gets_active,
+                fun() -> meck:passthrough([])
+                end).
 
 stop_fake_get_put_monitor() ->
-    case whereis(riak_kv_get_put_monitor) of
-        undefined ->
-            ok;
-        Pid ->
-            unlink(Pid),
-            exit(Pid, shutdown),
-            riak_kv_test_util:wait_for_pid(Pid)
-    end.
-
-fake_get_put_monitor(LastCast) ->
-    receive
-        {'$gen_call', From, last_cast} ->
-            gen_server:reply(From, LastCast),
-            fake_get_put_monitor(LastCast);
-        {'$gen_cast', stop} ->
-            ok;
-        {'$gen_cast', NewCast} ->
-            fake_get_put_monitor(NewCast);
-        _ ->
-            fake_get_put_monitor(LastCast)
-    end.
+    meck:unload(riak_kv_get_put_monitor).
 
 is_get_put_last_cast(Type, Pid) ->
-    case gen_server:call(riak_kv_get_put_monitor, last_cast) of
+    case last_spawn(lists:reverse(meck:history(riak_kv_get_put_monitor))) of
         {get_fsm_spawned, Pid} when Type == get ->
             true;
         {put_fsm_spawned, Pid} when Type == put ->
@@ -290,6 +267,18 @@ is_get_put_last_cast(Type, Pid) ->
         _ ->
             false
     end.
+
+%% Just get the last `XXX_fsm_spawned/1' from the list
+%% of meck history calls.
+%% Expects a reversed mecck:history()
+last_spawn([]) ->
+    undefined;
+last_spawn([{_MPid, {_Mod, TypeFun, [Pid]}, ok}|_Rest]) ->
+    {TypeFun, Pid};
+last_spawn([_Hist|Rest]) ->
+    last_spawn(Rest).
+
+
 
 start_fake_rng(ProcessName) ->
     Pid = spawn_link(?MODULE, fake_rng, [1]),

--- a/test/fsm_eqc_util.erl
+++ b/test/fsm_eqc_util.erl
@@ -270,7 +270,7 @@ is_get_put_last_cast(Type, Pid) ->
 
 %% Just get the last `XXX_fsm_spawned/1' from the list
 %% of meck history calls.
-%% Expects a reversed mecck:history()
+%% Expects a reversed meck:history()
 last_spawn([]) ->
     undefined;
 last_spawn([{_MPid, {_Mod, TypeFun, [Pid]}, ok}|_Rest]) ->

--- a/test/get_fsm_qc.erl
+++ b/test/get_fsm_qc.erl
@@ -199,7 +199,7 @@ prop_basic_get() ->
         {SoftCap, HardCap, Actual, Roll} = RRAbort,
         application:set_env(riak_kv, read_repair_soft, SoftCap),
         application:set_env(riak_kv, read_repair_max, HardCap),
-        FolsomKey = {riak_kv, node, gets, active},
+        FolsomKey = {riak_kv, node, gets, fsm, active},
         % don't really care if the key doesn't exist when we delete it.
         catch folsom_metrics:delete_metric(FolsomKey),
         folsom_metrics:new_counter(FolsomKey),


### PR DESCRIPTION
Un-gen_serverize get_put_monitor
Move the get/put stats to riak stat
Remove unused all_stats/0 fun from get/put monitor
Update eqc test to work with a spawn per fsm
