### PR TITLE
Add fsm active and error stats to the blob

### DIFF
--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -263,8 +263,10 @@ legacy_stat_map() ->
      {pbc_connects_total, {{riak_api, pbc_connects}, count}, spiral},
      {node_get_fsm_active, {riak_kv, node, gets, fsm, active}, counter},
      {node_get_fsm_errors, {{riak_kv, node, gets, fsm, errors}, one}, spiral},
+     {node_get_fsm_errors_total, {{riak_kv, node, gets, fsm, errors}, count}, spiral},
      {node_put_fsm_active, {riak_kv, node, puts, fsm, active}, counter},
-     {node_put_fsm_errors, {{riak_kv, node, puts, fsm, errors}, one}, spiral}
+     {node_put_fsm_errors, {{riak_kv, node, puts, fsm, errors}, one}, spiral},
+     {node_put_fsm_errors_total, {{riak_kv, node, puts, fsm, errors}, count}, spiral}
     ].
 
 %% @spec cpu_stats() -> proplist()

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -260,7 +260,11 @@ legacy_stat_map() ->
      {postcommit_fail, {riak_kv, postcommit_fail}, counter},
      {pbc_active, {riak_api, pbc_connects, active}, function},
      {pbc_connects, {{riak_api, pbc_connects}, one}, spiral},
-     {pbc_connects_total, {{riak_api, pbc_connects}, count}, spiral}
+     {pbc_connects_total, {{riak_api, pbc_connects}, count}, spiral},
+     {node_get_fsm_active, {riak_kv, node, gets, fsm, active}, counter},
+     {node_get_fsm_errors, {{riak_kv, node, gets, fsm, errors}, one}, spiral},
+     {node_put_fsm_active, {riak_kv, node, puts, fsm, active}, counter},
+     {node_put_fsm_errors, {{riak_kv, node, puts, fsm, errors}, one}, spiral}
     ].
 
 %% @spec cpu_stats() -> proplist()


### PR DESCRIPTION
Somehow these went missing from the stat blob, and it made people sad when trying to figure out how many fsm processes were active.
