### PR TITLE
use tuple modules instead of parameterized modules

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_client: object used for access into the riak system
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -22,26 +22,27 @@
 
 %% @doc object used for access into the riak system
 
--module(riak_client, [Node,ClientId]).
+-module(riak_client).
 -author('Justin Sheehy <justin@basho.com>').
 
--export([get/2, get/3,get/4]).
--export([put/1, put/2,put/3,put/4,put/5]).
--export([delete/2,delete/3,delete/4]).
--export([delete_vclock/3,delete_vclock/4,delete_vclock/5]).
--export([list_keys/1,list_keys/2,list_keys/3]).
--export([stream_list_keys/1,stream_list_keys/2,stream_list_keys/3]).
--export([filter_buckets/1]).
--export([filter_keys/2,filter_keys/3]).
--export([list_buckets/0,list_buckets/2]).
--export([get_index/3,get_index/2]).
--export([stream_get_index/3,stream_get_index/2]).
--export([set_bucket/2,get_bucket/1,reset_bucket/1]).
--export([reload_all/1]).
--export([remove_from_cluster/1]).
--export([get_stats/1]).
--export([get_client_id/0]).
--export([for_dialyzer_only_ignore/2]).
+-export([new/2]).
+-export([get/3, get/4,get/5]).
+-export([put/2, put/3,put/4,put/5,put/6]).
+-export([delete/3,delete/4,delete/5]).
+-export([delete_vclock/4,delete_vclock/5,delete_vclock/6]).
+-export([list_keys/2,list_keys/3,list_keys/4]).
+-export([stream_list_keys/2,stream_list_keys/3,stream_list_keys/4]).
+-export([filter_buckets/2]).
+-export([filter_keys/3,filter_keys/4]).
+-export([list_buckets/1,list_buckets/3]).
+-export([get_index/4,get_index/3]).
+-export([stream_get_index/4,stream_get_index/3]).
+-export([set_bucket/3,get_bucket/2,reset_bucket/2]).
+-export([reload_all/2]).
+-export([remove_from_cluster/2]).
+-export([get_stats/2]).
+-export([get_client_id/1]).
+-export([for_dialyzer_only_ignore/3]).
 -compile({no_auto_import,[put/2]}).
 %% @type default_timeout() = 60000
 -define(DEFAULT_TIMEOUT, 60000).
@@ -49,7 +50,12 @@
 
 -type riak_client() :: term().
 
-%% @spec get(riak_object:bucket(), riak_object:key()) ->
+%% @spec new(Node, ClientId) -> riak_client().
+%% @doc Return a riak client instance.
+new(Node, ClientId) ->
+    {?MODULE, [Node,ClientId]}.
+
+%% @spec get(riak_object:bucket(), riak_object:key(), riak_client()) ->
 %%       {ok, riak_object:riak_object()} |
 %%       {error, notfound} |
 %%       {error, timeout} |
@@ -59,10 +65,10 @@
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as the default
 %%      R-value for the nodes have responded with a value or error.
 %% @equiv get(Bucket, Key, R, default_timeout())
