### PR TITLE
Upgrade/Downgrade Path for 2i Bigint Bug

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,7 @@
         {eper, "0.61", {git, "git://github.com/basho/eper.git", {tag, "3280b736"}}},
         {eleveldb, "1.3.0", {git, "git://github.com/basho/eleveldb.git",
                           {tag, "1.3.0"}}},
-        {sext, "0.4.*", {git, "git://github.com/esl/sext", {tag, "0.4.1"}}},
+        {sext, "1.1", {git, "git://github.com/uwiger/sext", {tag, "1.1"}}},
         {riak_pipe, "1.3.0", {git, "git://github.com/basho/riak_pipe.git",
                                 {tag, "1.3.0"}}},
         {riak_api, "1.3.0", {git, "git://github.com/basho/riak_api.git", {tag, "1.3.0"}}}

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -36,7 +36,7 @@
          cluster_info/1,
          down/1,
          aae_status/1,
-         reformat_indices/1,
+         reformat_indexes/1,
          reload_code/1]).
 
 %% Arrow is 24 chars wide
@@ -422,17 +422,17 @@ format_timestamp(_Now, undefined) ->
 format_timestamp(Now, TS) ->
     riak_core_format:human_time_fmt("~.1f", timer:now_diff(Now, TS)).
 
-reformat_indices([]) ->
+reformat_indexes([]) ->
     start_index_reformat([]),
     io:format("index reformat started with default options~n"),
     io:format("check console.log for status information~n"),
     ok;
-reformat_indices(["--downgrade"]) ->
+reformat_indexes(["--downgrade"]) ->
     start_index_reformat([{downgrade, true}]),
     io:format("index reformat downgrade started with default options~n"),
     io:format("check console.log for status information~n"),
     ok;
-reformat_indices([ConcurrencyStr | Rest]) ->
+reformat_indexes([ConcurrencyStr | Rest]) ->
     {Valid, Opts} = try list_to_integer(ConcurrencyStr) of
                         Concurrency ->
                             BaseOpts = [{concurrency, Concurrency}],

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -36,6 +36,7 @@
          cluster_info/1,
          down/1,
          aae_status/1,
+         reformat_indices/1,
          reload_code/1]).
 
 %% Arrow is 24 chars wide
@@ -420,6 +421,51 @@ format_timestamp(_Now, undefined) ->
     "--";
 format_timestamp(Now, TS) ->
     riak_core_format:human_time_fmt("~.1f", timer:now_diff(Now, TS)).
+
+reformat_indices([]) ->
+    start_index_reformat([]),
+    io:format("index reformat started with default options~n"),
+    io:format("check console.log for status information~n"),
+    ok;
+reformat_indices(["--downgrade"]) ->
+    start_index_reformat([{downgrade, true}]),
+    io:format("index reformat downgrade started with default options~n"),
+    io:format("check console.log for status information~n"),
+    ok;
+reformat_indices([ConcurrencyStr | Rest]) ->
+    {Valid, Opts} = try list_to_integer(ConcurrencyStr) of
+                        Concurrency ->
+                            BaseOpts = [{concurrency, Concurrency}],
+                            Final = case lists:member("--downgrade", Rest) of
+                                        true -> [{downgrade, true} | BaseOpts];
+                                        false -> BaseOpts
+                                    end,
+                            {true, Final}
+                    catch
+                        _:_ ->
+                            {false, []}
+                    end,
+    case Valid of
+        true ->
+            start_index_reformat(Opts),
+            io:format("index reformat started with options: ~p~n", [Opts]),
+            io:format("check console.log for status information~n"),
+            ok;
+        false ->
+            io:format("~p is not an integer~n", [ConcurrencyStr]),
+            error
+    end.
+
+start_index_reformat(Opts) ->
+    spawn(fun() -> run_index_reformat(Opts) end).
+
+run_index_reformat(Opts) ->
+    try riak_kv_util:fix_incorrect_index_entries(Opts)
+    catch
+        Err:Reason ->
+            lager:error("index reformat crashed with error type ~p and reason: ~p",
+                        [Err, Reason])
+    end.
 
 %%%===================================================================
 %%% Private

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -594,10 +594,9 @@ fold_objects_fun(FoldObjectsFun, FilterBucket) ->
 %% Augment the fold options list if a
 %% bucket is defined.
 fold_opts(undefined, FoldOpts) ->
