### PR TITLE
Expose Backend Size to Handoff for Progress Tracking

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -42,6 +42,8 @@
          status/1,
          callback/3]).
 
+-export([data_size/1]).
+
 %% Helper API
 -export([key_counts/0,
          key_counts/1]).
@@ -54,7 +56,7 @@
 
 -define(MERGE_CHECK_INTERVAL, timer:minutes(3)).
 -define(API_VERSION, 1).
--define(CAPABILITIES, [async_fold]).
+-define(CAPABILITIES, [async_fold,size]).
 
 -record(state, {ref :: reference(),
                 data_dir :: string(),
@@ -353,6 +355,14 @@ status(#state{ref=Ref}) ->
     {KeyCount, Status} = bitcask:status(Ref),
     [{key_count, KeyCount}, {status, Status}].
 
+%% @doc Get the size of the bitcask backend (in number of keys)
+-spec data_size(state()) -> undefined | {non_neg_integer(), objects}.
+data_size(State) ->
+    Status = status(State),
+    case proplists:get_value(key_count, Status) of
+        undefined -> undefined;
+        KeyCount -> {KeyCount, objects}
+    end.
 
 %% @doc Register an asynchronous callback
 -spec callback(reference(), any(), state()) -> {ok, state()}.

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -32,16 +32,11 @@
          vnode_status/1,
          reip/1,
          ringready/1,
-         transfers/1,
          cluster_info/1,
          down/1,
          aae_status/1,
          reformat_indexes/1,
          reload_code/1]).
-
-%% Arrow is 24 chars wide
--define(ARROW, "=======================>").
-
 
 join([NodeStr]) ->
     join(NodeStr, fun riak_core:join/1,
@@ -249,77 +244,6 @@ ringready([]) ->
             error
     end.
 
-%% Provide a list of nodes with pending partition transfers (i.e. any secondary vnodes)
-%% and list any owned vnodes that are *not* running
--spec(transfers([]) -> ok).
-transfers([]) ->
-    try
-        {DownNodes, Pending} = riak_core_status:transfers(),
-        case DownNodes of
-            [] -> ok;
-            _  -> io:format("Nodes ~p are currently down.\n", [DownNodes])
-        end,
-        F = fun({waiting_to_handoff, Node, Count}, Acc) ->
-                io:format("~p waiting to handoff ~p partitions\n", [Node, Count]),
-                Acc + 1;
-            ({stopped, Node, Count}, Acc) ->
-                io:format("~p does not have ~p primary partitions running\n", [Node, Count]),
-                Acc + 1
-        end,
-        case lists:foldl(F, 0, Pending) of
-            0 ->
-                io:format("No transfers active\n"),
-                ok;
-            _ ->
-                error
-        end
-    catch
-        Exception:Reason ->
-            lager:error("Transfers failed ~p:~p", [Exception,
-                    Reason]),
-            io:format("Transfers failed, see log for details~n"),
-            error
-    end,
-
-    %% Now display active transfers
-    {Xfers, Down} = riak_core_status:all_active_transfers(),
-
-    DisplayXfer =
-        fun({{Mod, Partition}, Node, outbound, active, _Status}) ->
-                print_v1_status(Mod, Partition, Node);
-
-           ({status_v2, Status}) ->
-                %% Display base status
-                Type = proplists:get_value(type, Status),
-                Mod = proplists:get_value(mod, Status),
-                SrcPartition = proplists:get_value(src_partition, Status),
-                TargetPartition = proplists:get_value(target_partition, Status),
-                StartTS = proplists:get_value(start_ts, Status),
-                SrcNode = proplists:get_value(src_node, Status),
-                TargetNode = proplists:get_value(target_node, Status),
-
-                print_v2_status(Type, Mod, {SrcPartition, TargetPartition}, StartTS),
-
-                %% Get info about stats if there is any yet
-                Stats = proplists:get_value(stats, Status),
-
-                print_stats(SrcNode, TargetNode, Stats),
-                io:format("~n");
-
-           (_) ->
-                ignore
-        end,
-    DisplayDown =
-        fun(Node) ->
-                io:format("Node ~p could not be contacted~n", [Node])
-        end,
-
-    io:format("~nActive Transfers:~n~n", []),
-    [DisplayXfer(Xfer) || Xfer <- lists:flatten(Xfers)],
-
-    io:format("~n"),
-    [DisplayDown(Node) || Node <- Down].
-
 cluster_info([OutFile|Rest]) ->
     try
         case lists:reverse(atomify_nodestrs(Rest)) of
@@ -492,13 +416,6 @@ run_index_reformat(Opts) ->
 %%%===================================================================
 %%% Private
 %%%===================================================================
-
-datetime_str({_Mega, _Secs, _Micro}=Now) ->
-    datetime_str(calendar:now_to_datetime(Now));
-datetime_str({{Year, Month, Day}, {Hour, Min, Sec}}) ->
-    riak_core_format:fmt("~4..0B-~2..0B-~2..0B ~2..0B:~2..0B:~2..0B",
-                         [Year,Month,Day,Hour,Min,Sec]).
-
 format_stats([], Acc) ->
     lists:reverse(Acc);
 format_stats([{Stat, V}|T], Acc) ->
@@ -545,54 +462,3 @@ print_vnode_status([StatusItem | RestStatusItems]) ->
             io:format("Status: ~n~p~n", [StatusItem])
     end,
     print_vnode_status(RestStatusItems).
-
-print_v2_status(Type, Mod, {SrcPartition, TargetPartition}, StartTS) ->
-    StartTSStr = datetime_str(StartTS),
-    Running = timer:now_diff(os:timestamp(), StartTS),
-    RunningStr = riak_core_format:human_time_fmt("~.2f", Running),
-
-    io:format("transfer type: ~s~n", [Type]),
-    io:format("vnode type: ~p~n", [Mod]),
-    case Type of
-        repair ->
-            io:format("source partition: ~p~n", [SrcPartition]),
-            io:format("target partition: ~p~n", [TargetPartition]);
-        _ ->
-            io:format("partition: ~p~n", [TargetPartition])
-    end,
-    io:format("started: ~s [~s ago]~n", [StartTSStr, RunningStr]).
-
-print_v1_status(Mod, Partition, Node) ->
-    io:format("vnode type: ~p~n", [Mod]),
-    io:format("partition: ~p~n", [Partition]),
-    io:format("target node: ~p~n~n", [Node]).
-
-print_stats(SrcNode, TargetNode, no_stats) ->
-    ToFrom = riak_core_format:fmt("~16s ~s ~16s",
-                                  [SrcNode, ?ARROW, TargetNode]),
-    Width = length(ToFrom),
-
-    io:format("last update: no updates seen~n"),
-    io:format("objects transferred: unknown~n~n"),
-    io:format("~s~n", [string:centre("unknown", Width)]),
-    io:format("~s~n", [ToFrom]),
-    io:format("~s~n", [string:centre("unknown", Width)]);
-print_stats(SrcNode, TargetNode, Stats) ->
-    ObjsS = proplists:get_value(objs_per_s, Stats),
-    BytesS = proplists:get_value(bytes_per_s, Stats),
-    LastUpdate = proplists:get_value(last_update, Stats),
-    Diff = timer:now_diff(os:timestamp(), LastUpdate),
-    DiffStr = riak_core_format:human_time_fmt("~.2f", Diff),
-    Objs = proplists:get_value(objs_total, Stats),
-    ObjsSStr = riak_core_format:fmt("~p Objs/s", [ObjsS]),
-    ByteStr = riak_core_format:human_size_fmt("~.2f", BytesS) ++ "/s",
-    TS = datetime_str(LastUpdate),
-    ToFrom = riak_core_format:fmt("~16s ~s ~16s",
-                                  [SrcNode, ?ARROW, TargetNode]),
-    Width = length(ToFrom),
-
-    io:format("last update: ~s [~s ago]~n", [TS, DiffStr]),
-    io:format("objects transferred: ~p~n~n", [Objs]),
-    io:format("~s~n", [string:centre(ObjsSStr, Width)]),
-    io:format("~s~n", [ToFrom]),
-    io:format("~s~n", [string:centre(ByteStr, Width)]).

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -44,6 +44,8 @@
          status/1,
          callback/3]).
 
