### PR TITLE
Changes needed to expose FSM timeouts to clients

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -251,12 +251,7 @@ delete(Bucket,Key,Options,Timeout) when is_list(Options) ->
     riak_kv_delete_sup:start_delete(Node, [ReqId, Bucket, Key, Options, Timeout,
                                            Me, ClientId]),
     RTimeout = recv_timeout(Options),
-    lager:info("timeouts r ~p t ~p > ~p",
-               [RTimeout, Timeout, RTimeout > Timeout]),
-    case RTimeout > Timeout of 
-        true -> wait_for_reqid(ReqId, Timeout);
-        false -> wait_for_reqid(ReqId, RTimeout)
-    end;
+    wait_for_reqid(ReqId, erlang:min(Timeout, RTimeout));
 delete(Bucket,Key,RW,Timeout) ->
     delete(Bucket,Key,[{rw, RW}], Timeout).
 
@@ -302,10 +297,7 @@ delete_vclock(Bucket,Key,VClock,Options,Timeout) when is_list(Options) ->
     riak_kv_delete_sup:start_delete(Node, [ReqId, Bucket, Key, Options, Timeout,
                                            Me, ClientId, VClock]),
     RTimeout = recv_timeout(Options),
-    case RTimeout > Timeout of 
-        true -> wait_for_reqid(ReqId, Timeout);
-        false -> wait_for_reqid(ReqId, RTimeout)
-    end;
+    wait_for_reqid(ReqId, erlang:min(Timeout, RTimeout));
 delete_vclock(Bucket,Key,VClock,RW,Timeout) ->
     delete_vclock(Bucket,Key,VClock,[{rw, RW}],Timeout).
 

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -250,7 +250,13 @@ delete(Bucket,Key,Options,Timeout) when is_list(Options) ->
     ReqId = mk_reqid(),
     riak_kv_delete_sup:start_delete(Node, [ReqId, Bucket, Key, Options, Timeout,
                                            Me, ClientId]),
-    wait_for_reqid(ReqId, Timeout);
+    RTimeout = recv_timeout(Options),
+    lager:info("timeouts r ~p t ~p > ~p",
+               [RTimeout, Timeout, RTimeout > Timeout]),
+    case RTimeout > Timeout of 
+        true -> wait_for_reqid(ReqId, Timeout);
+        false -> wait_for_reqid(ReqId, RTimeout)
+    end;
 delete(Bucket,Key,RW,Timeout) ->
     delete(Bucket,Key,[{rw, RW}], Timeout).
 
@@ -295,7 +301,11 @@ delete_vclock(Bucket,Key,VClock,Options,Timeout) when is_list(Options) ->
     ReqId = mk_reqid(),
     riak_kv_delete_sup:start_delete(Node, [ReqId, Bucket, Key, Options, Timeout,
                                            Me, ClientId, VClock]),
-    wait_for_reqid(ReqId, Timeout);
+    RTimeout = recv_timeout(Options),
+    case RTimeout > Timeout of 
+        true -> wait_for_reqid(ReqId, Timeout);
+        false -> wait_for_reqid(ReqId, RTimeout)
+    end;
 delete_vclock(Bucket,Key,VClock,RW,Timeout) ->
     delete_vclock(Bucket,Key,VClock,[{rw, RW}],Timeout).
 

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -283,10 +283,8 @@ malformed_timeout_param(RD, Ctx) ->
                 _:_ ->
                     {true,
                      wrq:append_to_resp_body(io_lib:format("Bad timeout "
-                                                           "value ~p, "
-                                                           "using ~p~n", 
-                                                           [TimeoutStr, 
-                                                            ?DEFAULT_TIMEOUT]),
+                                                           "value ~p~n",
+                                                           [TimeoutStr]),
                                              wrq:set_resp_header(?HEAD_CTYPE, 
                                                                  "text/plain", RD)),
                      Ctx}


### PR DESCRIPTION
- change delete in riak_client to honor timeouts passed
  in Options
- change the various object interfaces to collect and
  pass on the timeout values

requires https://github.com/basho/riak_pb/issues/38
