### PR TITLE
Expose the put_fsm 'asis' option to clients

### DIFF
--- a/src/riak_kv_pb_object.erl
+++ b/src/riak_kv_pb_object.erl
@@ -176,7 +176,7 @@ process(#rpbputreq{bucket=B, key=K, vclock=PbVC,
 
 process(#rpbputreq{bucket=B, key=K, vclock=PbVC, content=RpbContent,
                    w=W0, dw=DW0, pw=PW0, return_body=ReturnBody,
-                   return_head=ReturnHead, timeout=Timeout},
+                   return_head=ReturnHead, timeout=Timeout, asis=AsIs},
         #state{client=C} = State) ->
 
     case K of
@@ -206,7 +206,7 @@ process(#rpbputreq{bucket=B, key=K, vclock=PbVC, content=RpbContent,
                       end
               end,
     case C:put(O, make_options([{w, W}, {dw, DW}, {pw, PW}, 
-                                {timeout, Timeout}]) ++ Options) of
+                                {timeout, Timeout}, {asis, AsIs}]) ++ Options) of
         ok when is_binary(ReturnKey) ->
             PutResp = #rpbputresp{key = ReturnKey},
             {reply, PutResp, State};

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -280,7 +280,7 @@ malformed_timeout_param(RD, Ctx) ->
     case wrq:get_qs_value("timeout", none, RD) of
         none ->
             {false, RD, Ctx};
