### PR TITLE
Fix PR/PW

### DIFF
--- a/src/riak_kv_put_core.erl
+++ b/src/riak_kv_put_core.erl
@@ -20,9 +20,13 @@
 %%
 %% -------------------------------------------------------------------
 -module(riak_kv_put_core).
--export([init/7, add_result/2, enough/1, response/1, 
+-export([init/10, add_result/2, enough/1, response/1, 
          final/1, result_shortcode/1, result_idx/1]).
 -export_type([putcore/0, result/0, reply/0]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
 
 -type vput_result() :: any().
 
@@ -39,7 +43,9 @@
 -record(putcore, {n :: pos_integer(),
                   w :: non_neg_integer(),
                   dw :: non_neg_integer(),
+                  pw :: non_neg_integer(),
                   w_fail_threshold :: pos_integer(),
+                  pw_fail_threshold :: pos_integer(),
                   dw_fail_threshold :: pos_integer(),
                   returnbody :: boolean(),
                   allowmult :: boolean(),
@@ -47,7 +53,10 @@
                   final_obj :: undefined | riak_object:riak_object(),
                   num_w = 0 :: non_neg_integer(),
                   num_dw = 0 :: non_neg_integer(),
-                  num_fail = 0 :: non_neg_integer()}).
+                  num_pw = 0 :: non_neg_integer(),
+                  num_fail = 0 :: non_neg_integer(),
+                  idx_type :: {non_neg_integer(), 'primary' | 'fallback'} %% mapping of idx -> primary | fallback
+                 }).
 -opaque putcore() :: #putcore{}.
 
 %% ====================================================================
@@ -56,14 +65,19 @@
 
 %% Initialize a put and return an opaque put core context
 -spec init(pos_integer(), non_neg_integer(), non_neg_integer(), 
-           pos_integer(), pos_integer(), boolean(), boolean()) -> putcore().
-init(N, W, DW, WFailThreshold, DWFailThreshold, AllowMult, ReturnBody) ->
-    #putcore{n = N, w = W, dw = DW,
+           non_neg_integer(), pos_integer(), pos_integer(),
+           pos_integer(), boolean(), boolean(),
+           orddict:orddict()) -> putcore().
+init(N, W, PW, DW, WFailThreshold, PWFailThreshold,
+     DWFailThreshold, AllowMult, ReturnBody, IdxType) ->
+    #putcore{n = N, w = W, pw = PW, dw = DW,
              w_fail_threshold = WFailThreshold,
+             pw_fail_threshold = PWFailThreshold,
              dw_fail_threshold = DWFailThreshold,
              allowmult = AllowMult,
-             returnbody = ReturnBody}.
-   
+             returnbody = ReturnBody,
+             idx_type = IdxType}.
+
 %% Add a result from the vnode
 -spec add_result(vput_result(), putcore()) -> putcore().
 add_result({w, Idx, _ReqId}, PutCore = #putcore{results = Results,
@@ -72,12 +86,12 @@ add_result({w, Idx, _ReqId}, PutCore = #putcore{results = Results,
                     num_w = NumW + 1};
 add_result({dw, Idx, _ReqId}, PutCore = #putcore{results = Results,
                                                  num_dw = NumDW}) ->
-    PutCore#putcore{results = [{Idx, {dw, undefined}} | Results], 
-                    num_dw = NumDW + 1};
+    num_pw(PutCore#putcore{results = [{Idx, {dw, undefined}} | Results],
+                    num_dw = NumDW + 1}, Idx);
 add_result({dw, Idx, ResObj, _ReqId}, PutCore = #putcore{results = Results,
                                                          num_dw = NumDW}) ->
-    PutCore#putcore{results = [{Idx, {dw, ResObj}} | Results],
-                    num_dw = NumDW + 1};
+    num_pw(PutCore#putcore{results = [{Idx, {dw, ResObj}} | Results],
+                    num_dw = NumDW + 1}, Idx);
 add_result({fail, Idx, _ReqId}, PutCore = #putcore{results = Results,
                                                    num_fail = NumFail}) ->
     PutCore#putcore{results = [{Idx, {error, undefined}} | Results],
