### PR TITLE
Document the environment in the logs; advise on bad settings.

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -88,6 +88,9 @@ start(_Type, _StartArgs) ->
     %% the app is missing or packaging is broken.
     catch cluster_info:register_app(riak_kv_cinfo),
 
+    %% print out critical env limits for support/debugging purposes
+    catch riak_kv_env:doc_env(),
+
     %% Spin up supervisor
     case riak_kv_sup:start_link() of
         {ok, Pid} ->

--- a/src/riak_kv_env.erl
+++ b/src/riak_kv_env.erl
@@ -1,0 +1,226 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_env: environmental utilities.
+%%
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+
+%% @doc utility functions for interacting with the environment.
+
+-module(riak_kv_env).
+
+-export([doc_env/0]).
+
+-define(LINUX_PARAMS, [
+                       {"vm.swappiness",                        0, gte}, 
+                       {"net.core.wmem_default",          8388608, lte},
+                       {"net.core.rmem_default",          8388608, lte},
+                       {"net.core.wmem_max",              8388608, lte},
+                       {"net.core.rmem_max",              8388608, lte},
+                       {"net.core.netdev_max_backlog",      10000, lte},
+                       {"net.core.somaxconn",                4000, lte},
+                       {"net.ipv4.tcp_max_syn_backlog",     40000, lte},
+                       {"net.ipv4.tcp_fin_timeout",            15, gte},
+                       {"net.ipv4.tcp_tw_reuse",                1, eq}
+                      ]).
+
+
+doc_env() ->
+    lager:info("Environment and OS variables:"),
+    Ulimits = check_ulimits(),
+    ErlLimits = check_erlang_limits(),
+    OSLimits = case os:type() of
+                   {unix, linux}  ->
+                       check_sysctls(?LINUX_PARAMS);
+                   {unix, freebsd} ->
+                       [];
+                   {unix, sunos} ->
+                       [];
+                   _ -> 
+                       [{warn, "Unknown OS type, no platform specific info", []}]
+               end,
+    lists:map(fun({F, Fmt, Args}) ->
+                      lager:debug("Term: ~p", [{F, Fmt, Args}]),
+                      %% fake out lager a bit here
+                      F1 = case F of
+                               info -> info_msg;
+                               warn -> warning_msg;
+                               error -> error_msg
+                           end,
+                      error_logger:F1("riak_kv_env: "++Fmt, Args)
+              end, Ulimits ++ ErlLimits ++ OSLimits).
+
+%% we don't really care about anything other than cores and open files
+%% @private
+check_ulimits() ->
+    %% file ulimit
+    FileLimit0 = string:strip(os:cmd("ulimit -n"), right, $\n),
+    FLMsg = case FileLimit0 of 
+                "unlimited" -> 
+                    %% check the OS limit;
+                    OSLimit = case os:type() of 
+                                  {unix, linux} ->
+                                      string:strip(os:cmd("sysctl -n fs.file-max"), 
+                                                   right, $\n);
+                                  _ -> unknown
+                              end,
+                    case OSLimit of
+                        unknown -> 
+                            {warn, "Open file limit unlimited but actual limit "
+                             ++ "could not be ascertained", []};
+                        _ -> 
+                            test_file_limit(OSLimit)
+                    end;
+                _ -> 
+                    test_file_limit(FileLimit0)
+            end, 
+    CoreLimit0 = string:strip(os:cmd("ulimit -c"), right, $\n),
+    CLMsg = case CoreLimit0 of 
+                "unlimited" -> 
+                    {info, "No core size limit", []};
+                _  ->
+                    CoreLimit = list_to_integer(CoreLimit0),
+                    case CoreLimit == 0 of 
+                        true ->
+                            {warn, "Cores are disabled, this may " 
+                             ++ "hinder debugging", []};
+                        false ->
+                            {info, "Core size limit: ~p", [CoreLimit]}
+                    end
+            end,
+    [FLMsg, CLMsg].
+
+%% @private
+test_file_limit(FileLimit0) ->
+    FileLimit = (catch list_to_integer(FileLimit0)),
+    case FileLimit of
+        {'EXIT', {badarg,_}} -> 
+            {warn, "Open file limit was read as non-integer string: ~s",
+             [FileLimit0]};
+    
+        _ -> 
+            case FileLimit < 4096 of 
+                true ->
+                    {warn, "Open file limit of ~p is low, at least "
+                     ++ "4096 is recommended", [FileLimit]};
+                false -> 
+                    {info, "Open file limit: ~p", [FileLimit]}
+            end
+    end.      
+
+%% @private
+check_erlang_limits() ->
+    %% processes
+    PLMsg = case erlang:system_info(process_limit) of
+                PL1 when PL1 < 4096 ->
+                    {warn, "Erlang process limit of ~p is low, at least "
+                     "4096 is recommended", [PL1]};
+                PL2 ->
+                    {info,"Erlang process limit: ~p", [PL2]}
+            end,
+    %% ports
+    PortLimit = case os:getenv("ERL_MAX_PORTS") of
+                    false -> 1024;
+                    PL -> list_to_integer(PL)
+                end,
+    PortMsg = case PortLimit < 4096 of
+                  true ->
+                      %% needs to be revisited for R16+
+                      {warn, "Erlang ports limit of ~p is low, at least "
+                       "4096 is recommended", [PortLimit]};
+                  false ->
+                      {info, "Erlang ports limit: ~p", [PortLimit]}
+              end,
+    
+    %% ets tables
+    ETSLimit = case os:getenv("ERL_MAX_ETS_TABLES") of
+                   false -> 1400;
+                   Limit -> list_to_integer(Limit)
+               end,
+    ETSMsg = case ETSLimit < 8192 of
+                 true ->
+                     {warn,"ETS table count limit of ~p is low, at least "
+                      "8192 is recommended.", [ETSLimit]};
+                 false ->
+                     {info, "ETS table count limit: ~p",
+                      [ETSLimit]}
+             end,
+
+    %% fullsweep_after
+    {fullsweep_after, GCGens} = erlang:system_info(fullsweep_after),
+    GCMsg = {info, "Generations before full sweep: ~p", [GCGens]},
+
+    %% async_threads
+    TPSMsg = case erlang:system_info(thread_pool_size) of
+                 TPS1 when TPS1 < 64 ->
+                     {warn,"Thread pool size of ~p is low, at least 64 "
+                      "suggested", [TPS1]};
+                 TPS2 ->
+                     {info, "Thread pool size: ~p", [TPS2]}
+             end,
+    %% schedulers
+    Schedulers = erlang:system_info(schedulers),
+    Cores = erlang:system_info(logical_processors_available),
+    SMsg = case Schedulers /= Cores of
+               true ->
+                   {warn, "Running ~p schedulers for ~p cores, "
+                    "these should match", [Schedulers, Cores]};
+               false ->
+                   {info, "Schedulers: ~p for ~p cores", 
+                    [Schedulers, Cores]}
+    end,
+    [PLMsg, PortMsg, ETSMsg, TPSMsg, GCMsg, SMsg].
+
+%% @private
+check_sysctls(Checklist) ->
+    Fn = fun({Param, Val, Direction}) ->
+                 Output = string:strip(os:cmd("sysctl -n "++Param), right, $\n),
+                 Actual = list_to_integer(Output -- "\n"),
+                 Good = case Direction of
+                            gte -> Actual =< Val;
+                            lte -> Actual >= Val;
+                            eq -> Actual == Val
+                        end,
+                 case Good of 
+                     true ->
+                         {info , "sysctl ~s is ~p ~s ~p)", 
+                          [Param, Actual, 
+                           direction_to_word(Direction), 
+                           Val]};
+                     false -> 
+                         {warn, "sysctl ~s is ~p, should be ~s~p)", 
+                          [Param, Actual, 
+                           direction_to_word2(Direction), 
+                           Val]}
+                 end
+         end,
+    lists:map(Fn, Checklist).
+                 
+%% @private
+direction_to_word(Direction) ->
+    case Direction of 
+        gte -> "greater than or equal to";
+        lte -> "lesser than or equal to";
+        eq  -> "equal to"
+    end.
+
+%% @private
+direction_to_word2(Direction) ->
+    case Direction of 
+        gte -> "no more than ";
+        lte -> "at least ";
+        eq  -> ""
+    end.