-get(Bucket, Key) ->
-    get(Bucket, Key, []).
+get(Bucket, Key, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    get(Bucket, Key, [], THIS).
 
-%% @spec get(riak_object:bucket(), riak_object:key(), options()) ->
+%% @spec get(riak_object:bucket(), riak_object:key(), options(), riak_client()) ->
 %%       {ok, riak_object:riak_object()} |
 %%       {error, notfound} |
 %%       {error, {deleted, vclock()}} |
@@ -72,7 +78,7 @@ get(Bucket, Key) ->
 %%       {error, Err :: term()}
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as R-value for the nodes
 %%      have responded with a value or error.
-get(Bucket, Key, Options) when is_list(Options) ->
+get(Bucket, Key, Options, {?MODULE, [Node, _ClientId]}) when is_list(Options) ->
     Me = self(),
     ReqId = mk_reqid(),
     case node() of
@@ -86,7 +92,7 @@ get(Bucket, Key, Options) when is_list(Options) ->
     Timeout = recv_timeout(Options),
     wait_for_reqid(ReqId, Timeout);
 
-%% @spec get(riak_object:bucket(), riak_object:key(), R :: integer()) ->
+%% @spec get(riak_object:bucket(), riak_object:key(), R :: integer(), riak_client()) ->
 %%       {ok, riak_object:riak_object()} |
 %%       {error, notfound} |
 %%       {error, timeout} |
@@ -96,11 +102,11 @@ get(Bucket, Key, Options) when is_list(Options) ->
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as R
 %%      nodes have responded with a value or error.
 %% @equiv get(Bucket, Key, R, default_timeout())
-get(Bucket, Key, R) ->
-    get(Bucket, Key, [{r, R}]).
+get(Bucket, Key, R, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    get(Bucket, Key, [{r, R}], THIS).
 
 %% @spec get(riak_object:bucket(), riak_object:key(), R :: integer(),
-%%           TimeoutMillisecs :: integer()) ->
+%%           TimeoutMillisecs :: integer(), riak_client()) ->
 %%       {ok, riak_object:riak_object()} |
 %%       {error, notfound} |
 %%       {error, timeout} |
@@ -109,13 +115,13 @@ get(Bucket, Key, R) ->
 %%       {error, Err :: term()}
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as R
 %%      nodes have responded with a value or error, or TimeoutMillisecs passes.
-get(Bucket, Key, R, Timeout) when is_binary(Bucket), is_binary(Key),
+get(Bucket, Key, R, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) when is_binary(Bucket), is_binary(Key),
                                   (is_atom(R) or is_integer(R)),
                                   is_integer(Timeout) ->
-    get(Bucket, Key, [{r, R}, {timeout, Timeout}]).
+    get(Bucket, Key, [{r, R}, {timeout, Timeout}], THIS).
 
 
-%% @spec put(RObj :: riak_object:riak_object()) ->
+%% @spec put(RObj :: riak_object:riak_object(), riak_client()) ->
 %%        ok |
 %%       {error, too_many_fails} |
 %%       {error, timeout} |
@@ -124,10 +130,10 @@ get(Bucket, Key, R, Timeout) when is_binary(Bucket), is_binary(Key),
 %%      Return as soon as the default W value number of nodes for this bucket
 %%      nodes have received the request.
 %% @equiv put(RObj, [])
-put(RObj) -> THIS:put(RObj, []).
+put(RObj, {?MODULE, [_Node, _ClientId]}=THIS) -> THIS:put(RObj, [], THIS).
 
 
-%% @spec put(RObj :: riak_object:riak_object(), riak_kv_put_fsm::options()) ->
+%% @spec put(RObj :: riak_object:riak_object(), riak_kv_put_fsm::options(), riak_client()) ->
 %%       ok |
 %%       {ok, details()} |
 %%       {ok, riak_object:riak_object()} |
@@ -138,7 +144,7 @@ put(RObj) -> THIS:put(RObj, []).
 %%       {error, Err :: term()}
 %%       {error, Err :: term(), details()}
 %% @doc Store RObj in the cluster.
-put(RObj, Options) when is_list(Options) ->
+put(RObj, Options, {?MODULE, [Node, ClientId]}) when is_list(Options) ->
     Me = self(),
     ReqId = mk_reqid(),
     case ClientId of
@@ -164,7 +170,7 @@ put(RObj, Options) when is_list(Options) ->
     Timeout = recv_timeout(Options),
     wait_for_reqid(ReqId, Timeout);
 
-%% @spec put(RObj :: riak_object:riak_object(), W :: integer()) ->
+%% @spec put(RObj :: riak_object:riak_object(), W :: integer(), riak_client()) ->
 %%        ok |
 %%       {error, too_many_fails} |
 %%       {error, timeout} |
@@ -172,9 +178,9 @@ put(RObj, Options) when is_list(Options) ->
 %% @doc Store RObj in the cluster.
 %%      Return as soon as at least W nodes have received the request.
 %% @equiv put(RObj, [{w, W}, {dw, W}])
-put(RObj, W) -> THIS:put(RObj, [{w, W}, {dw, W}]).
+put(RObj, W, {?MODULE, [_Node, _ClientId]}=THIS) -> put(RObj, [{w, W}, {dw, W}], THIS).
 
-%% @spec put(RObj::riak_object:riak_object(),W :: integer(),RW :: integer()) ->
+%% @spec put(RObj::riak_object:riak_object(),W :: integer(),RW :: integer(), riak_client()) ->
 %%        ok |
 %%       {error, too_many_fails} |
 %%       {error, timeout} |
@@ -183,10 +189,10 @@ put(RObj, W) -> THIS:put(RObj, [{w, W}, {dw, W}]).
 %%      Return as soon as at least W nodes have received the request, and
 %%      at least DW nodes have stored it in their storage backend.
 %% @equiv put(Robj, W, DW, default_timeout())
-put(RObj, W, DW) -> THIS:put(RObj, [{w, W}, {dw, DW}]).
+put(RObj, W, DW, {?MODULE, [_Node, _ClientId]}=THIS) -> put(RObj, [{w, W}, {dw, DW}], THIS).
 
 %% @spec put(RObj::riak_object:riak_object(), W :: integer(), RW :: integer(),
-%%           TimeoutMillisecs :: integer()) ->
+%%           TimeoutMillisecs :: integer(), riak_client()) ->
 %%        ok |
 %%       {error, too_many_fails} |
 %%       {error, timeout} |