@@ -86,34 +100,46 @@ add_result(_Other, PutCore = #putcore{num_fail = NumFail}) ->
     %% Treat unrecognized messages as failures - no index to store them against
     PutCore#putcore{num_fail = NumFail + 1}.
 
-%% Check if enough results have been added to respond 
+%% Check if enough results have been added to respond
 -spec enough(putcore()) -> boolean().
-enough(#putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW, 
-                num_fail = NumFail, w_fail_threshold = WFailThreshold,
-                dw_fail_threshold = DWFailThreshold}) ->
-    (NumW >= W andalso NumDW >= DW) orelse
-        (NumW >= W andalso NumFail >= DWFailThreshold) orelse
-        (NumW < W andalso NumFail >= WFailThreshold).
+%% The perfect world, all the quorum restrictions have been met.
+enough(#putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW, pw = PW, num_pw = NumPW}) when
+      NumW >= W, NumDW >= DW, NumPW >= PW ->
+    true;
+%% Enough failures that we can't meet the PW restriction
+enough(#putcore{ num_fail = NumFail, pw_fail_threshold = PWFailThreshold}) when
+      NumFail >= PWFailThreshold ->
+    true;
+%% Enough failures that we can't meet the DW restriction
+enough(#putcore{ num_fail = NumFail, dw_fail_threshold = DWFailThreshold}) when
+      NumFail >= DWFailThreshold ->
+    true;
+%% We've received all DW responses but can't satisfy PW
+enough(#putcore{n = N, num_dw = NumDW, num_fail = NumFail, pw = PW, num_pw = NumPW}) when
+      NumDW + NumFail >= N, NumPW < PW ->
+    true;
+enough(_PutCore) ->
+    false.
 
 %% Get success/fail response once enough results received
 -spec response(putcore()) -> {reply(), putcore()}.
-response(PutCore = #putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW,
-                            num_fail = NumFail,
-                            w_fail_threshold = WFailThreshold,
-                            dw_fail_threshold = DWFailThreshold}) ->
-    if
-        NumW >= W andalso NumDW >= DW ->
-            maybe_return_body(PutCore);
-        
-        NumW >= W andalso NumFail >= DWFailThreshold ->
-            {{error, too_many_fails}, PutCore};
-        
-       NumW < W andalso NumFail >= WFailThreshold ->
-            {{error, too_many_fails}, PutCore};
-        
-        true ->
-            {{error, {w_val_unsatisfied, NumW, NumDW, W, DW}}, PutCore}
-    end.
+%% Perfect world - all quora met
+response(PutCore = #putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW, pw = PW, num_pw = NumPW}) when
+      NumW >= W, NumDW >= DW, NumPW >= PW ->
+    maybe_return_body(PutCore);
+%% Everything is ok, except we didn't meet PW
+response(PutCore = #putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW, pw = PW, num_pw = NumPW}) when
+      NumW >= W, NumDW >= DW, NumPW < PW ->
+    {{error, pw_val_unsatisfied, PW, NumPW}, PutCore};
+%% Didn't make PW, and PW >= DW
+response(PutCore = #putcore{n = N, num_fail = NumFail, dw = DW, pw=PW, num_pw = NumPW}) when
+      NumFail > N - PW, PW >= DW ->
+    {{error, pw_val_unsatisfied, PW, NumPW}, PutCore};
+%% Didn't make DW and DW > PW
+response(PutCore = #putcore{n = N, num_fail = NumFail, dw = DW, num_dw = NumDW}) when
+      NumFail > N - DW ->
+    {{error, dw_val_unsatisfied, DW, NumDW}, PutCore}.
+
 
 %% Get final value - if returnbody did not need the result it allows delaying
 %% running reconcile until after the client reply is sent.
@@ -153,3 +179,128 @@ maybe_return_body(PutCore = #putcore{returnbody = true}) ->
     {ReplyObj, UpdPutCore} = final(PutCore),
     {{ok, ReplyObj}, UpdPutCore}.
 
+%% @private If the Idx is not in the IdxType
+%% the world should end
+is_primary_response(Idx, IdxType) ->
+    {Idx, Status} = lists:keyfind(Idx, 1, IdxType),
+    Status == primary.
+
+%% @private Increment PW, if appropriate
+num_pw(PutCore = #putcore{num_pw=NumPW, idx_type=IdxType}, Idx) ->
+    case is_primary_response(Idx, IdxType) of
+        true ->
+            PutCore#putcore{num_pw=NumPW+1};
+        false ->
+            PutCore
+    end.
+
+
+
+-ifdef(TEST).
+%% simple sanity tests
+enough_test_() ->
+    [
+        {"Checking W",
+            fun() ->
+                    %% you can never fail W directly...
+                    ?assertEqual(false, enough(#putcore{n=3, w=3, dw=0, pw=0, w_fail_threshold=1,
+                                dw_fail_threshold=4, pw_fail_threshold=4, num_w=1,
+                                num_dw=0, num_pw=0, num_fail=0})),
+                    ?assertEqual(false, enough(#putcore{n=3, w=3, dw=0, pw=0, w_fail_threshold=1,
+                                dw_fail_threshold=4, pw_fail_threshold=4, num_w=2,
+                                num_dw=0, num_pw=0, num_fail=0})),
+                    %% got enough Ws
+                    ?assertEqual(true, enough(#putcore{n=3, w=3, dw=0, pw=0, w_fail_threshold=1,
+                                dw_fail_threshold=4, pw_fail_threshold=4, num_w=3,
+                                num_dw=0, num_pw=0, num_fail=0})),
+                ok
+        end},
+        {"Checking DW",
+            fun() ->
+                    ?assertEqual(false, enough(#putcore{n=3, w=0, dw=3, pw=0, w_fail_threshold=4,
+                                dw_fail_threshold=1, pw_fail_threshold=4, num_w=3,
+                                num_dw=1, num_pw=0, num_fail=0})),
+                    ?assertEqual(false, enough(#putcore{n=3, w=0, dw=3, pw=0, w_fail_threshold=4,
+                                dw_fail_threshold=1, pw_fail_threshold=4, num_w=3,
+                                num_dw=2, num_pw=0, num_fail=0})),
+                    %% got enough DWs
+                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=3, pw=0, w_fail_threshold=4,
+                                dw_fail_threshold=1, pw_fail_threshold=4, num_w=3,
+                                num_dw=3, num_pw=0, num_fail=0})),
+                    %% exceeded failure threshold
+                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=3, pw=0, w_fail_threshold=4,
+                                dw_fail_threshold=1, pw_fail_threshold=4, num_w=3,
+                                num_dw=2, num_pw=0, num_fail=1})),
+                ok
+        end},
+        {"Checking PW",
+            fun() ->
+                    ?assertEqual(false, enough(#putcore{n=3, w=0, dw=0, pw=3, w_fail_threshold=4,
+                                dw_fail_threshold=4, pw_fail_threshold=1, num_w=3,
+                                num_dw=1, num_pw=1, num_fail=0})),
+                    ?assertEqual(false, enough(#putcore{n=3, w=0, dw=0, pw=3, w_fail_threshold=4,
+                                dw_fail_threshold=4, pw_fail_threshold=1, num_w=3,
+                                num_dw=2, num_pw=2, num_fail=0})),
+                    %% got enough PWs
+                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=0, pw=3, w_fail_threshold=4,
+                                dw_fail_threshold=4, pw_fail_threshold=1, num_w=3,
+                                num_dw=3, num_pw=3, num_fail=0})),
+                    %% exceeded failure threshold
+                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=0, pw=3, w_fail_threshold=4,
+                                dw_fail_threshold=4, pw_fail_threshold=1, num_w=3,
+                                num_dw=2, num_pw=2, num_fail=1})),
+                    %% can never satisfy PW
+                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=0, pw=3, w_fail_threshold=4,
+                                dw_fail_threshold=4, pw_fail_threshold=1, num_w=3,
+                                num_dw=3, num_pw=2, num_fail=0})),
+
+                ok
+        end}
+    ].
+
+response_test_() ->
+    [
+        {"Requirements met",
+            fun() ->
+                    ?assertMatch({ok, _},
+                        response(#putcore{n=3, w=1, dw=3, pw=2,
+                                w_fail_threshold=3,
+                                dw_fail_threshold=1, pw_fail_threshold=2, num_w=3,
+                                num_dw=3, num_pw=2, num_fail=0,
+                                returnbody=false})),
+                    ok
+            end},
+        {"DW val unsatisfied",
+            fun() ->
+                    ?assertMatch({{error, dw_val_unsatisfied, 3, 2}, _},
+                        response(#putcore{n=3, w=0, dw=3, pw=0, w_fail_threshold=4,
+                                dw_fail_threshold=1, pw_fail_threshold=4, num_w=3,
+                                num_dw=2, num_pw=0, num_fail=1})),
+                    %% can never satify PW or DW and PW >= DW
+                    ?assertMatch({{error, dw_val_unsatisfied, 3, 2}, _},
+                        response(#putcore{n=3, w=0, dw=3, pw=2, w_fail_threshold=4,
+                                dw_fail_threshold=1, pw_fail_threshold=2, num_w=3,
+                                num_dw=2, num_pw=1, num_fail=1})),
+                    ok
+            end},
+        {"PW val unsatisfied",
+            fun() ->
+                    ?assertMatch({{error, pw_val_unsatisfied, 3, 2}, _},
+                        response(#putcore{n=3, w=0, dw=0, pw=3, w_fail_threshold=4,
+                                dw_fail_threshold=4, pw_fail_threshold=1, num_w=3,
+                                num_dw=2, num_pw=2, num_fail=1})),
+                    ?assertMatch({{error, pw_val_unsatisfied, 3, 1}, _},
+                        response(#putcore{n=3, w=0, dw=0, pw=3, w_fail_threshold=4,
+                                dw_fail_threshold=4, pw_fail_threshold=1, num_w=3,
+                                num_dw=3, num_pw=1, num_fail=0})),
+                    %% can never satify PW or DW and PW >= DW
+                    ?assertMatch({{error, pw_val_unsatisfied, 3, 2}, _},
+                        response(#putcore{n=3, w=0, dw=3, pw=3, w_fail_threshold=4,
+                                dw_fail_threshold=1, pw_fail_threshold=1, num_w=3,
+                                num_dw=2, num_pw=2, num_fail=1})),
+                    ok
+            end}
+
+    ].
+
+-endif.

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -281,7 +281,7 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
     IdxType = [{Part, Type} || {{Part, _Node}, Type} <- Preflist2],
     NumPrimaries = length([x || {_,primary} <- Preflist2]),
     NumVnodes = length(Preflist2),
