### PR TITLE
Avoid a badarg in crypto:rand_uniform when N=1

### DIFF
--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -208,7 +208,7 @@ prepare(timeout, StateData0 = #state{from = From, robj = RObj,
         {_, true} ->
             %% This node is not in the preference list
             %% forward on to a random node
-            ListPos = crypto:rand_uniform(1, length(Preflist2)),
+            ListPos = crypto:rand_uniform(1, length(Preflist2)+1),
             {{_Idx, CoordNode},_Type} = lists:nth(ListPos, Preflist2),
             _Timeout = get_option(timeout, Options, ?DEFAULT_TIMEOUT),
             ?DTRACE(?C_PUT_FSM_PREPARE, [1],


### PR DESCRIPTION
crypto:rand_uniform(1, N) generates values in a range of 1 to N-1. This means that for N=1, we were calling rand_uniform(1, 1) which is obviously an impossible range (and throws a badarg). It also means that we'd _never_ forward to the last vnode in the preflist, because when N>1, we'd never randomly generate the Nth element in the list.

The resulting error is this:

```
2012-12-15 11:42:11.391 [error] <0.1919.0> gen_fsm <0.1919.0> in state prepare terminated with reason: bad argument in crypto:rand_uniform_pos/2 line 555
```

It is very simple to reproduce, just make a devrel of >1 nodes where the default n_val is 1, and fire basho_bench at it. Any coordinating puts that would require forwarding would crash.

Credit goes to @gburd to reporting it, but I can't find any branches from him fixing it.

cc @jonmeredith - I think this is a blocker for 1.3.