-        TimeoutStr -> 
+        TimeoutStr ->
             try
                 Timeout = list_to_integer(TimeoutStr),
                 {false, RD, Ctx#ctx{timeout=Timeout}}
@@ -290,7 +290,7 @@ malformed_timeout_param(RD, Ctx) ->
                      wrq:append_to_resp_body(io_lib:format("Bad timeout "
                                                            "value ~p~n",
                                                            [TimeoutStr]),
-                                             wrq:set_resp_header(?HEAD_CTYPE, 
+                                             wrq:set_resp_header(?HEAD_CTYPE,
                                                                  "text/plain", RD)),
                      Ctx}
             end
@@ -397,7 +397,7 @@ malformed_link_headers(RD, Ctx) ->
 %% @spec malformed_index_headers(reqdata(), context()) ->
 %%           {boolean(), reqdata(), context()}
 %%
-%% @doc Check that the Index headers (HTTP headers prefixed with index_") 
+%% @doc Check that the Index headers (HTTP headers prefixed with index_")
 %%      are valid. Store the parsed headers in context() if valid,
 %%      or print an error in reqdata() if not.
 %%      An index field should be of the form "index_fieldname_type"
@@ -751,7 +751,7 @@ multiple_choices(RD, Ctx) ->
 %%      property "rel=container".  The rest of the links will be
 %%      constructed from the links of the document.
 produce_doc_body(RD, Ctx) ->
-    Prefix = Ctx#ctx.prefix, 
+    Prefix = Ctx#ctx.prefix,
     Bucket = Ctx#ctx.bucket,
     APIVersion = Ctx#ctx.api_version,
     case select_doc(Ctx) of
@@ -763,7 +763,7 @@ produce_doc_body(RD, Ctx) ->
                     end,
             Links2 = riak_kv_wm_utils:format_links([{Bucket, "up"}|Links1], Prefix, APIVersion),
             LinkRD = wrq:merge_resp_headers(Links2, RD),
-            
+
             %% Add user metadata to response...
             UserMetaRD = case dict:find(?MD_USERMETA, MD) of
                         {ok, UserMeta} ->
@@ -896,7 +896,7 @@ ensure_doc(Ctx) -> Ctx.
 delete_resource(RD, Ctx=#ctx{bucket=B, key=K, client=C}) ->
     Options = make_options([], Ctx),
     Result = case wrq:get_req_header(?HEAD_VCLOCK, RD) of
-        undefined -> 
+        undefined ->
             C:delete(B,K,Options);
         _ ->
             C:delete_vclock(B,K,decode_vclock_header(RD),Options)
@@ -937,7 +937,7 @@ last_modified(RD, Ctx) ->
         multiple_choices ->
             {ok, Doc} = Ctx#ctx.doc,
             LMDates = [ normalize_last_modified(MD) ||
-                          MD <- riak_object:get_metadatas(Doc) ],            
+                          MD <- riak_object:get_metadatas(Doc) ],
             {lists:max(LMDates), RD, Ctx}
     end.
 
@@ -962,7 +962,7 @@ get_link_heads(RD, Ctx) ->
     Bucket = Ctx#ctx.bucket,
 
     %% Get a list of link headers...
-    LinkHeaders1 = 
+    LinkHeaders1 =
         case wrq:get_req_header(?HEAD_LINK, RD) of
             undefined -> [];
             Heads -> string:tokens(Heads, ",")
@@ -970,7 +970,7 @@ get_link_heads(RD, Ctx) ->
 
     %% Decode the link headers. Throw an exception if we can't
     %% properly parse any of the headers...
-    {BucketLinks, KeyLinks} = 
+    {BucketLinks, KeyLinks} =
         case APIVersion of
             1 ->
                 {ok, BucketRegex} = re:compile("</" ++ Prefix ++ "/([^/]+)>; ?rel=\"([^\"]+)\""),
@@ -986,12 +986,12 @@ get_link_heads(RD, Ctx) ->
     %% bucket...
     IsValid = (BucketLinks == []) orelse (BucketLinks == [{Bucket, <<"up">>}]),
     case IsValid of
-        true -> 
+        true ->
             KeyLinks;
         false ->
             throw({invalid_link_headers, LinkHeaders1})
     end.
-        
+
 %% Run each LinkHeader string() through the BucketRegex and
 %% KeyRegex. Return {BucketLinks, KeyLinks}.
 extract_links(LinkHeaders, BucketRegex, KeyRegex) ->
@@ -1119,9 +1119,9 @@ handle_common_error(Reason, RD, Ctx) ->
     end.
 
 make_options(Prev, Ctx) ->
-    NewOpts0 = [{rw, Ctx#ctx.rw}, {r, Ctx#ctx.r}, {w, Ctx#ctx.w}, 
-                {pr, Ctx#ctx.pr}, {pw, Ctx#ctx.pw}, {dw, Ctx#ctx.dw}, 
+    NewOpts0 = [{rw, Ctx#ctx.rw}, {r, Ctx#ctx.r}, {w, Ctx#ctx.w},
+                {pr, Ctx#ctx.pr}, {pw, Ctx#ctx.pw}, {dw, Ctx#ctx.dw},
                 {timeout, Ctx#ctx.timeout}],
-    NewOpts = [ {Opt, Val} || {Opt, Val} <- NewOpts0, 
+    NewOpts = [ {Opt, Val} || {Opt, Val} <- NewOpts0,
                               Val /= undefined, Val /= default ],
     Prev ++ NewOpts.

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -134,6 +134,7 @@
               pw,           %% integer() - number of primary nodes required in preflist on write
               basic_quorum, %% boolean() - whether to use basic_quorum
               notfound_ok,  %% boolean() - whether to treat notfounds as successes
+              asis,         %% boolean() - whether to send the put without modifying the vclock
               prefix,       %% string() - prefix for resource uris
               riak,         %% local | {node(), atom()} - params for riak client
               doc,          %% {ok, riak_object()}|{error, term()} - the object found
@@ -314,7 +315,8 @@ malformed_rw_params(RD, Ctx) ->
     lists:foldl(fun malformed_boolean_param/2,
                 Res,
                 [{#ctx.basic_quorum, "basic_quorum", "default"},
-                 {#ctx.notfound_ok, "notfound_ok", "default"}]).
+                 {#ctx.notfound_ok, "notfound_ok", "default"},
+                 {#ctx.asis, "asis", "false"}]).
 
 %% @spec malformed_rw_param({Idx::integer(), Name::string(), Default::string()},
 %%                          {boolean(), reqdata(), context()}) ->
@@ -1121,7 +1123,7 @@ handle_common_error(Reason, RD, Ctx) ->
 make_options(Prev, Ctx) ->
     NewOpts0 = [{rw, Ctx#ctx.rw}, {r, Ctx#ctx.r}, {w, Ctx#ctx.w},
                 {pr, Ctx#ctx.pr}, {pw, Ctx#ctx.pw}, {dw, Ctx#ctx.dw},
-                {timeout, Ctx#ctx.timeout}],
+                {timeout, Ctx#ctx.timeout}, {asis, Ctx#ctx.asis}],
     NewOpts = [ {Opt, Val} || {Opt, Val} <- NewOpts0,
                               Val /= undefined, Val /= default ],
     Prev ++ NewOpts.


### PR DESCRIPTION
This is an obscure feature of `riak_kv_put_fsm` that was originally only used for replication, but has potential benefits for bulk-loading. By adding the `asis` flag, clients can indicate that this is not an update and so the vector clock should not be incremented.
