### PR TITLE
When backend has uses_r_object capability, encode correctly (e.g. handoff)

### DIFF
--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -190,7 +190,9 @@ prepare(timeout, StateData=#state{bkey=BKey={Bucket,_Key},
                 true ->
                     riak_core_apl:get_apl_ann(DocIdx, N, UpNodes);
                 false ->
-                    riak_core_apl:get_primary_apl(DocIdx, N, UpNodes)
+                    %% TODO: Avoid 2nd call to node_watcher inside the
+                    %%       call to get_primary_apl/3.
+                    riak_core_apl:get_primary_apl(DocIdx, N, riak_kv)
             end,
     new_state_timeout(validate, StateData#state{starttime=riak_core_util:moment(),
                                           n = N,

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -607,8 +607,8 @@ to_binary_version(v1, _, _, <<?MAGIC:8/integer, 1:8/integer, _/binary>>=Bin) ->
     Bin;
 to_binary_version(Vsn, B, K, Bin) when is_binary(Bin) ->
     to_binary(Vsn, from_binary(B, K, Bin));
-to_binary_version(Vsn, _B, _K, O) when is_record(O, r_object) ->
-    to_binary(Vsn, O).
+to_binary_version(Vsn, _B, _K, Obj = #r_object{}) ->
+    to_binary(Vsn, Obj).
 
 %% @doc return the binary version the riak object binary is encoded in
 -spec binary_version(binary()) -> binary_version().

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -605,8 +605,11 @@ to_binary_version(v0, _, _, <<131,_/binary>>=Bin) ->
     Bin;
 to_binary_version(v1, _, _, <<?MAGIC:8/integer, 1:8/integer, _/binary>>=Bin) ->
     Bin;
-to_binary_version(Vsn, B, K, Bin) ->
-    to_binary(Vsn, from_binary(B, K, Bin)).
+to_binary_version(Vsn, B, K, Bin) when is_binary(Bin) ->
+    to_binary(Vsn, from_binary(B, K, Bin));
+%% r_object record definition isn't available, so hack the guard.
+to_binary_version(Vsn, _B, _K, O) when is_tuple(O), element(1, O) == r_object ->
+    to_binary(Vsn, O).
 
 %% @doc return the binary version the riak object binary is encoded in
 -spec binary_version(binary()) -> binary_version().

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -607,8 +607,7 @@ to_binary_version(v1, _, _, <<?MAGIC:8/integer, 1:8/integer, _/binary>>=Bin) ->
     Bin;
 to_binary_version(Vsn, B, K, Bin) when is_binary(Bin) ->
     to_binary(Vsn, from_binary(B, K, Bin));
-%% r_object record definition isn't available, so hack the guard.
-to_binary_version(Vsn, _B, _K, O) when is_tuple(O), element(1, O) == r_object ->
+to_binary_version(Vsn, _B, _K, O) when is_record(O, r_object) ->
     to_binary(Vsn, O).
 
 %% @doc return the binary version the riak object binary is encoded in

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -628,7 +628,9 @@ from_binary(B,K,<<?MAGIC:8/integer, 1:8/integer, Rest/binary>>=_ObjBin) ->
             #r_object{bucket=B,key=K,contents=Contents,vclock=Vclock};
         _Other ->
             {error, bad_object_format}
-    end.
+    end;
+from_binary(_B, _K, Obj = #r_object{}) ->
+    Obj.
 
 sibs_of_binary(Count,SibsBin) ->
     sibs_of_binary(Count, SibsBin, []).


### PR DESCRIPTION
Required bugfix for 1.4.0 release, sorry I missed it earlier.
