### PR TITLE
Various minor AAE changes prompted by Riak 1.3 QA

### DIFF
--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -241,12 +241,22 @@ new({Index,TreeId}, LinkedStore, Options) ->
 
 -spec close(hashtree()) -> hashtree().
 close(State) ->
-    eleveldb:close(State#state.ref),
-    State.
+    close_iterator(State#state.itr),
+    catch eleveldb:close(State#state.ref),
+    State#state{itr=undefined}.
+
+close_iterator(Itr) ->
+    try
+        eleveldb:iterator_close(Itr)
+    catch
+        _:_ ->
+            ok
+    end.
 
 -spec destroy(hashtree()) -> hashtree().
 destroy(State) ->
-    eleveldb:close(State#state.ref),
+    %% Assumption: close was already called on all hashtrees that
+    %%             use this LevelDB instance,
     ok = eleveldb:destroy(State#state.path, []),
     State.
 

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -633,7 +633,7 @@ multi_select_segment(#state{id=Id, itr=Itr}, Segments, F) ->
                _ ->
                    encode(Id, First, <<>>)
            end,
-    IS2 = iterate(eleveldb:iterator_move(Itr, Seek), IS1),
+    IS2 = iterate(iterator_move(Itr, Seek), IS1),
     #itr_state{current_segment=LastSegment,
                segment_acc=LastAcc,
                final_acc=FA} = IS2,
@@ -644,6 +644,16 @@ multi_select_segment(#state{id=Id, itr=Itr}, Segments, F) ->
             [];
         _ ->
             Result
+    end.
+
+iterator_move(undefined, _Seek) ->
+    {error, invalid_iterator};
+iterator_move(Itr, Seek) ->
+    try
+        eleveldb:iterator_move(Itr, Seek)
+    catch
+        _:badarg ->
+            {error, invalid_iterator}
     end.
 
 -spec iterate({'error','invalid_iterator'} | {'ok',binary(),binary()},
@@ -672,21 +682,21 @@ iterate({ok, K, V}, IS=#itr_state{itr=Itr,
             %% Still reading existing segment
             IS2 = IS#itr_state{current_segment=Segment,
                                segment_acc=[{K,V} | Acc]},
-            iterate(eleveldb:iterator_move(Itr, next), IS2);
+            iterate(iterator_move(Itr, next), IS2);
         {Id, _, [Seg|Remaining]} ->
             %% Pointing at next segment we are interested in
             IS2 = IS#itr_state{current_segment=Seg,
                                remaining_segments=Remaining,
                                segment_acc=[{K,V}],
                                final_acc=[{Segment, F(Acc)} | FinalAcc]},
-            iterate(eleveldb:iterator_move(Itr, next), IS2);
+            iterate(iterator_move(Itr, next), IS2);
         {Id, _, ['*']} ->
             %% Pointing at next segment we are interested in
             IS2 = IS#itr_state{current_segment=Seg,
                                remaining_segments=['*'],
                                segment_acc=[{K,V}],
                                final_acc=[{Segment, F(Acc)} | FinalAcc]},
-            iterate(eleveldb:iterator_move(Itr, next), IS2);
+            iterate(iterator_move(Itr, next), IS2);
         {Id, _, [NextSeg|Remaining]} ->
             %% Pointing at uninteresting segment, seek to next interesting one
             IS2 = IS#itr_state{current_segment=NextSeg,
@@ -694,7 +704,7 @@ iterate({ok, K, V}, IS=#itr_state{itr=Itr,
                                segment_acc=[],
                                final_acc=[{Segment, F(Acc)} | FinalAcc]},
             Seek = encode(Id, NextSeg, <<>>),
-            iterate(eleveldb:iterator_move(Itr, Seek), IS2);
+            iterate(iterator_move(Itr, Seek), IS2);
         _ ->
             %% Done with traversal
             IS

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -99,22 +99,28 @@ insert(Id, Key, Hash, Tree) ->
 %%       ``if_missing'' :: Only insert the key/hash pair if the key does not
 %%                         already exist in the hashtree.
 -spec insert(index_n(), binary(), binary(), pid(), proplist()) -> ok.
+insert(_Id, _Key, _Hash, undefined, _Options) ->
+    ok;
 insert(Id, Key, Hash, Tree, Options) ->
-    gen_server:cast(Tree, {insert, Id, Key, Hash, Options}).
+    catch gen_server:call(Tree, {insert, Id, Key, Hash, Options}, infinity).
 
 %% @doc Add a term_to_binary encoded riak_object associated with a given
 %%      bucket/key to the appropriate hashtree managed by the provided
 %%      index_hashtree pid. The hash value is generated using
 %%      {@link hash_object/1}.
 -spec insert_object({binary(), binary()}, riak_object_t2b(), pid()) -> ok.
+insert_object(_BKey, _RObj, undefined) ->
+    ok;
 insert_object(BKey, RObj, Tree) ->
-    gen_server:cast(Tree, {insert_object, BKey, RObj}).
+    catch gen_server:call(Tree, {insert_object, BKey, RObj}, infinity).
 
 %% @doc Remove the key/hash pair associated with a given bucket/key from the
 %%      appropriate hashtree managed by the provided index_hashtree pid.
 -spec delete({binary(), binary()}, pid()) -> ok.
+delete(_BKey, undefined) ->
+    ok;
 delete(BKey, Tree) ->
-    gen_server:cast(Tree, {delete, BKey}).
+    catch gen_server:call(Tree, {delete, BKey}, infinity).
 
 %% @doc Called by the entropy manager to finish the process used to acquire
 %%      remote vnode locks when starting an exchange. For more details,
@@ -220,6 +226,20 @@ handle_call({new_tree, Id}, _From, State) ->
 handle_call({get_lock, Type, Pid}, _From, State) ->
     {Reply, State2} = do_get_lock(Type, Pid, State),
     {reply, Reply, State2};
+
+handle_call({insert, Id, Key, Hash, Options}, _From, State) ->
+    State2 = do_insert(Id, Key, Hash, Options, State),
+    {reply, ok, State2};
+handle_call({insert_object, BKey, RObj}, _From, State) ->
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    IndexN = riak_kv_util:get_index_n(BKey, Ring),
+    State2 = do_insert(IndexN, term_to_binary(BKey), hash_object(RObj), [], State),
+    {reply, ok, State2};
+handle_call({delete, BKey}, _From, State) ->
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    IndexN = riak_kv_util:get_index_n(BKey, Ring),
+    State2 = do_delete(IndexN, term_to_binary(BKey), State),
+    {reply, ok, State2};
 
 handle_call({update_tree, Id}, From, State) ->
     lager:debug("Updating tree: (vnode)=~p (preflist)=~p", [State#state.index, Id]),

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -78,14 +78,16 @@
 
 %% @doc Spawn an index_hashtree process that manages the hashtrees (one
 %%      for each `index_n') for the specified partition index.
--spec start(index(), [index_n()], pid()) -> {ok, pid()} | {error, term()}.
-start(Index, IndexNs, VNPid) ->
+-spec start(index(), nonempty_list(index_n()), pid()) -> {ok, pid()} | 
+                                                         {error, term()}.
+start(Index, IndexNs=[_|_], VNPid) ->
     gen_server:start(?MODULE, [Index, IndexNs, VNPid], []).
 
 %% @doc Spawn an index_hashtree process that manages the hashtrees (one
 %%      for each `index_n') for the specified partition index.
--spec start_link(index(), [index_n()], pid()) -> {ok, pid()} | {error, term()}.
-start_link(Index, IndexNs, VNPid) ->
+-spec start_link(index(), nonempty_list(index_n()), pid()) -> {ok, pid()} |
+                                                              {error, term()}.
+start_link(Index, IndexNs=[_|_], VNPid) ->
     gen_server:start_link(?MODULE, [Index, IndexNs, VNPid], []).
 
 %% @doc Add a key/hash pair to the tree identified by the given tree id
@@ -296,20 +298,6 @@ handle_cast(build_failed, State) ->
     {noreply, State2};
 handle_cast(build_finished, State) ->
     State2 = do_build_finished(State),
-    {noreply, State2};
-
-handle_cast({insert, Id, Key, Hash, Options}, State) ->
-    State2 = do_insert(Id, Key, Hash, Options, State),
-    {noreply, State2};
-handle_cast({insert_object, BKey, RObj}, State) ->
-    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
-    IndexN = riak_kv_util:get_index_n(BKey, Ring),
-    State2 = do_insert(IndexN, term_to_binary(BKey), hash_object(RObj), [], State),
-    {noreply, State2};
-handle_cast({delete, BKey}, State) ->
-    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
-    IndexN = riak_kv_util:get_index_n(BKey, Ring),
-    State2 = do_delete(IndexN, term_to_binary(BKey), State),
     {noreply, State2};
 
 handle_cast({start_exchange_remote, FsmPid, From, _IndexN}, State) ->


### PR DESCRIPTION
This pull-request contains three changes to AAE based on on-going 1.3 release testing and LevelDB changes.

First, this pull-request makes calls between KV vnodes and `riak_kv_index_hashtree` synchronous, using calls rather than casts. This provides backpressure to the vnode if the hashtree writes cannot occur fast enough. Technically, this shouldn't happen. It happened during tests because LevelDB was unfairly throttling AAE writes, preventing AAE from making progress. This has since been changed. However, we want to play it safe and add backpressure anyway. Of course, this backpressure just shifts the problem. If hashtree writes can't happen fast enough, then we will have unbounded message queue growth somewhere. Without this pull-request, the growth would occur in a `riak_kv_index_hashtree` process, with this patch the growth occurs in a `riak_kv_vnode` process. However, because of the new KV health check code in Riak 1.3, Jon/I decided that having potential message queue growth in the KV vnode is preferred. If this scenario happens, the health check will notice, kick in, and disable the KV service on the node.

NOTE: It is intentional that I use 'catch' when generating the now synchronous calls. This is because the previous use of cast was assumed in the design, and there are scenarios where the `riak_kv_index_hashtree` process may be dead when a message is sent. For a cast, the message would be dropped. For a call, it will generate an exception. We catch the exception as to not crash the KV vnode. Easier to do this rather than re-writing/re-validating all of AAE to guarantee never passing in a potentially dead PID. Future plans for 1.4 already include a completely different approach to backpressure, so this is largely a temporary change/situation anyway. 

Second, this pull-request adds code to ensure that all hashtree iterators are closed before attempting to close the LevelDB instance backing a group of hashtrees. This change was originally necessary as new LevelDB code changed semantics requiring iterators to be closed before a database could be closed/cleaned up. Very recent LevelDB changes have once again returned to the original semantics (closing a database handle will close/cleanup iterators automatically), but Jon/I/Matthew decided that committing this code anyway can't hurt and is a good "just in case".

Third, this pull-request updates how `hashtree.erl` calls `eleveldb:iterator_move` to account for how LevelDB now generates error messages. In the past, passing in an already closed iterator would generate an error tuple, now it generates a `badarg` exception. The change to hashtree ensure that these exceptions are caught and ignored as desired, as hashtree was already coded with the assumption that `iterator_move` may be called on already closed iterators in some scenarios.
