### PR TITLE
move querying of fixed index status to seperate backend function

### DIFF
--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -36,6 +36,7 @@
          fix_index/3,
          mark_indexes_fixed/2,
          set_legacy_indexes/2,
+         fixed_index_status/1,
          fold_buckets/4,
          fold_keys/4,
          fold_objects/4,
@@ -278,6 +279,10 @@ mark_indexes_fixed(State=#state{ref=Ref, write_opts=WriteOpts}, ForUpgrade) ->
 
 set_legacy_indexes(State, WriteLegacy) ->
     State#state{legacy_indexes=WriteLegacy}.
+
+-spec fixed_index_status(state()) -> boolean().
+fixed_index_status(#state{fixed_indexes=Fixed}) ->
+    Fixed.
 
 %% @doc Delete an object from the eleveldb backend
 -spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -550,8 +550,8 @@ handle_command({get_index_entries, Opts},
     case lists:member(index_reformat, Caps) of
         true ->
             ModState = Mod:set_legacy_indexes(ModState0, not ForUpgrade),
-            Status = Mod:status(ModState),
-            case {ForUpgrade, proplists:get_value(fixed_indexes, Status)} of
+            Status = Mod:fixed_index_status(ModState),
+            case {ForUpgrade, Status} of
                 {true, true} -> {reply, done, State};
                 {_,  _} ->
                     BufferMod = riak_kv_fold_buffer,


### PR DESCRIPTION
makes top-level fixed_indexes status on multi-backend,
which messes with stats, unnecessary allowing it to be removed