-    FoldOpts;
+    [{first_key, to_first_key(undefined)} | FoldOpts];
 fold_opts(Bucket, FoldOpts) ->
-    BKey = sext:encode({Bucket, <<>>}),
-    [{first_key, BKey} | FoldOpts].
+    [{first_key, to_first_key({bucket, Bucket})} | FoldOpts].
 
 
 %% @private Given a scope limiter, use sext to encode an expression

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -54,7 +54,7 @@
 
 -define(API_VERSION, 1).
 -define(CAPABILITIES, [async_fold, indexes]).
--define(FIXED_INDEXES_KEY, sext:encode(fixed_indexes)).
+-define(FIXED_INDEXES_KEY, fixed_indexes).
 
 -record(state, {ref :: reference(),
                 data_root :: string(),
@@ -192,7 +192,7 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, #state{ref=Ref,
     end.
 
 indexes_fixed(#state{ref=Ref,read_opts=ReadOpts}) ->
-    case eleveldb:get(Ref, ?FIXED_INDEXES_KEY, ReadOpts) of
+    case eleveldb:get(Ref, to_md_key(?FIXED_INDEXES_KEY), ReadOpts) of
         {ok, <<1>>} ->
             true;
         {ok, <<0>>} ->
@@ -241,7 +241,7 @@ mark_indexes_fixed(State=#state{ref=Ref, write_opts=WriteOpts}, ForUpgrade) ->
                 true -> <<1>>;
                 false -> <<0>>
             end,
-    Updates = [{put, ?FIXED_INDEXES_KEY, Value}],
+    Updates = [{put, to_md_key(?FIXED_INDEXES_KEY), Value}],
     case eleveldb:write(Ref, Updates, WriteOpts) of
         ok ->
             {ok, State#state{fixed_indexes=ForUpgrade}};
@@ -679,6 +679,11 @@ from_index_key(LKey) ->
         _ ->
             undefined
     end.
+
+%% @doc Encode a key to store partition meta-data attributes.
+to_md_key(Key) ->
+    sext:encode({md, Key}).
+
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -35,7 +35,7 @@
          drop/1,
          fix_index/4,
          mark_indexes_fixed/2,
-         set_legacy_indices/2,
+         set_legacy_indexes/2,
          fold_buckets/4,
          fold_keys/4,
          fold_objects/4,
@@ -63,8 +63,8 @@
                 read_opts = [],
                 write_opts = [],
                 fold_opts = [{fill_cache, false}],
-                fixed_indexes = false, %% true if legacy indices have be rewritten
-                legacy_indices = false %% true if new writes use legacy indices (downgrade)
+                fixed_indexes = false, %% true if legacy indexes have be rewritten
+                legacy_indexes = false %% true if new writes use legacy indexes (downgrade)
                }).
 
 
@@ -164,7 +164,7 @@ get(Bucket, Key, #state{read_opts=ReadOpts,
                  {error, term(), state()}.
 put(Bucket, PrimaryKey, IndexSpecs, Val, #state{ref=Ref,
                                                 write_opts=WriteOpts,
-                                                legacy_indices=WriteLegacy,
+                                                legacy_indexes=WriteLegacy,
                                                 fixed_indexes=FixedIndexes}=State) ->
     %% Create the KV update...
     StorageKey = to_object_key(Bucket, PrimaryKey),
@@ -251,8 +251,8 @@ mark_indexes_fixed(State=#state{ref=Ref, write_opts=WriteOpts}, ForUpgrade) ->
             {error, Reason, State}
     end.
 
-set_legacy_indices(State, WriteLegacy) ->
-    State#state{legacy_indices=WriteLegacy}.
+set_legacy_indexes(State, WriteLegacy) ->
+    State#state{legacy_indexes=WriteLegacy}.
 
 %% @doc Delete an object from the eleveldb backend
 -spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
@@ -314,7 +314,7 @@ fold_buckets(FoldBucketsFun, Acc, Opts, #state{fold_opts=FoldOpts,
                 state()) -> {ok, term()} | {async, fun()}.
 fold_keys(FoldKeysFun, Acc, Opts, #state{fold_opts=FoldOpts,
                                          fixed_indexes=FixedIdx,
-                                         legacy_indices=WriteLegacyIdx,
+                                         legacy_indexes=WriteLegacyIdx,
                                          ref=Ref}) ->
     %% Figure out how we should limit the fold: by bucket, by
     %% secondary index, or neither (fold across everything.)

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -33,7 +33,7 @@
          put/5,
          delete/4,
          drop/1,
-         fix_index/3,
+         fix_index/4,
          mark_indexes_fixed/2,
          set_legacy_indices/2,
          fold_buckets/4,
@@ -53,7 +53,7 @@
 -endif.
 
 -define(API_VERSION, 1).
--define(CAPABILITIES, [async_fold, indexes]).
+-define(CAPABILITIES, [async_fold, indexes, index_reformat]).
 -define(FIXED_INDEXES_KEY, fixed_indexes).
 
 -record(state, {ref :: reference(),
@@ -209,9 +209,9 @@ index_deletes(FixedIndexes, Bucket, PrimaryKey, Field, Value) ->
                     || FixedIndexes =:= false],
     KeyDelete ++ LegacyDelete.
 
-fix_index(IndexKey, ForUpgrade, #state{ref=Ref,
-                                       read_opts=ReadOpts,
-                                       write_opts=WriteOpts} = State) ->
+fix_index(_Bucket, IndexKey, ForUpgrade, #state{ref=Ref,
+                                                read_opts=ReadOpts,
+                                                write_opts=WriteOpts} = State) ->
     case eleveldb:get(Ref, IndexKey, ReadOpts) of
         {ok, _} ->
             {Bucket, Key, Field, Value} = from_index_key(IndexKey),

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -63,7 +63,7 @@
                 read_opts = [],
                 write_opts = [],
                 fold_opts = [{fill_cache, false}],
-                fixed_indexes = false, %% true if legacy indices should be rewritten
+                fixed_indexes = false, %% true if legacy indices have be rewritten
                 legacy_indices = false %% true if new writes use legacy indices (downgrade)
                }).
 

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -204,9 +204,11 @@ indexes_fixed(#state{ref=Ref,read_opts=ReadOpts}) ->
     end.
 
 index_deletes(FixedIndexes, Bucket, PrimaryKey, Field, Value) ->
-    KeyDelete = [{delete, to_index_key(Bucket, PrimaryKey, Field, Value)}],
-    LegacyDelete = [{delete, to_legacy_index_key(Bucket, PrimaryKey, Field, Value)}
-                    || FixedIndexes =:= false],
+    IndexKey = to_index_key(Bucket, PrimaryKey, Field, Value),
+    LegacyKey = to_legacy_index_key(Bucket, PrimaryKey, Field, Value),
+    KeyDelete = [{delete, IndexKey}],
+    LegacyDelete = [{delete, LegacyKey}
+                    || FixedIndexes =:= false andalso IndexKey =/= LegacyKey],
     KeyDelete ++ LegacyDelete.
 
 fix_index(_Bucket, IndexKey, ForUpgrade, #state{ref=Ref,

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -40,7 +40,7 @@
          status/1,
          callback/3,
          fix_index/4,
-         set_legacy_indices/2,
+         set_legacy_indexes/2,
          mark_indexes_fixed/2]).
 
 -ifdef(TEST).
