### PR TITLE
Deprecate KV health checks

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -137,15 +137,16 @@ start(_Type, _StartArgs) ->
                                           [enabled_v1, disabled],
                                           disabled),
 
+            HealthCheckOn = app_helper:get_env(riak_kv, enable_health_checks, false),
             %% Go ahead and mark the riak_kv service as up in the node watcher.
             %% The riak_core_ring_handler blocks until all vnodes have been started
             %% synchronously.
             riak_core:register(riak_kv, [
                 {vnode_module, riak_kv_vnode},
-                {health_check, {?MODULE, check_kv_health, []}},
                 {bucket_validator, riak_kv_bucket},
                 {stat_mod, riak_kv_stat}
-            ]),
+            ]
+            ++ [{health_check, {?MODULE, check_kv_health, []}} || HealthCheckOn]),
 
             ok = riak_api_pb_service:register(?SERVICES),
 


### PR DESCRIPTION
We are adding other load protection mechanisms in KV and consider this
implementation of health checks as troublesome since it can cause nasty
flappings when the cluster is under load, so it's being deprecated.

This leaves in place the riak_core health checks mechanism, but disables
its use by riak_kv unless {enable_health_checks, true} is added in the
riak_kv section.  That way, customers who have the previously shipped
config with {enable_health_checks,true} in the riak_core section will
also stop having health checks, but could re-add if really necessary.

This PR is a retarget to the 1.3 branch of #541. See that one for review comments and such.
