### PR TITLE
Fix perf problems and bug in 2i reformat

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -422,26 +422,51 @@ format_timestamp(_Now, undefined) ->
 format_timestamp(Now, TS) ->
     riak_core_format:human_time_fmt("~.1f", timer:now_diff(Now, TS)).
 
+parse_int(IntStr) ->
+    try
+        list_to_integer(IntStr)
+    catch
+        error:badarg ->
+            undefined
+    end.
+
 index_reformat_options([], Opts) ->
     Opts;
-index_reformat_options(["--downgrade" | Rest], Opts) ->
-    index_reformat_options(Rest, [{downgrade, true} | Opts]);
+index_reformat_options(["--downgrade"], Opts) ->
+    [{downgrade, true} | Opts];
+index_reformat_options(["--downgrade" | More], _Opts) ->
+    io:format("Invalid arguments after downgrade switch : ~p~n", [More]),
+    undefined;
 index_reformat_options([IntStr | Rest], Opts) ->
-    %% Letting it crash here if not an integer
-    IntVal = list_to_integer(IntStr),
-    case lists:keymember(concurrency, 1, Opts) of
-        true ->
-            [{batch_size, IntVal} | Opts];
-        false ->
-            index_reformat_options(Rest, [{concurrency, IntVal} | Opts])
-    end.
+    HasConcurrency = lists:keymember(concurrency, 1, Opts),
+    HasBatchSize = lists:keymember(batch_size, 1, Opts),
+    case {parse_int(IntStr), HasConcurrency, HasBatchSize} of
+        {_, true, true} ->
+            io:format("Expected --downgrade instead of ~p~n", [IntStr]),
+            undefined;
+        {undefined, _, _ } ->
+            io:format("Expected integer parameter instead of ~p~n", [IntStr]),
+            undefined;
+        {IntVal, false, false} ->
+            index_reformat_options(Rest, [{concurrency, IntVal} | Opts]);
+        {IntVal, true, false} ->
+            index_reformat_options(Rest, [{batch_size, IntVal} | Opts])
+    end;
+index_reformat_options(_, _) ->
+    undefined.
 
 reformat_indexes(Args) ->
     Opts = index_reformat_options(Args, []),
-    start_index_reformat(Opts),
-    io:format("index reformat started with options ~p ~n", [Opts]),
-    io:format("check console.log for status information~n"),
-    ok.
+    case Opts of
+        undefined ->
+            io:format("Expected options: <concurrency> <batch size> [--downgrade]~n"),
+            ok;
+        _ ->
+            start_index_reformat(Opts),
+            io:format("index reformat started with options ~p ~n", [Opts]),
+            io:format("check console.log for status information~n"),
+            ok
+    end.
 
 start_index_reformat(Opts) ->
     spawn(fun() -> run_index_reformat(Opts) end).

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -431,7 +431,17 @@ parse_int(IntStr) ->
     end.
 
 index_reformat_options([], Opts) ->
-    Opts;
+    Defaults = [{concurrency, 2}, {batch_size, 100}],
+    AddIfAbsent =
+        fun({Name,Val}, Acc) ->
+            case lists:keymember(Name, 1, Acc) of
+                true ->
+                    Acc;
+                false ->
+                    [{Name, Val} | Acc]
+            end
+        end,
+    lists:foldl(AddIfAbsent, Opts, Defaults);
 index_reformat_options(["--downgrade"], Opts) ->
     [{downgrade, true} | Opts];
 index_reformat_options(["--downgrade" | More], _Opts) ->

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -36,6 +36,7 @@
          fix_index/3,
          mark_indexes_fixed/2,
          set_legacy_indexes/2,
+         fixed_index_status/1,
          fold_buckets/4,
          fold_keys/4,
          fold_objects/4,
@@ -278,6 +279,10 @@ mark_indexes_fixed(State=#state{ref=Ref, write_opts=WriteOpts}, ForUpgrade) ->
 
 set_legacy_indexes(State, WriteLegacy) ->
     State#state{legacy_indexes=WriteLegacy}.
+
+-spec fixed_index_status(state()) -> boolean().
+fixed_index_status(#state{fixed_indexes=Fixed}) ->
+    Fixed.
 
 %% @doc Delete an object from the eleveldb backend
 -spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -33,7 +33,7 @@
          put/5,
          delete/4,
          drop/1,
-         fix_index/4,
+         fix_index/3,
          mark_indexes_fixed/2,
          set_legacy_indexes/2,
          fold_buckets/4,
@@ -211,7 +211,7 @@ index_deletes(FixedIndexes, Bucket, PrimaryKey, Field, Value) ->
                     || FixedIndexes =:= false andalso IndexKey =/= LegacyKey],
     KeyDelete ++ LegacyDelete.
 
-fix_index(_Bucket, IndexKeys, ForUpgrade, #state{ref=Ref,
+fix_index(IndexKeys, ForUpgrade, #state{ref=Ref,
                                                 read_opts=ReadOpts,
                                                 write_opts=WriteOpts} = State)
                                         when is_list(IndexKeys) ->
@@ -226,9 +226,9 @@ fix_index(_Bucket, IndexKeys, ForUpgrade, #state{ref=Ref,
     Totals =
         lists:foldl(FoldFun, {0,0,0},
                     [fix_index(IndexKey, ForUpgrade, Ref, ReadOpts, WriteOpts)
-                        || IndexKey <- IndexKeys]),
+                        || {_Bucket, IndexKey} <- IndexKeys]),
     {reply, Totals, State};
