### PR TITLE
More Compact Riak Object Binary Format

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -137,6 +137,10 @@ start(_Type, _StartArgs) ->
                                           [enabled_v1, disabled],
                                           disabled),
 
+            riak_core_capability:register({riak_kv, object_format},
+                                          [v1, v0],
+                                          v0),
+
             %% Go ahead and mark the riak_kv service as up in the node watcher.
             %% The riak_core_ring_handler blocks until all vnodes have been started
             %% synchronously.

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -107,10 +107,11 @@ insert(_Id, _Key, _Hash, undefined, _Options) ->
 insert(Id, Key, Hash, Tree, Options) ->
     catch gen_server:call(Tree, {insert, Id, Key, Hash, Options}, infinity).
 
-%% @doc Add a term_to_binary encoded riak_object associated with a given
+%% @doc Add an encoded (binary) riak_object associated with a given
 %%      bucket/key to the appropriate hashtree managed by the provided
 %%      index_hashtree pid. The hash value is generated using
-%%      {@link hash_object/1}.
+%%      {@link hash_object/2}. Any encoding version is supported. The encoding
+%%      will be changed to the appropriate version before hashing the object.
 -spec insert_object({binary(), binary()}, riak_object_t2b(), pid()) -> ok.
 insert_object(_BKey, _RObj, undefined) ->
     ok;
@@ -240,7 +241,7 @@ handle_call({insert, Id, Key, Hash, Options}, _From, State) ->
 handle_call({insert_object, BKey, RObj}, _From, State) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     IndexN = riak_kv_util:get_index_n(BKey, Ring),
-    State2 = do_insert(IndexN, term_to_binary(BKey), hash_object(RObj), [], State),
+    State2 = do_insert(IndexN, term_to_binary(BKey), hash_object(BKey, RObj), [], State),
     {reply, ok, State2};
 handle_call({delete, BKey}, _From, State) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
@@ -300,7 +301,7 @@ handle_cast(stop, State) ->
 handle_cast({insert_object, BKey, RObj}, State) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     IndexN = riak_kv_util:get_index_n(BKey, Ring),
-    State2 = do_insert(IndexN, term_to_binary(BKey), hash_object(RObj), [], State),
+    State2 = do_insert(IndexN, term_to_binary(BKey), hash_object(BKey, RObj), [], State),
     {noreply, State2};
 
 handle_cast(build_failed, State) ->