-    MinVnodes = erlang:max(1, erlang:max(W, erlang:max(DW, PW))), % always need at least one vnode
+    MinVnodes = lists:max([1, W, DW, PW]), % always need at least one vnode
 
     if
         PW =:= error ->
@@ -616,7 +616,6 @@ handle_options([{_,_}|T], State) -> handle_options(T, State).
 init_putcore(State = #state{n = N, w = W, pw = PW, dw = DW, allowmult = AllowMult,
                             returnbody = ReturnBody}, IdxType) ->
     PutCore = riak_kv_put_core:init(N, W, PW, DW,
-                                    N-W+1,   % cannot ever get W replies
                                     N-PW+1,  % cannot ever get PW replies
                                     N-DW+1,  % cannot ever get DW replies
                                     AllowMult,
@@ -836,9 +835,7 @@ add_client_info(Reply, Details, State) ->
         ok ->
             {ok, Info};
         {OkError, ObjReason} ->
-            {OkError, ObjReason, Info};
-        {OkError, Error, ErrorInfo1, ErrorInfo2} ->
-            {OkError, Error, ErrorInfo1, ErrorInfo2, Info}
+            {OkError, ObjReason, Info}
     end.
 
 client_info(true, StateData, Info) ->

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -76,6 +76,7 @@
                 n :: pos_integer(),
                 w :: non_neg_integer(),
                 dw :: non_neg_integer(),
+                pw :: non_neg_integer(),
                 coord_pl_entry :: {integer(), atom()},
                 preflist2 :: riak_core_apl:preflist2(),
                 bkey :: {riak_object:bucket(), riak_object:key()},
@@ -93,7 +94,7 @@
                 put_usecs :: undefined | non_neg_integer(),
                 timing = [] :: [{atom(), {non_neg_integer(), non_neg_integer(),
                                           non_neg_integer()}}],
-                reply, % reply sent to client
+                reply, % reply sent to client,
                 tracked_bucket=false :: boolean() %% tracke per bucket stats
                }).
 
@@ -274,11 +275,14 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
         _ ->
             %% DW must always be 1 with node-based vclocks.
             %% The coord vnode is responsible for incrementing the vclock
-            DW = erlang:min(DW1, erlang:max(1, W))
+            DW = erlang:max(DW1, 1)
     end,
+
+    IdxType = [{Part, Type} || {{Part, _Node}, Type} <- Preflist2],
     NumPrimaries = length([x || {_,primary} <- Preflist2]),
     NumVnodes = length(Preflist2),
-    MinVnodes = erlang:max(1, erlang:max(W, DW)), % always need at least one vnode
+    MinVnodes = erlang:max(1, erlang:max(W, erlang:max(DW, PW))), % always need at least one vnode
+
     if
         PW =:= error ->
             process_reply({error, {pw_val_violation, PW0}}, StateData0);
@@ -306,7 +310,9 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                 if Disable -> [];
                    true -> get_hooks(postcommit, BucketProps)
                 end,
-            StateData1 = StateData0#state{n=N, w=W, dw=DW, allowmult=AllowMult,
+            StateData1 = StateData0#state{n=N,
+                                          w=W,
+                                          pw=PW, dw=DW, allowmult=AllowMult,
                                           precommit = Precommit,
                                           postcommit = Postcommit,
                                           req_id = ReqId,
@@ -314,7 +320,7 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
             Options = flatten_options(proplists:unfold(Options0 ++ ?DEFAULT_OPTS), []),
             StateData2 = handle_options(Options, StateData1),
             StateData3 = apply_updates(StateData2),
-            StateData = init_putcore(StateData3),
+            StateData = init_putcore(StateData3, IdxType),
             ?DTRACE(?C_PUT_FSM_VALIDATE, [N, W, PW, DW], []),
             case Precommit of
                 [] -> % Nothing to run, spare the timing code
