### PR TITLE
Try to make KV shutdown cleaner

### DIFF
--- a/src/riak_kv_get_put_monitor.erl
+++ b/src/riak_kv_get_put_monitor.erl
@@ -40,7 +40,7 @@
 %% ------------------------------------------------------------------
 
 -export([get_fsm_spawned/1, put_fsm_spawned/1,
-         gets_active/0, spawned/2]).
+         gets_active/0, puts_active/0, spawned/2]).
 
 %% ------------------------------------------------------------------
 %% API Function Definitions
@@ -78,3 +78,7 @@ put_fsm_spawned(Pid) ->
 gets_active() ->
     riak_kv_stat:active_gets().
 
+%% Returns the last count for the put fms's in progress.
+-spec puts_active() -> non_neg_integer().
+puts_active() ->
+    riak_kv_stat:active_puts().

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -41,7 +41,7 @@
          update/1, register_stats/0, produce_stats/0,
          leveldb_read_block_errors/0, stop/0]).
 -export([track_bucket/1, untrack_bucket/1]).
--export([active_gets/0]).
+-export([active_gets/0, active_puts/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -94,6 +94,10 @@ untrack_bucket(Bucket) when is_binary(Bucket) ->
 %% The current number of active get fsms in riak
 active_gets() ->
     folsom_metrics:get_metric_value({?APP, node, gets, fsm, active}).
+
+%% The current number of active put fsms in riak
+active_puts() ->
+    folsom_metrics:get_metric_value({?APP, node, puts, fsm, active}).
 
 stop() ->
     gen_server:cast(?SERVER, stop).


### PR DESCRIPTION
Unregister PB services and Webmachine routes and wait for any active put
FSMs to complete.

The goal of this is to prevent writes from continuing to happen while KV is stopping. Once we mark the service down and unregister http/pb endpoints, the node can no longer service client writes or act as the coordinating node for puts.