+-export([data_size/1]).
+
 -compile({inline, [
                    to_object_key/2, from_object_key/1,
                    to_index_key/4, from_index_key/1
@@ -54,7 +56,7 @@
 -endif.
 
 -define(API_VERSION, 1).
--define(CAPABILITIES, [async_fold, indexes, index_reformat]).
+-define(CAPABILITIES, [async_fold, indexes, index_reformat, size]).
 -define(FIXED_INDEXES_KEY, fixed_indexes).
 
 -record(state, {ref :: reference(),
@@ -460,6 +462,16 @@ status(State=#state{fixed_indexes=FixedIndexes}) ->
 -spec callback(reference(), any(), state()) -> {ok, state()}.
 callback(_Ref, _Msg, State) ->
     {ok, State}.
+
+%% @doc Get the size of the eleveldb backend in bytes
+-spec data_size(state()) -> undefined | {non_neg_integer(), bytes}.
+data_size(State) ->
+    try {ok, <<SizeStr/binary>>} = eleveldb:status(State#state.ref, <<"leveldb.total-bytes">>),
+         list_to_integer(binary_to_list(SizeStr)) of
+        Size -> {Size, bytes}
+    catch
+        error:_ -> undefined
+    end.
 
 %% ===================================================================
 %% Internal functions

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -56,6 +56,8 @@
          status/1,
          callback/3]).
 
+-export([data_size/1]).
+
 %% "Testing" backend API
 -export([reset/0]).
 
@@ -65,7 +67,7 @@
 -endif.
 
 -define(API_VERSION, 1).
--define(CAPABILITIES, [async_fold, indexes]).
+-define(CAPABILITIES, [async_fold, indexes, size]).
 
 %% Macros for working with indexes
 -define(DELETE_PTN(B,K), {{B,'_','_',K},'_'}).
@@ -355,6 +357,19 @@ status(#state{data_ref=DataRef,
              {index_table_status, IndexStatus},
              {time_table_status, TimeStatus}]
     end.
+
+%% @doc Get the size of the memory backend. Returns a dynamic size
+%%      since new writes may appear in an ets fold
+-spec data_size(state()) -> undefined | {function(), dynamic}.
+data_size(#state{data_ref=DataRef}) ->
+    F = fun() ->
+                DataStatus = ets:info(DataRef),
+                case proplists:get_value(size, DataStatus) of
+                    undefined -> undefined;
+                    ObjCount -> {ObjCount, objects}
+                end
+        end,
+    {F, dynamic}.
 
 %% @doc Register an asynchronous callback
 -spec callback(reference(), any(), state()) -> {ok, state()}.


### PR DESCRIPTION
This PR exposes the necessary information for tracking handoff progress (added in https://github.com/basho/riak_core/pull/290) of kv_vnodes using the memory, level, or bitcask backends. Each backend exposes an upper-bound on the amount of data stored, but each one comes with some caveats. Although these caveats are inconvenient, the metrics still provide a significantly better indication of progress than having no indication. The API has been designed so more accurate (or less accurate even) metrics can be used, in the future, instead.

The bitcask backend uses the existing knowledge of keydir size to expose the total number of keys that will be transferred. This is an ok but not great indicator of progress because it doesn't account for varying object sizes (transferring 99 1k objects and one 20MB object).

The eleveldb backend uses the support added in https://github.com/basho/leveldb/pull/74 to directly query the number of bytes in sst files. This has the downside that the returned number may include overwritten keys whose bytes will not be transferred. However, this still means that we will always have made equal or more progress than what is indicated, never less, which is sufficient. If https://github.com/basho/leveldb/pull/74 is not used, tracking handoff progress in eleveldb is not supported.

The memory backend uses built in stats info in ets to return the number of keys that will be transferred. This also has the same drawback as the bitcask backend. In addtion, since the ets fold is not a snapshot, the backend uses the dynamic size feature to make sure progress is tracked correctly. 

The multi backend is not supported. 

Example output of `riak-admin transfers` with these changes: https://gist.github.com/jrwest/588d85bbeaebaf940e59

This PR also completes the move of `transfers/1` to `riak_core_console` started in https://github.com/basho/riak_core/pull/290

Associated riak PR: https://github.com/basho/riak/pull/303
