### PR TITLE
Add pagination to 2i results

### DIFF
--- a/include/riak_kv_index.hrl
+++ b/include/riak_kv_index.hrl
@@ -1,0 +1,10 @@
+%% Index query records
+-record(riak_kv_index_v2, {
+          start_key= <<>> :: binary(),
+          filter_field :: binary() | undefined,
+          start_term :: binary() | undefined, %% Note, in a $key query, start_key==start_term
+          end_term :: binary() | undefined, %% Note, in an eq query, start==end
+          return_terms=true :: boolean(), %% Note, should be false for an equals query
+          start_inclusive=true :: boolean()}).
+
+-define(KV_INDEX_Q, #riak_kv_index_v2).

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -141,6 +141,10 @@ start(_Type, _StartArgs) ->
                                           [v1, v0],
                                           v0),
 
+            riak_core_capability:register({riak_kv, '2i_return_terms'},
+                                          [true, false],
+                                          false),
+
             %% Go ahead and mark the riak_kv service as up in the node watcher.
             %% The riak_core_ring_handler blocks until all vnodes have been started
             %% synchronously.

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -141,9 +141,9 @@ start(_Type, _StartArgs) ->
                                           [v1, v0],
                                           v0),
 
-            riak_core_capability:register({riak_kv, '2i_return_terms'},
-                                          [true, false],
-                                          false),
+            riak_core_capability:register({riak_kv, '2i_version'},
+                                          [v2, v1],
+                                          v1),
 
             %% Go ahead and mark the riak_kv service as up in the node watcher.
             %% The riak_core_ring_handler blocks until all vnodes have been started

--- a/src/riak_kv_coverage_filter.erl
+++ b/src/riak_kv_coverage_filter.erl
@@ -113,7 +113,7 @@ build_item_filter(FilterInput) ->
 
 %% @private
 build_preflist_fun(Bucket, Ring) ->
-    fun({Key, _Value}) ->
+    fun({_Value, Key}) ->
             ChashKey = riak_core_util:chash_key({Bucket, Key}),
             riak_core_ring:responsible_index(ChashKey, Ring);
        (Key) ->

--- a/src/riak_kv_coverage_filter.erl
+++ b/src/riak_kv_coverage_filter.erl
@@ -113,10 +113,15 @@ build_item_filter(FilterInput) ->
 
 %% @private
 build_preflist_fun(Bucket, Ring) ->
-    fun(Key) ->
+    fun({Key, _Value}) ->
+            ChashKey = riak_core_util:chash_key({Bucket, Key}),
+            riak_core_ring:responsible_index(ChashKey, Ring);
+       (Key) ->
             ChashKey = riak_core_util:chash_key({Bucket, Key}),
             riak_core_ring:responsible_index(ChashKey, Ring)
     end.
+
+
 
 compose([]) ->
     none;

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -45,6 +45,8 @@
                    to_index_key/4, from_index_key/1
                   ]}).
 
+-include("riak_kv_index.hrl").
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
@@ -421,7 +423,6 @@ fold_buckets_fun(FoldBucketsFun) ->
             end
     end.
 
-
 %% @private
 %% Return a function to fold over keys on this backend
 fold_keys_fun(FoldKeysFun, undefined) ->
