### PR TITLE
add stats for coverage query starts

### DIFF
--- a/src/riak_kv_buckets_fsm_sup.erl
+++ b/src/riak_kv_buckets_fsm_sup.erl
@@ -31,7 +31,14 @@
 -export([init/1]).
 
 start_buckets_fsm(Node, Args) ->
-    supervisor:start_child({?MODULE, Node}, Args).
+    case supervisor:start_child({?MODULE, Node}, Args) of
+        {ok, Pid} ->
+            riak_kv_stat:update({list_create, Pid}),
+            {ok, Pid};
+        Error ->
+            riak_kv_stat:update(list_create_error),
+            Error
+    end.
 
 %% @spec start_link() -> ServerRet
 %% @doc API for starting the supervisor.

--- a/src/riak_kv_index_fsm_sup.erl
+++ b/src/riak_kv_index_fsm_sup.erl
@@ -32,7 +32,14 @@
 -export([init/1]).
 
 start_index_fsm(Node, Args) ->
-    supervisor:start_child({?MODULE, Node}, Args).
+    case supervisor:start_child({?MODULE, Node}, Args) of
+        {ok, Pid} ->
+            riak_kv_stat:update({index_create, Pid}),
+            {ok, Pid};
+        Error ->
+            riak_kv_stat:update(index_create_error),
+            Error
+    end.
 
 %% @spec start_link() -> ServerRet
 %% @doc API for starting the supervisor.

--- a/src/riak_kv_keys_fsm_sup.erl
+++ b/src/riak_kv_keys_fsm_sup.erl
@@ -31,7 +31,14 @@
 -export([init/1]).
 
 start_keys_fsm(Node, Args) ->
-    supervisor:start_child({?MODULE, Node}, Args).
+    case supervisor:start_child({?MODULE, Node}, Args) of 
+        {ok, Pid} ->
+            riak_kv_stat:update({list_create, Pid}),
+            {ok, Pid};
+        Error ->
+            riak_kv_stat:update(list_create_error),
+            Error
+    end.
 
 %% @spec start_link() -> ServerRet
 %% @doc API for starting the supervisor.

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -45,10 +45,12 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+         terminate/2, code_change/3, monitor_loop/1]).
 
 -define(SERVER, ?MODULE).
 -define(APP, riak_kv).
+
+-record(state, {monitors}).
 
 start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
@@ -102,12 +104,28 @@ stop() ->
 
 init([]) ->
     register_stats(),
-    {ok, ok}.
+    State = {state, [spawn(?MODULE, monitor_loop, [index]), 
+                     spawn(?MODULE, monitor_loop, [list])]},
+    {ok, State}.
 
 handle_call({register, Name, Type}, _From, State) ->
     Rep = do_register_stat(Name, Type),
-    {reply, Rep, State}.
-
+    {reply, Rep, State};
+handle_call({get_monitor, Type}, _From, State) ->
+    Monitors = State#state.monitors,
+    [Monitor] = lists:filter(fun(Mon) ->
+                                     Mon ! {get_type, self()},
+                                     receive 
+                                         T when is_atom(T), 
+                                                T == Type ->
+                                             true;
+                                         _ -> false
+                                     after 
+                                         1000 -> false
+                                     end
+                             end,
+                             Monitors),
+    {reply, Monitor, State}.
 
 handle_cast(stop, State) ->
     {stop, normal, State};
@@ -177,9 +195,44 @@ do_update({fsm_exit, Type}) when Type =:= gets; Type =:= puts  ->
     folsom_metrics:notify_existing_metric({?APP, node, Type, fsm,  active}, {dec, 1}, counter);
 do_update({fsm_error, Type}) when Type =:= gets; Type =:= puts ->
     do_update({fsm_exit, Type}),
-    folsom_metrics:notify_existing_metric({?APP, node, Type, fsm, errors}, 1, spiral).
+    folsom_metrics:notify_existing_metric({?APP, node, Type, fsm, errors}, 1, spiral);
+do_update({index_create, Pid}) ->
+    folsom_metrics:notify_existing_metric({?APP, index, fsm, create}, 1, spiral),
+    folsom_metrics:notify_existing_metric({?APP, index, fsm, active}, {inc, 1}, counter),
+    add_monitor(index, Pid);
+do_update(index_create_error) ->
+    folsom_metrics:notify_existing_metric({?APP, index, fsm, create, error}, 1, spiral);
+do_update({list_create, Pid}) ->
+    folsom_metrics:notify_existing_metric({?APP, list, fsm, create}, 1, spiral),
+    folsom_metrics:notify_existing_metric({?APP, list, fsm, active}, {inc, 1}, counter),
+    add_monitor(list, Pid);
+do_update(list_create_error) ->
+    folsom_metrics:notify_existing_metric({?APP, list, fsm, create, error}, 1, spiral);
+do_update({fsm_destroy, Type}) ->
+    folsom_metrics:notify_existing_metric({?APP, Type, fsm, active}, {dec, 1}, counter).
 
 %% private
