### PR TITLE
Ring Resizing Support

### DIFF
--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -521,25 +521,31 @@ enqueue_exchanges(Exchanges, State) ->
                      riak_core_ring(),
                      state()) -> {any(), state()}.
 start_exchange(LocalVN, {RemoteIdx, IndexN}, Ring, State) ->
-    Owner = riak_core_ring:index_owner(Ring, RemoteIdx),
-    Nodes = lists:usort([node(), Owner]),
-    DownNodes = Nodes -- riak_core_node_watcher:nodes(riak_kv),
-    case DownNodes of
-        [] ->
-            RemoteVN = {RemoteIdx, Owner},
-            start_exchange(LocalVN, RemoteVN, IndexN, Ring, State);
-        _ ->
-            {{riak_kv_down, DownNodes}, State}
+    %% in rare cases, when the ring is resized, there may be an
+    %% exchange enqueued for an index that no longer exists. catch
+    %% the case here and move on
+    try riak_core_ring:index_owner(Ring, RemoteIdx) of
+        Owner ->
+            Nodes = lists:usort([node(), Owner]),
+            DownNodes = Nodes -- riak_core_node_watcher:nodes(riak_kv),
+            case DownNodes of
+                [] ->
+                    RemoteVN = {RemoteIdx, Owner},
+                    start_exchange(LocalVN, RemoteVN, IndexN, Ring, State);
+                _ ->
+                    {{riak_kv_down, DownNodes}, State}
+            end
+    catch
+        error:badarg ->
+            lager:warning("ignoring exchange to non-existent index: ~p", [RemoteIdx]),
+            {ok, State}
     end.
 
 start_exchange(LocalVN, RemoteVN, IndexN, Ring, State) ->
     {LocalIdx, _} = LocalVN,
     {RemoteIdx, _} = RemoteVN,