@@ -381,13 +382,13 @@ load_built(#state{trees=Trees}) ->
     end.
 
 %% Generate a hash value for a binary-encoded `riak_object'
--spec hash_object(riak_object_t2b()) -> binary().
-hash_object(RObjBin) ->
+-spec hash_object({riak_object:bucket(), riak_object:key()}, riak_object_t2b()) -> binary().
+hash_object({Bucket, Key}, RObjBin) ->
     %% Normalize the `riak_object' vector clock before hashing
-    RObj = binary_to_term(RObjBin),
+    RObj = riak_object:from_binary(Bucket, Key, RObjBin),
     Vclock = riak_object:vclock(RObj),
     UpdObj = riak_object:set_vclock(RObj, lists:sort(Vclock)),
-    Hash = erlang:phash2(term_to_binary(UpdObj)),
+    Hash = riak_object:hash(UpdObj),
     term_to_binary(Hash).
 
 %% Fold over a given vnode's data, inserting each object into the appropriate
@@ -402,7 +403,7 @@ fold_keys(Partition, Tree) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     Req = ?FOLD_REQ{foldfun=fun(BKey={Bucket,Key}, RObj, _) ->
                                     IndexN = riak_kv_util:get_index_n({Bucket, Key}, Ring),
-                                    insert(IndexN, term_to_binary(BKey), hash_object(RObj),
+                                    insert(IndexN, term_to_binary(BKey), hash_object(BKey, RObj),
                                            Tree, [if_missing]),
                                     ok
                             end,

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -386,9 +386,7 @@ load_built(#state{trees=Trees}) ->
 hash_object({Bucket, Key}, RObjBin) ->
     %% Normalize the `riak_object' vector clock before hashing
     RObj = riak_object:from_binary(Bucket, Key, RObjBin),
-    Vclock = riak_object:vclock(RObj),
-    UpdObj = riak_object:set_vclock(RObj, lists:sort(Vclock)),
-    Hash = riak_object:hash(UpdObj),
+    Hash = riak_object:hash(RObj),
     term_to_binary(Hash).
 
 %% Fold over a given vnode's data, inserting each object into the appropriate

--- a/src/riak_kv_reformat.erl
+++ b/src/riak_kv_reformat.erl
@@ -1,0 +1,86 @@
+-module(riak_kv_reformat).
+
+-export([run/2]).
+
+run(ObjectVsn, KillHandoffs) ->
+    lager:info("Setting preferred object format to ~p", [ObjectVsn]),
+    set_capabilities(ObjectVsn),
+    lager:info("Preferred object format set to ~p", [ObjectVsn]),
+    case KillHandoffs of
+        true ->
+            lager:info("killing any inbound and outbound handoffs", []);
+        false ->
+            lager:info("waiting on any in-flight inbound and outbound handoffs", [])
+    end,
+    kill_or_wait_on_handoffs(KillHandoffs, 0),
+
+    %% migrate each running vnode
+    Running = riak_core_vnode_manager:all_vnodes(riak_kv_vnode),
+    Me = node(),
+    Counts = riak_core_util:pmap(fun({riak_kv_vnode, Idx, _}) ->
+                                         lager:debug("reformatting partition ~p on ~p",
+                                                     [Idx, Me]),
+                                         reformat_partition(Idx)
+                                 end,
+                                 Running),
+    {SuccessCounts, IgnoredCounts, ErrorCounts} = lists:unzip3(Counts),
+    SuccessTotal = lists:sum(SuccessCounts),
+    IgnoredTotal = lists:sum(IgnoredCounts),
+    ErrorTotal = lists:sum(ErrorCounts),
+    lager:info("Completed reformating all partitions to ~p. Success: ~p. Ignored: ~p. Error: ~p",
+               [ObjectVsn, SuccessTotal, IgnoredTotal, ErrorTotal]),
+    if ErrorTotal > 0 ->
+            lager:info("There were errors reformatting ~p keys. Re-run before dowgrading",
+                       [ErrorTotal]);
+       true -> ok
+    end,
+    {SuccessTotal, IgnoredTotal, ErrorTotal}.
+
+%% set preferred object format to desired version. Although we could just
+%% switch the preference order, removing other versions premptively
+%% downgrades the whole cluster (after ring convergence) reducing the
+%% amount of data needing to be reformatted on other nodes (under the
+%% assumption those other nodes will be downgraded as well)
+set_capabilities(Vsn) ->
+    riak_core_capability:register({riak_kv, object_format},
+                                  [Vsn],
+                                  Vsn).
+
+
+kill_or_wait_on_handoffs(true, _) ->
+    riak_core_handoff_manager:kill_handoffs();
+kill_or_wait_on_handoffs(false, CheckCount) ->
+    case num_running_handoffs() of
+        0 -> kill_or_wait_on_handoffs(true, CheckCount);
+        N ->
+            case CheckCount rem 10 of
+                0 -> lager:info("~p handoffs still outstanding", [N]);
+                _ -> ok
+            end,
+            timer:sleep(1000),
+            kill_or_wait_on_handoffs(false, CheckCount+1)
+    end.
+
+reformat_partition(Idx) ->
+    riak_kv_vnode:fold({Idx, node()},
+                       fun(BKey,Value,Acc) -> reformat_object(Idx,BKey,Value,Acc) end,
+                       {0,0,0}).
+
+reformat_object(Idx, BKey, Value, {SuccessCount, IgnoredCount, ErrorCount}) ->
+    case riak_object:binary_version(Value) of
+        v0 -> {SuccessCount, IgnoredCount+1, ErrorCount};
+        %% TODO: accumulate and handle errors
+        _ ->
+            case riak_kv_vnode:reformat_object(Idx, BKey) of
+                ok -> {SuccessCount+1, IgnoredCount, ErrorCount};
+                {error, not_found} -> {SuccessCount, IgnoredCount+1, ErrorCount};
+                {error, _} -> {SuccessCount, IgnoredCount, ErrorCount+1}
+            end
+    end.
+
+num_running_handoffs() ->
+    Receivers=supervisor:count_children(riak_core_handoff_receiver_sup),
+    Senders=supervisor:count_children(riak_core_handoff_sender_sup),
+    ActiveReceivers=proplists:get_value(active,Receivers),
+    ActiveSenders=proplists:get_value(active,Senders),
+    ActiveSenders+ActiveReceivers.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -46,7 +46,8 @@
          repair_filter/1,
          hashtree_pid/1,
          rehash/3,
-         request_hashtree_pid/1]).
+         request_hashtree_pid/1,
+         reformat_object/2]).
 
 %% riak_core_vnode API
 -export([init/1,
@@ -317,6 +318,13 @@ rehash(Preflist, Bucket, Key) ->
                                    ignore,
                                    riak_kv_vnode_master).
 
+-spec reformat_object(index(), {riak_object:bucket(), riak_object:key()}) ->
+                             ok | {error, term()}.
+reformat_object(Partition, BKey) ->
+    riak_core_vnode_master:sync_spawn_command({Partition, node()},
+                                              {reformat_object, BKey},
+                                              riak_kv_vnode_master).
+
 %% VNode callbacks
 
 init([Index]) ->
@@ -511,7 +519,10 @@ handle_command(?KV_VNODE_STATUS_REQ{},
                             modstate=ModState}) ->
     BackendStatus = {backend_status, Mod, Mod:status(ModState)},
     VNodeStatus = [BackendStatus],
-    {reply, {vnode_status, Index, VNodeStatus}, State}.
+    {reply, {vnode_status, Index, VNodeStatus}, State};
+handle_command({reformat_object, BKey}, _Sender, State) ->
+    {Reply, UpdState} = do_reformat(BKey, State),
+    {reply, Reply, UpdState}.
 
 %% @doc Handle a coverage request.
 %% More information about the specification for the ItemFilter
@@ -928,6 +939,29 @@ perform_put({true, Obj},
             Reply = {fail, Idx, ReqID}
     end,
     {Reply, State#state{modstate=UpdModState}}.
+
+do_reformat({Bucket, Key}=BKey, State=#state{mod=Mod, modstate=ModState}) ->
+    case Mod:get(Bucket, Key, ModState) of
+        {error, not_found, _UpdModState} ->
+            Reply = {error, not_found},
+            UpdState = State;
+        {ok, ObjBin, _UpdModState} ->
+            %% since it is assumed capabilities have been properly set
+            %% to the desired version, to reformat, all we need to do
+            %% is submit a new write
+            RObj = riak_object:from_binary(Bucket, Key, ObjBin),
+            PutArgs = #putargs{returnbody=false,
+                               bkey=BKey,
+                               reqid=undefined,
+                               index_specs=[]},
+            case perform_put({true, RObj}, State, PutArgs) of
+                {{fail, _, _}, UpdState}  ->
+                    Reply = {error, backend_error};
+                {_, UpdState} ->
+                    Reply = ok
+            end
+    end,
+    {Reply, UpdState}.
 
 %% @private
 %% enforce allow_mult bucket property so that no backend ever stores

--- a/src/riak_kv_yessir_backend.erl
+++ b/src/riak_kv_yessir_backend.erl
@@ -169,7 +169,7 @@ get(Bucket, Key, #state{op_get = Gets} = S) ->
     Meta2 = dict:store(<<"X-Riak-VTag">>, make_vtag(erlang:now()), Meta1),
     O = riak_object:increment_vclock(riak_object:new(Bucket, Key, Bin, Meta2),
                                      <<"yessir!">>, 1),
-    {ok, term_to_binary(O), S#state{op_get = Gets + 1}}.
+    {ok, riak_object:to_binary(v0, O), S#state{op_get = Gets + 1}}.
 
 %% @doc Store an object, yes, sir!
 -type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
@@ -311,7 +311,7 @@ fold_objects_fun(FoldObjectsFun, Bucket, Size) ->
             Meta2 = dict:store(<<"X-Riak-VTag">>, make_vtag(erlang:now()), Meta1),
             O = riak_object:increment_vclock(riak_object:new(Bucket, Key, Bin, Meta2),
                                              <<"yessir!">>, 1),
-            FoldObjectsFun(Bucket, Key, term_to_binary(O), Acc);
+            FoldObjectsFun(Bucket, Key, riak_object:to_binary(v0, O), Acc);
        (_, _, Acc) ->
             Acc
     end.

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -89,7 +89,7 @@
 -export([to_json/1, from_json/1]).
 -export([index_specs/1, diff_index_specs/2]).
 -export([set_contents/2, set_vclock/2]). %% INTERNAL, only for riak_*
--export([to_binary/2, from_binary/3, to_binary_version/4]).
+-export([to_binary/2, from_binary/3, to_binary_version/4, binary_version/1]).
 
 %% @doc Convert riak object to binary form
 -spec to_binary(binary_version(), #r_object{}) -> r_object_bin().
@@ -105,6 +105,10 @@ to_binary_version(v1, _, _, <<?MAGIC:8/integer, 1:8/integer, _/binary>>=Bin) ->
     Bin;
 to_binary_version(Vsn, B, K, Bin) ->
     to_binary(Vsn, from_binary(B, K, Bin)).
+
+-spec binary_version(r_object_bin()) -> binary_version() | undefined.
+binary_version(<<131,_/binary>>) -> v0;
+binary_version(<<?MAGIC:8/integer, 1:8/integer, _/binary>>) -> v1.
 
 %% @doc Convert binary object to riak object
 -spec from_binary(bucket(),key(),binary()) -> #r_object{} | {error, atom()}.

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -82,7 +82,7 @@
 
 -export([new/3, new/4, ensure_robject/1, ancestors/1, reconcile/2, equal/2]).
 -export([increment_vclock/2, increment_vclock/3]).
--export([key/1, get_metadata/1, get_metadatas/1, get_values/1, get_value/1]).
+-export([key/1, get_metadata/1, get_metadatas/1, get_values/1, get_value/1, hash/1]).
 -export([vclock/1, update_value/2, update_metadata/2, bucket/1, value_count/1]).
 -export([get_update_metadata/1, get_update_value/1, get_contents/1]).
 -export([merge/2, apply_updates/1, syntactic_merge/2]).
@@ -455,6 +455,10 @@ get_value(Object=#r_object{}) ->
                                                 % this blows up intentionally (badmatch) if more than one content value!
     [{_M,Value}] = get_contents(Object),
     Value.
+
+-spec hash(#r_object{}) -> integer().
+hash(Obj=#r_object{}) ->
+    erlang:phash2(to_binary(v0, Obj)).
 
 %% @spec update_metadata(riak_object(), dict()) -> riak_object()
 %% @doc  Set the updated metadata of an object to M.

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -26,7 +26,6 @@
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
-%% TODO: refactor to remove wm_raw into two files, one that we pull in.
 -include("riak_kv_wm_raw.hrl").
 
 -export_type([riak_object/0, bucket/0, key/0, value/0, binary_version/0]).
@@ -50,29 +49,13 @@
           updatemetadata=dict:store(clean, true, dict:new()) :: dict(),
           updatevalue :: term()
          }).
--opaque riak_object() :: #r_object{} | r_object_bin().
+-opaque riak_object() :: #r_object{}.
 
 -type index_op() :: add | remove.
 -type index_value() :: integer() | binary().
+-type binary_version() :: v0 | v1.
 
 -define(MAX_KEY_SIZE, 65536).
-
-%% Riak Objects in binary format (on disk)
-
-%% -type binobj_header()     :: <<53:8, Version:8, VClockLen:32, VClockBin/binary,
-%%                                SibCount:32>>.
-%% -type binobj_flags()      :: <<Deleted:1, 0:7/bitstring>>.
-%% -type binobj_umeta_pair() :: <<KeyLen:32, Key/binary, ValueLen:32, Value/binary>>.
-%% -type binobj_meta()       :: <<LastMod:LastModLen, VTag:128, binobj_flags(),
-%%                                [binobj_umeta_pair()]>>.
-%% -type binobj_value()      :: <<ValueLen:32, ValueBin/binary, MetaLen:32,
-%%                                [binobj_meta()]>>.
-%% -type binobj()            :: <<binobj_header(), [binobj_value()]>>.
-
--type r_object_bin() :: binary().
--type r_content_bin() :: binary().
--type binary_version() :: v0 | v1.
-%% -type rfc1123_date() :: string(). % LastMod Date
 
 -define(LASTMOD_LEN, 29). %% static length of rfc1123_date() type. Hard-coded in Erlang.
 -define(V1_VERS, 1).
@@ -89,172 +72,8 @@
 -export([merge/2, apply_updates/1, syntactic_merge/2]).
 -export([to_json/1, from_json/1]).
 -export([index_specs/1, diff_index_specs/2]).
--export([set_contents/2, set_vclock/2]). %% INTERNAL, only for riak_*
 -export([to_binary/2, from_binary/3, to_binary_version/4, binary_version/1]).
-
-%% @doc Convert riak object to binary form
--spec to_binary(binary_version(), #r_object{}) -> r_object_bin().
-to_binary(v0, RObj) ->
-    term_to_binary(RObj);
-to_binary(v1, #r_object{contents=Contents, vclock=VClock}) ->
-    new_v1(VClock, Contents).
-
--spec to_binary_version(binary_version(), bucket(), key(), r_object_bin()) -> r_object_bin().
-to_binary_version(v0, _, _, <<131,_/binary>>=Bin) ->
-    Bin;
-to_binary_version(v1, _, _, <<?MAGIC:8/integer, 1:8/integer, _/binary>>=Bin) ->
-    Bin;
-to_binary_version(Vsn, B, K, Bin) ->
-    to_binary(Vsn, from_binary(B, K, Bin)).
-
--spec binary_version(r_object_bin()) -> binary_version() | undefined.
-binary_version(<<131,_/binary>>) -> v0;
-binary_version(<<?MAGIC:8/integer, 1:8/integer, _/binary>>) -> v1.
-
-%% @doc Convert binary object to riak object
--spec from_binary(bucket(),key(),binary()) -> #r_object{} | {error, atom()}.
-from_binary(_B,_K,<<131, _Rest/binary>>=ObjTerm) ->
-    binary_to_term(ObjTerm);
-from_binary(B,K,<<?MAGIC:8/integer, 1:8/integer, Rest/binary>>=_ObjBin) ->
-    %% Version 1 of binary riak object
-    case Rest of
-        <<VclockLen:32/integer, VclockBin:VclockLen/binary, SibCount:32/integer, SibsBin/binary>> ->
-            Vclock = binary_to_term(VclockBin),
-            Contents = sibs_of_binary(SibCount, SibsBin),
-            #r_object{bucket=B,key=K,contents=Contents,vclock=Vclock};
-        _Other ->
-            {error, bad_object_format}
-    end;
-from_binary(_B, _K, <<?MAGIC, _Ver, _Rest/binary>>=_ObjBin) ->
-    {error, unknown_version}.
-
-sibs_of_binary(Count,SibsBin) ->
-    sibs_of_binary(Count, SibsBin, []).
-
-sibs_of_binary(0, <<>>, Result) -> lists:reverse(Result);
-sibs_of_binary(0, _NotEmpty, _Result) ->
-    {error, corrupt_contents};
-sibs_of_binary(Count, SibsBin, Result) ->
-    {Sib, SibsRest} = sib_of_binary(SibsBin),
-    sibs_of_binary(Count-1, SibsRest, [Sib | Result]).
-
-sib_of_binary(<<ValLen:32/integer, ValBin:ValLen/binary, MetaLen:32/integer, MetaBin:MetaLen/binary, Rest/binary>>) ->
-    <<LMMega:32/integer, LMSecs:32/integer, LMMicro:32/integer, VTagLen:8/integer, VTag:VTagLen/binary, Deleted:1/binary-unit:8, MetaRestBin/binary>> = MetaBin,
-    DeletedVal = case Deleted of <<1>> -> true; _False -> false end,
-    MDList0 = case {LMMega, LMSecs, LMMicro} of
-                  {0, 0, 0} -> []; %% original meta had no last mod
-                  LM -> [{?MD_LASTMOD, LM}]
-              end,
-    MDList1 = case VTag of
-                  ?EMPTY_VTAG_BIN -> MDList0;
-                  _ -> MDList0 ++ [{?MD_VTAG, binary_to_list(VTag)}]
-              end,
-    MDList = case DeletedVal of
-                 true ->
-                     MDList1
-                         ++ [{?MD_DELETED, DeletedVal}]
-                         ++ meta_of_binary(MetaRestBin);
-                 false ->
-                     MDList1 ++ meta_of_binary(MetaRestBin)
-             end,
-    MD = dict:from_list(MDList),
-    {#r_content{metadata=MD, value=decode_maybe_binary(ValBin)}, Rest}.
-
-
-meta_of_binary(MetaBin) ->
-    meta_of_binary(MetaBin, []).
-meta_of_binary(<<>>, Acc) ->
-    Acc;
-meta_of_binary(<<KeyLen:32/integer, KeyBin:KeyLen/binary, ValueLen:32/integer, ValueBin:ValueLen/binary, Rest/binary>>, ResultList) ->
-    Key = decode_maybe_binary(KeyBin),
-    Value = decode_maybe_binary(ValueBin),
-    meta_of_binary(Rest, [{Key, Value} | ResultList]).
-
-%% @doc Contruct new binary riak objects.
--spec new_v1(vclock:vclock(), [#r_content{}]) -> r_object_bin().
-new_v1(Vclock, Siblings) ->
-    VclockBin = term_to_binary(Vclock),
-    VclockLen = byte_size(VclockBin),
-    SibCount = length(Siblings),
-    SibsBin = bin_contents(Siblings),
-    <<?MAGIC:8/integer, ?V1_VERS:8/integer, VclockLen:32/integer, VclockBin/binary, SibCount:32/integer, SibsBin/binary>>.
-
--spec bin_content(#r_content{}) -> r_content_bin().
-bin_content(#r_content{metadata=Meta, value=Val}) ->
-    ValBin = encode_maybe_binary(Val),
-    ValLen = byte_size(ValBin),
-    MetaBin = meta_bin(Meta),
-    MetaLen = byte_size(MetaBin),
-    <<ValLen:32/integer, ValBin:ValLen/binary, MetaLen:32/integer, MetaBin:MetaLen/binary>>.
-
-bin_contents(Contents) ->
-    F = fun(Content, Acc) ->
-                <<Acc/binary, (bin_content(Content))/binary>>
-        end,
-    lists:foldl(F, <<>>, Contents).
-
-meta_bin(MD) ->
-    {{VTagVal, Deleted, LastModVal}, RestBin} = dict:fold(fun fold_meta_to_bin/3,
-                                                          {{undefined, <<0>>, undefined}, <<>>},
-                                                          MD),
-    VTagBin = case VTagVal of
-                  undefined ->  ?EMPTY_VTAG_BIN;
-                  _ -> list_to_binary(VTagVal)
-              end,
-    VTagLen = byte_size(VTagBin),
-    LastModBin = case LastModVal of
-                     undefined -> <<0:32/integer, 0:32/integer, 0:32/integer>>;
-                     {Mega,Secs,Micro} -> <<Mega:32/integer, Secs:32/integer, Micro:32/integer>>
-                 end,
-    <<LastModBin/binary, VTagLen:8/integer, VTagBin:VTagLen/binary,
-      Deleted:1/binary-unit:8, RestBin/binary>>.
-
-fold_meta_to_bin(?MD_VTAG, Value, {{_Vt,Del,Lm},RestBin}) ->
-    {{Value, Del, Lm}, RestBin};
-fold_meta_to_bin(?MD_LASTMOD, Value, {{Vt,Del,_Lm},RestBin}) ->
-     {{Vt, Del, Value}, RestBin};
-fold_meta_to_bin(?MD_DELETED, true, {{Vt,_Del,Lm},RestBin})->
-     {{Vt, <<1>>, Lm}, RestBin};
-fold_meta_to_bin(?MD_DELETED, "true", Acc) ->
-    fold_meta_to_bin(?MD_DELETED, true, Acc);
-fold_meta_to_bin(?MD_DELETED, _, {{Vt,_Del,Lm},RestBin}) ->
-    {{Vt, <<0>>, Lm}, RestBin};
-fold_meta_to_bin(Key, Value, {{_Vt,_Del,_Lm}=Elems,RestBin}) ->
-    ValueBin = encode_maybe_binary(Value),
-    ValueLen = byte_size(ValueBin),
-    KeyBin = encode_maybe_binary(Key),
-    KeyLen = byte_size(KeyBin),
-    MetaBin = <<KeyLen:32/integer, KeyBin/binary, ValueLen:32/integer, ValueBin/binary>>,
-    {Elems, <<RestBin/binary, MetaBin/binary>>}.
-
-encode_maybe_binary(Bin) when is_binary(Bin) ->
-    <<1, Bin/binary>>;
-encode_maybe_binary(Bin) ->
-    <<0, (term_to_binary(Bin))/binary>>.
-
-decode_maybe_binary(<<1, Bin/binary>>) ->
-    Bin;
-decode_maybe_binary(<<0, Bin/binary>>) ->
-    binary_to_term(Bin).
-
-%% Get an approximation of object size by adding together the bucket, key,
-%% vectorclock, and all of the siblings. This is more complex than
-%% calling term_to_binary/1, but it should be easier on memory,
-%% especially for objects with large values.
--spec approximate_size(binary_version(), #r_object{}) -> integer().
-approximate_size(Vsn, #r_object{bucket=Bucket,key=Key,contents=Contents,vclock=VClock}) ->
-    size(Bucket) + size(Key) + size(term_to_binary(VClock)) + contents_size(Vsn, Contents).
-
-contents_size(Vsn, Contents) ->
-    lists:sum([metadata_size(Vsn, MD) + value_size(Val) || {MD, Val} <- Contents]).
-
-metadata_size(v0, MD) ->
-    size(term_to_binary(MD));
-metadata_size(v1, MD) ->
-    size(meta_bin(MD)).
-
-value_size(Value) when is_binary(Value) -> size(Value);
-value_size(Value) -> size(term_to_binary(Value)).
+-export([set_contents/2, set_vclock/2]). %% INTERNAL, only for riak_*
 
 %% @doc Constructor for new riak objects.
 -spec new(Bucket::bucket(), Key::key(), Value::value()) -> riak_object().
@@ -288,12 +107,12 @@ new(B, K, V, MD) when is_binary(B), is_binary(K) ->
             end
     end.
 
-%% Ensure the incoming term is a riak_object.
+%% @doc Ensure the incoming term is a riak_object.
 -spec ensure_robject(any()) -> riak_object().
 ensure_robject(Obj = #r_object{}) -> Obj.
 
--spec equal(riak_object(), riak_object()) -> true | false.
 %% @doc Deep (expensive) comparison of Riak objects.
+-spec equal(riak_object(), riak_object()) -> true | false.
 equal(Obj1,Obj2) ->
     (Obj1#r_object.bucket =:= Obj2#r_object.bucket)
         andalso (Obj1#r_object.key =:= Obj2#r_object.key)
@@ -319,13 +138,29 @@ equal_contents([C1|R1],[C2|R2]) ->
         andalso (C1#r_content.value =:= C2#r_content.value)
         andalso equal_contents(R1,R2).
 
-%% @spec reconcile([riak_object()], boolean()) -> riak_object()
+
+%% @doc  Given a list of riak_object()s, return the objects that are pure
+%%       ancestors of other objects in the list, if any.  The changes in the
+%%       objects returned by this function are guaranteed to be reflected in
+%%       the other objects in Objects, and can safely be discarded from the list
+%%       without losing data.
+-spec ancestors([riak_object()]) -> [riak_object()].
+ancestors(pure_baloney_to_fool_dialyzer) ->
+    [#r_object{vclock = vclock:fresh()}];
+ancestors(Objects) ->
+    ToRemove = [[O2 || O2 <- Objects,
+                       vclock:descends(O1#r_object.vclock,O2#r_object.vclock),
+                       (vclock:descends(O2#r_object.vclock,O1#r_object.vclock) == false)]
+                || O1 <- Objects],
+    lists:flatten(ToRemove).
+
 %% @doc  Reconcile a list of riak objects.  If AllowMultiple is true,
 %%       the riak_object returned may contain multiple values if Objects
 %%       contains sibling versions (objects that could not be syntactically
 %%       merged).   If AllowMultiple is false, the riak_object returned will
 %%       contain the value of the most-recently-updated object, as per the
 %%       X-Riak-Last-Modified header.
+-spec reconcile([riak_object()], boolean()) -> riak_object().
 reconcile(Objects, AllowMultiple) ->
     RObjs = reconcile(Objects),
     AllContents = lists:flatten([O#r_object.contents || O <- RObjs]),
@@ -341,22 +176,7 @@ reconcile(Objects, AllowMultiple) ->
                    updatemetadata=dict:store(clean, true, dict:new()),
                    updatevalue=undefined}.
 
-%% @spec ancestors([riak_object()]) -> [riak_object()]
-%% @doc  Given a list of riak_object()s, return the objects that are pure
-%%       ancestors of other objects in the list, if any.  The changes in the
-%%       objects returned by this function are guaranteed to be reflected in
-%%       the other objects in Objects, and can safely be discarded from the list
-%%       without losing data.
-ancestors(pure_baloney_to_fool_dialyzer) ->
-    [#r_object{vclock = vclock:fresh()}];
-ancestors(Objects) ->
-    ToRemove = [[O2 || O2 <- Objects,
-                       vclock:descends(O1#r_object.vclock,O2#r_object.vclock),
-                       (vclock:descends(O2#r_object.vclock,O1#r_object.vclock) == false)]
-                || O1 <- Objects],
-    lists:flatten(ToRemove).
-
-%% @spec reconcile([riak_object()]) -> [riak_object()]
+-spec reconcile([riak_object()]) -> [riak_object()].
 reconcile(Objects) ->
     All = sets:from_list(Objects),
     Del = sets:from_list(ancestors(Objects)),
@@ -399,9 +219,9 @@ compare_content_dates(C1,C2) ->
             C1 < C2
     end.
 
-%% @spec merge(riak_object(), riak_object()) -> riak_object()
 %% @doc  Merge the contents and vclocks of OldObject and NewObject.
 %%       Note:  This function calls apply_updates on NewObject.
+-spec merge(riak_object(), riak_object()) -> riak_object().
 merge(OldObject, NewObject) ->
     NewObj1 = apply_updates(NewObject),
     OldObject#r_object{contents=lists:umerge(lists:usort(NewObject#r_object.contents),
@@ -411,9 +231,9 @@ merge(OldObject, NewObject) ->
                        updatemetadata=dict:store(clean, true, dict:new()),
                        updatevalue=undefined}.
 
-%% @spec apply_updates(riak_object()) -> riak_object()
 %% @doc  Promote pending updates (made with the update_value() and
 %%       update_metadata() calls) to this riak_object.
+-spec apply_updates(riak_object()) -> riak_object().
 apply_updates(Object=#r_object{}) ->
     VL = case Object#r_object.updatevalue of
              undefined ->
@@ -436,79 +256,82 @@ apply_updates(Object=#r_object{}) ->
                     updatemetadata=dict:store(clean, true, dict:new()),
                     updatevalue=undefined}.
 
-%% @spec bucket(riak_object()) -> bucket()
 %% @doc Return the containing bucket for this riak_object.
+-spec bucket(riak_object()) -> bucket().
 bucket(#r_object{bucket=Bucket}) -> Bucket.
 
-%% @spec key(riak_object()) -> key()
 %% @doc  Return the key for this riak_object.
+-spec key(riak_object()) -> key().
 key(#r_object{key=Key}) -> Key.
 
-%% @spec vclock(riak_object()) -> vclock:vclock()
 %% @doc  Return the vector clock for this riak_object.
+-spec vclock(riak_object()) -> vclock:vclock().
 vclock(#r_object{vclock=VClock}) -> VClock.
 
-%% @spec value_count(riak_object()) -> non_neg_integer()
 %% @doc  Return the number of values (siblings) of this riak_object.
+-spec value_count(riak_object()) -> non_neg_integer().
 value_count(#r_object{contents=Contents}) -> length(Contents).
 
-%% @spec get_contents(riak_object()) -> [{dict(), value()}]
 %% @doc  Return the contents (a list of {metadata, value} tuples) for
 %%       this riak_object.
+-spec get_contents(riak_object()) -> [{dict(), value()}].
 get_contents(#r_object{contents=Contents}) ->
     [{Content#r_content.metadata, Content#r_content.value} ||
         Content <- Contents].
 
-%% @spec get_metadata(riak_object()) -> dict()
 %% @doc  Assert that this riak_object has no siblings and return its associated
 %%       metadata.  This function will fail with a badmatch error if the
 %%       object has siblings (value_count() > 1).
+-spec get_metadata(riak_object()) -> dict().
 get_metadata(O=#r_object{}) ->
-                                                % this blows up intentionally (badmatch) if more than one content value!
+    % this blows up intentionally (badmatch) if more than one content value!
     [{Metadata,_V}] = get_contents(O),
     Metadata.
 
-%% @spec get_metadatas(riak_object()) -> [dict()]
 %% @doc  Return a list of the metadata values for this riak_object.
+-spec get_metadatas(riak_object()) -> [dict()].
 get_metadatas(#r_object{contents=Contents}) ->
     [Content#r_content.metadata || Content <- Contents].
 
-%% @spec get_values(riak_object()) -> [value()]
 %% @doc  Return a list of object values for this riak_object.
+-spec get_values(riak_object()) -> [value()].
 get_values(#r_object{contents=C}) -> [Content#r_content.value || Content <- C].
 
-%% @spec get_value(riak_object()) -> value()
 %% @doc  Assert that this riak_object has no siblings and return its associated
 %%       value.  This function will fail with a badmatch error if the object
 %%       has siblings (value_count() > 1).
+-spec get_value(riak_object()) -> value().
 get_value(Object=#r_object{}) ->
-                                                % this blows up intentionally (badmatch) if more than one content value!
+    % this blows up intentionally (badmatch) if more than one content value!
     [{_M,Value}] = get_contents(Object),
     Value.
 
--spec hash(#r_object{}) -> integer().
+%% @doc calculates the hash of a riak object
+-spec hash(riak_object()) -> integer().
 hash(Obj=#r_object{}) ->
-    erlang:phash2(to_binary(v0, Obj)).
+    Vclock = vclock(Obj),
+    UpdObj = riak_object:set_vclock(Obj, lists:sort(Vclock)),
+    erlang:phash2(to_binary(v0, UpdObj)).
 
-%% @spec update_metadata(riak_object(), dict()) -> riak_object()
 %% @doc  Set the updated metadata of an object to M.
+-spec update_metadata(riak_object(), dict()) -> riak_object().
 update_metadata(Object=#r_object{}, M) ->
     Object#r_object{updatemetadata=dict:erase(clean, M)}.
 
-%% @spec update_value(riak_object(), value()) -> riak_object()
 %% @doc  Set the updated value of an object to V
+-spec update_value(riak_object(), value()) -> riak_object().
 update_value(Object=#r_object{}, V) -> Object#r_object{updatevalue=V}.
 
-%% @spec get_update_metadata(riak_object()) -> dict()
 %% @doc  Return the updated metadata of this riak_object.
+-spec get_update_metadata(riak_object()) -> dict().
 get_update_metadata(#r_object{updatemetadata=UM}) -> UM.
 
-%% @spec get_update_value(riak_object()) -> value()
 %% @doc  Return the updated value of this riak_object.
+-spec get_update_value(riak_object()) -> value().
 get_update_value(#r_object{updatevalue=UV}) -> UV.
 
-%% @spec set_vclock(riak_object(), vclock:vclock()) -> riak_object()
 %% @doc  INTERNAL USE ONLY.  Set the vclock of riak_object O to V.
+-spec set_vclock(riak_object(), vclock:vclock()) -> riak_object().
 set_vclock(Object=#r_object{}, VClock) -> Object#r_object{vclock=VClock}.
 
 %% @doc  Increment the entry for ClientId in O's vclock.
@@ -575,16 +398,16 @@ index_data(Obj) ->
 assemble_index_specs(Indexes, IndexOp) ->
     [{IndexOp, Index, Value} || {Index, Value} <- Indexes].
 
-%% @spec set_contents(riak_object(), [{dict(), value()}]) -> riak_object()
 %% @doc  INTERNAL USE ONLY.  Set the contents of riak_object to the
 %%       {Metadata, Value} pairs in MVs. Normal clients should use the
 %%       set_update_[value|metadata]() + apply_updates() method for changing
 %%       object contents.
+-spec set_contents(riak_object(), [{dict(), value()}]) -> riak_object().
 set_contents(Object=#r_object{}, MVs) when is_list(MVs) ->
     Object#r_object{contents=[#r_content{metadata=M,value=V} || {M, V} <- MVs]}.
 
-%% @spec to_json(riak_object()) -> {struct, list(any())}
 %% @doc Converts a riak_object into its JSON equivalent
+-spec to_json(riak_object()) -> {struct, list(any())}.
 to_json(Obj=#r_object{}) ->
     {_,Vclock} = riak_kv_wm_utils:vclock_header(Obj),
     {struct, [{<<"bucket">>, riak_object:bucket(Obj)},
@@ -712,6 +535,7 @@ is_updated(_Object=#r_object{updatemetadata=M,updatevalue=V}) ->
     end.
 
 
+-spec syntactic_merge(riak_object(), riak_object()) -> riak_object().
 syntactic_merge(CurrentObject, NewObject) ->
     %% Paranoia in case objects were incorrectly stored
     %% with update information.  Vclock is not updated
@@ -734,6 +558,180 @@ syntactic_merge(CurrentObject, NewObject) ->
                 false -> UpdatedCurr
             end
     end.
+
+%% @doc Get an approximation of object size by adding together the bucket, key,
+%% vectorclock, and all of the siblings. This is more complex than
+%% calling term_to_binary/1, but it should be easier on memory,
+%% especially for objects with large values.
+-spec approximate_size(binary_version(), riak_object()) -> integer().
+approximate_size(Vsn, Obj=#r_object{bucket=Bucket,key=Key,vclock=VClock}) ->
+    Contents = get_contents(Obj),
+    size(Bucket) + size(Key) + size(term_to_binary(VClock)) + contents_size(Vsn, Contents).
+
+contents_size(Vsn, Contents) ->
+    lists:sum([metadata_size(Vsn, MD) + value_size(Val) || {MD, Val} <- Contents]).
+
+metadata_size(v0, MD) ->
+    size(term_to_binary(MD));
+metadata_size(v1, MD) ->
+    size(meta_bin(MD)).
+
+value_size(Value) when is_binary(Value) -> size(Value);
+value_size(Value) -> size(term_to_binary(Value)).
+
+%% @doc Convert riak object to binary form
+-spec to_binary(binary_version(), riak_object()) -> binary().
+to_binary(v0, RObj) ->
+    term_to_binary(RObj);
+to_binary(v1, #r_object{contents=Contents, vclock=VClock}) ->
+    new_v1(VClock, Contents).
+
+%% @doc convert a binary encoded riak object to a different
+%% encoding version. If the binary is already in the desired
+%% encoding this is a no-op
+-spec to_binary_version(binary_version(), bucket(), key(), binary()) -> binary().
+to_binary_version(v0, _, _, <<131,_/binary>>=Bin) ->
+    Bin;
+to_binary_version(v1, _, _, <<?MAGIC:8/integer, 1:8/integer, _/binary>>=Bin) ->
+    Bin;
+to_binary_version(Vsn, B, K, Bin) ->
+    to_binary(Vsn, from_binary(B, K, Bin)).
+
+%% @doc return the binary version the riak object binary is encoded in
+-spec binary_version(binary()) -> binary_version().
+binary_version(<<131,_/binary>>) -> v0;
+binary_version(<<?MAGIC:8/integer, 1:8/integer, _/binary>>) -> v1.
+
+%% @doc Convert binary object to riak object
+-spec from_binary(bucket(),key(),binary()) -> riak_object().
+from_binary(_B,_K,<<131, _Rest/binary>>=ObjTerm) ->
+    binary_to_term(ObjTerm);
+from_binary(B,K,<<?MAGIC:8/integer, 1:8/integer, Rest/binary>>=_ObjBin) ->
+    %% Version 1 of binary riak object
+    case Rest of
+        <<VclockLen:32/integer, VclockBin:VclockLen/binary, SibCount:32/integer, SibsBin/binary>> ->
+            Vclock = binary_to_term(VclockBin),
+            Contents = sibs_of_binary(SibCount, SibsBin),
+            #r_object{bucket=B,key=K,contents=Contents,vclock=Vclock};
+        _Other ->
+            {error, bad_object_format}
+    end.
+
+sibs_of_binary(Count,SibsBin) ->
+    sibs_of_binary(Count, SibsBin, []).
+
+sibs_of_binary(0, <<>>, Result) -> lists:reverse(Result);
+sibs_of_binary(0, _NotEmpty, _Result) ->
+    {error, corrupt_contents};
+sibs_of_binary(Count, SibsBin, Result) ->
+    {Sib, SibsRest} = sib_of_binary(SibsBin),
+    sibs_of_binary(Count-1, SibsRest, [Sib | Result]).
+
+sib_of_binary(<<ValLen:32/integer, ValBin:ValLen/binary, MetaLen:32/integer, MetaBin:MetaLen/binary, Rest/binary>>) ->
+    <<LMMega:32/integer, LMSecs:32/integer, LMMicro:32/integer, VTagLen:8/integer, VTag:VTagLen/binary, Deleted:1/binary-unit:8, MetaRestBin/binary>> = MetaBin,
+
+    MDList0 = deleted_meta(Deleted, []),
+    MDList1 = last_mod_meta({LMMega, LMSecs, LMMicro}, MDList0),
+    MDList2 = vtag_meta(VTag, MDList1),
+    MDList = meta_of_binary(MetaRestBin, MDList2),
+    MD = dict:from_list(MDList),
+    {#r_content{metadata=MD, value=decode_maybe_binary(ValBin)}, Rest}.
+
+deleted_meta(<<1>>, MDList) ->
+    [{?MD_DELETED, true} | MDList];
+deleted_meta(_, MDList) ->
+    MDList.
+
+last_mod_meta({0, 0, 0}, MDList) ->
+    MDList;
+last_mod_meta(LM, MDList) ->
+    [{?MD_LASTMOD, LM} | MDList].
+
+vtag_meta(?EMPTY_VTAG_BIN, MDList) ->
+    MDList;
+vtag_meta(VTag, MDList) ->
+    [{?MD_VTAG, binary_to_list(VTag)} | MDList].
+
+meta_of_binary(<<>>, Acc) ->
+    Acc;
+meta_of_binary(<<KeyLen:32/integer, KeyBin:KeyLen/binary, ValueLen:32/integer, ValueBin:ValueLen/binary, Rest/binary>>, ResultList) ->
+    Key = decode_maybe_binary(KeyBin),
+    Value = decode_maybe_binary(ValueBin),
+    meta_of_binary(Rest, [{Key, Value} | ResultList]).
+
+%% V1 Riak Object Binary Encoding
+%% -type binobj_header()     :: <<53:8, Version:8, VClockLen:32, VClockBin/binary,
+%%                                SibCount:32>>.
+%% -type binobj_flags()      :: <<Deleted:1, 0:7/bitstring>>.
+%% -type binobj_umeta_pair() :: <<KeyLen:32, Key/binary, ValueLen:32, Value/binary>>.
+%% -type binobj_meta()       :: <<LastMod:LastModLen, VTag:128, binobj_flags(),
+%%                                [binobj_umeta_pair()]>>.
+%% -type binobj_value()      :: <<ValueLen:32, ValueBin/binary, MetaLen:32,
+%%                                [binobj_meta()]>>.
+%% -type binobj()            :: <<binobj_header(), [binobj_value()]>>.
+new_v1(Vclock, Siblings) ->
+    VclockBin = term_to_binary(Vclock),
+    VclockLen = byte_size(VclockBin),
+    SibCount = length(Siblings),
+    SibsBin = bin_contents(Siblings),
+    <<?MAGIC:8/integer, ?V1_VERS:8/integer, VclockLen:32/integer, VclockBin/binary, SibCount:32/integer, SibsBin/binary>>.
+
+bin_content(#r_content{metadata=Meta, value=Val}) ->
+    ValBin = encode_maybe_binary(Val),
+    ValLen = byte_size(ValBin),
+    MetaBin = meta_bin(Meta),
+    MetaLen = byte_size(MetaBin),
+    <<ValLen:32/integer, ValBin:ValLen/binary, MetaLen:32/integer, MetaBin:MetaLen/binary>>.
+
+bin_contents(Contents) ->
+    F = fun(Content, Acc) ->
+                <<Acc/binary, (bin_content(Content))/binary>>
+        end,
+    lists:foldl(F, <<>>, Contents).
+
+meta_bin(MD) ->
+    {{VTagVal, Deleted, LastModVal}, RestBin} = dict:fold(fun fold_meta_to_bin/3,
+                                                          {{undefined, <<0>>, undefined}, <<>>},
+                                                          MD),
+    VTagBin = case VTagVal of
+                  undefined ->  ?EMPTY_VTAG_BIN;
+                  _ -> list_to_binary(VTagVal)
+              end,
+    VTagLen = byte_size(VTagBin),
+    LastModBin = case LastModVal of
+                     undefined -> <<0:32/integer, 0:32/integer, 0:32/integer>>;
+                     {Mega,Secs,Micro} -> <<Mega:32/integer, Secs:32/integer, Micro:32/integer>>
+                 end,
+    <<LastModBin/binary, VTagLen:8/integer, VTagBin:VTagLen/binary,
+      Deleted:1/binary-unit:8, RestBin/binary>>.
+
+fold_meta_to_bin(?MD_VTAG, Value, {{_Vt,Del,Lm},RestBin}) ->
+    {{Value, Del, Lm}, RestBin};
+fold_meta_to_bin(?MD_LASTMOD, Value, {{Vt,Del,_Lm},RestBin}) ->
+     {{Vt, Del, Value}, RestBin};
+fold_meta_to_bin(?MD_DELETED, true, {{Vt,_Del,Lm},RestBin})->
+     {{Vt, <<1>>, Lm}, RestBin};
+fold_meta_to_bin(?MD_DELETED, "true", Acc) ->
+    fold_meta_to_bin(?MD_DELETED, true, Acc);
+fold_meta_to_bin(?MD_DELETED, _, {{Vt,_Del,Lm},RestBin}) ->
+    {{Vt, <<0>>, Lm}, RestBin};
+fold_meta_to_bin(Key, Value, {{_Vt,_Del,_Lm}=Elems,RestBin}) ->
+    ValueBin = encode_maybe_binary(Value),
+    ValueLen = byte_size(ValueBin),
+    KeyBin = encode_maybe_binary(Key),
+    KeyLen = byte_size(KeyBin),
+    MetaBin = <<KeyLen:32/integer, KeyBin/binary, ValueLen:32/integer, ValueBin/binary>>,
+    {Elems, <<RestBin/binary, MetaBin/binary>>}.
+
+encode_maybe_binary(Bin) when is_binary(Bin) ->
+    <<1, Bin/binary>>;
+encode_maybe_binary(Bin) ->
+    <<0, (term_to_binary(Bin))/binary>>.
+
+decode_maybe_binary(<<1, Bin/binary>>) ->
+    Bin;
+decode_maybe_binary(<<0, Bin/binary>>) ->
+    binary_to_term(Bin).
 
 -ifdef(TEST).
 

--- a/test/riak_object_eqc.erl
+++ b/test/riak_object_eqc.erl
@@ -55,4 +55,17 @@ riak_object_bin() ->
 binary_version() ->
     oneof([v0, v1]).
 
+%%====================================================================
+%% Shell helpers
+%%====================================================================
+
+test() ->
+    test(100).
+
+test(N) ->
+    quickcheck(numtests(N, prop_roundtrip())).
+
+check() ->
+    check(prop_roundtrip(), current_counterexample()).
+
 -endif. %% EQC

--- a/test/riak_object_eqc.erl
+++ b/test/riak_object_eqc.erl
@@ -1,0 +1,58 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_object_eqc: serialization/deserialization of riak_object for disk/wire
+%%                  and converting between versions
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_object_eqc).
+-ifdef(EQC).
+
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-define(QC_OUT(P),
+        eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).
+
+-compile(export_all).
+
+roundtrip_eqc_test_() ->
+    Res = eqc:quickcheck(numtests(1000, ?QC_OUT(prop_roundtrip()))),
+    ?_assertEqual(true, Res).
+
+%% deserializing a binary representation of a riak_object and
+%% reserializing it for the same version should result in the same
+%% binary
+prop_roundtrip() ->
+    ?FORALL({B,K,ObjBin,BinVsn},
+            riak_object_bin(),
+            collect(BinVsn,
+                      ObjBin =:=
+                          riak_object:to_binary(BinVsn, riak_object:from_binary(B,K,ObjBin)))).
+
+riak_object_bin() ->
+    ?LET({Obj, Vsn},
+         {fsm_eqc_util:riak_object(), binary_version()},
+         {riak_object:bucket(Obj),
+          riak_object:key(Obj),
+          riak_object:to_binary(Vsn, Obj),
+          Vsn}).
+
+binary_version() ->
+    oneof([v0, v1]).
+
+-endif. %% EQC


### PR DESCRIPTION
This PR changes how `riak_object`s are serialized before storing them on disk, with the goal of reducing overhead. The current `term_to_binary` approach used results in a significant amount of unnecessary overhead due to the metadata dict, among other things. This is especially true for small objects. It also means we store the bucket and key twice for each object (once as the actual key in the backend, and once in the serialized object). The new format addresses these issues by building its own binary that more compactly stores the metadata dictionary in addition to not including the bucket and key.

To support the new format several other changes were made: `riak_kv_vnode` uses a new capability to determine when the new format is supported and encodes the object for writes using the version negotiated by capabilities. Several sub-systems, e.g. aae, backup, handoff were also changed to account for the new version. The commit notes have specific details on what was changed and why.

Additionally, in order for rolling downgrades to be possible after new objects have been written, `riak_kv_format` is included in this PR with the intention of it being run on a live node before starting the downgrade. A `riak_test` for this can be found [here](https://github.com/basho/riak_test/pull/197). `riak_kv_format` is general enough that it can be used to upgrade the node's data as well.

Finally, this PR includes some general cleanup of the `riak_object` module.

There are several possible improvements, such as some potential binary optimizations, that could be made before this PR is merged or in a separate PR. I figured those were best left to discussion with a reviewer.

EDIT: much thanks to @argv0 @buddhisthead and @seancribbs who also worked on this branch. The author history was lost as part of rebasing many commits from the portland meetup.
