### PR TITLE
Feature request, optionally return indexed values with keys

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -141,6 +141,10 @@ start(_Type, _StartArgs) ->
                                           [v1, v0],
                                           v0),
 
+            riak_core_capability:register({riak_kv, '2i_return_terms'},
+                                          [true, false],
+                                          false),
+
             %% Go ahead and mark the riak_kv service as up in the node watcher.
             %% The riak_core_ring_handler blocks until all vnodes have been started
             %% synchronously.

--- a/src/riak_kv_coverage_filter.erl
+++ b/src/riak_kv_coverage_filter.erl
@@ -113,10 +113,15 @@ build_item_filter(FilterInput) ->
 
 %% @private
 build_preflist_fun(Bucket, Ring) ->
-    fun(Key) ->
+    fun({Key, _Value}) ->
+            ChashKey = riak_core_util:chash_key({Bucket, Key}),
+            riak_core_ring:responsible_index(ChashKey, Ring);
+       (Key) ->
             ChashKey = riak_core_util:chash_key({Bucket, Key}),
             riak_core_ring:responsible_index(ChashKey, Ring)
     end.
+
+
 
 compose([]) ->
     none;

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -64,3 +64,4 @@
 -define(Q_STREAM, "stream").
 -define(Q_VTAG,  "vtag").
 -define(Q_RETURNBODY, "returnbody").
+-define(Q_2I_RETURNTERMS, "returnterms").


### PR DESCRIPTION
https://github.com/basho/platform_tasks/issues/34

Depends on https://github.com/basho/riak_pb/pull/34

Currently a 2i query's results are a list of keys. This change adds
an optional request parameter to pb and http that, when set, will
cause pairs of `key:index_value` to be returned as the result of
a 2i query.

Has no effect on MapReduce.

Uses capabilities for rolling upgrade
situations.