@@ -356,14 +356,14 @@ callback(Ref, Msg, #state{backends=Backends}=State) ->
     [Mod:callback(Ref, Msg, ModState) || {_N, Mod, ModState} <- Backends],
     {ok, State}.
 
-set_legacy_indices(State=#state{backends=Backends}, WriteLegacy) ->
-    NewBackends = [{I, Mod, maybe_set_legacy_indices(Mod, ModState, WriteLegacy)} ||
+set_legacy_indexes(State=#state{backends=Backends}, WriteLegacy) ->
+    NewBackends = [{I, Mod, maybe_set_legacy_indexes(Mod, ModState, WriteLegacy)} ||
                       {I, Mod, ModState} <- Backends],
     State#state{backends=NewBackends}.
 
-maybe_set_legacy_indices(Mod, ModState, WriteLegacy) ->
+maybe_set_legacy_indexes(Mod, ModState, WriteLegacy) ->
     case backend_can_index_reformat(Mod, ModState) of
-        true -> Mod:set_legacy_indices(ModState, WriteLegacy);
+        true -> Mod:set_legacy_indexes(ModState, WriteLegacy);
         false -> ModState
     end.
 

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -38,14 +38,17 @@
          fold_objects/4,
          is_empty/1,
          status/1,
-         callback/3]).
+         callback/3,
+         fix_index/4,
+         set_legacy_indices/2,
+         mark_indexes_fixed/2]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
 -define(API_VERSION, 1).
--define(CAPABILITIES, [async_fold]).
+-define(CAPABILITIES, [async_fold, index_reformat]).
 
 -record (state, {backends :: [{atom(), atom(), term()}],
                  default_backend :: atom()}).
@@ -98,12 +101,12 @@ capabilities(State) ->
     %% Expose ?CAPABILITIES plus the intersection of all child
     %% backends. (This backend creates a shim for any backends that
     %% don't support async_fold.)
-    F = fun({_, Mod, ModState}, Acc) ->
+    F = fun(Mod, ModState) ->
                 {ok, S1} = Mod:capabilities(ModState),
-                S2 = ordsets:from_list(S1),
-                ordsets:intersection(Acc, S2)
+                ordsets:from_list(S1)
         end,
-    Caps1 = lists:foldl(F, ordsets:new(), State#state.backends),
+    AllCaps = [F(Mod, ModState) || {_, Mod, ModState} <- State#state.backends],
+    Caps1 = ordsets:intersection(AllCaps),
     Caps2 = ordsets:to_list(Caps1),
 
     Capabilities = lists:usort(?CAPABILITIES ++ Caps2),
@@ -319,7 +322,31 @@ status(#state{backends=Backends}) ->
     %% breaking this API list of two tuples return,
     %% add the tuple {mod, Mod} to the status for each
     %% backend.
-    [{N, [{mod, Mod} | Mod:status(ModState)]} || {N, Mod, ModState} <- Backends].
+    {Statuses, FixedIndexes} =
+        lists:mapfoldl(fun({N, Mod, ModState}, Acc) ->
+                               Status = Mod:status(ModState),
+                               Entry = {N, [{mod, Mod} | Status]},
+                               case fixed_index_status(Mod, ModState, Status) of
+                                   undefined -> {Entry, Acc};
+                                   Res ->
+                                       case Acc of
+                                           undefined -> {Entry, Res};
+                                           _ -> {Entry, Res andalso Acc}
+                                       end
+                               end
+                       end,
+                       undefined,
+                       Backends),
+    case FixedIndexes of
+        undefined -> Statuses;
+        _ -> [{fixed_indexes, FixedIndexes} | Statuses]
+    end.
+
+fixed_index_status(Mod, ModState, Status) ->
+    case backend_can_index_reformat(Mod, ModState) of
+        true -> proplists:get_value(fixed_indexes, Status);
+        false -> undefined
+    end.
 
 %% @doc Register an asynchronous callback
 -spec callback(reference(), any(), state()) -> {ok, state()}.
@@ -328,6 +355,51 @@ callback(Ref, Msg, #state{backends=Backends}=State) ->
     %% filter out if they need it.
     [Mod:callback(Ref, Msg, ModState) || {_N, Mod, ModState} <- Backends],
     {ok, State}.
+
+set_legacy_indices(State=#state{backends=Backends}, WriteLegacy) ->
+    NewBackends = [{I, Mod, maybe_set_legacy_indices(Mod, ModState, WriteLegacy)} ||
+                      {I, Mod, ModState} <- Backends],
+    State#state{backends=NewBackends}.
+
+maybe_set_legacy_indices(Mod, ModState, WriteLegacy) ->
+    case backend_can_index_reformat(Mod, ModState) of
+        true -> Mod:set_legacy_indices(ModState, WriteLegacy);
+        false -> ModState
+    end.
+
+mark_indexes_fixed(State=#state{backends=Backends}, ForUpgrade) ->
+    NewBackends = mark_indexes_fixed(Backends, [], ForUpgrade),
+    {ok, State#state{backends=NewBackends}}.
+
+mark_indexes_fixed([], NewBackends, _) ->
+    lists:reverse(NewBackends);
+mark_indexes_fixed([{I, Mod, ModState} | Backends], NewBackends, ForUpgrade) ->
+    Res = maybe_mark_indexes_fixed(Mod, ModState, ForUpgrade),
+    case Res of
+        {error, Reason} ->
+            {error, Reason};
+        {ok, NewModState} ->
+            mark_indexes_fixed(Backends, [{I, Mod, NewModState} | NewBackends], ForUpgrade)
+    end.
+
+maybe_mark_indexes_fixed(Mod, ModState, ForUpgrade) ->
+    case backend_can_index_reformat(Mod, ModState) of
+        true -> Mod:mark_indexes_fixed(ModState, ForUpgrade);
+        false -> {ok, ModState}
+    end.
+
+fix_index(Bucket, StorageKey, ForUpgrade, State) ->
+    {_, Mod,  ModState} = Backend = get_backend(Bucket, State),
+    case backend_can_index_reformat(Mod, ModState) of
+        true -> backend_fix_index(Backend, Bucket, StorageKey, ForUpgrade, State);
+        false -> {ok, State}
+    end.
+
+backend_fix_index({_, Mod, ModState}, Bucket, StorageKey, ForUpgrade, State) ->
+    case Mod:fix_index(Bucket, StorageKey, ForUpgrade, ModState) of
+        {ok, _UpModState} -> {ok, State};
+        {error, Reason} -> {error, Reason}
+    end.
 
 %% ===================================================================
 %% Internal functions
@@ -406,29 +478,45 @@ backend_fold_fun(ModFun, FoldFun, Opts, AsyncFold) ->
             %% Get the backend capabilities to determine
             %% if it supports asynchronous folding.
             {ok, ModCaps} = Module:capabilities(SubState),
-            case AsyncFold andalso
-                lists:member(async_fold, ModCaps) of
-                true ->
-                    AsyncWork =
-                        fun(Acc1) ->
-                                Module:ModFun(FoldFun,
-                                              Acc1,
-                                              Opts,
-                                              SubState)
-                        end,
-                    {Acc, [AsyncWork | WorkList]};
-                false ->
-                    Result = Module:ModFun(FoldFun,
-                                           Acc,
-                                           Opts,
-                                           SubState),
-                    case Result of
-                        {ok, Acc1} ->
-                            {Acc1, WorkList};
-                        {error, Reason} ->
-                            throw({error, {Module, Reason}})
-                    end
+            DoAsync = AsyncFold andalso lists:member(async_fold, ModCaps),
+            Indexes = proplists:get_value(indexes, Opts),
+            case Indexes of
+                {index, incorrect_format, _ForUpgrade} ->
+                    case lists:member(index_reformat, ModCaps) of
+                        true -> backend_fold_fun(Module, ModFun, SubState, FoldFun,
+                                                 Opts, {Acc, WorkList}, DoAsync);
+                        false -> {Acc, WorkList}
+                    end;
+                _ ->
+                    backend_fold_fun(Module,
+                                     ModFun,
+                                     SubState,
+                                     FoldFun,
+                                     Opts,
+                                     {Acc, WorkList},
+                                     DoAsync)
             end
+    end.
+
+backend_fold_fun(Module, ModFun, SubState, FoldFun, Opts, {Acc, WorkList}, true) ->
+    AsyncWork =
+        fun(Acc1) ->
+                Module:ModFun(FoldFun,
+                              Acc1,
+                              Opts,
+                              SubState)
+        end,
+    {Acc, [AsyncWork | WorkList]};
+backend_fold_fun(Module, ModFun, SubState, FoldFun, Opts, {Acc, WorkList}, false) ->
+    Result = Module:ModFun(FoldFun,
+                           Acc,
+                           Opts,
+                           SubState),
+    case Result of
+        {ok, Acc1} ->
+            {Acc1, WorkList};
+        {error, Reason} ->
+            throw({error, {Module, Reason}})
     end.
 
 async_fold_fun() ->
@@ -451,6 +539,10 @@ error_filter({error, _, _}) ->
     true;
 error_filter(_) ->
     false.
+
+backend_can_index_reformat(Mod, ModState) ->
+    {ok, Caps} = Mod:capabilities(ModState),
+    lists:member(index_reformat, Caps).
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -235,7 +235,6 @@ determine_all_n(Ring) ->
 fix_incorrect_index_entries() ->
     fix_incorrect_index_entries([]).
 
-%% needs to sum success/error/ignore accorss results of pmap
 fix_incorrect_index_entries(Opts) when is_list(Opts) ->
     MaxN = proplists:get_value(concurrency, Opts, 2),
     ForUpgrade = not proplists:get_value(downgrade, Opts, false),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -541,7 +541,7 @@ handle_command({get_index_entries, ForUpgrade},
     {ok, Caps} = Mod:capabilities(ModState0),
     case lists:member(index_reformat, Caps) of
         true ->
-            ModState = Mod:set_legacy_indices(ModState0, not ForUpgrade),
+            ModState = Mod:set_legacy_indexes(ModState0, not ForUpgrade),
             Status = Mod:status(ModState),
             case {ForUpgrade, proplists:get_value(fixed_indexes, Status)} of
                 {true, true} -> {reply, done, State};


### PR DESCRIPTION
As reported in #499, 2i range queries involving bigints could return incorrect results. The issue was caused by https://github.com/uwiger/sext/issues/5. The fix introduces an incompatibility in sext's encoding of bigints. This PR addresses handling of both the fixed and legacy encoding in Riak and provides a path for 2i users to upgrade stored indices that may be using the legacy format. A path for downgrading is also provided. 

With this change, when first started, Riak will write new indicies (or update indicies) using the legacy format. When indicies are removed (when an object is deleted or updated), initially, the backend will attempt to remove both the legacy and fixed encoding of the index. After `riak_kv_util:fix_incorrect_indices/0,1` has been run the additional delete of the legacy index will no longer occur. The additional delete will also not occur in partitions that are empty on startup. 

Users wishing to downgrade can use `riak_kv_util:fix_incorrect_indices/2` passing the option `{downgrade, true}`. This performs a similar operation to upgrading, however, after starting, index writes will be encoded in the legacy format.

In the case `riak_kv_util:fix_incorrect_indices/0,1` crashes or returns errors it is expected that it will be re-run. Re-running will "continue from where it left off" in the sense that indices rewritten before the crash will not be rewritten again. Results are written to the log as `info` messages.

Additionally, this PR changes the dependency on `sext`. It bumps the version to 1.1, which is necessary to include the encoding fix and uses Ulf Wiger's repository instead of ESL's since Ulf's is now the official one.
