### PR TITLE
vclock capability

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -144,6 +144,10 @@ start(_Type, _StartArgs) ->
                                           [v1, v0],
                                           v0),
 
+            riak_core_capability:register({riak_kv, vclock_encoding},
+                                          [encode_zlib, encode_raw],
+                                          encode_zlib), 
+
             %% Go ahead and mark the riak_kv service as up in the node watcher.
             %% The riak_core_ring_handler blocks until all vnodes have been started
             %% synchronously.

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -144,7 +144,7 @@ start(_Type, _StartArgs) ->
                                           [v1, v0],
                                           v0),
 
-            riak_core_capability:register({riak_kv, vclock_encoding},
+            riak_core_capability:register({riak_kv, vclock_data_encoding},
                                           [encode_zlib, encode_raw],
                                           encode_zlib), 
 

--- a/src/riak_kv_pb_object.erl
+++ b/src/riak_kv_pb_object.erl
@@ -309,11 +309,11 @@ erlify_rpbvc(undefined) ->
 erlify_rpbvc(<<>>) ->
     vclock:fresh();
 erlify_rpbvc(PbVc) ->
-    riak_kv_wm_utils:vclock_to_term(PbVc).
+    binary_to_term(riak_object:decode_vclock(PbVc)).
 
 %% Convert a vector clock to protocol buffers
 pbify_rpbvc(Vc) ->
-    riak_kv_wm_utils:term_to_vclock(Vc).
+    riak_object:encode_vclock(term_to_binary(Vc)).       
 
 %% ===================================================================
 %% Tests

--- a/src/riak_kv_pb_object.erl
+++ b/src/riak_kv_pb_object.erl
@@ -313,7 +313,7 @@ erlify_rpbvc(PbVc) ->
 
 %% Convert a vector clock to protocol buffers
 pbify_rpbvc(Vc) ->
-    riak_object:encode_vclock(term_to_binary(Vc)).       
+    riak_object:encode_vclock(term_to_binary(Vc)).
 
 %% ===================================================================
 %% Tests

--- a/src/riak_kv_pb_object.erl
+++ b/src/riak_kv_pb_object.erl
@@ -309,11 +309,11 @@ erlify_rpbvc(undefined) ->
 erlify_rpbvc(<<>>) ->
     vclock:fresh();
 erlify_rpbvc(PbVc) ->
-    binary_to_term(zlib:unzip(PbVc)).
+    riak_kv_wm_utils:vclock_to_term(PbVc).
 
 %% Convert a vector clock to protocol buffers
 pbify_rpbvc(Vc) ->
-    zlib:zip(term_to_binary(Vc)).
+    riak_kv_wm_utils:term_to_vclock(Vc).
 
 %% ===================================================================
 %% Tests

--- a/src/riak_kv_pb_object.erl
+++ b/src/riak_kv_pb_object.erl
@@ -309,11 +309,11 @@ erlify_rpbvc(undefined) ->
 erlify_rpbvc(<<>>) ->
     vclock:fresh();
 erlify_rpbvc(PbVc) ->
-    binary_to_term(riak_object:decode_vclock(PbVc)).
+    riak_object:decode_vclock(PbVc).
 
 %% Convert a vector clock to protocol buffers
 pbify_rpbvc(Vc) ->
-    riak_object:encode_vclock(term_to_binary(Vc)).
+    riak_object:encode_vclock(Vc).
 
 %% ===================================================================
 %% Tests

--- a/src/riak_kv_wm_link_walker.erl
+++ b/src/riak_kv_wm_link_walker.erl
@@ -404,7 +404,7 @@ multipart_encode_body(RiakObject, Ctx) ->
     APIVersion = Ctx#ctx.api_version,
     Prefix = Ctx#ctx.prefix,
     [{MD, V}|Rest] = riak_object:get_contents(RiakObject),
-    {VHead, Vclock} = riak_kv_wm_utils:vclock_header(RiakObject),
+    {VHead, Vclock} = riak_object:vclock_header(RiakObject),
     [VHead,": ",Vclock,"\r\n",
 
      case APIVersion of

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -841,7 +841,7 @@ encode_vclock_header(RD, #ctx{doc={error, {deleted, VClock}}}) ->
 %% @doc Transform the Erlang representation of the document's vclock
 %%      into something suitable for an HTTP header
 vclock_header(Doc) ->
-    EncodedVClock = riak_kv_wm_utils:encode_vclock(Doc),
+    EncodedVClock = riak_kv_wm_utils:term_to_http_vclock(Doc),
     {?HEAD_VCLOCK, EncodedVClock}.
 
 %% @spec decode_vclock_header(reqdata()) -> vclock()
@@ -851,7 +851,7 @@ vclock_header(Doc) ->
 decode_vclock_header(RD) ->
     case wrq:get_req_header(?HEAD_VCLOCK, RD) of
         undefined -> vclock:fresh();
-        Head      -> binary_to_term(riak_kv_wm_utils:decode_vclock(Head))
+        Head      -> riak_kv_wm_utils:vclock_to_term(Head)
     end.
 
 %% @spec ensure_doc(context()) -> context()
@@ -1053,7 +1053,7 @@ handle_common_error(Reason, RD, Ctx) ->
                 wrq:set_resp_header("Content-Type", "text/plain",
                     wrq:append_to_response_body(
                         io_lib:format("not found~n",[]),
-                        riak_kv_wm_utils:encode_vclock_header(RD, Ctx))),
+                        encode_vclock_header(RD, Ctx))),
                 Ctx};
         {error, {n_val_violation, N}} ->
             Msg = io_lib:format("Specified w/dw/pw values invalid for bucket"

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -834,14 +834,15 @@ encode_vclock_header(RD, #ctx{doc={ok, Doc}}) ->
     {Head, Val} = vclock_header(Doc),
     wrq:set_resp_header(Head, Val, RD);
 encode_vclock_header(RD, #ctx{doc={error, {deleted, VClock}}}) ->
-    wrq:set_resp_header(?HEAD_VCLOCK, riak_kv_wm_utils:encode_vclock(VClock), RD).
+    wrq:set_resp_header(?HEAD_VCLOCK, riak_object:encode_vclock(VClock), RD).
 
 
 %% @spec vclock_header(riak_object()) -> {Name::string(), Value::string()}
 %% @doc Transform the Erlang representation of the document's vclock
 %%      into something suitable for an HTTP header
 vclock_header(Doc) ->
-    EncodedVClock = riak_kv_wm_utils:term_to_http_vclock(Doc),
+    %% JFW: I'm slightly suspicious about this because we're dropping the initial term_to_binary(Doc):
+    EncodedVClock = binary_to_list(riak_object:encode_vclock(Doc)),
     {?HEAD_VCLOCK, EncodedVClock}.
 
 %% @spec decode_vclock_header(reqdata()) -> vclock()

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -834,8 +834,8 @@ encode_vclock_header(RD, #ctx{doc={ok, Doc}}) ->
     {Head, Val} = riak_object:vclock_header(Doc),
     wrq:set_resp_header(Head, Val, RD);
 encode_vclock_header(RD, #ctx{doc={error, {deleted, VClock}}}) ->
-    EncodedVClock = riak_object:encode_vclock(term_to_binary(VClock)),
-    wrq:set_resp_header(?HEAD_VCLOCK, binary_to_list(EncodedVClock), RD).
+    BinVClock = riak_object:encode_vclock(VClock),
+    wrq:set_resp_header(?HEAD_VCLOCK, binary_to_list(base64:encode(BinVClock)), RD).
 
 %% @spec decode_vclock_header(reqdata()) -> vclock()
 %% @doc Translate the X-Riak-Vclock header value from the request into
@@ -844,7 +844,7 @@ encode_vclock_header(RD, #ctx{doc={error, {deleted, VClock}}}) ->
 decode_vclock_header(RD) ->
     case wrq:get_req_header(?HEAD_VCLOCK, RD) of
         undefined -> vclock:fresh();
-             Head -> binary_to_term(riak_object:decode_vclock(Head))
+             Head -> riak_object:decode_vclock(base64:decode(Head))
     end.
 
 %% @spec ensure_doc(context()) -> context()

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -834,7 +834,7 @@ encode_vclock_header(RD, #ctx{doc={ok, Doc}}) ->
     {Head, Val} = riak_object:vclock_header(Doc),
     wrq:set_resp_header(Head, Val, RD);
 encode_vclock_header(RD, #ctx{doc={error, {deleted, VClock}}}) ->
-    EncodedVClock = riak_object:encode_vclock(VClock),
+    EncodedVClock = riak_object:encode_vclock(term_to_binary(VClock)),
     wrq:set_resp_header(?HEAD_VCLOCK, binary_to_list(EncodedVClock), RD).
 
 %% @spec decode_vclock_header(reqdata()) -> vclock()
@@ -844,7 +844,7 @@ encode_vclock_header(RD, #ctx{doc={error, {deleted, VClock}}}) ->
 decode_vclock_header(RD) ->
     case wrq:get_req_header(?HEAD_VCLOCK, RD) of
         undefined -> vclock:fresh();
-             Head      -> riak_object:decode_vclock(Head)
+             Head -> binary_to_term(riak_object:decode_vclock(Head))
     end.
 
 %% @spec ensure_doc(context()) -> context()

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -834,7 +834,7 @@ encode_vclock_header(RD, #ctx{doc={ok, Doc}}) ->
     {Head, Val} = riak_object:vclock_header(Doc),
     wrq:set_resp_header(Head, Val, RD);
 encode_vclock_header(RD, #ctx{doc={error, {deleted, VClock}}}) ->
-    EncodedVClock = riak_object:encode_vclock(term_to_binary(VClock)),
+    EncodedVClock = riak_object:encode_vclock(VClock),
     wrq:set_resp_header(?HEAD_VCLOCK, binary_to_list(EncodedVClock), RD).
 
 %% @spec decode_vclock_header(reqdata()) -> vclock()
@@ -844,7 +844,7 @@ encode_vclock_header(RD, #ctx{doc={error, {deleted, VClock}}}) ->
 decode_vclock_header(RD) ->
     case wrq:get_req_header(?HEAD_VCLOCK, RD) of
         undefined -> vclock:fresh();
-        Head      -> binary_to_term(riak_object:decode_vclock(Head))
+             Head      -> riak_object:decode_vclock(Head)
     end.
 
 %% @spec ensure_doc(context()) -> context()

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -834,7 +834,7 @@ encode_vclock_header(RD, #ctx{doc={ok, Doc}}) ->
     {Head, Val} = vclock_header(Doc),
     wrq:set_resp_header(Head, Val, RD);
 encode_vclock_header(RD, #ctx{doc={error, {deleted, VClock}}}) ->
-    wrq:set_resp_header(?HEAD_VCLOCK, encode_vclock(VClock), RD).
+    wrq:set_resp_header(?HEAD_VCLOCK, riak_kv_wm_utils:encode_vclock(VClock), RD).
 
 
 %% @spec vclock_header(riak_object()) -> {Name::string(), Value::string()}
@@ -843,12 +843,6 @@ encode_vclock_header(RD, #ctx{doc={error, {deleted, VClock}}}) ->
 vclock_header(Doc) ->
     EncodedVClock = riak_kv_wm_utils:encode_vclock(Doc),
     {?HEAD_VCLOCK, EncodedVClock}.
-%%JFW    {?HEAD_VCLOCK,
-%%          encode_vclock(riak_object:vclock(Doc))}.
-
-%% JFW
-%%encode_vclock(VClock) ->
-%%    binary_to_list(base64:encode(zlib:zip(term_to_binary(VClock)))).
 
 %% @spec decode_vclock_header(reqdata()) -> vclock()
 %% @doc Translate the X-Riak-Vclock header value from the request into
@@ -857,7 +851,6 @@ vclock_header(Doc) ->
 decode_vclock_header(RD) ->
     case wrq:get_req_header(?HEAD_VCLOCK, RD) of
         undefined -> vclock:fresh();
-%%JFW        Head      -> binary_to_term(zlib:unzip(base64:decode(Head)))
         Head      -> binary_to_term(riak_kv_wm_utils:decode_vclock(Head))
     end.
 

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -871,8 +871,6 @@ delete_resource(RD, Ctx=#ctx{bucket=B, key=K, client=C}) ->
         undefined -> 
             C:delete(B,K,Options);
         _ ->
-io:format("JFW: delete_resource() -- delete vclock called.~n"),
-io:format("JFW: delete_resource() decoded header: ~p~n", [decode_vclock_header(RD)]),
             C:delete_vclock(B,K,decode_vclock_header(RD),Options)
     end,
     case Result of

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -871,6 +871,8 @@ delete_resource(RD, Ctx=#ctx{bucket=B, key=K, client=C}) ->
         undefined -> 
             C:delete(B,K,Options);
         _ ->
+io:format("JFW: delete_resource() -- delete vclock called.~n"),
+io:format("JFW: delete_resource() decoded header: ~p~n", [decode_vclock_header(RD)]),
             C:delete_vclock(B,K,decode_vclock_header(RD),Options)
     end,
     case Result of

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -834,7 +834,7 @@ encode_vclock_header(RD, #ctx{doc={ok, Doc}}) ->
     {Head, Val} = riak_object:vclock_header(Doc),
     wrq:set_resp_header(Head, Val, RD);
 encode_vclock_header(RD, #ctx{doc={error, {deleted, VClock}}}) ->
-    EncodedVClock = riak_object:encode_vclock(VClock),
+    EncodedVClock = riak_object:encode_vclock(term_to_binary(VClock)),
     wrq:set_resp_header(?HEAD_VCLOCK, binary_to_list(EncodedVClock), RD).
 
 %% @spec decode_vclock_header(reqdata()) -> vclock()
@@ -844,7 +844,7 @@ encode_vclock_header(RD, #ctx{doc={error, {deleted, VClock}}}) ->
 decode_vclock_header(RD) ->
     case wrq:get_req_header(?HEAD_VCLOCK, RD) of
         undefined -> vclock:fresh();
-        Head      -> riak_object:decode_vclock(Head)
+        Head      -> binary_to_term(riak_object:decode_vclock(Head))
     end.
 
 %% @spec ensure_doc(context()) -> context()

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -32,6 +32,9 @@
          vclock_header/1,
          encode_vclock/1,
          decode_vclock/1,
+         term_to_vclock/1, 
+         vclock_to_term/1, 
+         term_to_http_vclock/1,
          format_links/3,
          format_uri/4,
          encode_value/1,
@@ -155,15 +158,13 @@ vclock_header(Doc) ->
 
 %% Fetch the preferred vclock encoding method:
 vclock_encoding_method() ->
-    EncodingMethod = riak_kv_capability:get({riak_kv, vclock_data_encoding}, encode_zlib),
-lager:info("JFW encoding method is: ~p", [EncodingMethod]),
-    EncodingMethod.
+    riak_kv_capability:get({riak_kv, vclock_data_encoding}, encode_zlib).
 
 %% Encode a vclock in accordance with our capability setting:
-encode_vclock(VClock) ->
+encode_vclock(VClock_Binary) ->
     case vclock_encoding_method() of
-        encode_zlib -> binary_to_list(base64:encode(zlib:zip(term_to_binary(VClock))));
-        encode_raw  -> binary_to_list(base64:encode(term_to_binary(VClock)))
+        encode_zlib -> base64:encode(zlib:zip(VClock_Binary));
+        encode_raw  -> base64:encode(VClock_Binary)
     end.
 
 %% Decode a vclock against our capability settings:
@@ -172,6 +173,17 @@ decode_vclock(VClock) ->
         encode_zlib -> zlib:unzip(base64:decode(VClock));
         encode_raw  -> base64:decode(VClock)
     end.
+
+%% Encode a vector clock with type conversion:
+term_to_vclock(VClock_Term) ->
+    encode_vclock(term_to_binary(VClock_Term)).
+
+%% Decode a vector clock with type conversion:
+vclock_to_term(EncodedVClock) ->
+    binary_to_term(decode_vclock(EncodedVClock)).
+
+term_to_http_vclock(VClock_Term) ->
+    binary_to_list(term_to_vclock(VClock_Term)).
 
 format_links(Links, Prefix, APIVersion) ->
     format_links(Links, Prefix, APIVersion, []).

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -29,11 +29,6 @@
          get_client_id/1,
          default_encodings/0,
          multipart_encode_body/4,
-         encode_vclock/1,
-         decode_vclock/1,
-         term_to_vclock/1, 
-         vclock_to_term/1, 
-         term_to_http_vclock/1,
          format_links/3,
          format_uri/4,
          encode_value/1,
@@ -147,37 +142,6 @@ multipart_encode_body(Prefix, Bucket, {MD, V}, APIVersion) ->
      end,
      "\r\n",
      encode_value(V)].
-
-%% Fetch the preferred vclock encoding method:
-vclock_encoding_method() ->
-    riak_core_capability:get({riak_kv, vclock_data_encoding}, encode_zlib).
-
-%% Encode a vclock in accordance with our capability setting:
-%% JFW: take a term, return binary 
-encode_vclock(VClock_Binary) ->
-    case vclock_encoding_method() of
-        encode_zlib -> base64:encode(zlib:zip(VClock_Binary));
-        encode_raw  -> base64:encode(VClock_Binary)
-    end.
-
-%% Decode a vclock against our capability settings:
-%% JFW: take a term, return vclock
-decode_vclock(VClock) ->
-    case vclock_encoding_method() of
-        encode_zlib -> zlib:unzip(base64:decode(VClock));
-        encode_raw  -> base64:decode(VClock)
-    end.
-
-%% Encode a vector clock with type conversion:
-term_to_vclock(VClock_Term) ->
-    encode_vclock(term_to_binary(VClock_Term)).
-
-%% Decode a vector clock with type conversion:
-vclock_to_term(EncodedVClock) ->
-    binary_to_term(decode_vclock(EncodedVClock)).
-
-term_to_http_vclock(VClock_Term) ->
-    binary_to_list(term_to_vclock(VClock_Term)).
 
 format_links(Links, Prefix, APIVersion) ->
     format_links(Links, Prefix, APIVersion, []).

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -153,6 +153,7 @@ vclock_encoding_method() ->
     riak_core_capability:get({riak_kv, vclock_data_encoding}, encode_zlib).
 
 %% Encode a vclock in accordance with our capability setting:
+%% JFW: take a term, return binary 
 encode_vclock(VClock_Binary) ->
     case vclock_encoding_method() of
         encode_zlib -> base64:encode(zlib:zip(VClock_Binary));
@@ -160,6 +161,7 @@ encode_vclock(VClock_Binary) ->
     end.
 
 %% Decode a vclock against our capability settings:
+%% JFW: take a term, return vclock
 decode_vclock(VClock) ->
     case vclock_encoding_method() of
         encode_zlib -> zlib:unzip(base64:decode(VClock));

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -31,6 +31,7 @@
          multipart_encode_body/4,
          vclock_header/1,
          encode_vclock/1,
+         decode_vclock/1,
          format_links/3,
          format_uri/4,
          encode_value/1,
@@ -154,7 +155,9 @@ vclock_header(Doc) ->
 
 %% Fetch the preferred vclock encoding method:
 vclock_encoding_method() ->
-    riak_kv_capability:get({riak_kv, vclock_data_encoding}, encode_zlib).
+    EncodingMethod = riak_kv_capability:get({riak_kv, vclock_data_encoding}, encode_zlib),
+lager:info("JFW encoding method is: ~p", [EncodingMethod]),
+    EncodingMethod.
 
 %% Encode a vclock in accordance with our capability setting:
 encode_vclock(VClock) ->
@@ -164,8 +167,8 @@ encode_vclock(VClock) ->
     end.
 
 %% Decode a vclock against our capability settings:
-decode_vlock(VClock) ->
-    case vlock_encoding_method() of
+decode_vclock(VClock) ->
+    case vclock_encoding_method() of
         encode_zlib -> zlib:unzip(base64:decode(VClock));
         encode_raw  -> base64:decode(VClock)
     end.

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -29,7 +29,6 @@
          get_client_id/1,
          default_encodings/0,
          multipart_encode_body/4,
-         vclock_header/1,
          encode_vclock/1,
          decode_vclock/1,
          term_to_vclock/1, 
@@ -149,16 +148,9 @@ multipart_encode_body(Prefix, Bucket, {MD, V}, APIVersion) ->
      "\r\n",
      encode_value(V)].
 
-%% @spec vclock_header(riak_object()) -> {Name::string(), Value::string()}
-%% @doc Transform the Erlang representation of the document's vclock
-%%      into something suitable for an HTTP header
-vclock_header(Doc) ->
-    {?HEAD_VCLOCK,
-        encode_vclock(riak_object:vclock(Doc))}.
-
 %% Fetch the preferred vclock encoding method:
 vclock_encoding_method() ->
-    riak_kv_capability:get({riak_kv, vclock_data_encoding}, encode_zlib).
+    riak_core_capability:get({riak_kv, vclock_data_encoding}, encode_zlib).
 
 %% Encode a vclock in accordance with our capability setting:
 encode_vclock(VClock_Binary) ->

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -427,7 +427,7 @@ from_json(Obj) ->
     Bucket = proplists:get_value(<<"bucket">>, Obj),
     Key = proplists:get_value(<<"key">>, Obj),
     VClock0 = proplists:get_value(<<"vclock">>, Obj),
-    VClock = binary_to_term(zlib:unzip(base64:decode(VClock0))),
+    VClock = riak_kv_wm_utils:decode_vclock(VClock0),
     [{struct, Values}] = proplists:get_value(<<"values">>, Obj),
     RObj0 = riak_object:new(Bucket, Key, <<"">>),
     RObj1 = riak_object:set_vclock(RObj0, VClock),

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -1000,7 +1000,6 @@ new_with_ctype_test() ->
     O = riak_object:new(<<"b">>, <<"k">>, <<"{\"a\":1}">>, "application/json"),
     ?assertEqual("application/json", dict:fetch(?MD_CTYPE, riak_object:get_metadata(O))).
 
-new_with_md_test() ->
     O = riak_object:new(<<"b">>, <<"k">>, <<"abc">>, dict:from_list([{?MD_CHARSET,"utf8"}])),
     ?assertEqual("utf8", dict:fetch(?MD_CHARSET, riak_object:get_metadata(O))).
 

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -435,7 +435,7 @@ from_json(Obj) ->
     Bucket = proplists:get_value(<<"bucket">>, Obj),
     Key = proplists:get_value(<<"key">>, Obj),
     VClock0 = proplists:get_value(<<"vclock">>, Obj),
-    VClock = riak_kv_wm_utils:decode_vclock(VClock0),
+    VClock = riak_kv_wm_utils:vclock_to_term(VClock0),
     [{struct, Values}] = proplists:get_value(<<"values">>, Obj),
     RObj0 = riak_object:new(Bucket, Key, <<"">>),
     RObj1 = riak_object:set_vclock(RObj0, VClock),

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -1001,6 +1001,7 @@ new_with_ctype_test() ->
     O = riak_object:new(<<"b">>, <<"k">>, <<"{\"a\":1}">>, "application/json"),
     ?assertEqual("application/json", dict:fetch(?MD_CTYPE, riak_object:get_metadata(O))).
 
+new_with_md_test() ->
     O = riak_object:new(<<"b">>, <<"k">>, <<"abc">>, dict:from_list([{?MD_CHARSET,"utf8"}])),
     ?assertEqual("utf8", dict:fetch(?MD_CHARSET, riak_object:get_metadata(O))).
 

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -67,7 +67,8 @@
 -export([increment_vclock/2, increment_vclock/3]).
 -export([key/1, get_metadata/1, get_metadatas/1, get_values/1, get_value/1]).
 -export([hash/1, approximate_size/2]).
--export([vclock/1, update_value/2, update_metadata/2, bucket/1, value_count/1]).
+-export([vclock/1, vclock_header/1, encode_vclock/1, decode_vclock/1]).
+-export([update_value/2, update_metadata/2, bucket/1, value_count/1]).
 -export([get_update_metadata/1, get_update_value/1, get_contents/1]).
 -export([merge/2, apply_updates/1, syntactic_merge/2]).
 -export([to_json/1, from_json/1]).
@@ -411,7 +412,7 @@ set_contents(Object=#r_object{}, MVs) when is_list(MVs) ->
 %%      into something suitable for an HTTP header
 vclock_header(Doc) ->
     {?HEAD_VCLOCK,
-        binary_to_list(riak_kv_wm_utils:encode_vclock(term_to_binary(riak_object:vclock(Doc))))}.
+        binary_to_list(encode_vclock(term_to_binary(riak_object:vclock(Doc))))}.
 
 %% @spec to_json(riak_object()) -> {struct, list(any())}
 %% @doc Converts a riak_object into its JSON equivalent
@@ -435,7 +436,7 @@ from_json(Obj) ->
     Bucket = proplists:get_value(<<"bucket">>, Obj),
     Key = proplists:get_value(<<"key">>, Obj),
     VClock0 = proplists:get_value(<<"vclock">>, Obj),
-    VClock = riak_kv_wm_utils:vclock_to_term(VClock0),
+    VClock = binary_to_term(decode_vclock(VClock0)),
     [{struct, Values}] = proplists:get_value(<<"values">>, Obj),
     RObj0 = riak_object:new(Bucket, Key, <<"">>),
     RObj1 = riak_object:set_vclock(RObj0, VClock),
@@ -567,6 +568,7 @@ syntactic_merge(CurrentObject, NewObject) ->
             end
     end.
 
+<<<<<<< HEAD
 %% @doc Get an approximation of object size by adding together the bucket, key,
 %% vectorclock, and all of the siblings. This is more complex than
 %% calling term_to_binary/1, but it should be easier on memory,
@@ -740,6 +742,31 @@ decode_maybe_binary(<<1, Bin/binary>>) ->
     Bin;
 decode_maybe_binary(<<0, Bin/binary>>) ->
     binary_to_term(Bin).
+=======
+
+%%
+%% Helpers for managing vector clock encoding and related capability:
+%%
+
+%% Fetch the preferred vclock encoding method:
+vclock_encoding_method() ->
+    riak_core_capability:get({riak_kv, vclock_data_encoding}, encode_zlib).
+
+%% Encode a vclock in accordance with our capability setting:
+-spec encode_vclock(VClock :: term()) -> binary().
+encode_vclock(VClock) ->
+    case vclock_encoding_method() of
+        encode_zlib -> base64:encode(zlib:zip(VClock));
+        encode_raw  -> base64:encode(VClock)
+    end.
+
+%% Decode a vclock against our capability settings:
+-spec decode_vclock(VClock :: term()) -> vclock:vclock().
+decode_vclock(VClock) ->
+    case vclock_encoding_method() of
+        encode_zlib -> zlib:unzip(base64:decode(VClock));
+        encode_raw  -> base64:decode(VClock)
+    end.
 
 -ifdef(TEST).
 

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -406,10 +406,18 @@ assemble_index_specs(Indexes, IndexOp) ->
 set_contents(Object=#r_object{}, MVs) when is_list(MVs) ->
     Object#r_object{contents=[#r_content{metadata=M,value=V} || {M, V} <- MVs]}.
 
+%% @spec vclock_header(riak_object()) -> {Name::string(), Value::string()}
+%% @doc Transform the Erlang representation of the document's vclock
+%%      into something suitable for an HTTP header
+vclock_header(Doc) ->
+    {?HEAD_VCLOCK,
+        binary_to_list(riak_kv_wm_utils:encode_vclock(term_to_binary(riak_object:vclock(Doc))))}.
+
+%% @spec to_json(riak_object()) -> {struct, list(any())}
 %% @doc Converts a riak_object into its JSON equivalent
 -spec to_json(riak_object()) -> {struct, list(any())}.
 to_json(Obj=#r_object{}) ->
-    {_,Vclock} = riak_kv_wm_utils:vclock_header(Obj),
+    {_,Vclock} = vclock_header(Obj),
     {struct, [{<<"bucket">>, riak_object:bucket(Obj)},
               {<<"key">>, riak_object:key(Obj)},
               {<<"vclock">>, list_to_binary(Vclock)},

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -411,8 +411,9 @@ set_contents(Object=#r_object{}, MVs) when is_list(MVs) ->
 %% @doc Transform the Erlang representation of the document's vclock
 %%      into something suitable for an HTTP header
 vclock_header(Doc) ->
-    {?HEAD_VCLOCK,
-        binary_to_list(encode_vclock(term_to_binary(riak_object:vclock(Doc))))}.
+    VClock = riak_object:vclock(Doc),
+    EncodedVClock = binary_to_list(encode_vclock(term_to_binary(VClock))), 
+    {?HEAD_VCLOCK, EncodedVClock}.
 
 %% @spec to_json(riak_object()) -> {struct, list(any())}
 %% @doc Converts a riak_object into its JSON equivalent

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -67,7 +67,7 @@
 -export([increment_vclock/2, increment_vclock/3]).
 -export([key/1, get_metadata/1, get_metadatas/1, get_values/1, get_value/1]).
 -export([hash/1, approximate_size/2]).
--export([vclock/1, vclock_header/1, encode_vclock/1, decode_vclock/1]).
+-export([vclock_encoding_method/0, vclock/1, vclock_header/1, encode_vclock/1, decode_vclock/1]).
 -export([update_value/2, update_metadata/2, bucket/1, value_count/1]).
 -export([get_update_metadata/1, get_update_value/1, get_contents/1]).
 -export([merge/2, apply_updates/1, syntactic_merge/2]).
@@ -750,11 +750,12 @@ decode_maybe_binary(<<0, Bin/binary>>) ->
 %%
 
 %% Fetch the preferred vclock encoding method:
+-spec vclock_encoding_method() -> atom().
 vclock_encoding_method() ->
     riak_core_capability:get({riak_kv, vclock_data_encoding}, encode_zlib).
 
 %% Encode a vclock in accordance with our capability setting:
--spec encode_vclock(VClock :: term()) -> binary().
+-spec encode_vclock(VClock :: base64:ascii_string() | base64:ascii_binary()) -> base64:ascii_binary().
 encode_vclock(VClock) ->
     case vclock_encoding_method() of
         encode_zlib -> base64:encode(zlib:zip(VClock));
@@ -762,7 +763,8 @@ encode_vclock(VClock) ->
     end.
 
 %% Decode a vclock against our capability settings:
--spec decode_vclock(VClock :: term()) -> vclock:vclock().
+%% JFW: -spec decode_vclock(VClock :: term()) -> vclock:vclock().
+-spec decode_vclock(VClock :: base64:ascii_string() | base64:ascii_binary()) -> vclock:vclock().
 decode_vclock(VClock) ->
     case vclock_encoding_method() of
         encode_zlib -> zlib:unzip(base64:decode(VClock));

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -763,7 +763,6 @@ encode_vclock(VClock) ->
     end.
 
 %% Decode a vclock against our capability settings:
-%% JFW: -spec decode_vclock(VClock :: term()) -> vclock:vclock().
 -spec decode_vclock(VClock :: base64:ascii_string() | base64:ascii_binary()) -> vclock:vclock().
 decode_vclock(VClock) ->
     case vclock_encoding_method() of


### PR DESCRIPTION
Adds a new capability to support different encoding options for vector clocks. Moves existing zlib support to a capability, implements raw encoding. The purpose is to allow users to better tune for compression or performance.