@@ -195,10 +201,11 @@ put(RObj, W, DW) -> THIS:put(RObj, [{w, W}, {dw, DW}]).
 %%      Return as soon as at least W nodes have received the request, and
 %%      at least DW nodes have stored it in their storage backend, or
 %%      TimeoutMillisecs passes.
-put(RObj, W, DW, Timeout) -> THIS:put(RObj,  [{w, W}, {dw, DW}, {timeout, Timeout}]).
+put(RObj, W, DW, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    put(RObj,  [{w, W}, {dw, DW}, {timeout, Timeout}], THIS).
 
 %% @spec put(RObj::riak_object:riak_object(), W :: integer(), RW :: integer(),
-%%           TimeoutMillisecs :: integer(), Options::list()) ->
+%%           TimeoutMillisecs :: integer(), Options::list(), riak_client()) ->
 %%        ok |
 %%       {error, too_many_fails} |
 %%       {error, timeout} |
@@ -207,10 +214,10 @@ put(RObj, W, DW, Timeout) -> THIS:put(RObj,  [{w, W}, {dw, DW}, {timeout, Timeou
 %%      Return as soon as at least W nodes have received the request, and
 %%      at least DW nodes have stored it in their storage backend, or
 %%      TimeoutMillisecs passes.
-put(RObj, W, DW, Timeout, Options) ->
-   THIS:put(RObj, [{w, W}, {dw, DW}, {timeout, Timeout} | Options]).
+put(RObj, W, DW, Timeout, Options, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    put(RObj, [{w, W}, {dw, DW}, {timeout, Timeout} | Options], THIS).
 
-%% @spec delete(riak_object:bucket(), riak_object:key()) ->
+%% @spec delete(riak_object:bucket(), riak_object:key(), riak_client()) ->
 %%        ok |
 %%       {error, too_many_fails} |
 %%       {error, notfound} |
@@ -219,9 +226,9 @@ put(RObj, W, DW, Timeout, Options) ->
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as RW
 %%      nodes have responded with a value or error.
 %% @equiv delete(Bucket, Key, RW, default_timeout())
-delete(Bucket,Key) -> delete(Bucket,Key,[],?DEFAULT_TIMEOUT).
+delete(Bucket,Key,{?MODULE, [_Node, _ClientId]}=THIS) -> delete(Bucket,Key,[],?DEFAULT_TIMEOUT,THIS).
 
-%% @spec delete(riak_object:bucket(), riak_object:key(), RW :: integer()) ->
+%% @spec delete(riak_object:bucket(), riak_object:key(), RW :: integer(), riak_client()) ->
 %%        ok |
 %%       {error, too_many_fails} |
 %%       {error, notfound} |
@@ -230,13 +237,13 @@ delete(Bucket,Key) -> delete(Bucket,Key,[],?DEFAULT_TIMEOUT).
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as W/DW (or RW)
 %%      nodes have responded with a value or error.
 %% @equiv delete(Bucket, Key, RW, default_timeout())
-delete(Bucket,Key,Options) when is_list(Options) ->
-    delete(Bucket,Key,Options,?DEFAULT_TIMEOUT);
-delete(Bucket,Key,RW) ->
-    delete(Bucket,Key,[{rw, RW}],?DEFAULT_TIMEOUT).
+delete(Bucket,Key,Options,{?MODULE, [_Node, _ClientId]}=THIS) when is_list(Options) ->
+    delete(Bucket,Key,Options,?DEFAULT_TIMEOUT,THIS);
+delete(Bucket,Key,RW,{?MODULE, [_Node, _ClientId]}=THIS) ->
+    delete(Bucket,Key,[{rw, RW}],?DEFAULT_TIMEOUT,THIS).
 
 %% @spec delete(riak_object:bucket(), riak_object:key(), RW :: integer(),
-%%           TimeoutMillisecs :: integer()) ->
+%%           TimeoutMillisecs :: integer(), riak_client()) ->
 %%        ok |
 %%       {error, too_many_fails} |
 %%       {error, notfound} |
@@ -245,16 +252,16 @@ delete(Bucket,Key,RW) ->
 %%       {error, Err :: term()}
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as W/DW (or RW)
 %%      nodes have responded with a value or error, or TimeoutMillisecs passes.
-delete(Bucket,Key,Options,Timeout) when is_list(Options) ->
+delete(Bucket,Key,Options,Timeout,{?MODULE, [Node, ClientId]}) when is_list(Options) ->
     Me = self(),
     ReqId = mk_reqid(),
     riak_kv_delete_sup:start_delete(Node, [ReqId, Bucket, Key, Options, Timeout,
                                            Me, ClientId]),
     wait_for_reqid(ReqId, Timeout);
-delete(Bucket,Key,RW,Timeout) ->
-    delete(Bucket,Key,[{rw, RW}], Timeout).
+delete(Bucket,Key,RW,Timeout,{?MODULE, [_Node, _ClientId]}=THIS) ->
+    delete(Bucket,Key,[{rw, RW}], Timeout, THIS).
 
-%% @spec delete_vclock(riak_object:bucket(), riak_object:key(), vclock:vclock()) ->
+%% @spec delete_vclock(riak_object:bucket(), riak_object:key(), vclock:vclock(), riak_client()) ->
 %%        ok |
 %%       {error, too_many_fails} |
 %%       {error, notfound} |
@@ -263,10 +270,11 @@ delete(Bucket,Key,RW,Timeout) ->
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as W/DW (or RW)
 %%      nodes have responded with a value or error.
 %% @equiv delete(Bucket, Key, RW, default_timeout())
-delete_vclock(Bucket,Key,VClock) ->
-    delete_vclock(Bucket,Key,VClock,[{rw,default}],?DEFAULT_TIMEOUT).
+delete_vclock(Bucket,Key,VClock,{?MODULE, [_Node, _ClientId]}=THIS) ->
+    delete_vclock(Bucket,Key,VClock,[{rw,default}],?DEFAULT_TIMEOUT,THIS).
 
-%% @spec delete_vclock(riak_object:bucket(), riak_object:key(), vclock::vclock(), RW :: integer()) ->
+%% @spec delete_vclock(riak_object:bucket(), riak_object:key(), vclock::vclock(),
+%%                     RW :: integer(), riak_client()) ->
 %%        ok |
 %%       {error, too_many_fails} |
 %%       {error, notfound} |
@@ -275,13 +283,13 @@ delete_vclock(Bucket,Key,VClock) ->
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as W/DW (or RW)
 %%      nodes have responded with a value or error.
 %% @equiv delete(Bucket, Key, RW, default_timeout())
-delete_vclock(Bucket,Key,VClock,Options) when is_list(Options) ->
-    delete_vclock(Bucket,Key,VClock,Options,?DEFAULT_TIMEOUT);
-delete_vclock(Bucket,Key,VClock,RW) ->
-    delete_vclock(Bucket,Key,VClock,[{rw, RW}],?DEFAULT_TIMEOUT).
+delete_vclock(Bucket,Key,VClock,Options,{?MODULE, [_Node, _ClientId]}=THIS) when is_list(Options) ->
+    delete_vclock(Bucket,Key,VClock,Options,?DEFAULT_TIMEOUT,THIS);
+delete_vclock(Bucket,Key,VClock,RW,{?MODULE, [_Node, _ClientId]}=THIS) ->
+    delete_vclock(Bucket,Key,VClock,[{rw, RW}],?DEFAULT_TIMEOUT,THIS).
 
 %% @spec delete_vclock(riak_object:bucket(), riak_object:key(), vclock:vclock(), RW :: integer(),
-%%           TimeoutMillisecs :: integer()) ->
+%%           TimeoutMillisecs :: integer(), riak_client()) ->
 %%        ok |
 %%       {error, too_many_fails} |
 %%       {error, notfound} |
@@ -290,17 +298,17 @@ delete_vclock(Bucket,Key,VClock,RW) ->
 %%       {error, Err :: term()}
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as W/DW (or RW)
 %%      nodes have responded with a value or error, or TimeoutMillisecs passes.
-delete_vclock(Bucket,Key,VClock,Options,Timeout) when is_list(Options) ->
+delete_vclock(Bucket,Key,VClock,Options,Timeout,{?MODULE, [Node, ClientId]}) when is_list(Options) ->
     Me = self(),
     ReqId = mk_reqid(),
     riak_kv_delete_sup:start_delete(Node, [ReqId, Bucket, Key, Options, Timeout,
                                            Me, ClientId, VClock]),
     wait_for_reqid(ReqId, Timeout);
-delete_vclock(Bucket,Key,VClock,RW,Timeout) ->
-    delete_vclock(Bucket,Key,VClock,[{rw, RW}],Timeout).
+delete_vclock(Bucket,Key,VClock,RW,Timeout,{?MODULE, [_Node, _ClientId]}=THIS) ->
+    delete_vclock(Bucket,Key,VClock,[{rw, RW}],Timeout,THIS).
 
 
-%% @spec list_keys(riak_object:bucket()) ->
+%% @spec list_keys(riak_object:bucket(), riak_client()) ->
 %%       {ok, [Key :: riak_object:key()]} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}
@@ -308,42 +316,43 @@ delete_vclock(Bucket,Key,VClock,RW,Timeout) ->
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
 %% @equiv list_keys(Bucket, default_timeout()*8)
-list_keys(Bucket) ->
-    list_keys(Bucket, ?DEFAULT_TIMEOUT*8).
+list_keys(Bucket, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    list_keys(Bucket, ?DEFAULT_TIMEOUT*8, THIS).
 
-%% @spec list_keys(riak_object:bucket(), TimeoutMillisecs :: integer()) ->
+%% @spec list_keys(riak_object:bucket(), TimeoutMillisecs :: integer(), riak_client()) ->
 %%       {ok, [Key :: riak_object:key()]} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}
 %% @doc List the keys known to be present in Bucket.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
-list_keys(Bucket, Timeout) ->
-    list_keys(Bucket, none, Timeout).
+list_keys(Bucket, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    list_keys(Bucket, none, Timeout, THIS).
 
-%% @spec list_keys(riak_object:bucket(), TimeoutMillisecs :: integer()) ->
+%% @spec list_keys(riak_object:bucket(), TimeoutMillisecs :: integer(), riak_client()) ->
 %%       {ok, [Key :: riak_object:key()]} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}
 %% @doc List the keys known to be present in Bucket.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
-list_keys(Bucket, Filter, Timeout) ->
+list_keys(Bucket, Filter, Timeout, {?MODULE, [Node, _ClientId]}) ->
     Me = self(),
     ReqId = mk_reqid(),
     riak_kv_keys_fsm_sup:start_keys_fsm(Node, [{raw, ReqId, Me}, [Bucket, Filter, Timeout]]),
     wait_for_listkeys(ReqId, Timeout).
 
-stream_list_keys(Bucket) ->
-    stream_list_keys(Bucket, ?DEFAULT_TIMEOUT).
+stream_list_keys(Bucket, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    stream_list_keys(Bucket, ?DEFAULT_TIMEOUT, THIS).
 
-stream_list_keys(Bucket, Timeout) ->
+stream_list_keys(Bucket, Timeout, {?MODULE, [_Node, _ClientId]}) ->
     Me = self(),
     stream_list_keys(Bucket, Timeout, Me).
 
 %% @spec stream_list_keys(riak_object:bucket(),
 %%                        TimeoutMillisecs :: integer(),
-%%                        Client :: pid()) ->
+%%                        Client :: pid(),
+%%                        riak_client()) ->
 %%       {ok, ReqId :: term()}
 %% @doc List the keys known to be present in Bucket.
 %%      Key lists are updated asynchronously, so this may be slightly
@@ -353,7 +362,7 @@ stream_list_keys(Bucket, Timeout) ->
 %%      and a final {ReqId, done} message.
 %%      None of the Keys lists will be larger than the number of
 %%      keys in Bucket on any single vnode.
-stream_list_keys(Input, Timeout, Client) when is_pid(Client) ->
+stream_list_keys(Input, Timeout, Client, {?MODULE, [Node, _ClientId]}) when is_pid(Client) ->
     ReqId = mk_reqid(),
     case Input of
         {Bucket, FilterInput} ->
@@ -379,7 +388,7 @@ stream_list_keys(Input, Timeout, Client) when is_pid(Client) ->
             {ok, ReqId}
     end.
 
-%% @spec filter_keys(riak_object:bucket(), Fun :: function()) ->
+%% @spec filter_keys(riak_object:bucket(), Fun :: function(), riak_client()) ->
 %%       {ok, [Key :: riak_object:key()]} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}
