### PR TITLE
Fix regression in 2i reformat status flag & add extra status function

### DIFF
--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -120,7 +120,12 @@ determine_fixed_index_status(State) ->
         true ->
             {ok, State#state{fixed_indexes=true}};
         false ->
-            case is_empty(State) of
+            %% call eleveldb directly to circumvent extra check
+            %% for fixed indexes entry. if entry is present we
+            %% don't want to ignore becasue it occurs on downgrade.
+            %% ignoring is not dangerous but reports confusing results
+            %% (empty downgraded partitions still returning fixed = true)
+            case eleveldb:is_empty(State#state.ref) of
                 true -> mark_indexes_fixed_on_start(State);
                 false -> {ok, State#state{fixed_indexes=false}}
             end

--- a/src/riak_kv_status.erl
+++ b/src/riak_kv_status.erl
@@ -24,7 +24,8 @@
 -export([statistics/0,
          ringready/0,
          transfers/0,
-         vnode_status/0]).
+         vnode_status/0,
+         fixed_index_status/0]).
 
 -include("riak_kv_vnode.hrl").
 
@@ -48,3 +49,34 @@ vnode_status() ->
     %% Get the kv vnode indexes and the associated pids for the node.
     PrefLists = riak_core_vnode_manager:all_index_pid(riak_kv_vnode),
     riak_kv_vnode:vnode_status(PrefLists).
+
+%% @doc Get status of 2i reformat. If the backend requires reformatting, a boolean
+%%      value is returned indicating if all partitions on the node have completed
+%%      upgrading (if downgrading then false indicates all partitions have been downgraded.
+%%      If the backend does not require reformatting, undefined is returned
+-spec fixed_index_status() -> boolean() | undefined.
+fixed_index_status() ->
+    Backend = app_helper:get_env(riak_kv, storage_backend),
+    fixed_index_status(Backend).
+
+fixed_index_status(Affected) when Affected =:= riak_kv_eleveldb_backend orelse
+                                  Affected =:= riak_kv_multi_backend ->
+    Statuses = vnode_status(),
+    fixed_index_status(Affected, Statuses);
+fixed_index_status(_) ->
+    undefined.
+
+fixed_index_status(Affected, Statuses) ->
+    lists:foldl(fun(Elem, Acc) -> Acc andalso are_indexes_fixed(Affected, Elem) end,
+                true, Statuses).
+
+are_indexes_fixed(riak_kv_eleveldb_backend, {_Idx, [{backend_status,_,Status}]}) ->
+    are_indexes_fixed(riak_kv_eleveldb_backend, Status);
+are_indexes_fixed(riak_kv_eleveldb_backend, Status) ->
+    case proplists:get_value(fixed_indexes, Status) of
+        Bool when is_boolean(Bool) -> Bool;
+        _ -> false
+    end;
+are_indexes_fixed(riak_kv_multi_backend, {_Idx, [{backend_status,_,Status}]}) ->
+    Statuses = [S || {_, S} <- Status, lists:member({mod, riak_kv_eleveldb_backend}, Status)],
+    fixed_index_status(riak_kv_eleveldb_backend, Statuses).


### PR DESCRIPTION
This PR fixes a regression introduced by  https://github.com/basho/riak_kv/commit/b50d1df73aee20c4260e72d73fdfcf6493603636 (see commit/patch for more details) and adds `riak_kv_status:fixed_index_status` which is meant to be used by riaknostic
