### PR TITLE
Fix put_fsm_eqc after local_put_failed change

### DIFF
--- a/src/riak_kv_test_util.erl
+++ b/src/riak_kv_test_util.erl
@@ -245,7 +245,7 @@ dep_apps(Test, Extra) ->
         end,
 
     [sasl, Silencer, crypto, public_key, ssl, riak_sysmon, os_mon,
-     runtime_tools, erlang_js, inets, mochiweb, webmachine,
+     runtime_tools, erlang_js, inets, mochiweb, webmachine, sidejob,
      basho_stats, bitcask, compiler, syntax_tools, lager, folsom,
      riak_core, riak_pipe, riak_api, riak_kv, DefaultSetupFun, Extra].
 

--- a/test/put_fsm_eqc.erl
+++ b/test/put_fsm_eqc.erl
@@ -566,8 +566,8 @@ expect(VPutResp, H, N, PW, RealPW, W, RealW, DW, EffDW, Options,
                                 0
                         end,
                 case H of
-                    [{w, _, _}, {fail, _, _} | _] ->
-                        {maybe_add_robj({error, local_put_failed}, ReturnObj, Precommit, Options), VPuts};
+                    [{w, _, _}, {fail, _, FailedReqId} | _] ->
+                        {maybe_add_robj({error, FailedReqId}, ReturnObj, Precommit, Options), VPuts};
                     _ ->
                         
                         {expect(HNoTimeout, {H, N, RealW, EffDW, RealPW, 0, 0, 0, 0, ReturnObj, Precommit, PL2}, Options), 


### PR DESCRIPTION
As part of the overload protection, the put fsm code was changed from
returning local_put_failed on failure to returning the request id, which
could sometimes be instead the overload token (hacky hack hack)
See commit https://github.com/basho/riak_kv/commit/29720ed4cc06663116caaffdfa497cbd6804e10e
Also, add sidejob to hard coded list of deps for test
I am not sure why we need it, but the riak_kv application will not start
during the test without it. Sigh...
