### PR TITLE
Expose Preflist via HTTP Header

### DIFF
--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -35,6 +35,7 @@
 -define(HEAD_INDEX_PREFIX,    "x-riak-index-").
 -define(HEAD_DELETED,         "X-Riak-Deleted").
 -define(HEAD_TIMEOUT,         "X-Riak-Timeout").
+-define(HEAD_PREFLIST,        "X-Riak-Preflist").
 
 %% Names of JSON fields in bucket properties
 -define(JSON_PROPS,   <<"props">>).

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -31,6 +31,7 @@
          multipart_encode_body/4,
          format_links/3,
          format_uri/4,
+         format_preflist/1,
          encode_value/1,
          accept_value/2,
          any_to_list/1,
@@ -177,6 +178,24 @@ format_uri(Bucket, Key, Prefix, 1) ->
     io_lib:format("/~s/~s/~s", [Prefix, Bucket, Key]);
 format_uri(Bucket, Key, _Prefix, 2) ->
     io_lib:format("/buckets/~s/keys/~s", [Bucket, Key]).
+    
+%% @doc Format the IP/Ports for correctly for the Preflist header
+format_preflist(Preflist) ->
+    binary_to_list(format_preflist_bin(Preflist)).
+
+format_preflist_bin([]) ->
+    <<>>;
+format_preflist_bin([{IP, Port}]) ->
+    iolist_to_binary(format_ip_port(IP, Port));
+format_preflist_bin([{IP, Port} | IPPortList]) ->
+    IPPort = iolist_to_binary(format_ip_port(IP, Port)),
+    Rest   = format_preflist_bin(IPPortList),
+    <<IPPort/binary, ", ", Rest/binary>>.
+    
+
+%% @doc Format a single IP/Port into a URL for the Preflist header
+format_ip_port(IP, Port) ->
+    io_lib:format("http://~ts:~B/", [IP, Port]).
 
 %% @spec get_ctype(dict(), term()) -> string()
 %% @doc Work out the content type for this object - use the metadata if provided


### PR DESCRIPTION
This adds a `X-Riak-Preflist` header to all non-error HTTP responses, which contains the http interface's ip/port for all the current Bucket/Key's primary nodes that the current node can reach.

In the [Dynamo paper](http://www.allthingsdistributed.com/files/amazon-dynamo-sosp2007.pdf), results are shown about allowing Clients to coordinate writes, with a significant reduction in both regular and tail latencies (§ 6.4 & Table 2).

Though we cannot allow clients to actually coordinate a read [citation needed], there should [citation needed] be a performance increase by hinting to clients which servers to aim their reads and writes at. 

I'm going to work on adding support for this header to the Erlang HTTP Client, so that I can start running benchmarks to see if there is actually any performance increase. The idea is that this information is cached for a short amount of time, to speed up tight GET-PUT cycles.