@@ -388,10 +397,11 @@ stream_list_keys(Input, Timeout, Client) when is_pid(Client) ->
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
 %% @equiv filter_keys(Bucket, Fun, default_timeout())
-filter_keys(Bucket, Fun) ->
-    list_keys(Bucket, Fun, ?DEFAULT_TIMEOUT).
+filter_keys(Bucket, Fun, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    list_keys(Bucket, Fun, ?DEFAULT_TIMEOUT, THIS).
 
-%% @spec filter_keys(riak_object:bucket(), Fun :: function(), TimeoutMillisecs :: integer()) ->
+%% @spec filter_keys(riak_object:bucket(), Fun :: function(), TimeoutMillisecs :: integer()
+%%                   riak_client()) ->
 %%       {ok, [Key :: riak_object:key()]} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}
@@ -399,10 +409,10 @@ filter_keys(Bucket, Fun) ->
 %%      filtered at the vnode according to Fun, via lists:filter.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
-filter_keys(Bucket, Fun, Timeout) ->
-            list_keys(Bucket, Fun, Timeout).
+filter_keys(Bucket, Fun, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
+            list_keys(Bucket, Fun, Timeout, THIS).
 
-%% @spec list_buckets() ->
+%% @spec list_buckets(riak_client()) ->
 %%       {ok, [Bucket :: riak_object:bucket()]} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}