-fix_index(_Bucket, IndexKey, ForUpgrade, #state{ref=Ref,
+fix_index(IndexKey, ForUpgrade, #state{ref=Ref,
                                                 read_opts=ReadOpts,
                                                 write_opts=WriteOpts} = State) ->
     case fix_index(IndexKey, ForUpgrade, Ref, ReadOpts, WriteOpts) of

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -390,8 +390,7 @@ maybe_mark_indexes_fixed(Mod, ModState, ForUpgrade) ->
 
 fix_index(BKeys, ForUpgrade, State) ->
     % Group keys per bucket 
-    PerBucket = lists:foldl(fun({B,K},D) -> dict:append(B,K,D) end, dict:new(),
-                            dict:new(), BKeys),
+    PerBucket = lists:foldl(fun(BK={B,_},D) -> dict:append(B,BK,D) end, dict:new(), BKeys),
     Result = 
         dict:fold(
             fun(Bucket, StorageKey, Acc = {Success, Ignore, Errors}) ->
@@ -408,7 +407,7 @@ fix_index(BKeys, ForUpgrade, State) ->
     {reply, Result, State}.
 
 backend_fix_index({_, Mod, ModState}, Bucket, StorageKey, ForUpgrade) ->
-    case Mod:fix_index(Bucket, StorageKey, ForUpgrade, ModState) of
+    case Mod:fix_index(StorageKey, ForUpgrade, ModState) of
         {reply, Reply, _UpModState} -> 
             Reply;
         {error, Reason} ->

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -238,10 +238,12 @@ fix_incorrect_index_entries() ->
 fix_incorrect_index_entries(Opts) when is_list(Opts) ->
     MaxN = proplists:get_value(concurrency, Opts, 2),
     ForUpgrade = not proplists:get_value(downgrade, Opts, false),
-    lager:info("index reformat starting with concurrency: ~p for upgrade: ~p",
-               [MaxN, ForUpgrade]),
+    BatchSize = proplists:get_value(batch_size, Opts, 100),
+    lager:info("index reformat: starting with concurrency: ~p, batch size: ~p, for upgrade: ~p",
+               [MaxN, BatchSize, ForUpgrade]),
     IdxList = [Idx || {riak_kv_vnode, Idx, _} <- riak_core_vnode_manager:all_vnodes()],
-    F = fun(X) -> fix_incorrect_index_entries(X, ForUpgrade) end,
+    FixOpts = [{batch_size, BatchSize}, {downgrade, not ForUpgrade}],
+    F = fun(X) -> fix_incorrect_index_entries(X, FixOpts) end,
     Counts = riak_core_util:pmap(F, IdxList, MaxN),
     {SuccessCounts, IgnoredCounts, ErrorCounts} = lists:unzip3(Counts),
     SuccessTotal = lists:sum(SuccessCounts),
@@ -249,21 +251,23 @@ fix_incorrect_index_entries(Opts) when is_list(Opts) ->
     ErrorTotal = lists:sum(ErrorCounts),
     case ErrorTotal of
         0 ->
-            lager:info("index reformat complete on all partitions. Fixed: ~p, Ignored: ~p",
+            lager:info("index reformat: complete on all partitions. Fixed: ~p, Ignored: ~p",
                        [SuccessTotal, IgnoredTotal]);
         _ ->
-            lager:info("index reformat encountered ~p errors reformatting keys. Please re-run",
+            lager:info("index reformat: encountered ~p errors reformatting keys. Please re-run",
                        [ErrorTotal])
     end,
     {SuccessTotal, IgnoredTotal, ErrorTotal}.
 
-fix_incorrect_index_entries(Idx, ForUpgrade) ->
-    fix_incorrect_index_entries(Idx, fun fix_incorrect_index_entry/4, {0, 0, 0}, ForUpgrade).
+fix_incorrect_index_entries(Idx, FixOpts) ->
+    fix_incorrect_index_entries(Idx, fun fix_incorrect_index_entry/4, {0, 0, 0}, FixOpts).
 
-fix_incorrect_index_entries(Idx, FixFun, Acc0, ForUpgrade) ->
+fix_incorrect_index_entries(Idx, FixFun, Acc0, FixOpts) ->
     Ref = make_ref(),
+    ForUpgrade = not proplists:get_value(downgrade, FixOpts, false),
+    lager:info("index reformat: querying partition ~p for index entries to reformat", [Idx]),
     riak_core_vnode_master:command({Idx, node()},
-                                   {get_index_entries, ForUpgrade},
+                                   {get_index_entries, FixOpts},
                                    {raw, Ref, self()},
                                    riak_kv_vnode_master),
     case process_incorrect_index_entries(Ref, Idx, ForUpgrade, FixFun, Acc0) of
@@ -279,9 +283,9 @@ fix_incorrect_index_entries(Idx, FixFun, Acc0, ForUpgrade) ->
             end
     end.
 
-fix_incorrect_index_entry(Idx, ForUpgrade, BadKey, {Success, Ignore, Error}) ->
+fix_incorrect_index_entry(Idx, ForUpgrade, BadKeys, {Success, Ignore, Error}) ->
     Res = riak_core_vnode_master:sync_command({Idx, node()},
-                                              {fix_incorrect_index_entry, BadKey, ForUpgrade},
+                                              {fix_incorrect_index_entry, BadKeys, ForUpgrade},
                                               riak_kv_vnode_master),
     case Res of
         ok ->
@@ -289,25 +293,42 @@ fix_incorrect_index_entry(Idx, ForUpgrade, BadKey, {Success, Ignore, Error}) ->
         ignore ->
             {Success, Ignore+1, Error};
         {error, _} ->
-            {Success, Ignore, Error+1}
+            {Success, Ignore, Error+1};
+        {S, I, E} ->
+            {Success+S, Ignore+I, Error+E}
     end.
 
 %% needs to take an acc to count success/error/ignore
-process_incorrect_index_entries(Ref, Idx, ForUpgrade, FixFun, Acc) ->
+process_incorrect_index_entries(Ref, Idx, ForUpgrade, FixFun, {S, I, E} = Acc) ->
     receive
         {Ref, ignore} ->
+            lager:info("index reformat: ignoring partition ~p", [Idx]),
             ignore;
         {Ref, done} ->
+            lager:info("index reformat: finished with partition ~p, Fixed=~p, Ignored=~p, Errors=~p", [Idx, S, I, E]),
             Acc;
-        {Ref, Key} ->
-            NextAcc = FixFun(Idx, ForUpgrade, Key, Acc),
+        {Ref, {Pid, BatchRef, Keys}} ->
+            {NS, NI, NE} = NextAcc = FixFun(Idx, ForUpgrade, Keys, Acc),
+            ReportN = 10000,
+            case ((NS+NI+NE) div ReportN) /= ((S+I+E) div ReportN) of
+               true ->
+                    lager:info("index reformat: reformatting partition ~p, Fixed=~p, Ignore=~p, Error=~p", [Idx, NS, NI, NE]);
+                false ->
+                    ok
+            end,
+            ack_incorrect_keys(Pid, BatchRef),
             process_incorrect_index_entries(Ref, Idx, ForUpgrade, FixFun, NextAcc)
     end.
+
+ack_incorrect_keys(Pid, Ref) ->
+    Pid ! {ack_keys, Ref}.
 
 mark_indexes_reformatted(Idx, 0, ForUpgrade) ->
     riak_core_vnode_master:sync_command({Idx, node()},
                                         {fix_incorrect_index_entry, {done, ForUpgrade}},
-                                        riak_kv_vnode_master);
+                                        riak_kv_vnode_master),
+    lager:info("index reformat: marked partition ~p as fixed", [Idx]),
+    ok;
 mark_indexes_reformatted(_Idx, _ErrorCount, _ForUpgrade) ->
     undefined.
 

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -571,7 +571,11 @@ handle_command({get_index_entries, Opts},
                         end,
                     Buffer = BufferMod:new(BufferSize, ResultFun),
                     FoldFun = fun(B, K, Buf) -> BufferMod:add({B, K}, Buf) end,
-                    FinishFun = fun(_) -> riak_core_vnode:reply(Sender, done) end,
+                    FinishFun =
+                        fun(FinalBuffer) ->
+                            BufferMod:flush(FinalBuffer),
+                            riak_core_vnode:reply(Sender, done)
+                        end,
                     FoldOpts = [{index, incorrect_format, ForUpgrade}, async_fold],
                     case list(FoldFun, FinishFun, Mod, fold_keys, ModState, FoldOpts, Buffer) of
                         {async, AsyncWork} ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -550,8 +550,8 @@ handle_command({get_index_entries, Opts},
     case lists:member(index_reformat, Caps) of
         true ->
             ModState = Mod:set_legacy_indexes(ModState0, not ForUpgrade),
-            Status = Mod:status(ModState),
-            case {ForUpgrade, proplists:get_value(fixed_indexes, Status)} of
+            Status = Mod:fixed_index_status(ModState),
+            case {ForUpgrade, Status} of
                 {true, true} -> {reply, done, State};
                 {_,  _} ->
                     BufferMod = riak_kv_fold_buffer,


### PR DESCRIPTION
Add batch size parameter to control how many keys
are fixed at a time.
Add backpressure to query of bad idx entries to avoid
having the reformat process flooded with msgs.
Fixed problem with list keys and code triggering a second
scan during 2i reformat transition.