@@ -464,8 +465,6 @@ fold_keys_fun(FoldKeysFun, {index, FilterBucket, {range, <<"$key">>, StartKey, E
             end
     end;
 fold_keys_fun(FoldKeysFun, {index, FilterBucket, {range, FilterField, StartTerm, EndTerm}}) ->
-    fold_keys_fun(FoldKeysFun, {index, FilterBucket, {range, FilterField, StartTerm, EndTerm, false}});
-fold_keys_fun(FoldKeysFun, {index, FilterBucket, {range, FilterField, StartTerm, EndTerm, Terms}}) ->
     %% 2I range query...
     fun(StorageKey, Acc) ->
             case from_index_key(StorageKey) of
@@ -473,18 +472,79 @@ fold_keys_fun(FoldKeysFun, {index, FilterBucket, {range, FilterField, StartTerm,
                                                 FilterField == Field,
                                                 StartTerm =< Term,
                                                 EndTerm >= Term ->
-                    case Terms of
-                        true ->
-                            FoldKeysFun(Bucket, {Key, Term}, Acc);
-                        false ->
-                            FoldKeysFun(Bucket, Key, Acc)
-                    end;
+                    FoldKeysFun(Bucket, Key, Acc);
+                _ ->
+                    throw({break, Acc})
+            end
+    end;
+%% v2 indexes - pagination support
+fold_keys_fun(FoldKeysFun, {index, FilterBucket, ?KV_INDEX_Q{filter_field= <<"$bucket">>,
+                                                             start_key=StartKey,
+                                                             start_inclusive=Incl}}) ->
+    %% Fold across a bucket
+    fun(StorageKey, Acc) ->
+            case from_object_key(StorageKey) of
+                {Bucket, Key} when Bucket == FilterBucket,
+                                   Key >= StartKey ->
+                    SkipItem = (Key == StartKey andalso not Incl),
+                    stoppable_fold(FoldKeysFun, Bucket, Key, Acc, SkipItem);
+                _ ->
+                    throw({break, Acc})
+            end
+    end;
+fold_keys_fun(FoldKeysFun, {index, FilterBucket, ?KV_INDEX_Q{filter_field= <<"$key">>,
+                                                             start_key=StartKey,
+                                                             end_term=EndKey,
+                                                             start_inclusive=Incl}}) ->
+    %% Fold across a key range
+    fun(StorageKey, Acc) ->
+            case from_object_key(StorageKey) of
+                {Bucket, Key} when Bucket == FilterBucket,
+                                   Key >= StartKey,
+                                   Key =< EndKey ->
+                    SkipItem = (Key == StartKey andalso not Incl),
+                    stoppable_fold(FoldKeysFun, Bucket, Key, Acc, SkipItem);
+                _ ->
+                    throw({break, Acc})
+            end
+    end;
+fold_keys_fun(FoldKeysFun, {index, FilterBucket, ?KV_INDEX_Q{filter_field=FilterField,
+                                                             start_key=StartKey,
+                                                             start_term=StartTerm,
+                                                             end_term=EndTerm,
+                                                             return_terms=Terms,
+                                                             start_inclusive=Incl}}) ->
+    %% range query
+    fun(StorageKey, Acc) ->
+            case from_index_key(StorageKey) of
+                {Bucket, Key, Field, Term} when FilterBucket == Bucket,
+                                                FilterField == Field,
+                                                Key >= StartKey,
+                                                Term =< EndTerm,
+                                                Term >= StartTerm ->
+                    Val = if
+                              Terms -> {Term, Key};
+                              true -> Key
+                          end,
+                    SkipItem = (Key == StartKey andalso not Incl),
+                    stoppable_fold(FoldKeysFun, Bucket, Val, Acc, SkipItem);
                 _ ->
                     throw({break, Acc})
             end
     end;
 fold_keys_fun(_FoldKeysFun, Other) ->
     throw({unknown_limiter, Other}).
+
+stoppable_fold(Fun, Bucket, Item, Acc, false) ->
+    try
+        Fun(Bucket, Item, Acc)
+    catch
+        stop_fold ->
+            throw({break, Acc})
+    end;
+%% Skip this item
+stoppable_fold(_, _, _, Acc, true) ->
+    Acc.
 
 %% @private
 %% Return a function to fold over the objects on this backend
@@ -510,7 +570,6 @@ fold_opts(Bucket, FoldOpts) ->
     BKey = sext:encode({Bucket, <<>>}),
     [{first_key, BKey} | FoldOpts].
 
-
 %% @private Given a scope limiter, use sext to encode an expression
 %% that represents the starting key for the scope. For example, since
 %% we store objects under {o, Bucket, Key}, the first key for the
@@ -521,6 +580,9 @@ to_first_key(undefined) ->
 to_first_key({bucket, Bucket}) ->
     %% Start at the first object for a given bucket...
     to_object_key(Bucket, <<>>);
+to_first_key({index, incorrect_format, ForUpgrade}) when is_boolean(ForUpgrade) ->
+    %% Start at first index entry
+    to_index_key(<<>>, <<>>, <<>>, <<>>);
 to_first_key({index, Bucket, {eq, <<"$bucket">>, _Term}}) ->
     %% 2I exact match query on special $bucket field...
     to_first_key({bucket, Bucket});
@@ -531,14 +593,20 @@ to_first_key({index, Bucket, {range, <<"$key">>, StartTerm, _EndTerm}}) ->
     %% 2I range query on special $key field...
     to_object_key(Bucket, StartTerm);
 to_first_key({index, Bucket, {range, Field, StartTerm, _EndTerm}}) ->
-    %% (Legacy) 2I range query...
+    %% 2I range query...
     to_index_key(Bucket, <<>>, Field, StartTerm);
-to_first_key({index, Bucket, {range, Field, StartTerm, _EndTerm, _Terms}}) ->
-    %% 2I range query (return terms too)
-    to_index_key(Bucket, <<>>, Field, StartTerm);
+%% V2 indexes
+to_first_key({index, Bucket,
+              ?KV_INDEX_Q{filter_field=Field,
+                          start_key=StartKey}}) when Field == <<"$key">>;
+                                                     Field == <<"$bucket">> ->
+    to_object_key(Bucket, StartKey);
+to_first_key({index, Bucket, ?KV_INDEX_Q{filter_field=Field,
+                                         start_key=StartKey,
+                                         start_term=StartTerm}}) ->
+    to_index_key(Bucket, StartKey, Field, StartTerm);
 to_first_key(Other) ->
     erlang:throw({unknown_limiter, Other}).
-
 
 to_object_key(Bucket, Key) ->
     sext:encode({o, Bucket, Key}).

--- a/src/riak_kv_index_fsm.erl
+++ b/src/riak_kv_index_fsm.erl
@@ -40,6 +40,8 @@
 -include_lib("riak_kv_vnode.hrl").
 
 -export([init/2,
+         plan/2,
+         process_results/3,
          process_results/2,
          finish/2]).
 -export([use_ack_backpressure/0,
@@ -48,7 +50,10 @@
 -type from() :: {atom(), req_id(), pid()}.
 -type req_id() :: non_neg_integer().
 
--record(state, {from :: from()}).
+-record(state, {from :: from(),
+                merge_sort_buffer :: sms:sms(),
+                max_results :: all | pos_integer(),
+                results_sent = 0 :: non_neg_integer()}).
 
 %% @doc Returns `true' if the new ack-based backpressure index
 %% protocol should be used.  This decision is based on the
@@ -77,14 +82,58 @@ req(Bucket, ItemFilter, Query) ->
 %% should cover, the service to use to check for available nodes,
 %% and the registered name to use to access the vnode master process.
 init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout]) ->
+    %% http://erlang.org/doc/reference_manual/expressions.html#id77404
+    %% atom() > number()
+    init(From, [Bucket, ItemFilter, Query, Timeout, all]);
+init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout, MaxResults]) ->
     %% Get the bucket n_val for use in creating a coverage plan
     BucketProps = riak_core_bucket:get_bucket(Bucket),
     NVal = proplists:get_value(n_val, BucketProps),
     %% Construct the key listing request
     Req = req(Bucket, ItemFilter, Query),
     {Req, all, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout,
-     #state{from=From}}.
+     #state{from=From, max_results=MaxResults}}.
 
+plan(CoverageVNodes, State) ->
+    {ok, State#state{merge_sort_buffer=sms:new(CoverageVNodes)}}.
+
+process_results(_VNode, {error, Reason}, _State) ->
+    {error, Reason};
+process_results(_VNode, {From, _Bucket, _Results}, State=#state{max_results=X, results_sent=Y})  when Y >= X ->
+    riak_kv_vnode:stop_fold(From),
+    {done, State};
+process_results(VNode, {From, Bucket, Results}, State) ->
+    {ok, State2} = process_results(VNode, {Bucket, Results}, State),
+    riak_kv_vnode:ack_keys(From),
+    {ok, State2};
+process_results(VNode, {_Bucket, Results}, State) ->
+    #state{merge_sort_buffer=MergeSortBuffer,
+           from={raw, ReqId, ClientPid}, results_sent=ResultsSent, max_results=MaxResults} = State,
+    %% add new results to buffer
+    BufferWithNewResults = sms:add_results(VNode, lists:reverse(Results), MergeSortBuffer),
+    ProcessBuffer = sms:sms(BufferWithNewResults),
+    {NewBuffer, Sent} = case ProcessBuffer of
+                            {[], BufferWithNewResults} ->
+                                {BufferWithNewResults, 0};
+                            {ToSend, NewBuff} ->
+                                DownTheWire = case (ResultsSent + length(ToSend)) > MaxResults of
+                                                  true ->
+                                                      lists:sublist(ToSend, MaxResults - ResultsSent);
+                                                  false ->
+                                                      ToSend
+                                              end,
+                                ClientPid ! {ReqId, {results, DownTheWire}},
+                                {NewBuff, length(DownTheWire)}
+                        end,
+    {ok, State#state{merge_sort_buffer=NewBuffer, results_sent=Sent+ResultsSent}};
+process_results(VNode, done, State) ->
+    %% tell the sms buffer about the done vnode
+    #state{merge_sort_buffer=MergeSortBuffer} = State,
+    BufferWithNewResults = sms:add_results(VNode, done, MergeSortBuffer),
+    {done, State#state{merge_sort_buffer=BufferWithNewResults}}.
+
+
+%% Legacy, unsorted 2i, should remove?
 process_results({error, Reason}, _State) ->
     {error, Reason};
 process_results({From, Bucket, Results},
@@ -106,9 +155,24 @@ finish({error, Error},
     ClientPid ! {ReqId, {error, Error}},
     {stop, normal, StateData};
 finish(clean,
-       StateData=#state{from={raw, ReqId, ClientPid}}) ->
+       StateData=#state{from={raw, ReqId, ClientPid}, merge_sort_buffer=undefined}) ->
     ClientPid ! {ReqId, done},
-    {stop, normal, StateData}.
+    {stop, normal, StateData};
+finish(clean,
+       State=#state{from={raw, ReqId, ClientPid},
+                    merge_sort_buffer=MergeSortBuffer,
+                    results_sent=ResultsSent,
+                    max_results=MaxResults}) ->
+    LastResults = sms:done(MergeSortBuffer),
+    DownTheWire = case (ResultsSent + length(LastResults)) > MaxResults of
+                      true ->
+                          lists:sublist(LastResults, MaxResults - ResultsSent);
+                      false ->
+                          LastResults
+                  end,
+    ClientPid ! {ReqId, {results, DownTheWire}},
+    ClientPid ! {ReqId, done},
+    {stop, normal, State}.
 
 %% ===================================================================
 %% Internal functions

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -83,18 +83,28 @@ process(#rpbindexreq{bucket=Bucket, index=Index, qtype=eq, key=SKey}, #state{cli
             {error, {format, Reason}, State}
     end;
 process(#rpbindexreq{bucket=Bucket, index=Index, qtype=range,
-                     range_min=Min, range_max=Max}, #state{client=Client}=State) ->
-    case riak_index:to_index_query(Index, [Min, Max]) of
+                     range_min=Min, range_max=Max, return_terms=ReturnTerms0}, #state{client=Client}=State) ->
+    CanReturnTerms = riak_core_capability:get({riak_kv, '2i_return_terms'}, false),
+    ReturnTerms = (normalize_bool(ReturnTerms0) andalso CanReturnTerms),
+    case riak_index:to_index_query(Index, [Min, Max], ReturnTerms) of
         {ok, Query} ->
-            case Client:get_index(Bucket, Query) of
-                {ok, Results} ->
+            case {ReturnTerms, Client:get_index(Bucket, Query)} of
+                {false, {ok, Results}} ->
                     {reply, #rpbindexresp{keys=Results}, State};
-                {error, QReason} ->
+                {true, {ok, Results0}} ->
+                    Results = [riak_pb_kv_codec:encode_index_pair(Res) || Res <- Results0],
+                    {reply, #rpbindexresp{results=Results}, State};
+                {_, {error, QReason}} ->
                     {error, {format, QReason}, State}
             end;
         {error, Reason} ->
             {error, {format, Reason}, State}
     end.
+
+normalize_bool(B) when is_boolean(B) ->
+    B;
+normalize_bool(_) ->
+    false.
 
 %% @doc process_stream/3 callback. This service does not create any
 %% streaming responses and so ignores all incoming messages.

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -46,7 +46,7 @@
          process/2,
          process_stream/3]).
 
--record(state, {client}).
+-record(state, {client, req_id, req, continuation, result_count=0}).
 
 %% @doc init/0 callback. Returns the service internal start
 %% state.
@@ -70,43 +70,85 @@ process(#rpbindexreq{qtype=eq, key=SKey}, State)
 process(#rpbindexreq{qtype=range, range_min=Min, range_max=Max}, State)
   when not (is_binary(Min) andalso is_binary(Max)) ->
     {error, {format, "Invalid range query: ~p -> ~p", [Min, Max]}, State};
-process(#rpbindexreq{bucket=Bucket, index=Index, qtype=eq, key=SKey}, #state{client=Client}=State) ->
-    case riak_index:to_index_query(Index, [SKey]) of
-        {ok, Query} ->
-            case Client:get_index(Bucket, Query) of
-                {ok, Results} ->
-                    {reply, #rpbindexresp{keys=Results}, State};
-                {error, QReason} ->
-                    {error, {format, QReason}, State}
-            end;
-        {error, Reason} ->
-            {error, {format, Reason}, State}
-    end;
-process(#rpbindexreq{bucket=Bucket, index=Index, qtype=range,
-                     range_min=Min, range_max=Max, return_terms=ReturnTerms0}, #state{client=Client}=State) ->
-    CanReturnTerms = riak_core_capability:get({riak_kv, '2i_return_terms'}, false),
-    ReturnTerms = (normalize_bool(ReturnTerms0) andalso CanReturnTerms),
-    case riak_index:to_index_query(Index, [Min, Max], ReturnTerms) of
-        {ok, Query} ->
-            case {ReturnTerms, Client:get_index(Bucket, Query)} of
-                {false, {ok, Results}} ->
-                    {reply, #rpbindexresp{keys=Results}, State};
-                {true, {ok, Results0}} ->
-                    Results = [riak_pb_kv_codec:encode_index_pair(Res) || Res <- Results0],
-                    {reply, #rpbindexresp{results=Results}, State};
-                {_, {error, QReason}} ->
-                    {error, {format, QReason}, State}
-            end;
-        {error, Reason} ->
-            {error, {format, Reason}, State}
-    end.
+process(Req=#rpbindexreq{}, State) ->
+    {Index, Args, Continuation} = query_params(Req),
+    Query = riak_index:to_index_query(Index, Args, Continuation),
+    maybe_perform_query(Query, Req, State).
 
-normalize_bool(B) when is_boolean(B) ->
-    B;
-normalize_bool(_) ->
-    false.
+maybe_perform_query({error, Reason}, _Req, State) ->
+    {error, {format, Reason}, State};
+maybe_perform_query({ok, Query}, Req=#rpbindexreq{stream=true}, State) ->
+    #rpbindexreq{bucket=Bucket, max_results=MaxResults} = Req,
+    #state{client=Client} = State,
+    {ok, ReqId} = Client:stream_get_index(Bucket, Query, [{max_results, MaxResults}]),
+    ReturnTerms = riak_index:return_terms(Req#rpbindexreq.return_terms, Query),
+    {reply, {stream, ReqId}, State#state{req_id=ReqId, req=Req#rpbindexreq{return_terms=ReturnTerms}}};
+maybe_perform_query({ok, Query}, Req, State) ->
+    #rpbindexreq{bucket=Bucket, max_results=MaxResults, return_terms=ReturnTerms0} = Req,
+    #state{client=Client} = State,
+    ReturnTerms =  riak_index:return_terms(ReturnTerms0, Query),
+    QueryResult = Client:get_index(Bucket, Query, [{max_results, MaxResults}]),
+    handle_query_results(ReturnTerms, MaxResults, QueryResult , State).
 
-%% @doc process_stream/3 callback. This service does not create any
-%% streaming responses and so ignores all incoming messages.
+handle_query_results(_, _, {error, Reason}, State) ->
+    {error, {format, Reason}, State};
+handle_query_results(ReturnTerms, MaxResults,  {ok, Results}, State) ->
+    Cont = make_continuation(MaxResults, Results, length(Results)),
+    Resp = encode_results(ReturnTerms, Results, Cont),
+    {reply, Resp, State}.
+
+query_params(#rpbindexreq{qtype=eq, index=Index, key=Value, continuation=Continuation}) ->
+    {Index, [Value], Continuation};
+query_params(#rpbindexreq{index=Index, range_min=Min, range_max=Max, continuation=Continuation}) ->
+    {Index, [Min, Max], Continuation}.
+
+encode_results(true, Results0, Continuation) ->
+    Results = [encode_result(Res) || Res <- Results0],
+    #rpbindexresp{results=Results, continuation=Continuation};
+encode_results(_, Results, Continuation) ->
+    JustTheKeys = filter_values(Results),
+    #rpbindexresp{keys=JustTheKeys, continuation=Continuation}.
+
+encode_result({V, K}) when is_integer(V) ->
+    V1 = list_to_binary(integer_to_list(V)),
+    riak_pb_kv_codec:encode_index_pair({V1, K});
+encode_result(Res) ->
+    riak_pb_kv_codec:encode_index_pair(Res).
+
+filter_values([]) ->
+    [];
+filter_values([{_, _} | _T]=Results) ->
+    [K || {_V, K} <- Results];
+filter_values(Results) ->
+    Results.
+
+make_continuation(MaxResults, Results, MaxResults) ->
+    riak_index:make_continuation(Results);
+make_continuation(_, _, _)  ->
+    undefined.
+
+%% @doc process_stream/3 callback. Handle streamed responses
+process_stream({ReqId, done}, ReqId, State=#state{req_id=ReqId,
+                                                  continuation=Continuation,
+                                                  req=Req,
+                                                  result_count=Count}) ->
+    %% Only add the continuation if there (may) be more results to send
+    #rpbindexreq{max_results=MaxResults} = Req,
+    lager:info("XXXX YO!!! ~p ~p ~p", [is_integer(MaxResults), Count, MaxResults]),
+    Resp = case is_integer(MaxResults) andalso Count =:= MaxResults of
+               true -> #rpbindexresp{done=1, continuation=Continuation};
+               false -> #rpbindexresp{done=1}
+           end,
+    {done, Resp, State};
+process_stream({ReqId, {results, []}}, ReqId, State=#state{req_id=ReqId}) ->
+    {ignore, State};
+process_stream({ReqId, {results, Results}}, ReqId, State=#state{req_id=ReqId, req=Req, result_count=Count}) ->
+    #rpbindexreq{return_terms=ReturnTerms, max_results=MaxResults} = Req,
+    Count2 = length(Results) + Count,
+    Continuation = make_continuation(MaxResults, Results, Count2),
+    Response = encode_results(ReturnTerms, Results, undefined),
+    {reply, Response, State#state{continuation=Continuation, result_count=Count2}};
+process_stream({ReqId, Error}, ReqId, State=#state{req_id=ReqId}) ->
+    {error, {format, Error}, State#state{req_id=undefined}};
 process_stream(_,_,State) ->
     {ignore, State}.

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -134,7 +134,6 @@ process_stream({ReqId, done}, ReqId, State=#state{req_id=ReqId,
                                                   result_count=Count}) ->
     %% Only add the continuation if there (may) be more results to send
     #rpbindexreq{max_results=MaxResults} = Req,
-    lager:info("XXXX YO!!! ~p ~p ~p", [is_integer(MaxResults), Count, MaxResults]),
     Resp = case is_integer(MaxResults) andalso Count =:= MaxResults of
                true -> #rpbindexresp{done=1, continuation=Continuation};
                false -> #rpbindexresp{done=1}

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -47,7 +47,8 @@
          hashtree_pid/1,
          rehash/3,
          request_hashtree_pid/1,
-         reformat_object/2]).
+         reformat_object/2,
+         stop_fold/1]).
 
 %% riak_core_vnode API
 -export([init/1,
@@ -1108,6 +1109,9 @@ result_fun_ack(Bucket, Sender) ->
             receive
                 {Monitor, ok} ->
                     erlang:demonitor(Monitor, [flush]);
+                {Monitor, stop_fold} ->
+                    erlang:demonitor(Monitor, [flush]),
+                    throw(stop_fold);
                 {'DOWN', Monitor, process, _Pid, _Reason} ->
                     throw(receiver_down)
             end
@@ -1120,6 +1124,9 @@ result_fun_ack(Bucket, Sender) ->
 -spec ack_keys(From::{pid(), reference()}) -> term().
 ack_keys({Pid, Ref}) ->
     Pid ! {Ref, ok}.
+
+stop_fold({Pid, Ref}) ->
+    Pid ! {Ref, stop_fold}.
 
 %% @private
 finish_fun(BufferMod, Sender) ->

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -45,8 +45,12 @@
           client,       %% riak_client() - the store client
           riak,         %% local | {node(), atom()} - params for riak client
           bucket,       %% The bucket to query.
-          index_query   %% The query..
+          index_query,   %% The query..
+          max_results :: all | pos_integer(), %% maximum nunber of 2i results to return, the page size.
+          return_terms = false :: boolean() %% should the index values be returned
          }).
+
+-define(ALL_2I_RESULTS, all).
 
 -include_lib("webmachine/include/webmachine.hrl").
 -include("riak_kv_wm_raw.hrl").
@@ -91,22 +95,45 @@ malformed_request(RD, Ctx) ->
     Args2 = [list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, X)) || X <- Args1],
     ReturnTerms0 = wrq:get_qs_value(?Q_2I_RETURNTERMS, "false", RD),
     ReturnTerms = normalize_boolean(string:to_lower(ReturnTerms0)),
-    CanReturnTerms = riak_core_capability:get({riak_kv, '2i_return_terms'}, false),
+    MaxResults0 = wrq:get_qs_value(?Q_2I_MAX_RESULTS, ?ALL_2I_RESULTS, RD),
+    Continuation = wrq:get_qs_value(?Q_2I_CONTINUATION, undefined, RD),
 
-    case riak_index:to_index_query(IndexField, Args2, (ReturnTerms andalso CanReturnTerms)) of
-        {ok, Query} ->
+    case {validate_max(MaxResults0), riak_index:to_index_query(IndexField, Args2, Continuation)} of
+        {{true, MaxResults}, {ok, Query}} ->
             %% Request is valid.
+            ReturnTerms1 = riak_index:return_terms(ReturnTerms, Query),
             NewCtx = Ctx#ctx{
                        bucket = Bucket,
-                       index_query = Query
+                       index_query = Query,
+                       max_results = MaxResults,
+                       return_terms = ReturnTerms1
                       },
             {false, RD, NewCtx};
-        {error, Reason} ->
+        {_, {error, Reason}} ->
             {true,
              wrq:set_resp_body(
                io_lib:format("Invalid query: ~p~n", [Reason]),
                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx};
+        {{false, BadVal}, _} ->
+            {true,
+             wrq:set_resp_body(io_lib:format("Invalid ~p. ~p is not a positive integer",
+                                             [?Q_2I_MAX_RESULTS, BadVal]),
+                               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx}
+    end.
+
+validate_max(all) ->
+    {true, all};
+validate_max(N) when is_list(N) ->
+    try
+        list_to_integer(N) of
+        Max when Max > 0  ->
+            {true, Max};
+        LessThanZero ->
+            {false, LessThanZero}
+    catch _:_ ->
+            {false, N}
     end.
 
 normalize_boolean("false") ->
@@ -137,19 +164,122 @@ encodings_provided(RD, Ctx) ->
 %% @spec produce_index_results(reqdata(), context()) -> {binary(), reqdata(), context()}
 %% @doc Produce the JSON response to an index lookup.
 produce_index_results(RD, Ctx) ->
-    %% Extract vars...
+    case wrq:get_qs_value("stream", "false", RD) of
+        "true" ->
+            handle_streaming_index_query(RD, Ctx);
+        _ ->
+            handle_all_in_memory_index_query(RD, Ctx)
+    end.
+
+handle_streaming_index_query(RD, Ctx) ->
     Client = Ctx#ctx.client,
     Bucket = Ctx#ctx.bucket,
     Query = Ctx#ctx.index_query,
+    MaxResults = Ctx#ctx.max_results,
+    ReturnTerms = Ctx#ctx.return_terms,
+
+    %% Create a new multipart/mixed boundary
+    Boundary = riak_core_util:unique_id_62(),
+    CTypeRD = wrq:set_resp_header(
+                "Content-Type",
+                "multipart/mixed;boundary="++Boundary,
+                RD),
+
+    {ok, ReqID} =  Client:stream_get_index(Bucket, Query, [{max_results, MaxResults}]),
+    StreamFun = index_stream_helper(ReqID, Boundary, ReturnTerms, MaxResults, undefined, 0),
+    {{stream, {<<>>, StreamFun}}, CTypeRD, Ctx}.
+
+index_stream_helper(ReqID, Boundary, ReturnTerms, MaxResults, LastResult, Count) ->
+    fun() ->
+            receive
+                {ReqID, done} ->
+                    Final = case make_continuation(MaxResults, [LastResult], Count) of
+                                undefined -> ["\r\n--", Boundary, "--\r\n"];
+                                Continuation ->
+                                    Json = encode_continuation(Continuation),
+                                    ["\r\n--", Boundary, "--\r\n",
+                                     "Content-Type: application/json\r\n\r\n",
+                                     Json,
+                                     "\r\n--", Boundary, "--\r\n"]
+                            end,
+                    {iolist_to_binary(Final), done};
+                {ReqID, {results, Results}} ->
+                    %% JSONify the results
+                    JsonResults = encode_results(Results, ReturnTerms),
+                    Body = ["\r\n--", Boundary, "\r\n",
+                            "Content-Type: application/json\r\n\r\n",
+                            JsonResults],
+                    %% don't let an empty result set wipe out
+                    %% a previous last result
+                    LastResult1 = case Results of
+                                     [] -> LastResult;
+                                     _ -> last_result(Results)
+                                 end,
+                    {iolist_to_binary(Body),
+                     index_stream_helper(ReqID, Boundary, ReturnTerms, MaxResults, LastResult1, Count+length(Results))};
+                {ReqID, Error} ->
+                    lager:error("Error in index wm: ~p", [Error]),
+                    Body = ["\r\n--", Boundary, "\r\n",
+                            "Content-Type: text/plain\r\n\r\n",
+                            "there was an error..."],
+                    {iolist_to_binary(Body), done}
+            after 60000 ->
+                    {error, timeout}
+            end
+    end.
+
+handle_all_in_memory_index_query(RD, Ctx) ->
+    Client = Ctx#ctx.client,
+    Bucket = Ctx#ctx.bucket,
+    Query = Ctx#ctx.index_query,
+    MaxResults = Ctx#ctx.max_results,
+    ReturnTerms = Ctx#ctx.return_terms,
 
     %% Do the index lookup...
-    case Client:get_index(Bucket, Query) of
+    case Client:get_index(Bucket, Query, [{max_results, MaxResults}]) of
         {ok, Results} ->
-            %% JSONify the results...
-            JsonKeys1 = {struct, [{?Q_KEYS, Results}]},
-            JsonKeys2 = mochijson2:encode(JsonKeys1),
-            {JsonKeys2, RD, Ctx};
+            Continuation = make_continuation(MaxResults, Results, length(Results)),
+            JsonResults = encode_results(ReturnTerms, Results, Continuation),
+            {JsonResults, RD, Ctx};
         {error, Reason} ->
             {{error, Reason}, RD, Ctx}
     end.
 
+encode_results(ReturnTerms, Results) ->
+    encode_results(ReturnTerms, Results, undefined).
+
+encode_results(true, Results, Continuation) ->
+    JsonKeys2 = {struct, [{?Q_RESULTS, [{struct, [{Val, Key}]} || {Val, Key} <- Results]}] ++ encode_continuation(Continuation)},
+    mochijson2:encode(JsonKeys2);
+encode_results(false, Results, Continuation) ->
+    JustTheKeys = filter_values(Results),
+    JsonKeys1 = {struct, [{?Q_KEYS, JustTheKeys}] ++ encode_continuation(Continuation)},
+    mochijson2:encode(JsonKeys1).
+
+encode_continuation(undefined) ->
+    [];
+encode_continuation(Continuation) ->
+    [{?Q_2I_CONTINUATION, Continuation}].
+
+filter_values([]) ->
+    [];
+filter_values([{_, _} | _T]=Results) ->
+    [K || {_V, K} <- Results];
+filter_values(Results) ->
+    Results.
+
+%% @doc Like `lists:last/1' but doesn't choke on an empty list
+-spec last_result([] | list()) -> term() | undefined.
+last_result([]) ->
+    undefined;
+last_result(L) ->
+    lists:last(L).
+
+%% @Doc if this is a paginated query make a continuation
+-spec make_continuation(Max::non_neg_integer() | undefined,
+                        list(),
+                        ResultCount::non_neg_integer()) -> binary() | undefined.
+make_continuation(MaxResults, Results, MaxResults) ->
+    riak_index:make_continuation(Results);
+make_continuation(_, _, _)  ->
+    undefined.

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -64,3 +64,4 @@
 -define(Q_STREAM, "stream").
 -define(Q_VTAG,  "vtag").
 -define(Q_RETURNBODY, "returnbody").
+-define(Q_2I_RETURNTERMS, "returnterms").

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -64,4 +64,7 @@
 -define(Q_STREAM, "stream").
 -define(Q_VTAG,  "vtag").
 -define(Q_RETURNBODY, "returnbody").
--define(Q_2I_RETURNTERMS, "returnterms").
+-define(Q_2I_RETURNTERMS, "return_terms").
+-define(Q_2I_MAX_RESULTS, "max_results").
+-define(Q_2I_CONTINUATION, "continuation").
+-define(Q_RESULTS,  "results").

--- a/src/riak_kv_worker.erl
+++ b/src/riak_kv_worker.erl
@@ -47,6 +47,7 @@ handle_work({fold, FoldFun, FinishFun}, _Sender, State) ->
     try
         FinishFun(FoldFun())
     catch
-        receiver_down -> ok
+        receiver_down -> ok;
+        stop_fold -> ok
     end,
     {noreply, State}.

--- a/src/sms.erl
+++ b/src/sms.erl
@@ -1,0 +1,98 @@
+%% -------------------------------------------------------------------
+%%
+%% sms: Streaming merge sort
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(sms).
+
+-define(DICTMODULE, orddict).
+
+-export([new/1,
+         add_results/3,
+         done/1,
+         sms/1]).
+
+-export_type([sms/0]).
+
+-opaque sms() :: ?DICTMODULE:?DICTMODULE().
+
+%% @doc create a new sms buffer for the given covering set
+%% of `Vnodes'
+-spec new([non_neg_integer()]) -> sms().
+new(Vnodes) ->
+    DictList = [{VnodeID, {active,[]}} || VnodeID <- Vnodes],
+    ?DICTMODULE:from_list(DictList).
+
+%% @doc Append `Results' to existing buffer for `VnodeID' in
+%% `Data'
+-spec add_results(non_neg_integer(), list(), sms()) -> sms().
+add_results(VnodeID, done, Data) ->
+    UpdateFun = fun({active, Prev}) -> {done, Prev} end,
+    update(VnodeID, UpdateFun, Data);
+add_results(VnodeID, Results, Data) ->
+    UpdateFun = fun ({active, Prev}) -> {active, Prev ++ Results} end,
+    update(VnodeID, UpdateFun, Data).
+
+%% @private
+update(VnodeID, UpdateFun, Data) ->
+    ?DICTMODULE:update(VnodeID, UpdateFun, Data).
+
+%% @doc get all data in buffer, for all vnodes, merged
+-spec done(sms()) -> [term()].
+done(Data) ->
+    Values = values(Data),
+    lists:merge(Values).
+
+
+%% @doc perform the streaming merge sort over given `Data:sms()'
+%% returns a two tuple of {`MergedReadyToSendResults::[term()], sms()},
+%% where the first element is the merge-sorted data from all vnodes that can
+%% be consumed by the client, and `sms()' is a buffer of remaining results.
+-spec sms(sms()) -> {[term()] | [], sms()}.
+sms(Data) ->
+    case any_empty(values(Data)) of
+        true ->
+            {[], Data};
+        false ->
+            unsafe_sms(Data)
+    end.
+
+%% @private, perform the merge
+unsafe_sms(Data) ->
+    MinOfLastsOfLists = lists:min([lists:last(List) || List <- values(Data)]),
+    SplitFun = fun (Elem) -> Elem =< MinOfLastsOfLists end,
+    Split = ?DICTMODULE:map(fun (_Key, {Status, V}) -> {Status, lists:splitwith(SplitFun, V)} end, Data),
+    LessThan = ?DICTMODULE:map(fun (_Key, {Status, V}) -> {Status, element(1, V)} end, Split),
+    GreaterThan = ?DICTMODULE:map(fun (_Key, {Status, V}) -> {Status, element(2, V)} end, Split),
+    Merged = lists:merge(values(LessThan)),
+    {Merged, GreaterThan}.
+
+%% @private
+values(Data) ->
+    %% Don't make the SMS wait forever for vnodes that are done
+    [V || {_Key, {_Status, V}=T} <- ?DICTMODULE:to_list(Data), T /= {done, []}].
+
+%% @private
+empty([]) -> true;
+empty(_) -> false.
+
+%% @private
+any_empty(Lists) ->
+    lists:any(fun empty/1, Lists).


### PR DESCRIPTION
Adds a `max_results` option to PB and HTTP 2i endpoints for limiting
the number of results returned for a 2i query.  Will return an opaque
`continuation` if there are `max_results` results returned. A
subsequent query that includes the `continuation` as a parameter will
return the next `max_results` results.

The results will be returned sorted ascending. In the case of $key
and $bucket queries, and equals queries, the results will be sorted by
primary key In the case of range queries the results will be sorted by
index value, then primary key. Since the values must be returned from the backend for
sorting, there is a further option `return_terms` that will cause the
indexed terms to be returned to the user also, where relevant (range
queries on index fields.)

Sorting is performed by the module `sms.erl` originally written by Reid
Draper. It is used as a buffer by `riak_kv_index_fsm`.

A new vnode function `stop_fold` has been added so the fsm can tell
the backend to break out of the fold when enough results have been
gathered.

The option to stream 2i results has also been added. Adding the
`stream` option to either HTTP or PB queries will cause the API
endpoints to return chunks of results as they are received from the
fsm This can lead to much lower perceived latencies as the application
recieves the first results of a large set much sooner.

An example HTTP query: 

`curl "http://127.0.0.1:10018/buckets/2ibucket/index/field2_int/1/999?return_terms=true&max_results=100"`

Will return the first 100 {value, key} pairs for the `field2_int`
index, sorted by value, then primary key.  If there are 100 results returned, it will
also return an opaque `continuation` that may be sumbitted to continue
the query: 

`curl "http://127.0.0.1:10018/buckets/2ibucket/index/field2_int/1/999?return_terms=true&continuation=some_gibberish_looking_value&max_results=100"`

A further `continuation` maybe returned with the results.

---

Riak tests can be found at https://github.com/basho/riak_test/tree/pt29-2i-pagination
Riak-Erlang-Client support at https://github.com/basho/riak-erlang-client/tree/pt29-2i-pagination

NOTE: requires
https://github.com/basho/riak_core/tree/pt29-2i-pagination
https://github.com/basho/riak_pb/tree/pt29-2i-pagination