@@ -368,6 +374,8 @@ execute_local(StateData=#state{robj=RObj, req_id = ReqId,
     %% Must always wait for local vnode - it contains the object with updated vclock
     %% to use for the remotes. (Ignore optimization for N=1 case for now).
     new_state(waiting_local_vnode, StateData2).
+
+
 
 %% @private
 waiting_local_vnode(request_timeout, StateData) ->
@@ -605,13 +613,15 @@ handle_options([{returnbody, false}|T], State = #state{postcommit = Postcommit})
     end;
 handle_options([{_,_}|T], State) -> handle_options(T, State).
 
-init_putcore(State = #state{n = N, w = W, dw = DW, allowmult = AllowMult,
-                            returnbody = ReturnBody}) ->
-    PutCore = riak_kv_put_core:init(N, W, DW,
+init_putcore(State = #state{n = N, w = W, pw = PW, dw = DW, allowmult = AllowMult,
+                            returnbody = ReturnBody}, IdxType) ->
+    PutCore = riak_kv_put_core:init(N, W, PW, DW,
                                     N-W+1,   % cannot ever get W replies
+                                    N-PW+1,  % cannot ever get PW replies
                                     N-DW+1,  % cannot ever get DW replies
                                     AllowMult,
-                                    ReturnBody),
+                                    ReturnBody,
+                                    IdxType),
     State#state{putcore = PutCore}.
 
 
@@ -826,7 +836,9 @@ add_client_info(Reply, Details, State) ->
         ok ->
             {ok, Info};
         {OkError, ObjReason} ->
-            {OkError, ObjReason, Info}
+            {OkError, ObjReason, Info};
+        {OkError, Error, ErrorInfo1, ErrorInfo2} ->
+            {OkError, Error, ErrorInfo1, ErrorInfo2, Info}
     end.
 
 client_info(true, StateData, Info) ->

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -1032,12 +1032,12 @@ handle_common_error(Reason, RD, Ctx) ->
                             [Returned, Requested]),
                         RD)),
                 Ctx};
-        {error, {w_val_unsatisfied, NumW, NumDW, W, DW}} ->
+        {error, {dw_val_unsatisfied, DW, NumDW}} ->
             {{halt, 503},
                 wrq:set_resp_header("Content-Type", "text/plain",
                     wrq:append_to_response_body(
-                        io_lib:format("W/DW-value unsatisfied: w=~p/~p dw=~p/~p~n",
-                            [NumW, W, NumDW, DW]),
+                        io_lib:format("DW-value unsatisfied: ~p/~p~n",
+                            [NumDW, DW]),
                         RD)),
                 Ctx};
         {error, {pr_val_unsatisfied, Requested, Returned}} ->

--- a/test/fsm_eqc_vnode.erl
+++ b/test/fsm_eqc_vnode.erl
@@ -102,7 +102,6 @@ init([]) ->
 active(?VNODE_REQ{index=Idx,
                   sender=Sender,
                   request=?KV_GET_REQ{req_id=ReqId}}, State) ->
-    %io:format(user, "Get ~p reqid ~p\n", [Idx, ReqId]),
     {Value, State1} = get_data(Idx,State),
     case Value of
         {error, timeout} ->

--- a/test/get_fsm_eqc.erl
+++ b/test/get_fsm_eqc.erl
@@ -1,4 +1,4 @@
--module(get_fsm_qc).
+-module(get_fsm_eqc).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -22,6 +22,7 @@
                 pr,
                 real_pr,
                 num_primaries,
+                preflist,
                 history,
                 objects,
                 deleted,
@@ -46,7 +47,7 @@ eqc_test_() ->
        fun cleanup/1,
        [%% Run the quickcheck tests
         {timeout, 60000, % do not trust the docs - timeout is in msec
-         ?_assertEqual(true, quickcheck(numtests(500, ?QC_OUT(prop_basic_get()))))}
+         ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(50, ?QC_OUT(prop_basic_get()))))}
        ]
       }
      ]
@@ -84,10 +85,22 @@ test() ->
     test(100).
 
 test(N) ->
-    quickcheck(numtests(N, prop_basic_get())).
+    fsm_eqc_util:start_mock_servers(),
+    fsm_eqc_util:start_fake_rng(?MODULE),
+    try quickcheck(numtests(N, prop_basic_get()))
+    after
+        fsm_eqc_util:cleanup_mock_servers(),
+        exit(whereis(?MODULE), kill)
+    end.
 
 check() ->
-    check(prop_basic_get(), current_counterexample()).
+    fsm_eqc_util:start_mock_servers(),
+    fsm_eqc_util:start_fake_rng(?MODULE),
+    try check(prop_basic_get(), current_counterexample())
+    after
+        fsm_eqc_util:cleanup_mock_servers(),
+        exit(whereis(?MODULE), kill)
+    end.
 
 %%====================================================================
 %% Generators
@@ -237,7 +250,7 @@ prop_basic_get() ->
         DeletedVClock = proplists:get_value(deletedvclock, Options, false),
         NumPrimaries = length([xx || {_,primary} <- PL2]),
         State = expect(#state{n = N, r = R, real_r = RealR, pr = PR, real_pr = RealPR,
-                              history = History,
+                              history = History, preflist=PL2,
                               objects = Objects, deleted = Deleted, options = Options,
                               notfound_is_ok = NotFoundIsOk, basic_quorum = BasicQuorum,
                               num_primaries = NumPrimaries, deletedvclock = DeletedVClock}),
@@ -249,8 +262,15 @@ prop_basic_get() ->
                             0;
                         {error, {pr_val_violation, _}} ->
                             0;
-                        {error, {pr_val_unsatisfied, _, _}} ->
-                            0;
+                        {error, {pr_val_unsatisfied, _, Y}} ->
+                            case Y >= NumPrimaries of
+                                true ->
+                                    %% if this preflist can never satisfy PR,
+                                    %% the put fsm will bail early
+                                    0;
+                                false ->
+                                    length([xx || {_, Resp} <- VGetResps, Resp /= timeout])
+                            end;
                         _ ->
                             length([xx || {_, Resp} <- VGetResps, Resp /= timeout])
                     end,
