### PR TITLE
Make AAE default to 'off' when not configured

### DIFF
--- a/src/riak_kv.app.src
+++ b/src/riak_kv.app.src
@@ -36,8 +36,8 @@
          %% use the legacy routines for tracking kv stats
          {legacy_stats, true},
 
-         %% Enable active anti-entropy
-         {anti_entropy, {on, []}},
+         %% Disable active anti-entropy by default
+         {anti_entropy, {off, []}},
 
          %% Allow Erlang MapReduce functions to be specified as
          %% strings.


### PR DESCRIPTION
The intention of this commit is to make AAE be disabled by default
when performing an in-place upgrade of Riak, but be enabled by default
for new installs.

This change disables AAE when missing from the top-level app.config.
In Riak, the top-level app.config defaults to having AAE enabled, thus
overriding the default. However, users performing an in-place rolling
upgrade of Riak maintain their existing app.config which is missing
the override. Users who want to enable AAE after an upgrade will need
to add the appropriate settings to their app.config.
