### PR TITLE
provide a Location header for the same api version on POST

### DIFF
--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -572,11 +572,11 @@ post_is_create(RD, Ctx) ->
 %% @doc Choose the Key for the document created during a bucket-level POST.
 %%      This function also sets the Location header to generate a
 %%      201 Created response.
-create_path(RD, Ctx=#ctx{prefix=P, bucket=B}) ->
+create_path(RD, Ctx=#ctx{prefix=P, bucket=B, api_version=V}) ->
     K = riak_core_util:unique_id_62(),
     {K,
      wrq:set_resp_header("Location",
-                         lists:append(["/",P,"/",binary_to_list(B),"/",K]),
+                         riak_kv_wm_utils:format_uri(B, K, P, V),
                          RD),
      Ctx#ctx{key=list_to_binary(K)}}.
 

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -32,6 +32,7 @@
          vclock_header/1,
          encode_vclock/1,
          format_links/3,
+         format_uri/4,
          encode_value/1,
          accept_value/2,
          any_to_list/1,
@@ -175,18 +176,19 @@ format_links([{Bucket, Key, Tag}|Rest], Prefix, APIVersion, Acc) ->
     Bucket1 = mochiweb_util:quote_plus(Bucket),
     Key1 = mochiweb_util:quote_plus(Key),
     Tag1 = mochiweb_util:quote_plus(Tag),
-    Val = 
-        case APIVersion of 
-            1 ->
-                io_lib:format("</~s/~s/~s>; riaktag=\"~s\"",
-                              [Prefix, Bucket1, Key1, Tag1]);
-            2 ->
-                io_lib:format("</buckets/~s/keys/~s>; riaktag=\"~s\"",
-                          [Bucket1, Key1, Tag1])
-        end,
+    Val = io_lib:format("<~s>; riaktag=\"~s\"",
+                        [format_uri(Bucket1, Key1, Prefix, APIVersion),
+                         Tag1]),
     format_links(Rest, Prefix, APIVersion, [{?HEAD_LINK, Val}|Acc]);
 format_links([], _Prefix, _APIVersion, Acc) ->
     Acc.
+
+%% @doc Format the URI for a bucket/key correctly for the api version
+%% used. (APIVersion is the final parameter.)
+format_uri(Bucket, Key, Prefix, 1) ->
+    io_lib:format("/~s/~s/~s", [Prefix, Bucket, Key]);
+format_uri(Bucket, Key, _Prefix, 2) ->
+    io_lib:format("/buckets/~s/keys/~s", [Bucket, Key]).
 
 %% @spec get_ctype(dict(), term()) -> string()
 %% @doc Work out the content type for this object - use the metadata if provided


### PR DESCRIPTION
If a POST comes in to /buckets/B/keys, the Location header generated
should be of the form /buckets/B/keys/K. If the post arrived at /riak/B,
the Location should be /riak/B/K.

This PR addresses @seancribbs concern in #432.

A test for this behavior is provided in basho/riak_test#205.
