### PR TITLE
Bound the number of get/put FSMs to prevent overload

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,6 +10,7 @@
 
 {deps, [
         {riak_core, "1.2.*", {git, "git://github.com/basho/riak_core", {tag, "1.2.1p1"}}},
+        {sidejob, "0.1", {git, "git://github.com/basho/sidejob", "master"}},
         {luke, "0.2.5", {git, "git://github.com/basho/luke", {tag, "0.2.5"}}},
         {erlang_js, "1.2.1", {git, "git://github.com/basho/erlang_js", {tag, "1.2.1"}}},
         {bitcask, "1.5.2", {git, "git://github.com/basho/bitcask", {tag, "1.5.2"}}},

--- a/src/riak_kv.app.src
+++ b/src/riak_kv.app.src
@@ -10,6 +10,7 @@
                   sasl,
                   crypto,
                   riak_core,
+                  sidejob,
                   luke,
                   erlang_js,
                   mochiweb,

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -257,7 +257,7 @@ check_kv_health(_Pid) ->
     Passed.
 
 wait_for_put_fsms(N) ->
-    case riak_kv_get_put_monitor:puts_active() of
+    case riak_kv_util:exact_puts_active() of
         0 -> ok;
         Count ->
             case N of

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -111,9 +111,10 @@ start_link(From, Bucket, Key, GetOptions) ->
                                                 gen_fsm, start_link,
                                                 [?MODULE, Args, []]) of
                 {error, overload} ->
-                    riak_kv_util:overload_reply(From);
-                {ok, _Pid} ->
-                    ok
+                    riak_kv_util:overload_reply(From),
+                    {error, overload};
+                {ok, Pid} ->
+                    {ok, Pid}
             end
     end.
 

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -136,9 +136,10 @@ start_link(From, Object, PutOptions) ->
                                                 gen_fsm, start_link,
                                                 [?MODULE, Args, []]) of
                 {error, overload} ->
-                    riak_kv_util:overload_reply(From);
-                {ok, _Pid} ->
-                    ok
+                    riak_kv_util:overload_reply(From),
+                    {error, overload};
+                {ok, Pid} ->
+                    {ok, Pid}
             end
     end.
 

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -125,12 +125,13 @@ start_link(ReqId,RObj,W,DW,Timeout,ResultPid,Options) ->
     start_link({raw, ReqId, ResultPid}, RObj, [{w, W}, {dw, DW}, {timeout, Timeout} | Options]).
 
 start_link(From, Object, PutOptions) ->
-    Args = [From, Object, PutOptions],
     case whereis(riak_kv_put_fsm_sj) of
         undefined ->
             %% Overload protection disabled
+            Args = [From, Object, PutOptions, true],
             gen_fsm:start_link(?MODULE, Args, []);
         _ ->
+            Args = [From, Object, PutOptions, false],
             case sidejob_supervisor:start_child(riak_kv_put_fsm_sj,
                                                 gen_fsm, start_link,
                                                 [?MODULE, Args, []]) of
@@ -155,7 +156,7 @@ start_link(From, Object, PutOptions) ->
 %%
 %% As test, but linked to the caller
 test_link(From, Object, PutOptions, StateProps) ->
-    gen_fsm:start_link(?MODULE, {test, [From, Object, PutOptions], StateProps}, []).
+    gen_fsm:start_link(?MODULE, {test, [From, Object, PutOptions, true], StateProps}, []).
 
 -endif.
 
@@ -165,13 +166,13 @@ test_link(From, Object, PutOptions, StateProps) ->
 %% ====================================================================
 
 %% @private
-init([From, RObj, Options]) ->
+init([From, RObj, Options, Monitor]) ->
     BKey = {Bucket, Key} = {riak_object:bucket(RObj), riak_object:key(RObj)},
     StateData = add_timing(prepare, #state{from = From,
                                            robj = RObj,
                                            bkey = BKey,
                                            options = Options}),
-    riak_kv_get_put_monitor:put_fsm_spawned(self()),
+    (Monitor =:= true) andalso riak_kv_get_put_monitor:put_fsm_spawned(self()),
     riak_core_dtrace:put_tag(io_lib:format("~p,~p", [Bucket, Key])),
     case riak_kv_util:is_x_deleted(RObj) of
         true  ->

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -39,6 +39,9 @@
          fix_incorrect_index_entries/0,
          responsible_preflists/1,
          responsible_preflists/2,
+         puts_active/0,
+         exact_puts_active/0,
+         gets_active/0,
          overload_reply/1]).
 
 -include_lib("riak_kv_vnode.hrl").
@@ -337,6 +340,30 @@ overload_reply({raw, ReqId, Pid}) ->
     Pid ! {ReqId, {error, overload}};
 overload_reply(_) ->
     ok.
+
+puts_active() ->
+    case whereis(riak_kv_put_fsm_sj) of
+        undefined ->
+            riak_kv_get_put_monitor:puts_active();
+        _ ->
+            sidejob_resource_stats:usage(riak_kv_put_fsm_sj)
+    end.
+
+exact_puts_active() ->
+    case whereis(riak_kv_put_fsm_sj) of
+        undefined ->
+            riak_kv_get_put_monitor:puts_active();
+        _ ->
+            length(sidejob_supervisor:which_children(riak_kv_put_fsm_sj))
+    end.
+
+gets_active() ->
+    case whereis(riak_kv_get_fsm_sj) of
+        undefined ->
+            riak_kv_get_put_monitor:gets_active();
+        _ ->
+            sidejob_resource_stats:usage(riak_kv_get_fsm_sj)
+    end.
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -33,7 +33,8 @@
          expand_rw_value/4,
          normalize_rw_value/2,
          make_request/2,
-         mapred_system/0]).
+         mapred_system/0,
+         overload_reply/1]).
 
 -include_lib("riak_kv_vnode.hrl").
 
@@ -155,6 +156,10 @@ normalize_rw_value(_, _) -> error.
 mapred_system() ->
     riak_core_capability:get({riak_kv, mapred_system}, legacy).
 
+overload_reply({raw, ReqId, Pid}) ->
+    Pid ! {ReqId, {error, overload}};
+overload_reply(_) ->
+    ok.
 
 %% ===================================================================
 %% EUnit tests


### PR DESCRIPTION
This pull-request implements FSM overload protection that prevents Riak from spawning an unbounded number of get/put FSMs, eventually reaching the maximum number of allowed processes and crashing.

The limit is configured by setting the `riak_kv/fsm_limit` application variable. Setting to `undefined` disables overload protection, falling back to the prior code path. This value cannot be changed at runtime, a node restart is necessary for a change to take effect.

The limiting is implemented using the [sidejob](https://github.com/basho/sidejob) library. There are two sidejob_supervisors, one for get FSMs and one for put FSMs. Each supervisor independently enforces the FSM limit, thus there can be at most (limit) get FSMs and (limit) put FSMs.

The response `{error, overload}` is returned whenever the limit is reached.

This pull-request requires the related pull-request: basho/sidejob#1

I will update this pull-request with benchmark results within the next day or so. As well as a link to the related riak_test, which tests both this change as well as the the new vnode overload protection.
