### PR TITLE
url encode/decode 2i headers

### DIFF
--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -139,7 +139,7 @@ multipart_encode_body(Prefix, Bucket, {MD, V}, APIVersion) ->
      end,
      case dict:find(?MD_INDEX, MD) of
          {ok, IF} ->
-             [[?HEAD_INDEX_PREFIX,Key,": ",any_to_list(Val),"\r\n"] || {Key,Val} <- IF];
+             [[?HEAD_INDEX_PREFIX,mochiweb_util:quote_plus(Key),": ",any_to_list(mochiweb_util:quote_plus(Val)),"\r\n"] || {Key,Val} <- IF];
          error -> []
      end,
      "\r\n",


### PR DESCRIPTION
This stems from the StackOverflow Q found here:
http://stackoverflow.com/questions/16335296/url-unsafe-secondary-index-names-in-riak-do-not-work

Currently we don't URL-decode the field-name or the value of x-riak-index-*
headers on a POST/PUT. The problem then arrises that on a GET for an index
you need to url-encode then url-escape everything because we do url-decode the
hierarchical part of the URL. It also then means that the same query
using protocol buffers has to be url-encoded which is ... silly.

By url-decoding the field-name and the value then storing the raw bytes we
avoid all this confusion. GET requests work as expected using HTTP and PB
queries do not have to be URL encoded.

The one outstanding consideration is ... what to do about people who
are currently URL-encoding / escaping, etc. When the decoding was added
for the GET (which is actually what broke this, ironically enough) there
was a environment setting and an optional header added to toggle the feature
on/off (see [riak_kv_wm_utils:maybe_decode_uri/2](https://github.com/basho/riak_kv/blob/x-riak-index-url-decode/src/riak_kv_wm_utils.erl#L46) - today the default is "on")

I can easily add the same type of thing which I'm thinking we may have to do?