### PR DESCRIPTION
Warning users in the shell is distracting and potentially inaccurate.  This commit captures a variety of system and erlang variables and puts them into the logs, along with warnings when they're too low or not right.

This is meant to address riak issue 278: https://github.com/basho/riak/issues/278

An example of the output on an untuned linux VM:

```
2013-03-04 11:10:55.342 [info] <0.290.0>@riak_kv_app:doc_env:285 Environment and OS variables:
2013-03-04 11:10:55.350 [info] <0.272.0>@riak_core:wait_for_application:444 Wait complete for application riak_pipe (0 seconds)
2013-03-04 11:10:55.440 [info] <0.290.0> Open file limit: 4096
2013-03-04 11:10:55.442 [info] <0.290.0> Core limit: 4096
2013-03-04 11:10:55.446 [info] <0.290.0> Open file limit: 32768
2013-03-04 11:10:55.446 [info] <0.290.0> Erlang ports limit: 4096
2013-03-04 11:10:55.447 [info] <0.290.0> ETS table count limit: 8192
2013-03-04 11:10:55.448 [info] <0.290.0> Thread pool size: 64
2013-03-04 11:10:55.448 [info] <0.290.0> Generations before full sweep: 0
2013-03-04 11:10:55.451 [info] <0.290.0> Schedulers: 1 for 1 cores
2013-03-04 11:10:55.451 [warning] <0.290.0> sysctl vm.swappiness is 60, should be no more than 0)
2013-03-04 11:10:55.452 [warning] <0.290.0> sysctl net.core.wmem_default is 229376, should be at least 8388608)
2013-03-04 11:10:55.452 [warning] <0.290.0> sysctl net.core.rmem_default is 229376, should be at least 8388608)
2013-03-04 11:10:55.455 [warning] <0.290.0> sysctl net.core.wmem_max is 131071, should be at least 8388608)
2013-03-04 11:10:55.455 [warning] <0.290.0> sysctl net.core.rmem_max is 131071, should be at least 8388608)
2013-03-04 11:10:55.456 [warning] <0.290.0> sysctl net.core.netdev_max_backlog is 1000, should be at least 10000)
2013-03-04 11:10:55.459 [warning] <0.290.0> sysctl net.core.somaxconn is 128, should be at least 4000)
2013-03-04 11:10:55.459 [warning] <0.290.0> sysctl net.ipv4.tcp_max_syn_backlog is 512, should be at least 40000)
2013-03-04 11:10:55.460 [warning] <0.290.0> sysctl net.ipv4.tcp_fin_timeout is 60, should be no more than 15)
2013-03-04 11:10:55.463 [warning] <0.290.0> sysctl net.ipv4.tcp_tw_reuse is 0, should be 1)
```
