### PR TITLE
Remove Link headers from bucket and key lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ priv/*
 doc
 test.*-temp-data
 ebin
+/.eqc-info
+/current_counterexample.eqc

--- a/src/riak_kv_wm_keylist.erl
+++ b/src/riak_kv_wm_keylist.erl
@@ -128,9 +128,7 @@ encodings_provided(RD, Ctx) ->
 %%      is specified, keys will be streamed back to the client in JSON chunks
 %%      like so: {"keys":[Key1, Key2,...]}.
 %%      A Link header will also be added to the response by this function
-%%      if the keys are included in the JSON object.  The Link header
-%%      will include links to all keys in the bucket, with the property
-%%      "rel=contained".
+%%      if the keys are included in the JSON object.
 produce_bucket_body(RD, #ctx{client=Client,
                              bucket=Bucket,
                              allow_props_param=AllowProps}=Ctx) ->

--- a/src/riak_kv_wm_keylist.erl
+++ b/src/riak_kv_wm_keylist.erl
@@ -127,8 +127,6 @@ encodings_provided(RD, Ctx) ->
 %%      "keys=false" query param is specified. If "keys=stream" query param
 %%      is specified, keys will be streamed back to the client in JSON chunks
 %%      like so: {"keys":[Key1, Key2,...]}.
-%%      A Link header will also be added to the response by this function
-%%      if the keys are included in the JSON object.
 produce_bucket_body(RD, #ctx{client=Client,
                              bucket=Bucket,
                              allow_props_param=AllowProps}=Ctx) ->
@@ -168,8 +166,6 @@ produce_bucket_body(RD, #ctx{client=Client,
             {ok, KeyList} = Client:list_keys(Bucket),
             JsonKeys = mochijson2:encode({struct, BucketPropsJson ++
                                               [{?Q_KEYS, KeyList}]}),
-
-            %% Create a new RD with link headers for each key...
             {JsonKeys, RD, Ctx};
         _ ->
             JsonProps = mochijson2:encode({struct, BucketPropsJson}),

--- a/src/riak_kv_wm_keylist.erl
+++ b/src/riak_kv_wm_keylist.erl
@@ -131,13 +131,10 @@ encodings_provided(RD, Ctx) ->
 %%      if the keys are included in the JSON object.  The Link header
 %%      will include links to all keys in the bucket, with the property
 %%      "rel=contained".
-produce_bucket_body(RD, Ctx) ->
-    APIVersion = Ctx#ctx.api_version,
-    Prefix = Ctx#ctx.prefix,
-    Client = Ctx#ctx.client,
-    Bucket = Ctx#ctx.bucket,
-
-    IncludeBucketProps = (Ctx#ctx.allow_props_param == true)
+produce_bucket_body(RD, #ctx{client=Client,
+                             bucket=Bucket,
+                             allow_props_param=AllowProps}=Ctx) ->
+    IncludeBucketProps = (AllowProps == true)
         andalso (wrq:get_qs_value(?Q_PROPS, RD) /= ?Q_FALSE),
 
     BucketPropsJson =
@@ -171,15 +168,11 @@ produce_bucket_body(RD, Ctx) ->
         ?Q_TRUE ->
             %% Get the JSON response...
             {ok, KeyList} = Client:list_keys(Bucket),
-            JsonKeys1 = BucketPropsJson ++ [{?Q_KEYS, KeyList}],
-            JsonKeys2 = {struct, JsonKeys1},
-            JsonKeys3 = mochijson2:encode(JsonKeys2),
+            JsonKeys = mochijson2:encode({struct, BucketPropsJson ++
+                                              [{?Q_KEYS, KeyList}]}),
 
             %% Create a new RD with link headers for each key...
-            Links1 = [{Bucket, X, "contained"} || X <- KeyList],
-            Links2 = riak_kv_wm_utils:format_links(Links1, Prefix, APIVersion),
-            NewRD = wrq:merge_resp_headers(Links2, RD),
-            {JsonKeys3, NewRD, Ctx};
+            {JsonKeys, RD, Ctx};
         _ ->
             JsonProps = mochijson2:encode({struct, BucketPropsJson}),
             {JsonProps, RD, Ctx}


### PR DESCRIPTION
While webmachine/mochiweb only accepts headers up to 8KB in size, it has no problem producing huge headers. However, many clients cannot handle large headers. Since the same information is produced in the body of these requests anyway, we have no need to produce Link headers as well. If we want to really use HATEOAS, other things need to be reconsidered. Since we don't really have HATEOAS, let's not pretend anymore.

This also adds some ignores for EQC artifacts.
