### PR TITLE
Backend capability to use Riak r_object records

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,8 @@
 {cover_enabled, true}.
 {edoc_opts, [{preprocess, true}]}.
-{erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
+{erl_opts, [warnings_as_errors,
+            {parse_transform, lager_transform},
+            {d, 'TEST_FS2_BACKEND_IN_RIAK_KV'}]}.
 {eunit_opts, [verbose]}.
 
 {erl_first_files, [

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1542,7 +1542,7 @@ object_info({Bucket, _Key}=BKey) ->
     {Bucket, Hash}.
 
 -spec encode_and_Mod_put(
-        Obj::riak_object:object(), Mod::term(), Bucket::riak_object:bucket(),
+        Obj::riak_object:riak_object(), Mod::term(), Bucket::riak_object:bucket(),
         Key::riak_object:key(), IndexSpecs::list(), ModState::term()) ->
            {{ok, UpdModState::term()}, EncodedObj::binary()} |
            {{error, Reason::term(), UpdModState::term()}, EncodedObj::binary()}.

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -727,7 +727,7 @@ multiple_choices(RD, Ctx) ->
     case select_doc(Ctx) of
         {M, _} ->
             case dict:find(?MD_DELETED, M) of
-                {ok, true} ->
+                {ok, "true"} ->
                     {false,
                         wrq:set_resp_header(?HEAD_DELETED, "true", RD),
                         Ctx};

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -723,7 +723,20 @@ multiple_choices(RD, Ctx=#ctx{vtag=undefined, doc={ok, Doc}}) ->
     end;
 multiple_choices(RD, Ctx) ->
     %% specific vtag was specified
-    {false, RD, Ctx}.
+    %% if it's a tombstone add the X-Riak-Deleted header
+    case select_doc(Ctx) of
+        {M, _} ->
+            case dict:find(?MD_DELETED, M) of
+                {ok, true} ->
+                    {false,
+                        wrq:set_resp_header(?HEAD_DELETED, "true", RD),
+                        Ctx};
+                error ->
+                    {false, RD, Ctx}
+            end;
+        multiple_choices ->
+            throw({unexpected_code_path, ?MODULE, multiple_choices, multiple_choices})
+    end.
 
 %% @spec produce_doc_body(reqdata(), context()) -> {binary(), reqdata(), context()}
 %% @doc Extract the value of the document, and place it in the
@@ -1054,9 +1067,10 @@ handle_common_error(Reason, RD, Ctx) ->
         {error, {deleted, _VClock}} ->
             {{halt, 404},
                 wrq:set_resp_header("Content-Type", "text/plain",
-                    wrq:append_to_response_body(
-                        io_lib:format("not found~n",[]),
-                        encode_vclock_header(RD, Ctx))),
+                    wrq:set_resp_header(?HEAD_DELETED, "true",
+                        wrq:append_to_response_body(
+                            io_lib:format("not found~n",[]),
+                            encode_vclock_header(RD, Ctx)))),
                 Ctx};
         {error, {n_val_violation, N}} ->
             Msg = io_lib:format("Specified w/dw/pw values invalid for bucket"


### PR DESCRIPTION
Add the optional riak_kv backend capability to pass Riak r_object records to/from the backend rather than binary blobs that are serialized/unserialized by `riak_kv_vnode`.

Also, rearrange the QuickCheck tests to permit easier testing of the fs2 backend.