@@ -412,10 +422,10 @@ filter_keys(Bucket, Fun, Timeout) ->
 %%      either adds the first key or removes the last remaining key from
 %%      a bucket.
 %% @equiv list_buckets(default_timeout())
-list_buckets() ->
-    list_buckets(none, ?DEFAULT_TIMEOUT).
+list_buckets({?MODULE, [_Node, _ClientId]}=THIS) ->
+    list_buckets(none, ?DEFAULT_TIMEOUT, THIS).
 
-%% @spec list_buckets(TimeoutMillisecs :: integer()) ->
+%% @spec list_buckets(TimeoutMillisecs :: integer(), riak_client()) ->
 %%       {ok, [Bucket :: riak_object:bucket()]} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}
@@ -424,113 +434,117 @@ list_buckets() ->
 %%      out of date if called immediately after any operation that
 %%      either adds the first key or removes the last remaining key from
 %%      a bucket.
-list_buckets(Filter, Timeout) ->
+list_buckets(Filter, Timeout, {?MODULE, [Node, _ClientId]}) ->
     Me = self(),
     ReqId = mk_reqid(),
     riak_kv_buckets_fsm_sup:start_buckets_fsm(Node, [{raw, ReqId, Me}, [Filter, Timeout]]),
     wait_for_listbuckets(ReqId, Timeout).
 
