### PR TITLE
Fix incorrect arg in call to get_primary_apl/3 by put FSM

### DIFF
--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -193,13 +193,11 @@ prepare(timeout, StateData=#state{bkey=BKey={Bucket,_Key},
             {stop, normal, StateData2};
         _ ->
             StatTracked = proplists:get_value(stat_tracked, BucketProps, false),
-            UpNodes = riak_core_node_watcher:nodes(riak_kv),
             Preflist2 = case proplists:get_value(sloppy_quorum, Options, true) of
                         true ->
+                            UpNodes = riak_core_node_watcher:nodes(riak_kv),
                             riak_core_apl:get_apl_ann(DocIdx, N, UpNodes);
                         false ->
-                            %% TODO: Avoid 2nd call to node_watcher inside the
-                            %%       call to get_primary_apl/3.
                             riak_core_apl:get_primary_apl(DocIdx, N, riak_kv)
                     end,
             new_state_timeout(validate, StateData#state{starttime=riak_core_util:moment(),

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -227,12 +227,12 @@ prepare(timeout, StateData0 = #state{from = From, robj = RObj,
             process_reply(Error, StateData0);
         _ ->
             StatTracked = proplists:get_value(stat_tracked, BucketProps, false),
-            UpNodes = riak_core_node_watcher:nodes(riak_kv),
             Preflist2 = case proplists:get_value(sloppy_quorum, Options, true) of
                             true ->
+                                UpNodes = riak_core_node_watcher:nodes(riak_kv),
                                 riak_core_apl:get_apl_ann(DocIdx, N, UpNodes);
                             false ->
-                                riak_core_apl:get_primary_apl(DocIdx, N, UpNodes)
+                                riak_core_apl:get_primary_apl(DocIdx, N, riak_kv)
                         end,
             %% Check if this node is in the preference list so it can coordinate
             LocalPL = [IndexNode || {{_Index, Node} = IndexNode, _Type} <- Preflist2,


### PR DESCRIPTION
Fix incorrect arg in call to `riak_core_apl:get_primary_apl/3` by the put FSM.

Additionally, optimize the get and put FSMs to only compute a list of up nodes when using sloppy quorums. The strict quorum code path uses `get_primary_apl/3` which already computes the list of up nodes internally.

Without this change, puts that attempt to use strict quorums (ie. disable sloppy quorums) always fail:

``` erlang
> {ok, C} = riak:local_client().
> C:put(riak_object:new(<<"abc">>, <<"xyz">>, <<"123">>),
        [{sloppy_quorum, false}]).
{error,all_nodes_down}
```

With this patch, things work as desired.

``` erlang
> {ok, C} = riak:local_client().
> C:put(riak_object:new(<<"abc">>, <<"xyz">>, <<"123">>),
        [{sloppy_quorum, false}]).
ok
```
