### PR TITLE
spell badarg correctly

### DIFF
--- a/src/riak_kv_mrc_pipe.erl
+++ b/src/riak_kv_mrc_pipe.erl
@@ -283,7 +283,7 @@ mapred_stream_sink(Inputs, Query, Timeout) ->
                           sender={Sender,SenderMon},
                           timer={Timer,PipeRef},
                           keeps=NumKeeps}}
-    catch throw:{badard, Fitting, Reason} ->
+    catch throw:{badarg, Fitting, Reason} ->
             riak_kv_mrc_sink:stop(Sink),
             {error, {Fitting, Reason}}
     end.


### PR DESCRIPTION
Spelled incorrectly, the catch clause fails to prevent the process from
blowing up on error. Spelled correctly, the user receives an error
message describing what the problem is.

Compare before this change:

```
$ curl -X POST -H "content-type: application/json" http://localhost:8098/mapred --data "{\"inputs\":\"foo\",\"query\":[{\"map\":{\"language\":\"erlang\",\"module\":\"does_not_exist\",\"function\":\"does_not_exist\"}}]}"
<html><head><title>500 Internal Server Error</title></head><body><h1>Internal Server Error</h1>The server encountered an error while processing this request:<br><pre>{error,{throw,{badarg,0,
                      [105,110,118,97,108,105,100,32,109,111,100,117,108,101,
                       32,110,97,109,101,100,32,105,110,32,"PhaseSpec",32,102,
                       117,110,99,116,105,111,110,58,"\n",
                       [[],32,109,117,115,116,32,98,101,32,97,32,118,97,108,
                        105,100,32,109,111,100,117,108,101,32,110,97,109,101,
                        32,40,102,97,105,108,101,100,32,116,111,32,108,111,97,
                        100,32,"does_not_exist",58,32,"nofile",41]]},
              [{riak_pipe_fitting,validate_fitting,1,
                                  [{file,"src/riak_pipe_fitting.erl"},
                                   {line,470}]},
               {riak_pipe,'-exec/2-lc$^0/1-0-',1,
                          [{file,"src/riak_pipe.erl"},{line,219}]},
               {riak_pipe,exec,2,[{file,"src/riak_pipe.erl"},{line,219}]},
               {riak_kv_mrc_pipe,mapred_stream,2,
                                 [{file,"src/riak_kv_mrc_pipe.erl"},
                                  {line,251}]},
               {riak_kv_mrc_pipe,mapred_stream_sink,3,
                                 [{file,"src/riak_kv_mrc_pipe.erl"},
                                  {line,269}]},
               {riak_kv_wm_mapred,pipe_mapred,2,
                                  [{file,"src/riak_kv_wm_mapred.erl"},
                                   {line,163}]},
               {webmachine_resource,resource_call,3,
                                    [{file,"src/webmachine_resource.erl"},
                                     {line,183}]},
               {webmachine_resource,do,3,
                                    [{file,"src/webmachine_resource.erl"},
                                     {line,141}]}]}}</pre><P><HR><ADDRESS>mochiweb+webmachine web server</ADDRESS></body></html>
```

To after this change:

```
$ curl -X POST -H "content-type: application/json" http://localhost:8098/mapred --data "{\"inputs\":\"foo\",\"query\":[{\"map\":{\"language\":\"erlang\",\"module\":\"does_not_exist\",\"function\":\"does_not_exist\"}}]}"
{"phase":0,"error":"invalid module named in PhaseSpec function:\n must be a valid module name (failed to load does_not_exist: nofile)"}
```