@@ -473,8 +493,7 @@ expect(State = #state{real_pr = RealPR, num_primaries = NumPrimaries}) when Real
     State#state{exp_result = {error, {pr_val_unsatisfied, RealPR, NumPrimaries}}};
 expect(State = #state{history = History, objects = Objects,
                       deletedvclock = DeletedVClock, deleted = _Deleted}) ->
-    H = [ V || {_, V} <- History ],
-    State1 = expect(H, State, 0, 0 , 0, 0, []),
+    State1 = expect(History, State, 0, 0, 0, 0, 0, []),
     case State1#state.exp_result of
         {ok, Heads} ->
             Object = build_merged_object(Heads, Objects),
@@ -491,16 +510,32 @@ expect(State = #state{history = History, objects = Objects,
 
 %% decide on error message - if only got notfound messages, return notfound
 %% otherwise let caller know R value was not met.
-notfound_or_error(NotFound, 0, 0, _Oks, _R) when NotFound > 0 ->
+notfound_or_error(NotFound, 0, 0, _Oks, _R, _PR, _PROks) when NotFound > 0 ->
     notfound;
-notfound_or_error(_NotFound, _NumNotDeleted, _Err, Oks, R) ->
-    {r_val_unsatisfied, R, Oks}.
+notfound_or_error(_NotFound, _NumNotDeleted, _Err, Oks, R, PR, PROks) ->
+    %% PR trumps R, if PR >= R
+    if Oks >= R, PROks < PR ->
+            {pr_val_unsatisfied, PR, PROks};
+        R > PR ->
+            {r_val_unsatisfied, erlang:max(R, PR), Oks};
+        true ->
+            {pr_val_unsatisfied, PR, PROks}
+    end.
 
-expect(H, State = #state{n = N, real_r = R, deleted = Deleted, notfound_is_ok = NotFoundIsOk,
-                         basic_quorum = BasicQuorum},
-       NotFounds, Oks, DelOks, Errs, Heads) ->
+expect(H, State = #state{n = N, real_r = R, real_pr = PR, deleted = Deleted, notfound_is_ok = NotFoundIsOk,
+                         basic_quorum = BasicQuorum, preflist=Preflist},
+       NotFounds, Oks, PROks, DelOks, Errs, Heads) ->
+    FailR = erlang:max(PR, R),
+    FailThreshold =
+    case BasicQuorum of
+        true ->
+            erlang:min((N div 2)+1, % basic quorum, or
+                (N-FailR+1)); % cannot ever get R 'ok' replies
+        _ElseFalse ->
+            N - FailR + 1 % cannot ever get R 'ok' replies
+    end,
     Pending = N - (NotFounds + Oks + Errs),
-    if  Oks >= R ->                     % we made quorum
+    if  Oks >= R andalso PROks >= PR -> % we made quorum
             ExpResult = case Heads of
                             [] ->
                                 notfound;
@@ -509,29 +544,56 @@ expect(H, State = #state{n = N, real_r = R, deleted = Deleted, notfound_is_ok = 
                         end,
             State#state{exp_result = ExpResult, num_oks = Oks, num_errs = Errs};
         (BasicQuorum andalso (NotFounds + Errs)*2 > N) orelse % basic quorum
-        Pending + Oks < R ->            % no way we'll make quorum
+            Pending + Oks < R ->            % no way we'll make quorum
             %% Adjust counts to make deleted objects count towards notfound.
             State#state{exp_result = notfound_or_error(NotFounds + DelOks, Oks - DelOks,
-                                                       Errs, Oks, R),
+                                                       Errs, Oks, R, PR, PROks),
+                        num_oks = Oks, del_oks = DelOks, num_errs = Errs};
+        (PROks < PR andalso (NotFounds + Errs >= FailThreshold)) ->
+            State#state{exp_result = notfound_or_error(NotFounds + DelOks, Oks - DelOks,
+                                                       Errs, Oks, R, PR, PROks),
                         num_oks = Oks, del_oks = DelOks, num_errs = Errs};
         true ->
             case H of
                 [] ->
-                    State#state{exp_result = timeout, num_oks = Oks, num_errs = Errs};
-                [timeout|Rest] ->
-                    expect(Rest, State, NotFounds, Oks, DelOks, Errs, Heads);
-                [notfound|Rest] ->
+                    case PROks < PR andalso (Oks + Errs + NotFounds) == N of
+                        true ->
+                            State#state{exp_result = notfound_or_error(NotFounds + DelOks, Oks - DelOks,
+                                    Errs, Oks, R, PR, PROks),
+                                num_oks = Oks, del_oks = DelOks, num_errs = Errs};
+                        false ->
+                            %% not enough responses, must be a timeout
+                            State#state{exp_result = timeout, num_oks = Oks, num_errs = Errs}
+                    end;
+                [{_Idx, timeout}|Rest] ->
+                    expect(Rest, State, NotFounds, Oks, PROks, DelOks, Errs, Heads);
+                [{Idx, notfound}|Rest] ->
+                    PRInc = case lists:keyfind(Idx, 1, [{Index, Primacy} ||
+                                {{Index, _Pid}, Primacy} <- Preflist]) of
+                        {Idx, primary} ->
+                            1;
+                        _ ->
+                            0
+                    end,
                     case NotFoundIsOk of
                         true ->
-                            expect(Rest, State, NotFounds, Oks + 1, DelOks, Errs, Heads);
+                            expect(Rest, State, NotFounds, Oks + 1, PROks +
+                                PRInc, DelOks, Errs, Heads);
                         false ->
-                            expect(Rest, State, NotFounds + 1, Oks, DelOks, Errs, Heads)
+                            expect(Rest, State, NotFounds + 1, Oks, PROks, DelOks, Errs, Heads)
                     end;
-                [error|Rest] ->
-                    expect(Rest, State, NotFounds, Oks, DelOks, Errs + 1, Heads);
-                [{ok,Lineage}|Rest] ->
+                [{_Idx, error}|Rest] ->
+                    expect(Rest, State, NotFounds, Oks, PROks, DelOks, Errs + 1, Heads);
+                [{Idx, {ok,Lineage}}|Rest] ->
+                    PRInc = case lists:keyfind(Idx, 1, [{Index, Primacy} ||
+                                {{Index, _Pid}, Primacy} <- Preflist]) of
+                        {Idx, primary} ->
+                            1;
+                        _ ->
+                            0
+                    end,
                     IncDelOks = length([xx || {Lineage1, deleted} <- Deleted, Lineage1 == Lineage]),
