### PR TITLE
Improve AAE backpressure on K/V vnode write-path

### DIFF
--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -47,6 +47,7 @@
          insert/4,
          insert/5,
          insert_object/3,
+         async_insert_object/3,
          stop/1,
          destroy/1]).
 
@@ -115,6 +116,10 @@ insert_object(_BKey, _RObj, undefined) ->
     ok;
 insert_object(BKey, RObj, Tree) ->
     catch gen_server:call(Tree, {insert_object, BKey, RObj}, infinity).
+
+%% @doc Asynchronous version of {@link insert_object/3}.
+async_insert_object(BKey, RObj, Tree) ->
+    gen_server:cast(Tree, {insert_object, BKey, RObj}).
 
 %% @doc Remove the key/hash pair associated with a given bucket/key from the
 %%      appropriate hashtree managed by the provided index_hashtree pid.
@@ -291,6 +296,12 @@ handle_cast(poke, State) ->
 handle_cast(stop, State) ->
     close_trees(State),
     {stop, normal, State};
+
+handle_cast({insert_object, BKey, RObj}, State) ->
+    {ok, Ring} = riak_core_ring_manager:get_my_ring(),
+    IndexN = riak_kv_util:get_index_n(BKey, Ring),
+    State2 = do_insert(IndexN, term_to_binary(BKey), hash_object(RObj), [], State),
+    {noreply, State2};
 
 handle_cast(build_failed, State) ->
     riak_kv_entropy_manager:requeue_poke(State#state.index),


### PR DESCRIPTION
Original AAE design had `riak_kv_vnode` send async casts to the `riak_kv_index_hashtree` to decouple the two processes and ensure AAE had little impact on K/V performance. Testing uncovered issues where the K/V vnode could operate faster the AAE hashtree, leading to unbounded message queue growth. To fix this, the updates were changes to be synchronous calls to add backpressure.

However, doing a blocking call for every update impacts K/V performance.  This is especially noticeable when running a fast backend, such as Memory or Bitcask. This commit moves to a hybrid approach. A fixed number of updates are sent asynchronously after which the next update is performed synchronously. The value is currently hardcoded to 90 asynchronous requests. The worse-case message queue size is therefore 91 outstanding messages.
