### PR TITLE
Protocol Buffers interface allows the creation of records with an empty key

### DIFF
--- a/src/riak_kv_pb_object.erl
+++ b/src/riak_kv_pb_object.erl
@@ -98,6 +98,10 @@ process(#rpbsetclientidreq{client_id = ClientId}, State) ->
                end,
     {reply, rpbsetclientidresp, NewState};
 
+process(#rpbgetreq{bucket = <<>>}, State) ->
+    {error, "Bucket cannot be zero-length", State};
+process(#rpbgetreq{key = <<>>}, State) ->
+    {error, "Key cannot be zero-length", State};
 process(#rpbgetreq{bucket=B, key=K, r=R0, pr=PR0, notfound_ok=NFOk,
                    basic_quorum=BQ, if_modified=VClock,
                    head=Head, deletedvclock=DeletedVClock,
@@ -139,6 +143,10 @@ process(#rpbgetreq{bucket=B, key=K, r=R0, pr=PR0, notfound_ok=NFOk,
             {error, {format,Reason}, State}
     end;
 
+process(#rpbputreq{bucket = <<>>}, State) ->
+    {error, "Bucket cannot be zero-length", State};
+process(#rpbputreq{key = <<>>}, State) ->
+    {error, "Key cannot be zero-length", State};
 process(#rpbputreq{bucket=B, key=K, vclock=PbVC,
                    if_not_modified=NotMod, if_none_match=NoneMatch} = Req,
         #state{client=C} = State) when NotMod; NoneMatch ->


### PR DESCRIPTION
Clients using protobufs can create records using an empty string as the key. This can be reproduced using an example from CorrugatedIron: https://github.com/DistributedNonsense/CorrugatedIron/issues/112 The HTTP interface falls down on this sort of behavior and attempts lists bucket props instead. 

Although both behaviors may be correct, the difference in client interfaces may create confusion for users - both interfaces should agree on basic CRUD operations.
