### PR TITLE
Fix health check code to handle dead pids

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -223,7 +223,9 @@ check_kv_health(_Pid) ->
 
     SlowVNs =
         [{Idx,Len} || {Idx, Pid} <- VNodes,
-                      {message_queue_len, Len} <- process_info(Pid, [message_queue_len]),
+                      Info <- [process_info(Pid, [message_queue_len])],
+                      is_list(Info),
+                      {message_queue_len, Len} <- Info,
                       Len > Threshold],
     Passed = (SlowVNs =:= []),
 


### PR DESCRIPTION
If the health check code calls `process_info` on a dead pid, the result will be `undefined` rather than the expected list of information.  This causes the list comprehension to crash. This pull-request fixes the list comprehension to handle this case.
