### PR TITLE
Get rid of parametrized modules

### DIFF
--- a/src/riak.erl
+++ b/src/riak.erl
@@ -180,7 +180,7 @@ code_hash() ->
 -define(CLIENT_TEST_KEY, <<"key1">>).
 
 client_test_phase1(Client) ->
-    case Client:get(?CLIENT_TEST_BUCKET, ?CLIENT_TEST_KEY, 1) of
+    case riak_client:get(Client, ?CLIENT_TEST_BUCKET, ?CLIENT_TEST_KEY, 1) of
         {ok, Object} ->
             client_test_phase2(Client, Object);
         {error, notfound} ->
@@ -193,7 +193,7 @@ client_test_phase1(Client) ->
 client_test_phase2(Client, Object0) ->
     Now = calendar:universal_time(),
     Object = riak_object:update_value(Object0, Now),
-    case Client:put(Object, 1) of
+    case riak_client:put(Client, Object, 1) of
         ok ->
             client_test_phase3(Client, Now);
         Error ->
@@ -202,7 +202,7 @@ client_test_phase2(Client, Object0) ->
     end.
 
 client_test_phase3(Client, WrittenValue) ->
-    case Client:get(?CLIENT_TEST_BUCKET, ?CLIENT_TEST_KEY, 1) of
+    case riak_client:get(Client, ?CLIENT_TEST_BUCKET, ?CLIENT_TEST_KEY, 1) of
         {ok, Object} ->
             case lists:member(WrittenValue, riak_object:get_values(Object)) of
                 true ->

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -22,59 +22,67 @@
 
 %% @doc object used for access into the riak system
 
--module(riak_client, [Node,ClientId]).
+-module(riak_client).
 -author('Justin Sheehy <justin@basho.com>').
 
--export([get/2, get/3,get/4]).
--export([put/1, put/2,put/3,put/4,put/5]).
--export([delete/2,delete/3,delete/4]).
--export([delete_vclock/3,delete_vclock/4,delete_vclock/5]).
--export([list_keys/1,list_keys/2,list_keys/3]).
--export([stream_list_keys/1,stream_list_keys/2,stream_list_keys/3]).
--export([filter_buckets/1]).
--export([filter_keys/2,filter_keys/3]).
--export([list_buckets/0, list_buckets/1, list_buckets/2]).
--export([stream_list_buckets/0, stream_list_buckets/1, 
-         stream_list_buckets/2, stream_list_buckets/3]).
--export([get_index/3,get_index/2]).
--export([stream_get_index/3,stream_get_index/2]).
--export([set_bucket/2,get_bucket/1,reset_bucket/1]).
--export([reload_all/1]).
--export([remove_from_cluster/1]).
--export([get_stats/1]).
--export([get_client_id/0]).
--export([for_dialyzer_only_ignore/2]).
--compile({no_auto_import,[put/2]}).
+-export([new/2, get/3, get/4,get/5]).
+-export([put/2, put/3,put/4,put/5,put/6]).
+-export([delete/3,delete/4,delete/5]).
+-export([delete_vclock/4,delete_vclock/5,delete_vclock/6]).
+-export([list_keys/2,list_keys/3,list_keys/4]).
+-export([stream_list_keys/2,stream_list_keys/3,stream_list_keys/4]).
+-export([filter_buckets/2]).
+-export([filter_keys/3,filter_keys/4]).
+-export([list_buckets/1, list_buckets/2, list_buckets/3]).
+-export([stream_list_buckets/1, stream_list_buckets/2, 
+         stream_list_buckets/3, stream_list_buckets/4]).
+-export([get_index/4,get_index/3]).
+-export([stream_get_index/4,stream_get_index/3]).
+-export([set_bucket/3,get_bucket/2,reset_bucket/2]).
+-export([reload_all/2]).
+-export([remove_from_cluster/2]).
+-export([get_stats/2]).
+-export([get_client_id/1]).
+
 %% @type default_timeout() = 60000
 -define(DEFAULT_TIMEOUT, 60000).
 -define(DEFAULT_ERRTOL, 0.00003).
 
--type riak_client() :: term().
+-record(riak_client, {node :: node(), client_id :: term()}).
+-opaque riak_client() :: #riak_client{}.
+-export_type([riak_client/0]).
 
-%% @spec get(riak_object:bucket(), riak_object:key()) ->
-%%       {ok, riak_object:riak_object()} |
-%%       {error, notfound} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}} |
-%%       {error, {r_val_unsatisfied, R::integer(), Replies::integer()}} |
-%%       {error, Err :: term()}
+-spec new(node(), term()) -> riak_client().
+%% @doc Initialize a client instance.
+new(Node, ClientId) ->
+    #riak_client{node = Node, client_id = ClientId}.
+
+-spec get(riak_client(), riak_object:bucket(), riak_object:key()) ->
+      {ok, riak_object:riak_object()} |
+      {error, notfound} |
+      {error, timeout} |
+      {error, {n_val_violation, N::integer()}} |
+      {error, {r_val_unsatisfied, R::integer(), Replies::integer()}} |
+      {error, Err :: term()}.
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as the default
 %%      R-value for the nodes have responded with a value or error.
-%% @equiv get(Bucket, Key, R, default_timeout())
-get(Bucket, Key) ->
-    get(Bucket, Key, []).
+%% @equiv get(RClient, Bucket, Key, R, default_timeout())
+get(#riak_client{} = RClient, Bucket, Key) ->
+    get(RClient, Bucket, Key, []).
 
-%% @spec get(riak_object:bucket(), riak_object:key(), options()) ->
-%%       {ok, riak_object:riak_object()} |
-%%       {error, notfound} |
-%%       {error, {deleted, vclock()}} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}} |
-%%       {error, {r_val_unsatisfied, R::integer(), Replies::integer()}} |
-%%       {error, Err :: term()}
+-spec get(riak_client(), riak_object:bucket(), riak_object:key(),
+          riak_kv_get_fsm:options() | integer()) ->
+      {ok, riak_object:riak_object()} |
+      {error, notfound} |
+      {error, {deleted, vclock:vclock()}} |
+      {error, timeout} |
+      {error, {n_val_violation, N::integer()}} |
+      {error, {r_val_unsatisfied, R::integer(), Replies::integer()}} |
+      {error, Err :: term()}.
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as R-value for the nodes
 %%      have responded with a value or error.
-get(Bucket, Key, Options) when is_list(Options) ->
+get(#riak_client{node = Node}, Bucket, Key, Options)
+  when is_list(Options) ->
     Me = self(),
     ReqId = mk_reqid(),
     case node() of
@@ -87,60 +95,52 @@ get(Bucket, Key, Options) when is_list(Options) ->
     %% TODO: Investigate adding a monitor here and eliminating the timeout.
     Timeout = recv_timeout(Options),
     wait_for_reqid(ReqId, Timeout);
+get(#riak_client{} = RClient, Bucket, Key, R) ->
+    get(RClient, Bucket, Key, [{r, R}]).
 
-%% @spec get(riak_object:bucket(), riak_object:key(), R :: integer()) ->
-%%       {ok, riak_object:riak_object()} |
-%%       {error, notfound} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}} |
-%%       {error, {r_val_unsatisfied, R::integer(), Replies::integer()}} |
-%%       {error, Err :: term()}
-%% @doc Fetch the object at Bucket/Key.  Return a value as soon as R
-%%      nodes have responded with a value or error.
-%% @equiv get(Bucket, Key, R, default_timeout())
-get(Bucket, Key, R) ->
-    get(Bucket, Key, [{r, R}]).
-
-%% @spec get(riak_object:bucket(), riak_object:key(), R :: integer(),
-%%           TimeoutMillisecs :: integer()) ->
-%%       {ok, riak_object:riak_object()} |
-%%       {error, notfound} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}} |
-%%       {error, {r_val_unsatisfied, R::integer(), Replies::integer()}} |
-%%       {error, Err :: term()}
+-spec get(riak_client(), riak_object:bucket(), riak_object:key(),
+          R :: integer(), TimeoutMillisecs :: integer()) ->
+      {ok, riak_object:riak_object()} |
+      {error, notfound} |
+      {error, timeout} |
+      {error, {n_val_violation, N::integer()}} |
+      {error, {r_val_unsatisfied, R::integer(), Replies::integer()}} |
+      {error, Err :: term()}.
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as R
 %%      nodes have responded with a value or error, or TimeoutMillisecs passes.