-    case riak_core_ring:index_owner(Ring, LocalIdx) == node() of
-        false ->
-            %% No longer owner of this partition, ignore exchange
-            {not_responsible, State};
-        true ->
+    case riak_core_ring:vnode_type(Ring, LocalIdx) of
+        primary ->
             case orddict:find(LocalIdx, State#state.trees) of
                 error ->
                     %% The local vnode has not yet registered it's
@@ -561,7 +567,11 @@ start_exchange(LocalVN, RemoteVN, IndexN, Ring, State) ->
                         {error, Reason} ->
                             {Reason, State}
                     end
-            end
+            end;
+        _ ->
+            %% No longer owner of this partition or partition is
+            %% part or larger future ring, ignore exchange
+            {not_responsible, State}
     end.
 
 -spec all_pairwise_exchanges(index(), riak_core_ring())

--- a/src/riak_kv_get_core.erl
+++ b/src/riak_kv_get_core.erl
@@ -254,11 +254,16 @@ merge(Replies, AllowMult) ->
             end
     end.
 
-%% @private If the Idx is not in the IdxType
-%% the world should end
+%% @private Checks IdxType to see if Idx is a primary.
+%% If the Idx is not in the IdxType the world must be
+%% resizing (ring expanding). In that case, Idx is
+%% assumed to be a primary, since only primaries forward.
 is_primary_response(Idx, IdxType) ->
-    {Idx, Status} = lists:keyfind(Idx, 1, IdxType),
-    Status == primary.
+    case lists:keyfind(Idx, 1, IdxType) of
+        false -> true;
+        {Idx, Status} -> Status == primary
+    end.
+
 
 %% @private Increment PR, if appropriate
 num_pr(GetCore = #getcore{num_pok=NumPOK, idx_type=IdxType}, Idx) ->

--- a/src/riak_kv_put_core.erl
+++ b/src/riak_kv_put_core.erl
@@ -178,11 +178,15 @@ maybe_return_body(PutCore = #putcore{returnbody = true}) ->
     {ReplyObj, UpdPutCore} = final(PutCore),
     {{ok, ReplyObj}, UpdPutCore}.
 
-%% @private If the Idx is not in the IdxType
-%% the world should end
+%% @private Checks IdxType to see if Idx is a primary.
+%% If the Idx is not in the IdxType the world must be
+%% resizing (ring expanding). In that case, Idx is
+%% assumed to be a primary, since only primaries forward.
 is_primary_response(Idx, IdxType) ->
-    {Idx, Status} = lists:keyfind(Idx, 1, IdxType),
-    Status == primary.
+    case lists:keyfind(Idx, 1, IdxType) of
+        false -> true;
+        {Idx, Status} -> Status == primary
+    end.
 
 %% @private Increment PW, if appropriate
 num_pw(PutCore = #putcore{num_pw=NumPW, idx_type=IdxType}, Idx) ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -731,11 +731,9 @@ handle_handoff_command(Req, Sender, State) ->
     handle_command(Req, Sender, State).
 
 %% callback used by dynamic ring sizing to determine where
-%% requests should be forwarded. Gets/puts/deletes are forwarded
+%% requests should be forwarded. Puts/deletes are forwarded
 %% during the operation, all other requests are not
 request_hash(?KV_PUT_REQ{bkey=BKey}) ->
-    riak_core_util:chash_key(BKey);
-request_hash(?KV_GET_REQ{bkey=BKey}) ->
     riak_core_util:chash_key(BKey);
 request_hash(?KV_DELETE_REQ{bkey=BKey}) ->
     riak_core_util:chash_key(BKey);

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -59,6 +59,7 @@
          delete/1,
          request_hash/1,
          object_info/1,
+         nval_map/1,
          handle_handoff_command/3,
          handoff_starting/2,
          handoff_cancelled/1,
@@ -290,8 +291,8 @@ repair_filter(Target) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     riak_core_repair:gen_filter(Target,
                                 Ring,
-                                bucket_nval_map(Ring),
-                                default_object_nval(),
+                                nval_map(Ring),
+                                riak_core_bucket:default_object_nval(),
                                 fun object_info/1).
 
 -spec hashtree_pid(index()) -> {ok, pid()}.
@@ -1509,13 +1510,9 @@ count_index_specs(IndexSpecs) ->
         end,
     lists:foldl(F, {0, 0}, IndexSpecs).
 
-%% @private
-bucket_nval_map(Ring) ->
-    riak_core_bucket:bucket_nval_map(Ring).
 
-%% @private
-default_object_nval() ->
-    riak_core_bucket:default_object_nval().
+nval_map(Ring) ->
+    riak_core_bucket:bucket_nval_map(Ring).
 
 %% @private
 object_info({Bucket, _Key}=BKey) ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -57,6 +57,8 @@
          handle_coverage/4,
          is_empty/1,
          delete/1,
+         request_hash/1,
+         object_info/1,
          handle_handoff_command/3,
          handoff_starting/2,
          handoff_cancelled/1,
@@ -728,6 +730,17 @@ handle_handoff_command(Req=?KV_PUT_REQ{}, Sender, State) ->
 handle_handoff_command(Req, Sender, State) ->
     handle_command(Req, Sender, State).
 
+%% callback used by dynamic ring sizing to determine where
+%% requests should be forwarded. Gets/puts/deletes are forwarded
+%% during the operation, all other requests are not
+request_hash(?KV_PUT_REQ{bkey=BKey}) ->
+    riak_core_util:chash_key(BKey);
+request_hash(?KV_GET_REQ{bkey=BKey}) ->
+    riak_core_util:chash_key(BKey);
+request_hash(?KV_DELETE_REQ{bkey=BKey}) ->
+    riak_core_util:chash_key(BKey);
+request_hash(_Req) ->
+    undefined.
 
 handoff_starting(_TargetNode, State) ->
     {true, State#state{in_handoff=true}}.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1511,12 +1511,11 @@ count_index_specs(IndexSpecs) ->
 
 %% @private
 bucket_nval_map(Ring) ->
-    [{riak_core_bucket:name(B), riak_core_bucket:n_val(B)} ||
-        B <- riak_core_bucket:get_buckets(Ring)].
+    riak_core_bucket:bucket_nval_map(Ring).
 
 %% @private
 default_object_nval() ->
-    riak_core_bucket:n_val(riak_core_config:default_bucket_props()).
+    riak_core_bucket:default_object_nval().
 
 %% @private
 object_info({Bucket, _Key}=BKey) ->


### PR DESCRIPTION
support for https://github.com/basho/riak_core/pull/301

This PR includes the following changes:
- exports the already existing `riak_kv_vnode:object_info/1` function, which is used during resize transfers
- add `riak_kv_vnode:request_hash/1`. has the effect of only forwarding puts/deletes during ring resizing, all other requests are handled locally
- slight modifications to AAE so entropy_manager and vnodes don't crash when ring is expanding
- modifications to PR/PW in get/put_core (see updated comments in source)
