### PR TITLE
Add sloppy_quorum and n_val options

### DIFF
--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -110,6 +110,7 @@ get_r_options(Bucket, Options) ->
             undefined ->
                 proplists:get_value(n_val, BucketProps);
             N_val when is_integer(N_val), N_val > 0 ->
+                %% TODO: No sanity check of this value vs. "real" n_val.
                 N_val
         end,
     %% specifying R/W AND RW together doesn't make sense, so check if R or W

--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -89,8 +89,9 @@ delete(ReqId,Bucket,Key,Options,Timeout,Client,ClientId,VClock) ->
             {ok,C} = riak:local_client(ClientId),
             Reply = C:put(Tombstone, [{w,W},{pw,PW},{dw, DW},{timeout,Timeout}]++PassThruOptions),
             Client ! {ReqId, Reply},
+            HasCustomN_val = proplists:get_value(n_val, Options) /= undefined,
             case Reply of
-                ok ->
+                ok when HasCustomN_val == false ->
                     ?DTRACE(?C_DELETE_INIT2, [1], [<<"reap">>]),
                     {ok, C2} = riak:local_client(),
                     AsyncTimeout = 60*1000,     % Avoid client-specified value

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -46,7 +46,7 @@
                   {details, true} |
                   details |
                   {sloppy_quorum, boolean()} | %% default = true
-                  {n_val, boolean()}.          %% default = bucket props
+                  {n_val, pos_integer()}.      %% default = bucket props
 
 -type options() :: [option()].
 -type req_id() :: non_neg_integer().

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -67,7 +67,7 @@
         asis |
         %% Use a sloppy quorum, default = true
         {sloppy_quorum, boolean()} |
-        %% Use a sloppy quorum, default = value from bucket properties
+        %% The N value, default = value from bucket properties
         {n_val, pos_integer()}.
 
 -type options() :: [option()].

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -456,10 +456,10 @@ multibackend_read_block_errors([{_Name, Status}|Rest], undefined) ->
 multibackend_read_block_errors(_, Val) ->
     rbe_val(Val).
 
-rbe_val(undefined) ->
-    undefined;
-rbe_val(Bin) ->
-    list_to_integer(binary_to_list(Bin)).
+rbe_val(Bin) when is_binary(Bin) ->
+    list_to_integer(binary_to_list(Bin));
+rbe_val(_) ->
+    undefined.
 
 %% All stat creation is serialized through riak_kv_stat.
 %% Some stats are created on demand as part of the call to `update/1'.

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -727,7 +727,7 @@ multiple_choices(RD, Ctx) ->
     case select_doc(Ctx) of
         {M, _} ->
             case dict:find(?MD_DELETED, M) of
-                {ok, true} ->
+                {ok, "true"} ->
                     {false,
                         wrq:set_resp_header(?HEAD_DELETED, "true", RD),
                         Ctx};

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -723,7 +723,20 @@ multiple_choices(RD, Ctx=#ctx{vtag=undefined, doc={ok, Doc}}) ->
     end;
 multiple_choices(RD, Ctx) ->
     %% specific vtag was specified
-    {false, RD, Ctx}.
+    %% if it's a tombstone add the X-Riak-Deleted header
+    case select_doc(Ctx) of
+        {M, _} ->
+            case dict:find(?MD_DELETED, M) of
+                {ok, true} ->
+                    {false,
+                        wrq:set_resp_header(?HEAD_DELETED, "true", RD),
+                        Ctx};
+                error ->
+                    {false, RD, Ctx}
+            end;
+        multiple_choices ->
+            throw({unexpected_code_path, ?MODULE, multiple_choices, multiple_choices})
+    end.
 
 %% @spec produce_doc_body(reqdata(), context()) -> {binary(), reqdata(), context()}
 %% @doc Extract the value of the document, and place it in the
@@ -1054,9 +1067,10 @@ handle_common_error(Reason, RD, Ctx) ->
         {error, {deleted, _VClock}} ->
             {{halt, 404},
                 wrq:set_resp_header("Content-Type", "text/plain",
-                    wrq:append_to_response_body(
-                        io_lib:format("not found~n",[]),
-                        encode_vclock_header(RD, Ctx))),
+                    wrq:set_resp_header(?HEAD_DELETED, "true",
+                        wrq:append_to_response_body(
+                            io_lib:format("not found~n",[]),
+                            encode_vclock_header(RD, Ctx)))),
                 Ctx};
         {error, {n_val_violation, N}} ->
             Msg = io_lib:format("Specified w/dw/pw values invalid for bucket"


### PR DESCRIPTION
Add experimental `sloppy_quorum` and `n_val` options.  "Experimental" because there's only one user for them at the moment, Riak CS; any other app that uses them should be aware that they may change or disappear without warning.