-get(Bucket, Key, R, Timeout) when is_binary(Bucket), is_binary(Key),
-                                  (is_atom(R) or is_integer(R)),
-                                  is_integer(Timeout) ->
-    get(Bucket, Key, [{r, R}, {timeout, Timeout}]).
+get(#riak_client{} = RClient, Bucket, Key, R, Timeout)
+  when is_binary(Bucket), is_binary(Key),
+       (is_atom(R) or is_integer(R)),
+       is_integer(Timeout) ->
+    get(RClient, Bucket, Key, [{r, R}, {timeout, Timeout}]).
 
 
-%% @spec put(RObj :: riak_object:riak_object()) ->
-%%        ok |
-%%       {error, too_many_fails} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}}
+-spec put(riak_client(), RObj :: riak_object:riak_object()) ->
+       ok |
+      {error, too_many_fails} |
+      {error, timeout} |
+      {error, {n_val_violation, N::integer()}}.
 %% @doc Store RObj in the cluster.
 %%      Return as soon as the default W value number of nodes for this bucket
 %%      nodes have received the request.
-%% @equiv put(RObj, [])
-put(RObj) -> THIS:put(RObj, []).
+%% @equiv put(RClient, RObj, [])
+put(#riak_client{} = RClient, RObj) -> put(RClient, RObj, []).
 
 
-%% @spec put(RObj :: riak_object:riak_object(), riak_kv_put_fsm::options()) ->
-%%       ok |
-%%       {ok, details()} |
-%%       {ok, riak_object:riak_object()} |
-%%       {ok, riak_object:riak_object(), details()} |
-%%       {error, notfound} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}} |
-%%       {error, Err :: term()}
-%%       {error, Err :: term(), details()}
+-spec put(riak_client(), RObj :: riak_object:riak_object(),
+          riak_kv_put_fsm:options() | integer()) ->
+      ok |
+      {ok, riak_kv_put_fsm:detail()} |
+      {ok, riak_object:riak_object()} |
+      {ok, riak_object:riak_object(), riak_kv_put_fsm:detail()} |
+      {error, notfound} |
+      {error, timeout} |
+      {error, {n_val_violation, N::integer()}} |
+      {error, Err :: term()} |
+      {error, Err :: term(), riak_kv_put_fsm:detail()}.
 %% @doc Store RObj in the cluster.
-put(RObj, Options) when is_list(Options) ->
+put(#riak_client{node = Node, client_id = ClientId}, RObj, Options)
+  when is_list(Options) ->
     Me = self(),
     ReqId = mk_reqid(),
     case ClientId of
@@ -165,174 +165,177 @@ put(RObj, Options) when is_list(Options) ->
     %% TODO: Investigate adding a monitor here and eliminating the timeout.
     Timeout = recv_timeout(Options),
     wait_for_reqid(ReqId, Timeout);
+put(#riak_client{} = RClient, RObj, W) -> put(RClient, RObj, [{w, W}, {dw, W}]).
 
-%% @spec put(RObj :: riak_object:riak_object(), W :: integer()) ->
-%%        ok |
-%%       {error, too_many_fails} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}}
-%% @doc Store RObj in the cluster.
-%%      Return as soon as at least W nodes have received the request.
-%% @equiv put(RObj, [{w, W}, {dw, W}])
-put(RObj, W) -> THIS:put(RObj, [{w, W}, {dw, W}]).
-
-%% @spec put(RObj::riak_object:riak_object(),W :: integer(),RW :: integer()) ->
-%%        ok |
-%%       {error, too_many_fails} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}}
+-spec put(riak_client(), RObj::riak_object:riak_object(),
+          W :: integer(),RW :: integer()) ->
+       ok |
+      {error, too_many_fails} |
+      {error, timeout} |
+      {error, {n_val_violation, N::integer()}}.
 %% @doc Store RObj in the cluster.
 %%      Return as soon as at least W nodes have received the request, and
 %%      at least DW nodes have stored it in their storage backend.
-%% @equiv put(Robj, W, DW, default_timeout())
-put(RObj, W, DW) -> THIS:put(RObj, [{w, W}, {dw, DW}]).
+%% @equiv put(RClient, Robj, W, DW, default_timeout())
+put(#riak_client{} = RClient, RObj, W, DW) -> put(RClient, RObj, [{w, W}, {dw, DW}]).
 
-%% @spec put(RObj::riak_object:riak_object(), W :: integer(), RW :: integer(),
-%%           TimeoutMillisecs :: integer()) ->
-%%        ok |
-%%       {error, too_many_fails} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}}
+-spec put(riak_client(), RObj::riak_object:riak_object(), W :: integer(),
+          RW :: integer(), TimeoutMillisecs :: integer()) ->
+       ok |
+      {error, too_many_fails} |
+      {error, timeout} |
+      {error, {n_val_violation, N::integer()}}.
 %% @doc Store RObj in the cluster.
 %%      Return as soon as at least W nodes have received the request, and
 %%      at least DW nodes have stored it in their storage backend, or
 %%      TimeoutMillisecs passes.
-put(RObj, W, DW, Timeout) -> THIS:put(RObj,  [{w, W}, {dw, DW}, {timeout, Timeout}]).
+put(#riak_client{} = RClient, RObj, W, DW, Timeout) ->
+    put(RClient, RObj,  [{w, W}, {dw, DW}, {timeout, Timeout}]).
 
-%% @spec put(RObj::riak_object:riak_object(), W :: integer(), RW :: integer(),
-%%           TimeoutMillisecs :: integer(), Options::list()) ->
-%%        ok |
-%%       {error, too_many_fails} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}}
+-spec put(riak_client(), RObj::riak_object:riak_object(), W :: integer(),
+          RW :: integer(), TimeoutMillisecs :: integer(), Options::list()) ->
+       ok |
+      {error, too_many_fails} |
+      {error, timeout} |
+      {error, {n_val_violation, N::integer()}}.
 %% @doc Store RObj in the cluster.
 %%      Return as soon as at least W nodes have received the request, and
 %%      at least DW nodes have stored it in their storage backend, or
 %%      TimeoutMillisecs passes.
