### PR TITLE
Fix AAE exchange bug for the N=1 case

### DIFF
--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -642,9 +642,13 @@ next_exchange(_Ring, State=#state{exchange_queue=[],
                                   mode=Mode}) when Mode == manual ->
     {none, State};
 next_exchange(Ring, State=#state{exchange_queue=[]}) ->
-    [Exchange|Rest] = prune_exchanges(all_exchanges(node(), Ring, State)),
-    State2 = State#state{exchange_queue=Rest},
-    {Exchange, State2};
+    case prune_exchanges(all_exchanges(node(), Ring, State)) of
+        [] ->
+            {none, State};
+        [Exchange|Rest] ->
+            State2 = State#state{exchange_queue=Rest},
+            {Exchange, State2}
+    end;
 next_exchange(_Ring, State=#state{exchange_queue=Exchanges}) ->
     [Exchange|Rest] = Exchanges,
     State2 = State#state{exchange_queue=Rest},


### PR DESCRIPTION
When `N=1`, AAE doesn't need to do any KV exchanges. However, entropy manager used pattern match that expected there would always be exchanges to be done. This pull-request fixes that assumption and prevents the `riak_kv_entropy_manager` from constantly crashing every tick when a Riak cluster only includes `N=1` buckets.