-                    expect(Rest, State, NotFounds, Oks + 1, DelOks + IncDelOks, Errs,
+                    expect(Rest, State, NotFounds, Oks + 1, PROks + PRInc, DelOks + IncDelOks, Errs,
                            merge_heads(Lineage, Heads))
             end
     end.

--- a/test/put_fsm_eqc.erl
+++ b/test/put_fsm_eqc.erl
@@ -81,7 +81,7 @@ eqc_test_() ->
                                                             []}, 5)),
         %% Run the quickcheck tests
         {timeout, 60000, % do not trust the docs - timeout is in msec
-         ?_assertEqual(true, quickcheck(numtests(1000, ?QC_OUT(prop_basic_put()))))}
+         ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(50, ?QC_OUT(prop_basic_put()))))}
        ]
       }
      ]
@@ -143,15 +143,24 @@ cleanup(started) ->
 prepare() ->
     fsm_eqc_util:start_mock_servers(),
     start_javascript().
-    
+
 test() ->
     test(100).
 
 test(N) ->
-    quickcheck(numtests(N, prop_basic_put())).
+    State = setup(),
+    try quickcheck(numtests(N, prop_basic_put()))
+    after
+        cleanup(State)
+    end.
 
 check() ->
-    check(prop_basic_put(), current_counterexample()).
+    State = setup(),
+    try check(prop_basic_put(), current_counterexample())
+    after
+        cleanup(State)
+    end.
+
 
 %%====================================================================
 %% Generators
@@ -286,8 +295,10 @@ prop_basic_put() ->
 
         N = length(VPutResp),
         {PW, RealPW} = pw_val(N, 1000000, PWSeed),
-        {W, RealW} = w_dw_val(N, 1000000, WSeed),
-        {DW, RealDW}  = w_dw_val(N, RealW, DWSeed),
+        %% DW is always at least 1 because of coordinating puts
+        {DW, RealDW}  = w_dw_val(N, 1, DWSeed),
+        %% W can be 0
+        {W, RealW0} = w_dw_val(N, 0, WSeed),
 
         %% {Q, _Ring, NodeStatus} = fsm_eqc_util:mock_ring(N + NQdiff, NodeStatus0), 
 
@@ -347,8 +358,12 @@ prop_basic_put() ->
         %% Work out the expected results.  Have to determine the effective dw
         %% the FSM would have used to know when it would have stopped processing responses
         %% and returned to the client.
-        EffDW = get_effective_dw(RealDW, Options, Postcommit),
-        ExpectObject = expect_object(H, RealW, EffDW, AllowMult),
+        EffDW0 = get_effective_dw(RealDW, Options, Postcommit),
+
+        EffDW = erlang:max(EffDW0, RealPW),
+        RealW = erlang:max(EffDW, RealW0),
+
+        ExpectObject = expect_object(H, RealW, EffDW, RealPW, AllowMult, PL2),
         {Expected, ExpectedPostCommits, ExpectedVnodePuts} = 
             expect(VPutResp, H, N, PW, RealPW, W, RealW, DW, EffDW, Options,
                    Precommit, Postcommit, ExpectObject, PL2),
@@ -367,8 +382,12 @@ prop_basic_put() ->
                                    {ok, RetObj, Info0} ->
                                        {{ok, RetObj}, Info0};
                                    {error, Reason, Info0} ->
