### PR TITLE
Add new backend capability for Riak r_object use

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,8 @@
 {cover_enabled, true}.
 {edoc_opts, [{preprocess, true}]}.
-{erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
+{erl_opts, [warnings_as_errors,
+            {parse_transform, lager_transform},
+            {d, 'TEST_FS2_BACKEND_IN_RIAK_KV'}]}.
 {eunit_opts, [verbose]}.
 
 {erl_first_files, [

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1542,7 +1542,7 @@ object_info({Bucket, _Key}=BKey) ->
     {Bucket, Hash}.
 
 -spec encode_and_Mod_put(
-        Obj::riak_object:object(), Mod::term(), Bucket::riak_object:bucket(),
+        Obj::riak_object:riak_object(), Mod::term(), Bucket::riak_object:bucket(),
         Key::riak_object:key(), IndexSpecs::list(), ModState::term()) ->
            {{ok, UpdModState::term()}, EncodedObj::binary()} |
            {{error, Reason::term(), UpdModState::term()}, EncodedObj::binary()}.


### PR DESCRIPTION
Add the optional riak_kv backend capability to pass Riak r_object records to/from the backend rather than binary blobs that are serialized/unserialized by `riak_kv_vnode`.

Also, rearrange the QuickCheck tests to permit easier testing of the fs2 backend.