-%% @spec filter_buckets(Fun :: function()) ->
+%% @spec filter_buckets(Fun :: function(), riak_client()) ->
 %%       {ok, [Bucket :: riak_object:bucket()]} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}
 %% @doc Return a list of filtered buckets.
-filter_buckets(Fun) ->
-    list_buckets(Fun, ?DEFAULT_TIMEOUT).
-
-%% @spec get_index(Bucket :: binary(),
-%%                 Query :: riak_index:query_def()) ->
-%%       {ok, [Key :: riak_object:key()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}.
-%%
-%% @doc Run the provided index query.
-get_index(Bucket, Query) ->
-    get_index(Bucket, Query, ?DEFAULT_TIMEOUT).
+filter_buckets(Fun, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    list_buckets(Fun, ?DEFAULT_TIMEOUT, THIS).
 
 %% @spec get_index(Bucket :: binary(),
 %%                 Query :: riak_index:query_def(),
-%%                 TimeoutMillisecs :: integer()) ->
+%%                 riak_client()) ->
 %%       {ok, [Key :: riak_object:key()]} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}.
 %%
 %% @doc Run the provided index query.
-get_index(Bucket, Query, Timeout) ->
+get_index(Bucket, Query, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    get_index(Bucket, Query, ?DEFAULT_TIMEOUT, THIS).
+
+%% @spec get_index(Bucket :: binary(),
+%%                 Query :: riak_index:query_def(),
+%%                 TimeoutMillisecs :: integer(),
+%%                 riak_client()) ->
+%%       {ok, [Key :: riak_object:key()]} |
+%%       {error, timeout} |
+%%       {error, Err :: term()}.
+%%
+%% @doc Run the provided index query.
+get_index(Bucket, Query, Timeout, {?MODULE, [Node, _ClientId]}) ->
     Me = self(),
     ReqId = mk_reqid(),
     riak_kv_index_fsm_sup:start_index_fsm(Node, [{raw, ReqId, Me}, [Bucket, none, Query, Timeout]]),
     wait_for_query_results(ReqId, Timeout).
 
 %% @spec stream_get_index(Bucket :: binary(),
-%%                        Query :: riak_index:query_def()) ->
+%%                        Query :: riak_index:query_def(),
+%%                        riak_client()) ->
 %%       {ok, pid()} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}.
 %%
 %% @doc Run the provided index query, return a stream handle.
