### PR TITLE
Improve interaction between AAE and K/V deletion

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -470,8 +470,8 @@ handle_command({rehash, Bucket, Key}, _, State=#state{mod=Mod, modstate=ModState
         {ok, Bin, _UpdModState} ->
             update_hashtree(Bucket, Key, Bin, State);
         _ ->
-            %% Do nothing if data doesn't exist
-            ok
+            %% Make sure hashtree isn't tracking deleted data
+            riak_kv_index_hashtree:delete({Bucket, Key}, State#state.hashtrees)
     end,
     {noreply, State};
 


### PR DESCRIPTION
This pull-request improves AAE's handling around object deletion.

First, the pull-request changes the rehash logic in `riak_kv_vnode` to delete AAE hashes if an object is found to be missing. Thus, if a K/V delete fails to update the relevant AAE hashtree, the hashtree will be fixed on the first repair. Without this change, AAE could continually attempt to repair keys that have been deleted without informing the relevant AAE hashtree. This is scenario is hard to trigger in practice, but it's better to be safe as the fix is easy and straightforward.

Second, this pull-request changes the AAE hashtrees to buffer deletes using the same logic used for buffering writes. Thus, both deletes and writes are buffered and submitted to LevelDB as a single batch operation. As previously shown, write-batching is necessary to make AAE have low impact on the cluster, thus this change is also important for users that frequently delete data.
