### PR TITLE
Adds X-Riak-Deleted where missing

### DIFF
--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -708,7 +708,7 @@ multiple_choices(RD, Ctx) ->
     case select_doc(Ctx) of
         {M, _} ->
             case dict:find(?MD_DELETED, M) of
-                {ok, true} ->
+                {ok, "true"} ->
                     {false,
                         wrq:set_resp_header(?HEAD_DELETED, "true", RD),
                         Ctx};


### PR DESCRIPTION
In the case of a single object being returned which is a
tombstone and the case where a single sibling has been
requested via a vtag and it is a tombstone, the
X-Riak-Deleted header will now be added and
returned.

Ideally both these would return 204 rather than 404 and 200
respectively but doing so would have breaking consequences
for clients.

Fixes #518 
