### PR TITLE
Expose FSM timeouts via the HTTP API

### DIFF
--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -142,7 +142,7 @@
               links,        %% [link()] - links of the object
               index_fields, %% [index_field()]
               method,       %% atom() - HTTP method for the request
-              timeout=60000 %% integer() - passed-in timeout value in ms
+              timeout       %% integer() - passed-in timeout value in ms
              }).
 %% @type link() = {{Bucket::binary(), Key::binary()}, Tag::binary()}
 %% @type index_field() = {Key::string(), Value::string()}
@@ -175,7 +175,9 @@ service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
                           list_to_integer(TimeoutStr)
                       catch
                           _:_ ->
-                              lager:error("Bad timeout value~n", []),
+                              lager:error("Bad timeout value ~p, "
+                                          "using ~d~n", 
+                                          [TimeoutStr, ?DEFAULT_TIMEOUT]),
                               ?DEFAULT_TIMEOUT
                       end
               end,

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -141,10 +141,13 @@
               bucketprops,  %% proplist() - properties of the bucket
               links,        %% [link()] - links of the object
               index_fields, %% [index_field()]
-              method        %% atom() - HTTP method for the request
+              method,       %% atom() - HTTP method for the request
+              timeout=60000 %% integer() - passed-in timeout value in ms
              }).
 %% @type link() = {{Bucket::binary(), Key::binary()}, Tag::binary()}
 %% @type index_field() = {Key::string(), Value::string()}
+
+-define(DEFAULT_TIMEOUT, 60000).
 
 -include_lib("webmachine/include/webmachine.hrl").
 -include("riak_kv_wm_raw.hrl").
@@ -165,6 +168,18 @@ init(Props) ->
 %%      bindings from the dispatch, as well as any vtag
 %%      query parameter.
 service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
+    Timeout = case wrq:get_req_header(?HEAD_TIMEOUT, RD) of 
+                  undefined -> ?DEFAULT_TIMEOUT;
+                  TimeoutStr -> 
+                      try
+                          list_to_integer(TimeoutStr)
+                      catch
+                          _:_ ->
+                              lager:error("Bad timeout value~n", []),
+                              ?DEFAULT_TIMEOUT
+                      end
+              end,
+    
     case riak_kv_wm_utils:get_riak_client(RiakProps, riak_kv_wm_utils:get_client_id(RD)) of
         {ok, C} ->
             {true,
@@ -180,7 +195,8 @@ service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
                        undefined -> undefined;
                        K -> list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, K))
                    end,
-               vtag=wrq:get_qs_value(?Q_VTAG, RD)
+               vtag=wrq:get_qs_value(?Q_VTAG, RD),
+               timeout=Timeout
               }};
         Error ->
             {false,
@@ -594,7 +610,8 @@ accept_doc_body(RD, Ctx=#ctx{bucket=B, key=K, client=C, links=L, index_fields=IF
     MDDoc = riak_object:update_metadata(VclockDoc, IndexMD),
     Doc = riak_object:update_value(MDDoc, riak_kv_wm_utils:accept_value(CType, wrq:req_body(RD))),
     Options = case wrq:get_qs_value(?Q_RETURNBODY, RD) of ?Q_TRUE -> [returnbody]; _ -> [] end,
-    case C:put(Doc, [{w, Ctx#ctx.w}, {dw, Ctx#ctx.dw}, {pw, Ctx#ctx.pw}, {timeout, 60000} |
+    case C:put(Doc, [{w, Ctx#ctx.w}, {dw, Ctx#ctx.dw}, {pw, Ctx#ctx.pw}, 
+                     {timeout, Ctx#ctx.timeout} |
                 Options]) of
         {error, Reason} ->
             handle_common_error(Reason, RD, Ctx);
@@ -830,15 +847,18 @@ ensure_doc(Ctx=#ctx{doc=undefined, key=undefined}) ->
 ensure_doc(Ctx=#ctx{doc=undefined, bucket=B, key=K, client=C, r=R,
         pr=PR, basic_quorum=Quorum, notfound_ok=NotFoundOK}) ->
     Ctx#ctx{doc=C:get(B, K, [deletedvclock, {r, R}, {pr, PR},
-                {basic_quorum, Quorum}, {notfound_ok, NotFoundOK}])};
+                             {basic_quorum, Quorum}, 
+                             {notfound_ok, NotFoundOK}, 
+                             {timeout, Ctx#ctx.timeout}])};
 ensure_doc(Ctx) -> Ctx.
 
 %% @spec delete_resource(reqdata(), context()) -> {true, reqdata(), context()}
 %% @doc Delete the document specified.
 delete_resource(RD, Ctx=#ctx{bucket=B, key=K, client=C, rw=RW, r=R, w=W,
-        pr=PR, pw=PW, dw=DW}) ->
+        pr=PR, pw=PW, dw=DW, timeout=Timeout}) ->
     Options = lists:filter(fun({_, default}) -> false; (_) -> true end,
-        [{rw, RW}, {r, R}, {w, W}, {pr, PR}, {pw, PW}, {dw, DW}]),
+        [{rw, RW}, {r, R}, {w, W}, {pr, PR}, {pw, PW}, {dw, DW}, 
+         {timeout, Timeout}]),
     Result = case wrq:get_req_header(?HEAD_VCLOCK, RD) of
         undefined -> 
             C:delete(B,K,Options);

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -34,6 +34,7 @@
 -define(HEAD_USERMETA_PREFIX, "x-riak-meta-").
 -define(HEAD_INDEX_PREFIX,    "x-riak-index-").
 -define(HEAD_DELETED,         "X-Riak-Deleted").
+-define(HEAD_TIMEOUT,         "X-Riak-Timeout").
 
 %% Names of JSON fields in bucket properties
 -define(JSON_PROPS,   <<"props">>).


### PR DESCRIPTION
adding the header 'X-Riak-Timeout=<some_int_in_ms>' will now cause the request to return a timeout error if it takes longer than the specified time interval.  This works for DELETEs, PUTs, and GETs, but in the case of a PUT or a get, a timeout failure does not guarantee anything about the state of the cluster when it happens.  The PUT or DELETE may or may not have succeeded; the correct course of action after the timeout is to retry the same action until a 200 is received.