-                                       {{error, Reason}, Info0}
-                               end,                                                 
+                                       {{error, Reason}, Info0};
+                                   {error, Reason, Info0, Info1} ->
+                                       {{error, Reason, Info0, Info1}, undefined};
+                                   {error, Reason, Info0, Info1, _Info2} ->
+                                       {{error, Reason, Info0, Info1}, undefined}
+                               end,
 
         ?WHENFAIL(
            begin
@@ -522,7 +541,7 @@ expect(VPutResp, H, N, PW, RealPW, W, RealW, DW, EffDW, Options,
             DW =:= garbage ->
                 {{error, {dw_val_violation, garbage}}, 0};
 
-            RealW > N orelse EffDW > N orelse RealPW > N ->
+            RealW > N orelse EffDW > N orelse RealPW > N  ->
                 {{error, {n_val_violation, N}}, 0};
 
             RealPW > NumPrimaries ->
@@ -550,12 +569,15 @@ expect(VPutResp, H, N, PW, RealPW, W, RealW, DW, EffDW, Options,
                     [{w, _, _}, {fail, _, _} | _] ->
                         {maybe_add_robj({error, local_put_failed}, ReturnObj, Precommit, Options), VPuts};
                     _ ->
-                        {expect(HNoTimeout, {H, N, RealW, EffDW, 0, 0, 0, ReturnObj, Precommit}, Options), 
+                        
+                        {expect(HNoTimeout, {H, N, RealW, EffDW, RealPW, 0, 0, 0, 0, ReturnObj, Precommit, PL2}, Options), 
                          VPuts}
                 end
         end,
     ExpectPostcommit = case {ExpectResult, Postcommit} of
                            {{error, _}, _} ->
+                               [];
+                           {{error, _, _, _}, _} ->
                                [];
                            {timeout, _} ->
                                [];
@@ -569,7 +591,7 @@ expect(VPutResp, H, N, PW, RealPW, W, RealW, DW, EffDW, Options,
                        end,
     {ExpectResult, ExpectPostcommit, ExpectVnodePuts}.
 
-expect([], {_H, _N, _W, _DW, _NumW, _NumDW, _NumFail, RObj, Precommit}=S,
+expect([], {_H, _N, _W, _DW, _PW, _NumW, _NumDW, _NumPW, _NumFail, RObj, Precommit, _PL}=S,
       Options) ->
     case enough_replies(S) of % this handles W=0 case
         {true, Expect} ->
@@ -577,9 +599,9 @@ expect([], {_H, _N, _W, _DW, _NumW, _NumDW, _NumFail, RObj, Precommit}=S,
         false ->
             maybe_add_robj({error, timeout}, RObj, Precommit, Options)
     end;
-expect([{w, _, _}|Rest], {H, N, W, DW, NumW, NumDW, NumFail, RObj, Precommit},
+expect([{w, _Idx, _}|Rest], {H, N, W, DW, PW, NumW, NumDW, NumPW,  NumFail, RObj, Precommit, PL},
       Options) ->
-    S = {H, N, W, DW, NumW + 1, NumDW, NumFail, RObj, Precommit},
+    S = {H, N, W, DW, PW, NumW + 1, NumDW, NumPW, NumFail, RObj, Precommit, PL},
 
     case enough_replies(S) of
         {true, Expect} ->
@@ -588,9 +610,12 @@ expect([{w, _, _}|Rest], {H, N, W, DW, NumW, NumDW, NumFail, RObj, Precommit},
         false ->
             expect(Rest, S, Options)
     end;
-expect([DWReply|Rest], {H, N, W, DW, NumW, NumDW, NumFail, RObj, Precommit},
+expect([DWReply|Rest], {H, N, W, DW, PW, NumW, NumDW, NumPW, NumFail, RObj, Precommit, PL},
        Options) when element(1, DWReply) == dw->
-    S = {H, N, W, DW, NumW, NumDW + 1, NumFail, RObj, Precommit},
+    Idx = element(2, DWReply),
+    POK = primacy(Idx, PL),
+
+    S = {H, N, W, DW, PW, NumW, NumDW + 1, NumPW+POK, NumFail, RObj, Precommit, PL},
     case enough_replies(S) of
         {true, Expect} ->
             maybe_add_robj(Expect, RObj, Precommit, Options);
@@ -598,12 +623,12 @@ expect([DWReply|Rest], {H, N, W, DW, NumW, NumDW, NumFail, RObj, Precommit},
             expect(Rest, S, Options)
     end;
 %% Fail on coordindating vnode - request fails
-expect([{fail, {1, _}, _}|_Rest], {_H, _N, _W, _DW, _NumW, _NumDW, _NumFail, RObj, Precommit},
+expect([{fail, {1, _}, _}|_Rest], {_H, _N, _W, _DW, _PW, _NumW, _NumDW, _NumPW, _NumFail, RObj, Precommit, _PL},
        Options) ->
     maybe_add_robj({error, too_many_fails}, RObj, Precommit, Options);
-expect([{fail, _, _}|Rest], {H, N, W, DW, NumW, NumDW, NumFail, RObj, Precommit},
+expect([{fail, _, _}|Rest], {H, N, W, DW, PW, NumW, NumDW, NumPW, NumFail, RObj, Precommit, PL},
        Options) ->
-    S = {H, N, W, DW, NumW, NumDW, NumFail + 1, RObj, Precommit},
+    S = {H, N, W, DW, PW, NumW, NumDW, NumPW, NumFail + 1, RObj, Precommit, PL},
     case enough_replies(S) of
         {true, Expect} ->
             maybe_add_robj(Expect, RObj, Precommit, Options);
@@ -613,29 +638,32 @@ expect([{fail, _, _}|Rest], {H, N, W, DW, NumW, NumDW, NumFail, RObj, Precommit}
 expect([{{timeout,_Stage}, _, _}|Rest], S, Options) ->
     expect(Rest, S, Options).
 
-expect_object(H, W, DW, AllowMult) ->
-    expect_object(filter_timeouts(H), W, DW, AllowMult, 0, 0, []).
+expect_object(H, W, DW, PW, AllowMult, PL) ->
+    expect_object(filter_timeouts(H), W, DW, PW, AllowMult, PL, 0, 0, 0, []).
 
 %% Once W and DW are met, reconcile the returned object
-expect_object([], _W, _DW, _AllowMult, _NumW, _NumDW, _Objs) ->
+expect_object([], _W, _DW, _PW, _AllowMult, _PL, _NumW, _NumDW, _NumPW, _Objs) ->
     noreply;
-expect_object([{w,_,_} | H], W, DW, AllowMult, NumW, NumDW, Objs) ->
-    case NumW+1 >= W andalso NumDW >= DW andalso Objs /= [] of
+expect_object([{w,_,_} | H], W, DW, PW, AllowMult, PL, NumW, NumDW, NumPW, Objs) ->
+    case NumW+1 >= W andalso NumDW >= DW andalso
+            Objs /= [] andalso NumPW >= PW of
         true ->
             riak_object:reconcile(Objs, AllowMult);
         false ->
-            expect_object(H, W, DW, AllowMult, NumW + 1, NumDW, Objs)
+            expect_object(H, W, DW, PW, AllowMult, PL, NumW + 1, NumDW, NumPW, Objs)
     end;
  %%   expect_object(H, W, DW, AllowMult, NumW + 1, NumDW, Objs);
-expect_object([{dw,_,Obj, _} | H], W, DW, AllowMult, NumW, NumDW, Objs) ->
-    case NumW >= W andalso NumDW +1 >= DW of
+expect_object([{dw,Idx,Obj, _} | H], W, DW,  PW, AllowMult, PL, NumW, NumDW, NumPW, Objs) ->
+    POK = primacy(Idx, PL),
+    case NumW >= W andalso NumDW +1 >= DW andalso NumPW+POK >= PW of
         true ->
             riak_object:reconcile([Obj | Objs], AllowMult);
         false ->
-            expect_object(H, W, DW, AllowMult, NumW, NumDW + 1, [Obj | Objs])
+            expect_object(H, W, DW, PW, AllowMult, PL, NumW, NumDW + 1,
+                NumPW+POK, [Obj | Objs])
     end;
-expect_object([_ | H], W, DW, AllowMult, NumW, NumDW, Objs) ->
-    expect_object(H, W, DW, AllowMult, NumW, NumDW, Objs).
+expect_object([_ | H], W, DW, PW, AllowMult, PL, NumW, NumDW, NumPW, Objs) ->
+    expect_object(H, W, DW, PW, AllowMult, PL, NumW, NumDW, NumPW, Objs).
 
 %% Work out W and DW given a seed.
 %% Generate a value from 0..N+1
@@ -643,7 +671,7 @@ w_dw_val(_N, _Min, garbage) ->
     {garbage, 1000000};
 w_dw_val(N, Min, Seed) when is_number(Seed) ->
     Val = Seed rem (N + 2),
-    {Val, erlang:max(1, erlang:min(Min, Val))};
+    {Val, erlang:max(1, erlang:max(Min, Val))};
 w_dw_val(N, Min, Seed) ->
     Val = case Seed of
               one -> 1;
@@ -651,7 +679,17 @@ w_dw_val(N, Min, Seed) ->
               X when X == quorum; X == default; X == missing -> (N div 2) + 1;
               _ -> Seed
           end,
-    {Seed, erlang:max(1, erlang:min(Min, Val))}.
+    {Seed, erlang:max(Min, Val)}.
+
+%% Is the given index a primary index accoring to the preflist?
+primacy(Idx, Preflist) ->
+    case lists:keyfind(Idx, 1, [{Index, Primacy} ||
+                                   {{Index, _Pid}, Primacy} <- Preflist]) of
+        {Idx, primary} ->
+            1;
+        _ ->
+            0
+    end.
 
 %% Work out W and DW given a seed.
 %% Generate a value from 0..N+1
@@ -700,23 +738,25 @@ filter_timeouts(H) ->
                     (_) -> true
                  end, H).
 
-enough_replies({_H, N, W, DW, NumW, NumDW, NumFail, _RObj, _Precommit}) ->
-    MaxWFails =  N - W,
-    MaxDWFails =  N - DW,
-    if
-        NumW >= W andalso NumDW >= DW ->
-            {true, ok};
+%% All quorum satisfied
+enough_replies({_H, _N, W, DW, PW, NumW, NumDW, NumPW, _NumFail, _RObj, _Precommit, _PL}) when
+      NumW >= W, NumDW >= DW, NumPW >= PW ->
+    {true, ok};
+%% Too many failures to reach PW & PW >= DW
+enough_replies({_H, N, _W, DW, PW, _NumW, _NumDW, NumPW, NumFail, _RObj, _Precommit, _PL}) when
+      NumFail > N - PW, PW >= DW ->
+    {true, {error, pw_val_unsatisfied, PW, NumPW}};
+%% Too many failures to reach DW
+enough_replies({_H, N, _W, DW, _PW, _NumW, NumDW, _NumPW, NumFail, _RObj, _Precommit, _PL}) when
+      NumFail > N - DW ->
+    {true, {error, dw_val_unsatisfied, DW, NumDW}};
+%% Got N responses, but not PW
+enough_replies({_H, N, _W, _DW, PW, _NumW, NumDW, NumPW, NumFail, _RObj, _Precommit, _PL}) when
+      NumFail + NumDW >= N, NumPW < PW ->
+    {true, {error, pw_val_unsatisfied, PW, NumPW}};
+enough_replies(_) ->
+    false.
 
-        NumW < W andalso NumFail > MaxWFails ->
-            {true, {error, too_many_fails}};
-
-        NumW >= W andalso NumFail > MaxDWFails ->
-            {true, {error, too_many_fails}};
-
-        true ->
-            false
-    end.
- 
 maybe_add_robj(ok, RObj, Precommit, Options) ->
     case precommit_should_fail(Precommit, Options) of
         {true, Expect} ->

--- a/test/put_fsm_eqc.erl
+++ b/test/put_fsm_eqc.erl
@@ -745,15 +745,15 @@ enough_replies({_H, _N, W, DW, PW, NumW, NumDW, NumPW, _NumFail, _RObj, _Precomm
 %% Too many failures to reach PW & PW >= DW
 enough_replies({_H, N, _W, DW, PW, _NumW, _NumDW, NumPW, NumFail, _RObj, _Precommit, _PL}) when
       NumFail > N - PW, PW >= DW ->
-    {true, {error, pw_val_unsatisfied, PW, NumPW}};
+    {true, {error, {pw_val_unsatisfied, PW, NumPW}}};
 %% Too many failures to reach DW
 enough_replies({_H, N, _W, DW, _PW, _NumW, NumDW, _NumPW, NumFail, _RObj, _Precommit, _PL}) when
       NumFail > N - DW ->
-    {true, {error, dw_val_unsatisfied, DW, NumDW}};
+    {true, {error, {dw_val_unsatisfied, DW, NumDW}}};
 %% Got N responses, but not PW
 enough_replies({_H, N, _W, _DW, PW, _NumW, NumDW, NumPW, NumFail, _RObj, _Precommit, _PL}) when
       NumFail + NumDW >= N, NumPW < PW ->
-    {true, {error, pw_val_unsatisfied, PW, NumPW}};
+    {true, {error, {pw_val_unsatisfied, PW, NumPW}}};
 enough_replies(_) ->
     false.
 


### PR DESCRIPTION
Originally, PR/PW simply checked, in the validate phase of the GET/PUT
FSM that the required number of primaries were online.

However, that was insufficient. Consider PW=2, PR=2, N=3 case; if 2 primaries
are online. You do the write, but one primary and one fallback receive
the write, the third write fails (but you've already returned a result
to the client, because 2 writes succeeded). Now, when you go to read
that key, 2 primaries are still online, but you read from the primary
that just replaced the fallback and the primary that failed the write
before. Congratulations, you just failed to read-your-own-writes.

It gets worse, even. Because the node_watcher can lag behind the actual
up/down state of a node, especially if the node kernel panics or has its
NIC unplugged, primaries can be reported up for some time after they've
stopped responding (until the distributed erlang connection closes).
This means that its even easier to fail PR/PW but still have the FSM
pass the validation stage. And since R and PR are unrelated, even PW=N
could spuriously validate (if R < PR).

The solution to all this is to simply use the preflist to check we get
the required number of responses from a primary before the FSM will
return. However, this required significant modification to the
Quickcheck tests. Additionally, some simple sanity check eunit tests
were added. Most of the actual changes in this branch are just
EQC/Eunit changes and refactoring.

This also means that PR/PW will now _block_ a response from returning
until they've been satisfied. Thusly, PR=2 now will wait for at least 2
replies, possibly all N if necessary, to satisfy the constraint, meaning
you don't need to specify PR _and_ R anymore. The same is true for PW,
except that PW waits for DW responses, not W responses, to satisfy the
constraint.

Additionally, the rules on how DW relates to W have been changed, DW is
always at least 1 (for the coordinating put), but it is no longer
demoted to match W.
