### PR TITLE
Make index_hashtree process exit when related vnode exits

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -123,7 +123,7 @@ maybe_create_hashtrees(true, State=#state{idx=Index}) ->
             State;
         true ->
             RP = riak_kv_util:responsible_preflists(Index),
-            case riak_kv_index_hashtree:start(Index, RP) of
+            case riak_kv_index_hashtree:start(Index, RP, self()) of
                 {ok, Trees} ->
                     monitor(process, Trees),
                     State#state{hashtrees=Trees};


### PR DESCRIPTION
When a riak_kv_vnode exits, the associated riak_kv_index_hashtree should also shutdown because a future riak_kv_vnode process will try to create a new riak_kv_index_hashtree. If the old index_hashtree is still alive, it retains a lock to the LevelDB instance, causing the newer index_hashtree to fail endlessly when trying to open the LevelDB instance.

This commit changes riak_kv_index_hashtree to monitor the associated riak_kv_vnode, shutting down if the riak_kv_vnode ever exits.