-put(RObj, W, DW, Timeout, Options) ->
-   THIS:put(RObj, [{w, W}, {dw, DW}, {timeout, Timeout} | Options]).
+put(#riak_client{} = RClient, RObj, W, DW, Timeout, Options) ->
+   put(RClient, RObj, [{w, W}, {dw, DW}, {timeout, Timeout} | Options]).
 
-%% @spec delete(riak_object:bucket(), riak_object:key()) ->
-%%        ok |
-%%       {error, too_many_fails} |
-%%       {error, notfound} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec delete(riak_client(), riak_object:bucket(), riak_object:key()) ->
+       ok |
+      {error, too_many_fails} |
+      {error, notfound} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as RW
 %%      nodes have responded with a value or error.
-%% @equiv delete(Bucket, Key, RW, default_timeout())
-delete(Bucket,Key) -> delete(Bucket,Key,[],?DEFAULT_TIMEOUT).
+%% @equiv delete(RClient, Bucket, Key, RW, default_timeout())
+delete(#riak_client{} = RClient,Bucket,Key) ->
+    delete(RClient,Bucket,Key,[],?DEFAULT_TIMEOUT).
 
-%% @spec delete(riak_object:bucket(), riak_object:key(), RW :: integer()) ->
-%%        ok |
-%%       {error, too_many_fails} |
-%%       {error, notfound} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec delete(riak_client(), riak_object:bucket(),
+             riak_object:key(), RW :: integer()) ->
+       ok |
+      {error, too_many_fails} |
+      {error, notfound} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as W/DW (or RW)
 %%      nodes have responded with a value or error.
-%% @equiv delete(Bucket, Key, RW, default_timeout())
-delete(Bucket,Key,Options) when is_list(Options) ->
-    delete(Bucket,Key,Options,?DEFAULT_TIMEOUT);
-delete(Bucket,Key,RW) ->
-    delete(Bucket,Key,[{rw, RW}],?DEFAULT_TIMEOUT).
+%% @equiv delete(RClient, Bucket, Key, RW, default_timeout())
+delete(#riak_client{} = RClient,Bucket,Key,Options) when is_list(Options) ->
+    delete(RClient,Bucket,Key,Options,?DEFAULT_TIMEOUT);
+delete(#riak_client{} = RClient,Bucket,Key,RW) ->
+    delete(RClient,Bucket,Key,[{rw, RW}],?DEFAULT_TIMEOUT).
 
-%% @spec delete(riak_object:bucket(), riak_object:key(), RW :: integer(),
-%%           TimeoutMillisecs :: integer()) ->
-%%        ok |
-%%       {error, too_many_fails} |
-%%       {error, notfound} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}} |
-%%       {error, Err :: term()}
+-spec delete(riak_client(), riak_object:bucket(), riak_object:key(),
+             RW :: integer(), TimeoutMillisecs :: integer()) ->
+       ok |
+      {error, too_many_fails} |
+      {error, notfound} |
+      {error, timeout} |
+      {error, {n_val_violation, N::integer()}} |
+      {error, Err :: term()}.
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as W/DW (or RW)
 %%      nodes have responded with a value or error, or TimeoutMillisecs passes.
-delete(Bucket,Key,Options,Timeout) when is_list(Options) ->
+delete(#riak_client{node = Node, client_id = ClientId},
+       Bucket,Key,Options,Timeout) when is_list(Options) ->
     Me = self(),
     ReqId = mk_reqid(),
     riak_kv_delete_sup:start_delete(Node, [ReqId, Bucket, Key, Options, Timeout,
                                            Me, ClientId]),
     RTimeout = recv_timeout(Options),
     wait_for_reqid(ReqId, erlang:min(Timeout, RTimeout));
-delete(Bucket,Key,RW,Timeout) ->
-    delete(Bucket,Key,[{rw, RW}], Timeout).
+delete(#riak_client{} = RClient,Bucket,Key,RW,Timeout) ->
+    delete(RClient,Bucket,Key,[{rw, RW}], Timeout).
 
-%% @spec delete_vclock(riak_object:bucket(), riak_object:key(), vclock:vclock()) ->
-%%        ok |
-%%       {error, too_many_fails} |
-%%       {error, notfound} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec delete_vclock(riak_client(), riak_object:bucket(),
+                    riak_object:key(), vclock:vclock()) ->
+       ok |
+      {error, too_many_fails} |
+      {error, notfound} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as W/DW (or RW)
 %%      nodes have responded with a value or error.
-%% @equiv delete(Bucket, Key, RW, default_timeout())
-delete_vclock(Bucket,Key,VClock) ->
-    delete_vclock(Bucket,Key,VClock,[{rw,default}],?DEFAULT_TIMEOUT).
+%% @equiv delete(RClient, Bucket, Key, RW, default_timeout())
+delete_vclock(#riak_client{} = RClient,Bucket,Key,VClock) ->
+    delete_vclock(RClient,Bucket,Key,VClock,[{rw,default}],?DEFAULT_TIMEOUT).
 
-%% @spec delete_vclock(riak_object:bucket(), riak_object:key(), vclock::vclock(), RW :: integer()) ->
-%%        ok |
-%%       {error, too_many_fails} |
-%%       {error, notfound} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec delete_vclock(riak_client(), riak_object:bucket(),
+                    riak_object:key(), vclock:vclock(), RW :: integer()) ->
+       ok |
+      {error, too_many_fails} |
+      {error, notfound} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as W/DW (or RW)
 %%      nodes have responded with a value or error.
-%% @equiv delete(Bucket, Key, RW, default_timeout())
-delete_vclock(Bucket,Key,VClock,Options) when is_list(Options) ->
-    delete_vclock(Bucket,Key,VClock,Options,?DEFAULT_TIMEOUT);
-delete_vclock(Bucket,Key,VClock,RW) ->
-    delete_vclock(Bucket,Key,VClock,[{rw, RW}],?DEFAULT_TIMEOUT).
+%% @equiv delete(RClient, Bucket, Key, RW, default_timeout())
+delete_vclock(#riak_client{} = RClient,Bucket,Key,VClock,Options)
+  when is_list(Options) ->
+    delete_vclock(RClient,Bucket,Key,VClock,Options,?DEFAULT_TIMEOUT);
+delete_vclock(#riak_client{} = RClient,Bucket,Key,VClock,RW) ->
+    delete_vclock(RClient,Bucket,Key,VClock,[{rw, RW}],?DEFAULT_TIMEOUT).
 
-%% @spec delete_vclock(riak_object:bucket(), riak_object:key(), vclock:vclock(), RW :: integer(),
-%%           TimeoutMillisecs :: integer()) ->
-%%        ok |
-%%       {error, too_many_fails} |
-%%       {error, notfound} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}} |
-%%       {error, Err :: term()}
+-spec delete_vclock(riak_client(), riak_object:bucket(),
+                    riak_object:key(), vclock:vclock(), RW :: integer(),
+                    TimeoutMillisecs :: integer()) ->
+       ok |
+      {error, too_many_fails} |
+      {error, notfound} |
+      {error, timeout} |
+      {error, {n_val_violation, N::integer()}} |
+      {error, Err :: term()}.
 %% @doc Delete the object at Bucket/Key.  Return a value as soon as W/DW (or RW)
 %%      nodes have responded with a value or error, or TimeoutMillisecs passes.
-delete_vclock(Bucket,Key,VClock,Options,Timeout) when is_list(Options) ->
+delete_vclock(#riak_client{node = Node, client_id = ClientId},
+              Bucket,Key,VClock,Options,Timeout) when is_list(Options) ->
     Me = self(),
     ReqId = mk_reqid(),
     riak_kv_delete_sup:start_delete(Node, [ReqId, Bucket, Key, Options, Timeout,
                                            Me, ClientId, VClock]),
     RTimeout = recv_timeout(Options),
     wait_for_reqid(ReqId, erlang:min(Timeout, RTimeout));
-delete_vclock(Bucket,Key,VClock,RW,Timeout) ->
-    delete_vclock(Bucket,Key,VClock,[{rw, RW}],Timeout).
+delete_vclock(#riak_client{} = RClient,Bucket,Key,VClock,RW,Timeout) ->
+    delete_vclock(RClient,Bucket,Key,VClock,[{rw, RW}],Timeout).
 
 
-%% @spec list_keys(riak_object:bucket()) ->
-%%       {ok, [Key :: riak_object:key()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec list_keys(riak_client(), riak_object:bucket()) ->
+      {ok, [Key :: riak_object:key()]} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc List the keys known to be present in Bucket.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
-%% @equiv list_keys(Bucket, default_timeout()*8)
-list_keys(Bucket) ->
-    list_keys(Bucket, ?DEFAULT_TIMEOUT*8).
+%% @equiv list_keys(RClient, Bucket, default_timeout()*8)
+list_keys(#riak_client{} = RClient, Bucket) ->
+    list_keys(RClient, Bucket, ?DEFAULT_TIMEOUT*8).
 
-%% @spec list_keys(riak_object:bucket(), TimeoutMillisecs :: integer()) ->
-%%       {ok, [Key :: riak_object:key()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec list_keys(riak_client(), riak_object:bucket(),
+                TimeoutMillisecs :: integer()) ->
+      {ok, [Key :: riak_object:key()]} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc List the keys known to be present in Bucket.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
-list_keys(Bucket, Timeout) ->
-    list_keys(Bucket, none, Timeout).
+list_keys(#riak_client{} = RClient, Bucket, Timeout) ->
+    list_keys(RClient, Bucket, none, Timeout).
 
-%% @spec list_keys(riak_object:bucket(), TimeoutMillisecs :: integer()) ->
-%%       {ok, [Key :: riak_object:key()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec list_keys(riak_client(), riak_object:bucket(),
+                Filter :: fun() | none, TimeoutMillisecs :: integer()) ->
+      {ok, [Key :: riak_object:key()]} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc List the keys known to be present in Bucket.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
-list_keys(Bucket, Filter, Timeout0) ->
+list_keys(#riak_client{node = Node}, Bucket, Filter, Timeout0) ->
     Timeout = 
         case Timeout0 of
             T when is_integer(T) -> T; 
@@ -343,19 +346,20 @@ list_keys(Bucket, Filter, Timeout0) ->
     riak_kv_keys_fsm_sup:start_keys_fsm(Node, [{raw, ReqId, Me}, [Bucket, Filter, Timeout]]),
     wait_for_listkeys(ReqId).
 
-stream_list_keys(Bucket) ->
-    stream_list_keys(Bucket, ?DEFAULT_TIMEOUT).
+stream_list_keys(#riak_client{} = RClient, Bucket) ->
+    stream_list_keys(RClient, Bucket, ?DEFAULT_TIMEOUT).
 
-stream_list_keys(Bucket, undefined) ->
-    stream_list_keys(Bucket, ?DEFAULT_TIMEOUT);
-stream_list_keys(Bucket, Timeout) ->
+stream_list_keys(#riak_client{} = RClient, Bucket, undefined) ->
+    stream_list_keys(RClient, Bucket, ?DEFAULT_TIMEOUT);
+stream_list_keys(#riak_client{} = RClient, Bucket, Timeout) ->
     Me = self(),
-    stream_list_keys(Bucket, Timeout, Me).
+    stream_list_keys(RClient, Bucket, Timeout, Me).
 
-%% @spec stream_list_keys(riak_object:bucket(),
-%%                        TimeoutMillisecs :: integer(),
-%%                        Client :: pid()) ->
-%%       {ok, ReqId :: term()}
+-spec stream_list_keys(riak_client(),
+                       riak_object:bucket(),
+                       TimeoutMillisecs :: integer(),
+                       Client :: pid()) ->
+      {ok, ReqId :: term()}.
 %% @doc List the keys known to be present in Bucket.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
@@ -364,7 +368,8 @@ stream_list_keys(Bucket, Timeout) ->
 %%      and a final {ReqId, done} message.
 %%      None of the Keys lists will be larger than the number of
 %%      keys in Bucket on any single vnode.
-stream_list_keys(Input, Timeout, Client) when is_pid(Client) ->
+stream_list_keys(#riak_client{node = Node},
+                 Input, Timeout, Client) when is_pid(Client) ->
     ReqId = mk_reqid(),
     case Input of
         {Bucket, FilterInput} ->
@@ -390,67 +395,69 @@ stream_list_keys(Input, Timeout, Client) when is_pid(Client) ->
             {ok, ReqId}
     end.
 
-%% @spec filter_keys(riak_object:bucket(), Fun :: function()) ->
-%%       {ok, [Key :: riak_object:key()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec filter_keys(riak_client(), riak_object:bucket(), Fun :: function()) ->
+      {ok, [Key :: riak_object:key()]} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc List the keys known to be present in Bucket,
 %%      filtered at the vnode according to Fun, via lists:filter.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
-%% @equiv filter_keys(Bucket, Fun, default_timeout())
-filter_keys(Bucket, Fun) ->
-    list_keys(Bucket, Fun, ?DEFAULT_TIMEOUT).
+%% @equiv filter_keys(RClient, Bucket, Fun, default_timeout())
+filter_keys(#riak_client{} = RClient, Bucket, Fun) ->
+    list_keys(RClient, Bucket, Fun, ?DEFAULT_TIMEOUT).
 
-%% @spec filter_keys(riak_object:bucket(), Fun :: function(), TimeoutMillisecs :: integer()) ->
-%%       {ok, [Key :: riak_object:key()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec filter_keys(riak_client(), riak_object:bucket(),
+                  Fun :: function(), TimeoutMillisecs :: integer()) ->
+      {ok, [Key :: riak_object:key()]} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc List the keys known to be present in Bucket,
 %%      filtered at the vnode according to Fun, via lists:filter.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
-filter_keys(Bucket, Fun, Timeout) ->
-            list_keys(Bucket, Fun, Timeout).
+filter_keys(#riak_client{} = RClient, Bucket, Fun, Timeout) ->
+            list_keys(RClient, Bucket, Fun, Timeout).
 
-%% @spec list_buckets() ->
-%%       {ok, [Bucket :: riak_object:bucket()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec list_buckets(riak_client()) ->
+      {ok, [Bucket :: riak_object:bucket()]} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc List buckets known to have keys.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after any operation that
 %%      either adds the first key or removes the last remaining key from
 %%      a bucket.
-%% @equiv list_buckets(default_timeout())
-list_buckets() ->
-    list_buckets(none, ?DEFAULT_TIMEOUT).
+%% @equiv list_buckets(RClient, default_timeout())
+list_buckets(#riak_client{} = RClient) ->
+    list_buckets(RClient, none, ?DEFAULT_TIMEOUT).
 
-%% @spec list_buckets(timeout()) ->
-%%       {ok, [Bucket :: riak_object:bucket()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec list_buckets(riak_client(), timeout()) ->
+      {ok, [Bucket :: riak_object:bucket()]} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc List buckets known to have keys.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after any operation that
 %%      either adds the first key or removes the last remaining key from
 %%      a bucket.
-%% @equiv list_buckets(default_timeout())
-list_buckets(Timeout) ->
-    list_buckets(none, Timeout);
-list_buckets(undefined) ->
-    list_buckets(none, ?DEFAULT_TIMEOUT*8).
+%% @equiv list_buckets(RClient, none, default_timeout())
+list_buckets(#riak_client{} = RClient, undefined) ->
+    list_buckets(RClient, none, ?DEFAULT_TIMEOUT*8);
+list_buckets(#riak_client{} = RClient, Timeout) ->
+    list_buckets(RClient, none, Timeout).
 
-%% @spec list_buckets(TimeoutMillisecs :: integer()) ->
-%%       {ok, [Bucket :: riak_object:bucket()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec list_buckets(riak_client(), Filter :: fun() | none,
+                   TimeoutMillisecs :: integer()) ->
+      {ok, [Bucket :: riak_object:bucket()]} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc List buckets known to have keys.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after any operation that
 %%      either adds the first key or removes the last remaining key from
 %%      a bucket.
-list_buckets(Filter, Timeout) ->
+list_buckets(#riak_client{node = Node}, Filter, Timeout) ->
     Me = self(),
     ReqId = mk_reqid(),
     {ok, _Pid} = riak_kv_buckets_fsm_sup:start_buckets_fsm(Node, 
@@ -459,40 +466,40 @@ list_buckets(Filter, Timeout) ->
                                                              false]]),
     wait_for_listbuckets(ReqId).
 
-%% @spec filter_buckets(Fun :: function()) ->
-%%       {ok, [Bucket :: riak_object:bucket()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec filter_buckets(riak_client(), Fun :: function()) ->
+      {ok, [Bucket :: riak_object:bucket()]} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc Return a list of filtered buckets.
-filter_buckets(Fun) ->
-    list_buckets(Fun, ?DEFAULT_TIMEOUT).
+filter_buckets(#riak_client{} = RClient, Fun) ->
+    list_buckets(RClient, Fun, ?DEFAULT_TIMEOUT).
 
-stream_list_buckets() ->
-    stream_list_buckets(none, ?DEFAULT_TIMEOUT).
+stream_list_buckets(#riak_client{} = RClient) ->
+    stream_list_buckets(RClient, none, ?DEFAULT_TIMEOUT).
 
-stream_list_buckets(undefined) ->
-    stream_list_buckets(none, ?DEFAULT_TIMEOUT);
-stream_list_buckets(Timeout) when is_integer(Timeout) ->
-    stream_list_buckets(none, Timeout);
-stream_list_buckets(Filter) when is_function(Filter) ->
-    stream_list_buckets(Filter, ?DEFAULT_TIMEOUT).    
+stream_list_buckets(#riak_client{} = RClient, undefined) ->
+    stream_list_buckets(RClient, none, ?DEFAULT_TIMEOUT);
+stream_list_buckets(#riak_client{} = RClient, Timeout) when is_integer(Timeout) ->
+    stream_list_buckets(RClient, none, Timeout);
+stream_list_buckets(#riak_client{} = RClient, Filter) when is_function(Filter) ->
+    stream_list_buckets(RClient, Filter, ?DEFAULT_TIMEOUT).    
 
-stream_list_buckets(Filter, Timeout) ->
+stream_list_buckets(#riak_client{} = RClient, Filter, Timeout) ->
     Me = self(),
-    stream_list_buckets(Filter, Timeout, Me).
+    stream_list_buckets(RClient, Filter, Timeout, Me).
 
-%% @spec stream_list_buckets(FilterFun :: fun(),
-%%                           TimeoutMillisecs :: integer(),
-%%                           Client :: pid()) ->
-%%       {ok, [Bucket :: riak_object:bucket()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec stream_list_buckets(riak_client(), FilterFun :: fun(),
+                          TimeoutMillisecs :: integer(),
+                          Client :: pid()) ->
+      {ok, [Bucket :: riak_object:bucket()]} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc List buckets known to have keys.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after any operation that
 %%      either adds the first key or removes the last remaining key from
 %%      a bucket.
-stream_list_buckets(Filter, Timeout, Client) ->
+stream_list_buckets(#riak_client{node = Node}, Filter, Timeout, Client) ->
     ReqId = mk_reqid(),
     {ok, _Pid} = riak_kv_buckets_fsm_sup:start_buckets_fsm(Node, 
                                                            [{raw, ReqId, 
@@ -501,25 +508,23 @@ stream_list_buckets(Filter, Timeout, Client) ->
                                                              true]]),
     {ok, ReqId}.
 
-%% @spec get_index(Bucket :: binary(),
-%%                 Query :: riak_index:query_def()) ->
-%%       {ok, [Key :: riak_object:key()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}.
-%%
+-spec get_index(riak_client(), Bucket :: binary(),
+                Query :: riak_index:query_def()) ->
+      {ok, [Key :: riak_object:key()]} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc Run the provided index query.
-get_index(Bucket, Query) ->
-    get_index(Bucket, Query, [{timeout, ?DEFAULT_TIMEOUT}]).
+get_index(#riak_client{} = RClient, Bucket, Query) ->
+    get_index(RClient, Bucket, Query, [{timeout, ?DEFAULT_TIMEOUT}]).
 
-%% @spec get_index(Bucket :: binary(),
-%%                 Query :: riak_index:query_def(),
-%%                 TimeoutMillisecs :: integer()) ->
-%%       {ok, [Key :: riak_object:key()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}.
-%%
+-spec get_index(riak_client(), Bucket :: binary(),
+                Query :: riak_index:query_def(),
+                TimeoutMillisecs :: integer()) ->
+      {ok, [Key :: riak_object:key()]} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc Run the provided index query.
-get_index(Bucket, Query, Opts) ->
+get_index(#riak_client{node = Node}, Bucket, Query, Opts) ->
     Timeout = proplists:get_value(timeout, Opts, ?DEFAULT_TIMEOUT),
     MaxResults = proplists:get_value(max_results, Opts, all),
     Me = self(),
@@ -527,25 +532,23 @@ get_index(Bucket, Query, Opts) ->
     riak_kv_index_fsm_sup:start_index_fsm(Node, [{raw, ReqId, Me}, [Bucket, none, Query, Timeout, MaxResults]]),
     wait_for_query_results(ReqId, Timeout).
 
-%% @spec stream_get_index(Bucket :: binary(),
-%%                        Query :: riak_index:query_def()) ->
-%%       {ok, pid()} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}.
-%%
+-spec stream_get_index(riak_client(), Bucket :: binary(),
+                       Query :: riak_index:query_def()) ->
+      {ok, pid()} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc Run the provided index query, return a stream handle.
-stream_get_index(Bucket, Query) ->
-    stream_get_index(Bucket, Query, [{timeout, ?DEFAULT_TIMEOUT}]).
+stream_get_index(#riak_client{} = RClient, Bucket, Query) ->
+    stream_get_index(RClient, Bucket, Query, [{timeout, ?DEFAULT_TIMEOUT}]).
 
-%% @spec stream_get_index(Bucket :: binary(),
-%%                        Query :: riak_index:query_def(),
-%%                        TimeoutMillisecs :: integer()) ->
-%%       {ok, pid()} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}.
-%%
+-spec stream_get_index(riak_client(), Bucket :: binary(),
+                       Query :: riak_index:query_def(),
+                       TimeoutMillisecs :: integer()) ->
+      {ok, pid()} |
+      {error, timeout} |
+      {error, Err :: term()}.
 %% @doc Run the provided index query, return a stream handle.
-stream_get_index(Bucket, Query, Opts) ->
+stream_get_index(#riak_client{node = Node}, Bucket, Query, Opts) ->
     Timeout = proplists:get_value(timeout, Opts, ?DEFAULT_TIMEOUT),
     MaxResults = proplists:get_value(max_results, Opts, all),
     Me = self(),
@@ -553,51 +556,46 @@ stream_get_index(Bucket, Query, Opts) ->
     riak_kv_index_fsm_sup:start_index_fsm(Node, [{raw, ReqId, Me}, [Bucket, none, Query, Timeout, MaxResults]]),
     {ok, ReqId}.
 
-%% @spec set_bucket(riak_object:bucket(), [BucketProp :: {atom(),term()}]) -> ok
+-spec set_bucket(riak_client(), riak_object:bucket(),
+                 [BucketProp :: {atom(),term()}]) -> ok.
 %% @doc Set the given properties for Bucket.
 %%      This is generally best if done at application start time,
 %%      to ensure expected per-bucket behavior.
 %% See riak_core_bucket for expected useful properties.
-set_bucket(BucketName,BucketProps) ->
+set_bucket(#riak_client{node = Node}, BucketName,BucketProps) ->
     rpc:call(Node,riak_core_bucket,set_bucket,[BucketName,BucketProps]).
-%% @spec get_bucket(riak_object:bucket()) -> [BucketProp :: {atom(),term()}]
+-spec get_bucket(riak_client(),
+                 riak_object:bucket()) -> [BucketProp :: {atom(),term()}].
 %% @doc Get all properties for Bucket.
 %% See riak_core_bucket for expected useful properties.
-get_bucket(BucketName) ->
+get_bucket(#riak_client{node = Node}, BucketName) ->
     rpc:call(Node,riak_core_bucket,get_bucket,[BucketName]).
-%% @spec reset_bucket(riak_object:bucket()) -> ok
+-spec reset_bucket(riak_client(), riak_object:bucket()) -> ok.
 %% @doc Reset properties for this Bucket to the default values
-reset_bucket(BucketName) ->
+reset_bucket(#riak_client{node = Node}, BucketName) ->
     rpc:call(Node,riak_core_bucket,reset_bucket,[BucketName]).
-%% @spec reload_all(Module :: atom()) -> term()
+-spec reload_all(riak_client(), Module :: atom()) -> term().
 %% @doc Force all Riak nodes to reload Module.
 %%      This is used when loading new modules for map/reduce functionality.
-reload_all(Module) -> rpc:call(Node,riak_core_util,reload_all,[Module]).
+reload_all(#riak_client{node = Node}, Module) ->
+    rpc:call(Node,riak_core_util,reload_all,[Module]).
 
-%% @spec remove_from_cluster(ExitingNode :: atom()) -> term()
+-spec remove_from_cluster(riak_client(), ExitingNode :: atom()) -> term().
 %% @doc Cause all partitions owned by ExitingNode to be taken over
 %%      by other nodes.
-remove_from_cluster(ExitingNode) ->
+remove_from_cluster(#riak_client{node = Node}, ExitingNode) ->
     rpc:call(Node, riak_core_gossip, remove_from_cluster,[ExitingNode]).
 
-get_stats(local) ->
+get_stats(#riak_client{node = Node}, local) ->
     [{Node, rpc:call(Node, riak_kv_stat, get_stats, [])}];
-get_stats(global) ->
+get_stats(#riak_client{node = Node}, global) ->
     {ok, Ring} = rpc:call(Node, riak_core_ring_manager, get_my_ring, []),
     Nodes = riak_core_ring:all_members(Ring),
     [{N, rpc:call(N, riak_kv_stat, get_stats, [])} || N <- Nodes].
 
 %% @doc Return the client id beign used for this client
-get_client_id() ->
+get_client_id(#riak_client{client_id = ClientId}) ->
     ClientId.
-
-%% @private
-%% This function exists only to avoid compiler errors (unused type).
-%% Unfortunately, I can't figure out how to suppress the bogus "Contract for
-%% function that does not exist" warning from Dialyzer, so ignore that one.
--spec for_dialyzer_only_ignore(term(), term()) -> riak_client().
-for_dialyzer_only_ignore(X, Y) ->
-    ?MODULE:new(X, Y).
 
 %% @private
 mk_reqid() ->

--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -67,12 +67,13 @@
 -type value() :: binary() | integer().
 -type key() :: binary().
 -opaque continuation() :: binary(). %% encoded last_result().
+-export_type([continuation/0]).
 
 mapred_index(Dest, Args) ->
     mapred_index(Dest, Args, ?TIMEOUT).
 mapred_index(_Pipe, [Bucket, Query], Timeout) ->
     {ok, C} = riak:local_client(),
-    {ok, ReqId} = C:stream_get_index(Bucket, Query, [{timeout, Timeout}]),
+    {ok, ReqId} = riak_client:stream_get_index(C, Bucket, Query, [{timeout, Timeout}]),
     {ok, Bucket, ReqId}.
 
 %% @spec parse_object_hook(riak_object:riak_object()) ->

--- a/src/riak_kv_backup.erl
+++ b/src/riak_kv_backup.erl
@@ -149,7 +149,7 @@ read_and_restore_function(Client, BinTerm) ->
     Obj1 = make_binary_bucket(Bucket, Key, Obj),
 
     %% Store the object; be sure to tell the FSM not to update last modified!
-    Response = Client:put(Obj1,1,1,1200000, [asis,{update_last_modified, false}]),
+    Response = riak_client:put(Client,Obj1,1,1,1200000, [asis,{update_last_modified, false}]),
     {continue, Response}.
    
 %%% DATA CLEANING %%% 

--- a/src/riak_kv_exchange_fsm.erl
+++ b/src/riak_kv_exchange_fsm.erl
@@ -229,7 +229,7 @@ read_repair_keydiff(RC, LocalVN, RemoteVN, {_, KeyBin}) ->
     %%       redbug to trace read_repair_keydiff when needed. Of course,
     %%       users can't do that.
     %% lager:debug("Anti-entropy forced read repair: ~p/~p", [Bucket, Key]),
-    RC:get(Bucket, Key),
+    riak_client:get(RC, Bucket, Key),
     %% Force vnodes to update AAE tree in case read repair wasn't triggered
     riak_kv_vnode:rehash([LocalVN, RemoteVN], Bucket, Key),
     ok.

--- a/src/riak_kv_mrc_map.erl
+++ b/src/riak_kv_mrc_map.erl
@@ -66,6 +66,7 @@
                 phase :: riak_kv_mrc_pipe:map_query_fun(),
                 arg :: term()}).
 -opaque state() :: #state{}.
+-export_type([state/0]).
 
 -define(DEFAULT_JS_RESERVE_ATTEMPTS, 10).
 
@@ -100,7 +101,7 @@ init_phase({Anon, {Bucket, Key}})
   when Anon =:= jsanon; Anon =:= strfun ->
     %% lookup source for stored functions only at fitting worker startup
     {ok, C} = riak:local_client(),
-    case C:get(Bucket, Key, 1) of
+    case riak_client:get(C, Bucket, Key, 1) of
         {ok, Object} ->
             case riak_object:get_value(Object) of
                 Source when Anon =:= jsanon, is_binary(Source) ->

--- a/src/riak_kv_mrc_pipe.erl
+++ b/src/riak_kv_mrc_pipe.erl
@@ -309,7 +309,7 @@ mapred_plan(BucketOrList, Query) ->
                     BucketOrList;
                is_binary(BucketOrList) ->
                     {ok, C} = riak:local_client(),
-                    {ok, Keys} = C:list_keys(BucketOrList),
+                    {ok, Keys} = riak_client:list_keys(C, BucketOrList),
                     [{BucketOrList, Key} || Key <- Keys]
             end,
     [{bkeys, BKeys}|mapred_plan(Query)].
@@ -976,12 +976,12 @@ example_setup() ->
 -spec example_setup(pos_integer()) -> ok.
 example_setup(Num) when Num > 0 ->
     {ok, C} = riak:local_client(),
-    C:put(riak_object:new(<<"foo">>, <<"bar">>, <<"what did you expect?">>)),
-    [C:put(riak_object:new(<<"foo">>,
+    riak_client:put(C, riak_object:new(<<"foo">>, <<"bar">>, <<"what did you expect?">>)),
+    [riak_client:put(C, riak_object:new(<<"foo">>,
                            list_to_binary("bar"++integer_to_list(X)),
                            list_to_binary("bar val "++integer_to_list(X))))
      || X <- lists:seq(1, Num)],
-    [C:put(riak_object:new(<<"foonum">>,
+    [riak_client:put(C, riak_object:new(<<"foonum">>,
                            list_to_binary("bar"++integer_to_list(X)),
                            X)) ||
         X <- lists:seq(1, Num)],

--- a/src/riak_kv_pb_bucket.erl
+++ b/src/riak_kv_pb_bucket.erl
@@ -75,10 +75,10 @@ process(#rpblistbucketsreq{timeout=T, stream=S}=Req,
         #state{client=C} = State) -> 
     case S of 
         true -> 
-            {ok, ReqId} = C:stream_list_buckets(T),
+            {ok, ReqId} = riak_client:stream_list_buckets(C, T),
             {reply, {stream, ReqId}, State#state{req = Req, req_ctx = ReqId}};
         _ ->
-            case C:list_buckets(T) of
+            case riak_client:list_buckets(C, T) of
                 {ok, Buckets} ->
                     {reply, #rpblistbucketsresp{buckets = Buckets}, State};
                 {error, Reason} ->
@@ -93,7 +93,7 @@ process(rpblistbucketsreq, State) ->
 %% Start streaming in list keys
 process(#rpblistkeysreq{bucket=B,timeout=T}=Req, #state{client=C} = State) ->
     %% stream_list_keys results will be processed by process_stream/3
-    {ok, ReqId} = C:stream_list_keys(B, T),
+    {ok, ReqId} = riak_client:stream_list_keys(C, B, T),
     {reply, {stream, ReqId}, State#state{req = Req, req_ctx = ReqId}}.
 
 %% @doc process_stream/3 callback. Handles streaming keys messages and

--- a/src/riak_kv_pb_counter.erl
+++ b/src/riak_kv_pb_counter.erl
@@ -79,7 +79,7 @@ process(#rpbcountergetreq{bucket=B, key=K, r=R0, pr=PR0, notfound_ok=NFOk,
                    basic_quorum=BQ}, #state{client=C} = State) ->
     R = decode_quorum(R0),
     PR = decode_quorum(PR0),
-    case C:get(B, K, make_option(r, R) ++
+    case riak_client:get(C, B, K, make_option(r, R) ++
                    make_option(pr, PR) ++
                    make_option(notfound_ok, NFOk) ++
                    make_option(basic_quorum, BQ)) of
@@ -103,7 +103,7 @@ process(#rpbcounterupdatereq{bucket=B, key=K,  w=W0, dw=DW0, pw=PW0, amount=Coun
             DW = decode_quorum(DW0),
             PW = decode_quorum(PW0),
             Options = [{counter_op, CounterOp}] ++ return_value(RetVal),
-            case C:put(O, make_option(w, W) ++ make_option(dw, DW) ++
+            case riak_client:put(C, O, make_option(w, W) ++ make_option(dw, DW) ++
                            make_option(pw, PW) ++ [{timeout, default_timeout()} | Options]) of
                 ok ->
                     {reply, #rpbcounterupdateresp{}, State};

--- a/src/riak_kv_pb_csbucket.erl
+++ b/src/riak_kv_pb_csbucket.erl
@@ -75,7 +75,8 @@ maybe_perform_query({error, Reason}, _Req, State) ->
 maybe_perform_query({ok, Query}, Req, State) ->
     #rpbcsbucketreq{bucket=Bucket, max_results=MaxResults} = Req,
     #state{client=Client} = State,
-    {ok, ReqId} = Client:stream_get_index(Bucket, Query, [{max_results, MaxResults}]),
+    {ok, ReqId} = riak_client:stream_get_index(
+                    Client, Bucket, Query, [{max_results, MaxResults}]),
     {reply, {stream, ReqId}, State#state{req_id=ReqId, req=Req}}.
 
 

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -80,14 +80,16 @@ maybe_perform_query({error, Reason}, _Req, State) ->
 maybe_perform_query({ok, Query}, Req=#rpbindexreq{stream=true}, State) ->
     #rpbindexreq{bucket=Bucket, max_results=MaxResults} = Req,
     #state{client=Client} = State,
-    {ok, ReqId} = Client:stream_get_index(Bucket, Query, [{max_results, MaxResults}]),
+    {ok, ReqId} = riak_client:stream_get_index(
+                    Client, Bucket, Query, [{max_results, MaxResults}]),
     ReturnTerms = riak_index:return_terms(Req#rpbindexreq.return_terms, Query),
     {reply, {stream, ReqId}, State#state{req_id=ReqId, req=Req#rpbindexreq{return_terms=ReturnTerms}}};
 maybe_perform_query({ok, Query}, Req, State) ->
     #rpbindexreq{bucket=Bucket, max_results=MaxResults, return_terms=ReturnTerms0} = Req,
     #state{client=Client} = State,
     ReturnTerms =  riak_index:return_terms(ReturnTerms0, Query),
-    QueryResult = Client:get_index(Bucket, Query, [{max_results, MaxResults}]),
+    QueryResult = riak_client:get_index(
+                    Client, Bucket, Query, [{max_results, MaxResults}]),
     handle_query_results(ReturnTerms, MaxResults, QueryResult , State).
 
 handle_query_results(_, _, {error, Reason}, State) ->

--- a/src/riak_kv_pipe_get.erl
+++ b/src/riak_kv_pipe_get.erl
@@ -64,6 +64,7 @@
 
 -record(state, {partition, fd}).
 -opaque state() :: #state{}.
+-export_type([state/0]).
 
 -type input() :: {Bucket :: binary(), Key :: binary()}
                | {{Bucket :: binary(), Key :: binary()}, KeyData :: term()}

--- a/src/riak_kv_pipe_index.erl
+++ b/src/riak_kv_pipe_index.erl
@@ -51,6 +51,7 @@
 -record(state, {p :: riak_pipe_vnode:partition(),
                 fd :: riak_pipe_fitting:details()}).
 -opaque state() :: #state{}.
+-export_type([state/0]).
 
 %% @doc Init just stashes the `Partition' and `FittingDetails' for later.
 -spec init(riak_pipe_vnode:partition(), riak_pipe_fitting:details()) ->

--- a/src/riak_kv_pipe_listkeys.erl
+++ b/src/riak_kv_pipe_listkeys.erl
@@ -51,6 +51,7 @@
 -record(state, {p :: riak_pipe_vnode:partition(),
                 fd :: riak_pipe_fitting:details()}).
 -opaque state() :: #state{}.
+-export_type([state/0]).
 
 %% @doc Init just stashes the `Partition' and `FittingDetails' for later.
 -spec init(riak_pipe_vnode:partition(), riak_pipe_fitting:details()) ->

--- a/src/riak_kv_w_reduce.erl
+++ b/src/riak_kv_w_reduce.erl
@@ -120,6 +120,7 @@
                 p :: riak_pipe_vnode:partition(),
                 fd :: riak_pipe_fitting:details()}).
 -opaque state() :: #state{}.
+-export_type([state/0]).
 
 -define(DEFAULT_JS_RESERVE_ATTEMPTS, 10).
 
@@ -259,7 +260,7 @@ no_input_run_reduce_once() ->
 -spec stored_source(binary(), binary()) -> binary().
 stored_source(Bucket, Key) ->
     {ok, C} = riak:local_client(),
-    {ok, Object} = C:get(Bucket, Key, 1),
+    {ok, Object} = riak_client:get(C, Bucket, Key, 1),
     riak_object:get_value(Object).
 
 %% @doc Produce a function suitable for this fitting's `Arg' that will

--- a/src/riak_kv_wm_buckets.erl
+++ b/src/riak_kv_wm_buckets.erl
@@ -153,12 +153,12 @@ produce_bucket_list(RD, #ctx{client=Client,
     case wrq:get_qs_value(?Q_BUCKETS, RD) of
         ?Q_TRUE ->
             %% Get the buckets.
-            {ok, Buckets} = Client:list_buckets(Timeout),
+            {ok, Buckets} = riak_client:list_buckets(Client, Timeout),
             {mochijson2:encode({struct, [{?JSON_BUCKETS, Buckets}]}), 
              RD, Ctx};
         ?Q_STREAM ->
             F = fun() ->
-                        {ok, ReqId} = Client:stream_list_buckets(Timeout),
+                        {ok, ReqId} = riak_client:stream_list_buckets(Client, Timeout),
                         stream_buckets(ReqId)
                 end,
             {{stream, {[], F}}, RD, Ctx};

--- a/src/riak_kv_wm_counter.erl
+++ b/src/riak_kv_wm_counter.erl
@@ -255,7 +255,7 @@ accept_doc_body(RD, Ctx=#ctx{bucket=B, key=K, client=C,
         true ->
             Doc = riak_kv_counter:new(B, K),
             Options = [{counter_op, CounterOp}] ++ return_value(RD),
-            case C:put(Doc, [{w, Ctx#ctx.w}, {dw, Ctx#ctx.dw}, {pw, Ctx#ctx.pw}, {timeout, 60000} |
+            case riak_client:put(C, Doc, [{w, Ctx#ctx.w}, {dw, Ctx#ctx.dw}, {pw, Ctx#ctx.pw}, {timeout, 60000} |
                                    Options]) of
                 {error, Reason} ->
                     handle_common_error(Reason, RD, Ctx);
@@ -291,7 +291,7 @@ ensure_doc(Ctx=#ctx{doc=undefined, key=undefined}) ->
     Ctx#ctx{doc={error, notfound}};
 ensure_doc(Ctx=#ctx{doc=undefined, bucket=B, key=K, client=C, r=R,
         pr=PR, basic_quorum=Quorum, notfound_ok=NotFoundOK}) ->
-    Ctx#ctx{doc=C:get(B, K, [{r, R}, {pr, PR},
+    Ctx#ctx{doc=riak_client:get(C, B, K, [{r, R}, {pr, PR},
                 {basic_quorum, Quorum}, {notfound_ok, NotFoundOK}])};
 ensure_doc(Ctx) -> Ctx.
 

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -189,7 +189,8 @@ handle_streaming_index_query(RD, Ctx) ->
                 "multipart/mixed;boundary="++Boundary,
                 RD),
 
-    {ok, ReqID} =  Client:stream_get_index(Bucket, Query, [{max_results, MaxResults}]),
+    {ok, ReqID} =  riak_client:stream_get_index(
+                     Client, Bucket, Query, [{max_results, MaxResults}]),
     StreamFun = index_stream_helper(ReqID, Boundary, ReturnTerms, MaxResults, undefined, 0),
     {{stream, {<<>>, StreamFun}}, CTypeRD, Ctx}.
 
@@ -239,7 +240,7 @@ handle_all_in_memory_index_query(RD, Ctx) ->
     ReturnTerms = Ctx#ctx.return_terms,
 
     %% Do the index lookup...
-    case Client:get_index(Bucket, Query, [{max_results, MaxResults}]) of
+    case riak_client:get_index(Client, Bucket, Query, [{max_results, MaxResults}]) of
         {ok, Results} ->
             Continuation = make_continuation(MaxResults, Results, length(Results)),
             JsonResults = encode_results(ReturnTerms, Results, Continuation),

--- a/src/riak_kv_wm_keylist.erl
+++ b/src/riak_kv_wm_keylist.erl
@@ -177,8 +177,9 @@ produce_bucket_body(RD, #ctx{client=Client,
         ?Q_STREAM ->
             %% Start streaming the keys...
             F = fun() ->
-                        {ok, ReqId} = Client:stream_list_keys(Bucket, 
-                                                              Timeout),
+                        {ok, ReqId} = riak_client:stream_list_keys(Client,
+                                                                   Bucket, 
+                                                                   Timeout),
                         stream_keys(ReqId)
                 end,
 
@@ -196,7 +197,7 @@ produce_bucket_body(RD, #ctx{client=Client,
 
         ?Q_TRUE ->
             %% Get the JSON response...
-            case Client:list_keys(Bucket, Timeout) of
+            case riak_client:list_keys(Client, Bucket, Timeout) of
                 {ok, KeyList} ->
                     JsonKeys = mochijson2:encode({struct, BucketPropsJson ++
                                                       [{?Q_KEYS, KeyList}]}),

--- a/src/riak_kv_wm_link_walker.erl
+++ b/src/riak_kv_wm_link_walker.erl
@@ -155,8 +155,9 @@
 %% @doc Extract the links from Object that match {Bucket, Tag}.
 %%      Set this function as the bucket property linkfun to enable
 %%      {link, Bucket, Key, Acc} syntax in mapreduce queries on the bucket.
-%%      Client:set_bucket(Bucket, [{linkfun, {modfun, riak_kv_wm_link_walker,
-%%                                            mapreduce_linkfun}}])
+%%      riak_client:set_bucket(Client, Bucket,
+%%                             [{linkfun, {modfun, riak_kv_wm_link_walker,
+%%                             mapreduce_linkfun}}])
 mapreduce_linkfun({error, notfound}, _, _) -> [];
 mapreduce_linkfun(Object, _, {Bucket, Tag}) ->
     links(Object, Bucket, Tag).
@@ -280,7 +281,7 @@ expires(RD, Ctx=#ctx{cache_secs=Secs}) ->
 %% @doc This resource exists if Riak returns {ok, riak_object()} from
 %%      a get of the starting document.
 resource_exists(RD, Ctx=#ctx{bucket=B, key=K, client=C}) ->
-    case C:get(B, K, 2) of
+    case riak_client:get(C, B, K, 2) of
         {ok, Start} ->
             {true, RD, Ctx#ctx{start=Start}};
         _ ->

--- a/src/riak_kv_wm_props.erl
+++ b/src/riak_kv_wm_props.erl
@@ -199,7 +199,7 @@ produce_bucket_body(RD, Ctx) ->
     {JsonProps3, RD, Ctx}.
 
 get_bucket_props_json(Client, Bucket) ->
-    Props1 = Client:get_bucket(Bucket),
+    Props1 = riak_client:get_bucket(Client, Bucket),
     Props2 = lists:map(fun jsonify_bucket_prop/1, Props1),
     {?JSON_PROPS, {struct, Props2}}.
 
@@ -208,7 +208,7 @@ get_bucket_props_json(Client, Bucket) ->
 %%      bucket-level PUT request.
 accept_bucket_body(RD, Ctx=#ctx{bucket=B, client=C, bucketprops=Props}) ->
     ErlProps = lists:map(fun erlify_bucket_prop/1, Props),
-    case C:set_bucket(B, ErlProps) of
+    case riak_client:set_bucket(C, B, ErlProps) of
         ok ->
             {true, RD, Ctx};
         {error, Details} ->
@@ -220,7 +220,7 @@ accept_bucket_body(RD, Ctx=#ctx{bucket=B, client=C, bucketprops=Props}) ->
 %% @spec delete_resource(reqdata(), context()) -> {boolean, reqdata(), context()}
 %% @doc Reset the bucket properties back to the default values
 delete_resource(RD, Ctx=#ctx{bucket=B, client=C}) ->
-    C:reset_bucket(B),
+    riak_client:reset_bucket(C, B),
     {true, RD, Ctx}.
 
 %% @spec jsonify_bucket_prop({Property::atom(), erlpropvalue()}) ->


### PR DESCRIPTION
Mostly the same as #469, but without tuple modules, e.g. C:function(...) becomes riak_client:function(C, ...). Eunit passes without any errors.
NOTE: absolutely backward _incompatible_.
This is _not_ a concurrent pull-request. This is just an option if you don't like tuple modules.