-stream_get_index(Bucket, Query) ->
-    stream_get_index(Bucket, Query, ?DEFAULT_TIMEOUT).
+stream_get_index(Bucket, Query, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    stream_get_index(Bucket, Query, ?DEFAULT_TIMEOUT, THIS).
 
 %% @spec stream_get_index(Bucket :: binary(),
 %%                        Query :: riak_index:query_def(),
-%%                        TimeoutMillisecs :: integer()) ->
+%%                        TimeoutMillisecs :: integer(),
+%%                        riak_client()) ->
 %%       {ok, pid()} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}.
 %%
 %% @doc Run the provided index query, return a stream handle.
-stream_get_index(Bucket, Query, Timeout) ->
+stream_get_index(Bucket, Query, Timeout, {?MODULE, [Node, _ClientId]}) ->
     Me = self(),
     ReqId = mk_reqid(),
     riak_kv_index_fsm_sup:start_index_fsm(Node, [{raw, ReqId, Me}, [Bucket, none, Query, Timeout]]),
     {ok, ReqId}.
 
-%% @spec set_bucket(riak_object:bucket(), [BucketProp :: {atom(),term()}]) -> ok
+%% @spec set_bucket(riak_object:bucket(), [BucketProp :: {atom(),term()}], riak_client()) -> ok
 %% @doc Set the given properties for Bucket.
 %%      This is generally best if done at application start time,
 %%      to ensure expected per-bucket behavior.
 %% See riak_core_bucket for expected useful properties.
