### PR TITLE
make multibackend caps work as advertised

### DIFF
--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -98,12 +98,11 @@ capabilities(State) ->
     %% Expose ?CAPABILITIES plus the intersection of all child
     %% backends. (This backend creates a shim for any backends that
     %% don't support async_fold.)
-    F = fun({_, Mod, ModState}, Acc) ->
-                {ok, S1} = Mod:capabilities(ModState),
-                S2 = ordsets:from_list(S1),
-                ordsets:intersection(Acc, S2)
-        end,
-    Caps1 = lists:foldl(F, ordsets:new(), State#state.backends),
+    AllCaps = lists:map(fun({_, Mod, ModState}) ->
+                                {ok, Cs} = Mod:capabilities(ModState),
+                                ordsets:from_list(Cs)
+                        end, State#state.backends),
+    Caps1 = ordsets:intersection(AllCaps),
     Caps2 = ordsets:to_list(Caps1),
 
     Capabilities = lists:usort(?CAPABILITIES ++ Caps2),


### PR DESCRIPTION
The multibackend performs set intersection to determine intersecting capabilities
of all sub-backends but it used the empty set as `Acc0`, which resulted in the empty set
always. This addresses this issue by using ordsets:intersection/1 instead.

~~Note: this has the side-effect of making the multi-backend index capable if all
sub-backends support indexing (e.g. some mix of memory and leveldb).~~ (the multibackend supported indexing due to the fact that `capabilities/2` returned the proper values based on the sub-backend's capabilities, this just fixes an inconsistency).

Addresses #507 
