### PR TITLE
Change AAE hashtree to buffer and batch write to LevelDB

### DIFF
--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -455,9 +455,11 @@ new_segment_store(Opts, State) ->
                   SegmentPath ->
                       SegmentPath
               end,
-    Options = [{create_if_missing, true},
-               {write_buffer_size, 1024*1024},
-               {max_open_files, 20}],
+    Config = app_helper:get_env(riak_kv,
+                                anti_entropy_leveldb_opts,
+                                [{write_buffer_size, 4*1024*1024},
+                                 {max_open_files, 20}]),
+    Options = [{create_if_missing, true} | Config],
     filelib:ensure_dir(DataDir),
     {ok, Ref} = eleveldb:open(DataDir, Options),
     State#state{ref=Ref, path=DataDir}.

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -279,7 +279,8 @@ maybe_flush_buffer(State=#state{write_buffer_count=WCount}) ->
     end.
 
 flush_buffer(State=#state{write_buffer=WBuffer}) ->
-    Updates = [{put, Key, Hash} || {Key, Hash} <- WBuffer],
+    %% Write buffer is built backwards, reverse before building update list
+    Updates = [{put, Key, Hash} || {Key, Hash} <- lists:reverse(WBuffer)],
     ok = eleveldb:write(State#state.ref, Updates, []),
     State#state{write_buffer=[],
                 write_buffer_count=0}.

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -86,6 +86,10 @@
 %% LevelDB instance, however updates and exchanges operate over a snapshot of
 %% the tree.
 %%
+%% In order to improve performance, writes are buffered in memory and sent
+%% to LevelDB using a single batch write. Writes are flushed whenever the
+%% buffer becomes full, as well as before updating the hashtree.
+%%
 %% Tree exchange is provided by the ``compare/2'' and ``compare/3'' functions.
 %% The behavior of these functions is determined through a provided function
 %% that implements logic to get buckets and segments for a given remote tree,


### PR DESCRIPTION
Change AAE to batch write to LevelDB rather than write hash updates one at a time. While AAE writes are small and asynchronous, having 2x the writes (normal Riak write + AAE write) going into LevelDB has shown to have an impact on Riak throughput. This pull-request has hashtrees buffer writes in memory until there are 200 hash updates, and then send all writes to LevelDB as a single batch write. This has been benchmarked to show a noticeable performance improvement.

In addition to batch writing once every 200 writes, the hashtree will also always flush writes before updating a tree and performing a tree exchange. Thus, AAE semantics are identical between non-batched and batched approach.

If a `riak_kv_index_hashtree` crashes for some reason, and therefore crashes the `hashtree` processes, we may lose the last few writes buffered in RAM. This isn't a problem, as AAE is designed to be lossy anyway, and exchanges with other replicas and/or eventual re-building of the tree will sort things out.

This pull-request also makes the LevelDB options used by AAE configurable, as well as bumps the default write-buffer size from 1 MB to 4 MB.
