### PR TITLE
Count async MR results against the sink buffer size cap

### DIFF
--- a/src/riak_kv_mrc_sink.erl
+++ b/src/riak_kv_mrc_sink.erl
@@ -189,12 +189,14 @@ collect_output(next, State) ->
             end
     end;
 collect_output(#pipe_result{ref=Ref, from=PhaseId, result=Res},
-               #state{ref=Ref, results=Acc}=State) ->
+               #state{ref=Ref, results=Acc, buffer_left=Left}=State) ->
     NewAcc = add_result(PhaseId, Res, Acc),
-    {next_state, collect_output, State#state{results=NewAcc}};
+    {next_state, collect_output,
+     State#state{results=NewAcc, buffer_left=Left-1}};
 collect_output(#pipe_log{ref=Ref, from=PhaseId, msg=Msg},
-               #state{ref=Ref, logs=Acc}=State) ->
-    {next_state, collect_output, State#state{logs=[{PhaseId, Msg}|Acc]}};
+               #state{ref=Ref, logs=Acc, buffer_left=Left}=State) ->
+    {next_state, collect_output,
+     State#state{logs=[{PhaseId, Msg}|Acc], buffer_left=Left-1}};
 collect_output(#pipe_eoi{ref=Ref}, #state{ref=Ref}=State) ->
     {next_state, collect_output, State#state{done=true}};
 collect_output(_, State) ->


### PR DESCRIPTION
While chasing another issue, I found that MR results delivered to an FSM sink via `gen_fsm:send_event/2` are not counted against the buffer size limit. This method is used to deliver 10 results before `gen_fsm:sync_send_event/3` is used once. Since only the results sent synchronously were counted against the buffer size limit, the limit actually imposed was effectively 10 times higher than expected.

The first commit in this PR modifies the eunit test to demonstrate the issue. The second commit fixes the problem.
