### PR TITLE
kv_wm_utils expects ?MD_DELETED to be "true" not 'true'

### DIFF
--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -638,7 +638,7 @@ sib_of_binary(<<ValLen:32/integer, ValBin:ValLen/binary, MetaLen:32/integer, Met
     {#r_content{metadata=MD, value=decode_maybe_binary(ValBin)}, Rest}.
 
 deleted_meta(<<1>>, MDList) ->
-    [{?MD_DELETED, true} | MDList];
+    [{?MD_DELETED, "true"} | MDList];
 deleted_meta(_, MDList) ->
     MDList.
 


### PR DESCRIPTION
minimal possible fix. long term these types of things should be encapsulated
in riak_object

found here (includes steps to recreate): https://github.com/basho/riak_kv/pull/520#issuecomment-16616515 (Note: to recreate issue you must create a _tombstone_ sibling, not just a sibling)

Java code that exposes issue: https://gist.github.com/broach/57ce9237ec32b47d8897

cc/ @broach @seancribbs
