### PR TITLE
Changes to support vnode overload protection

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -770,6 +770,14 @@ mk_reqid() ->
 %% @private
 wait_for_reqid(ReqId, Timeout) ->
     receive
+        {ReqId, {error, overload}=Response} ->
+            case app_helper:get_env(riak_kv, overload_backoff, undefined) of
+                Msecs when is_number(Msecs) ->
+                    timer:sleep(Msecs);
+                undefined ->
+                    ok
+            end,
+            Response;
         {ReqId, Response} -> Response
     after Timeout ->
             {error, timeout}

--- a/src/riak_kv_get_core.erl
+++ b/src/riak_kv_get_core.erl
@@ -223,7 +223,13 @@ merge(Replies, AllowMult) ->
 
 fail_reply(_R, _NumR, 0, NumNotFound, []) when NumNotFound > 0 ->
     {error, notfound};
-fail_reply(R, NumR, _NumNotDeleted, _NumNotFound, _Fails) ->
-    {error, {r_val_unsatisfied, R,  NumR}}.
+fail_reply(R, NumR, _NumNotDeleted, _NumNotFound, Fails) ->
+    case [x || {_,{error, overload}} <- Fails] of
+        [] ->
+            {error, {r_val_unsatisfied, R,  NumR}};
+        _->
+            {error, overload}
+    end.
+
 
 

--- a/src/riak_kv_put_core.erl
+++ b/src/riak_kv_put_core.erl
@@ -100,7 +100,8 @@ enough(#putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW,
 response(PutCore = #putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW,
                             num_fail = NumFail,
                             w_fail_threshold = WFailThreshold,
-                            dw_fail_threshold = DWFailThreshold}) ->
+                            dw_fail_threshold = DWFailThreshold,
+                            results = Results}) ->
     if
         NumW >= W andalso NumDW >= DW ->
             maybe_return_body(PutCore);
@@ -112,7 +113,12 @@ response(PutCore = #putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW,
             {{error, too_many_fails}, PutCore};
         
         true ->
-            {{error, {w_val_unsatisfied, NumW, NumDW, W, DW}}, PutCore}
+            case [x || {_,{fail, _Idx, overload}} <- Results] of
+                [] ->
+                    {{error, {w_val_unsatisfied, NumW, NumDW, W, DW}}, PutCore};
+                _ ->
+                    {{error, overload}, PutCore}
+            end
     end.
 
 %% Get final value - if returnbody did not need the result it allows delaying

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -375,11 +375,11 @@ waiting_local_vnode(request_timeout, StateData) ->
 waiting_local_vnode(Result, StateData = #state{putcore = PutCore}) ->
     UpdPutCore1 = riak_kv_put_core:add_result(Result, PutCore),
     case Result of
-        {fail, Idx, _ReqId} ->
+        {fail, Idx, ReqIdSubvertedToReason} ->
             ?DTRACE(?C_PUT_FSM_WAITING_LOCAL_VNODE, [-1],
                     [integer_to_list(Idx)]),
             %% Local vnode failure is enough to sink whole operation
-            process_reply({error, local_put_failed}, StateData#state{putcore = UpdPutCore1});
+            process_reply({error, ReqIdSubvertedToReason}, StateData#state{putcore = UpdPutCore1});
         {w, Idx, _ReqId} ->
             ?DTRACE(?C_PUT_FSM_WAITING_LOCAL_VNODE, [1],
                     [integer_to_list(Idx)]),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -275,8 +275,8 @@ init([Index]) ->
     end.
 
 
-handle_overload_command(?KV_PUT_REQ{req_id=ReqID}, Sender, Idx) ->
-    riak_core_vnode:reply(Sender, {fail, Idx, ReqID});
+handle_overload_command(?KV_PUT_REQ{}, Sender, Idx) ->
+    riak_core_vnode:reply(Sender, {fail, Idx, overload}); % subvert ReqId
 handle_overload_command(?KV_GET_REQ{req_id=ReqID}, Sender, Idx) ->
     riak_core_vnode:reply(Sender, {r, {error, overload}, Idx, ReqID});
 handle_overload_command(_, _, _) ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -47,6 +47,7 @@
 -export([init/1,
          terminate/2,
          handle_command/3,
+         handle_overload_command/3,
          handle_coverage/4,
          is_empty/1,
          delete/1,
@@ -273,6 +274,14 @@ init([Index]) ->
             {error, Reason1}
     end.
 
+
+handle_overload_command(?KV_PUT_REQ{req_id=ReqID}, Sender, Idx) ->
+    riak_core_vnode:reply(Sender, {fail, Idx, ReqID});
+handle_overload_command(?KV_GET_REQ{req_id=ReqID}, Sender, Idx) ->
+    riak_core_vnode:reply(Sender, {r, {error, overload}, Idx, ReqID});
+handle_overload_command(_, _, _) ->
+    %% not handled yet
+    ok.
 
 handle_command(?KV_PUT_REQ{bkey=BKey,
                            object=Object,


### PR DESCRIPTION
This pull-request provides the `riak_kv` components for the new vnode overload protection work that is implemented in basho/riak_core#314