-set_bucket(BucketName,BucketProps) ->
+set_bucket(BucketName,BucketProps,{?MODULE, [Node, _ClientId]}) ->
     rpc:call(Node,riak_core_bucket,set_bucket,[BucketName,BucketProps]).
-%% @spec get_bucket(riak_object:bucket()) -> [BucketProp :: {atom(),term()}]
+%% @spec get_bucket(riak_object:bucket(), riak_client()) -> [BucketProp :: {atom(),term()}]
 %% @doc Get all properties for Bucket.
 %% See riak_core_bucket for expected useful properties.
-get_bucket(BucketName) ->
+get_bucket(BucketName, {?MODULE, [Node, _ClientId]}) ->
     rpc:call(Node,riak_core_bucket,get_bucket,[BucketName]).
-%% @spec reset_bucket(riak_object:bucket()) -> ok
+%% @spec reset_bucket(riak_object:bucket(), riak_client()) -> ok
 %% @doc Reset properties for this Bucket to the default values
-reset_bucket(BucketName) ->
+reset_bucket(BucketName, {?MODULE, [Node, _ClientId]}) ->
     rpc:call(Node,riak_core_bucket,reset_bucket,[BucketName]).
-%% @spec reload_all(Module :: atom()) -> term()
+%% @spec reload_all(Module :: atom(), riak_client()) -> term()
 %% @doc Force all Riak nodes to reload Module.
 %%      This is used when loading new modules for map/reduce functionality.
-reload_all(Module) -> rpc:call(Node,riak_core_util,reload_all,[Module]).
+reload_all(Module, {?MODULE, [Node, _ClientId]}) -> rpc:call(Node,riak_core_util,reload_all,[Module]).
 
-%% @spec remove_from_cluster(ExitingNode :: atom()) -> term()
+%% @spec remove_from_cluster(ExitingNode :: atom(), riak_client()) -> term()
 %% @doc Cause all partitions owned by ExitingNode to be taken over
 %%      by other nodes.
-remove_from_cluster(ExitingNode) ->
+remove_from_cluster(ExitingNode, {?MODULE, [Node, _ClientId]}) ->
     rpc:call(Node, riak_core_gossip, remove_from_cluster,[ExitingNode]).
 
-get_stats(local) ->
+get_stats(local, {?MODULE, [Node, _ClientId]}) ->
     [{Node, rpc:call(Node, riak_kv_stat, get_stats, [])}];
-get_stats(global) ->
+get_stats(global, {?MODULE, [Node, _ClientId]}) ->
     {ok, Ring} = rpc:call(Node, riak_core_ring_manager, get_my_ring, []),
     Nodes = riak_core_ring:all_members(Ring),
     [{N, rpc:call(N, riak_kv_stat, get_stats, [])} || N <- Nodes].
 
-%% @doc Return the client id beign used for this client
-get_client_id() ->
+%% @doc Return the client id being used for this client
+get_client_id({?MODULE, [_Node, ClientId]}) ->
     ClientId.
 
 %% @private
 %% This function exists only to avoid compiler errors (unused type).
 %% Unfortunately, I can't figure out how to suppress the bogus "Contract for
 %% function that does not exist" warning from Dialyzer, so ignore that one.
--spec for_dialyzer_only_ignore(term(), term()) -> riak_client().
-for_dialyzer_only_ignore(X, Y) ->
-    ?MODULE:new(X, Y).
+-spec for_dialyzer_only_ignore(term(), term(), riak_client()) -> riak_client().
+for_dialyzer_only_ignore(_X, _Y, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    THIS.
 
 %% @private
 mk_reqid() ->


### PR DESCRIPTION
Erlang R16, coming soon, will do away with parameterized modules (see Issue
4 under http://www.erlang.org/news/35 for details). Change riak_client to
use tuple modules instead, since they will continue to be supported in R16
and beyond. These changes are backward compatible.