+
+add_monitor(Type, Pid) ->
+    M = gen_server:call(?SERVER, {get_monitor, Type}),
+    case M of 
+        Mon when is_pid(Mon) ->
+            Mon ! {add_pid, Pid}; 
+        error -> 
+            lager:error("No couldn't find procress to add monitor")
+    end.           
+
+monitor_loop(Type) ->
+    receive 
+        {add_pid, Pid} ->
+            erlang:monitor(process, Pid);
+        {get_type, Sender} ->
+            Sender ! Type;
+        {'DOWN', _Ref, process, _Pid, _Reason} ->
+            do_update({fsm_destroy, Type})
+    end,
+    monitor_loop(Type).        
+
 %% Per index stats (by op)
 do_per_index(Op, Idx, USecs) ->
     IdxAtom = list_to_atom(integer_to_list(Idx)),
@@ -289,6 +342,12 @@ stats() ->
      {[node, gets, fsm, active], counter},
      {[node, puts, fsm, errors], spiral},
      {[node, gets, fsm, errors], spiral},
+     {[index, fsm, create], spiral},
+     {[index, fsm, create, error], spiral},
+     {[index, fsm, active], counter},
+     {[list, fsm, create], spiral},
+     {[list, fsm, create, error], spiral},
+     {[list, fsm, active], counter},
      {mapper_count, counter},
      {precommit_fail, counter},
      {postcommit_fail, counter},

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -104,8 +104,8 @@ stop() ->
 
 init([]) ->
     register_stats(),
-    State = {state, [spawn(?MODULE, monitor_loop, [index]), 
-                     spawn(?MODULE, monitor_loop, [list])]},
+    State = {state, [spawn_link(?MODULE, monitor_loop, [index]), 
+                     spawn_link(?MODULE, monitor_loop, [list])]},
     {ok, State}.
 
 handle_call({register, Name, Type}, _From, State) ->

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -232,7 +232,13 @@ legacy_stat_map() ->
      {coord_redirs_total, {riak_kv,node,puts,coord_redirs}, counter},
      {executing_mappers, {riak_kv,mapper_count}, counter},
      {precommit_fail, {riak_kv, precommit_fail}, counter},
-     {postcommit_fail, {riak_kv, postcommit_fail}, counter}
+     {postcommit_fail, {riak_kv, postcommit_fail}, counter},
+     {index_fsm_create, {{riak_kv, index, fsm, create}, one}, spiral},
+     {index_fsm_create_error, {{riak_kv, index, fsm, create}, one}, spiral},
+     {index_fsm_active, {riak_kv, index, fsm, active}, counter},
+     {list_fsm_create, {{riak_kv, list, fsm, create}, one}, spiral},
+     {list_fsm_create_error, {{riak_kv, list, fsm, create}, one}, spiral},
+     {list_fsm_active, {riak_kv, list, fsm, active}, counter}
     ].
 
 %% PB stats are now under riak_api. In the past they were part of riak_kv.

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -234,10 +234,10 @@ legacy_stat_map() ->
      {precommit_fail, {riak_kv, precommit_fail}, counter},
      {postcommit_fail, {riak_kv, postcommit_fail}, counter},
      {index_fsm_create, {{riak_kv, index, fsm, create}, one}, spiral},
-     {index_fsm_create_error, {{riak_kv, index, fsm, create}, one}, spiral},
+     {index_fsm_create_error, {{riak_kv, index, fsm, create, error}, one}, spiral},
      {index_fsm_active, {riak_kv, index, fsm, active}, counter},
      {list_fsm_create, {{riak_kv, list, fsm, create}, one}, spiral},
-     {list_fsm_create_error, {{riak_kv, list, fsm, create}, one}, spiral},
+     {list_fsm_create_error, {{riak_kv, list, fsm, create, error}, one}, spiral},
      {list_fsm_active, {riak_kv, list, fsm, active}, counter}
     ].
 


### PR DESCRIPTION
- index fsm: create, create_error, active
- keys and bucket fsms (as 'list'): create, create_error, active

This should give us a better picture as to how many index and list queries are being executed against each riak node.

cc @russelldb 
