### PR TITLE
Enable stat updates to use sidejob workers

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
 
 {deps, [
         {riak_core, "1.3.2", {git, "git://github.com/basho/riak_core", {tag, "1.3.2"}}},
-        {sidejob, "0.1.0", {git, "git://github.com/basho/sidejob", {tag, "0.1.0"}}},
+        {sidejob, "0.1.0", {git, "git://github.com/basho/sidejob", {branch, "jdb-unbounded"}}},
         {erlang_js, "1.2.2", {git, "git://github.com/basho/erlang_js", {tag, "1.2.2"}}},
         {bitcask, "1.6.2", {git, "git://github.com/basho/bitcask", {tag, "1.6.2"}}},
         {merge_index, "1.3.0", {git, "git://github.com/basho/merge_index",

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -52,6 +52,8 @@ start(_Type, _StartArgs) ->
             sidejob:new_resource(riak_kv_get_fsm_sj, sidejob_supervisor, FSM_Limit)
     end,
 
+    sidejob:new_resource(riak_kv_stat_sj, riak_kv_stat_worker, 10000),
+
     %% Look at the epoch and generating an error message if it doesn't match up
     %% to our expectations
     check_epoch(),

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -52,7 +52,12 @@ start(_Type, _StartArgs) ->
             sidejob:new_resource(riak_kv_get_fsm_sj, sidejob_supervisor, FSM_Limit)
     end,
 
-    sidejob:new_resource(riak_kv_stat_sj, riak_kv_stat_worker, 10000),
+    case app_helper:get_env(riak_kv, direct_stats, false) of
+        true ->
+            ok;
+        false ->
+            sidejob:new_resource(riak_kv_stat_sj, riak_kv_stat_worker, 10000)
+    end,
 
     %% Look at the epoch and generating an error message if it doesn't match up
     %% to our expectations

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -38,7 +38,7 @@
 
 %% API
 -export([start_link/0, get_stats/0,
-         update/1, register_stats/0, produce_stats/0,
+         update/1, perform_update/1, register_stats/0, produce_stats/0,
          leveldb_read_block_errors/0, stop/0]).
 -export([track_bucket/1, untrack_bucket/1]).
 -export([active_gets/0, active_puts/0]).
@@ -75,10 +75,12 @@ register_stat(Name, Type) ->
     gen_server:call(?SERVER, {register, Name, Type}).
 
 update(Arg) ->
-    %% Large message queues on heavily loaded nodes
-    %% mean calling folsom direct, rather than casting here.
-    %% We catch the update so a failed stat update
-    %% does not fail a read / write to riak.
+    %% Dispatch request to sidejob worker
+    riak_kv_stat_worker:update(Arg).
+
+%% @doc
+%% Callback used by a {@link riak_kv_stat_worker} to perform actual update
+perform_update(Arg) ->
     try do_update(Arg) of
         _ ->
             ok

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -75,8 +75,13 @@ register_stat(Name, Type) ->
     gen_server:call(?SERVER, {register, Name, Type}).
 
 update(Arg) ->
-    %% Dispatch request to sidejob worker
-    riak_kv_stat_worker:update(Arg).
+    case erlang:module_loaded(riak_kv_stat_sj) of
+        true ->
+            %% Dispatch request to sidejob worker
+            riak_kv_stat_worker:update(Arg);
+        false ->
+            perform_update(Arg)
+    end.
 
 %% @doc
 %% Callback used by a {@link riak_kv_stat_worker} to perform actual update

--- a/src/riak_kv_stat_worker.erl
+++ b/src/riak_kv_stat_worker.erl
@@ -1,0 +1,61 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_kv_stat_worker).
+-behaviour(gen_server).
+
+%% API
+-export([update/1]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-record(state, {}).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+update(Arg) ->
+    sidejob:cast(riak_kv_stat_sj, {update, Arg}).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([_Name]) ->
+    {ok, #state{}}.
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast({update, Arg}, State) ->
+    riak_kv_stat:perform_update(Arg),
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/src/riak_kv_stat_worker.erl
+++ b/src/riak_kv_stat_worker.erl
@@ -35,7 +35,7 @@
 %%%===================================================================
 
 update(Arg) ->
-    sidejob:cast(riak_kv_stat_sj, {update, Arg}).
+    sidejob:unbounded_cast(riak_kv_stat_sj, {update, Arg}).
 
 %%%===================================================================
 %%% gen_server callbacks


### PR DESCRIPTION
This pull-request enables Riak K/V stat updates to be sent to `sidejob` workers to avoid the impact of updating stats directly in get/put FSM processes. To keep the overload low, this change uses `sidejob:unbounded_cast` to dispatch the requests. Of course, this prevents `sidejob` from being able to enforce a capacity limit. In practice, message queues are kept reasonable given the use of multiple workers processes to handle the requests.

This pull-request makes the use of `sidejob` for stat updates the default behavior. However, adding `{direct_stats, true}` to the `riak_kv` section of `app.config` can override this behavior, returning to the direct, in-process approach.

Requires related pull-request: basho/sidejob#3
