### PR TITLE
Fix final multipart boundary when streaming 2i with max_results.

### DIFF
--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -224,7 +224,8 @@ index_stream_helper(ReqID, Boundary, ReturnTerms, MaxResults, LastResult, Count)
                     ErrorJson = mochijson2:encode({struct, [{error, Error}]}),
                     Body = ["\r\n--", Boundary, "\r\n",
                             "Content-Type: application/json\r\n\r\n",
-                            ErrorJson],
+                            ErrorJson,
+                            "\r\n--", Boundary, "--\r\n"],
                     {iolist_to_binary(Body), done}
             after 60000 ->
                     {error, timeout}

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -201,7 +201,7 @@ index_stream_helper(ReqID, Boundary, ReturnTerms, MaxResults, LastResult, Count)
                                 undefined -> ["\r\n--", Boundary, "--\r\n"];
                                 Continuation ->
                                     Json = mochijson2:encode(mochify_continuation(Continuation)),
-                                    ["\r\n--", Boundary, "--\r\n",
+                                    ["\r\n--", Boundary, "\r\n",
                                      "Content-Type: application/json\r\n\r\n",
                                      Json,
                                      "\r\n--", Boundary, "--\r\n"]


### PR DESCRIPTION
In the output below, the "final" marker of the multipart/mixed body is erroneously produced even though there is an additional hunk in the stream that contains the continuation data. This is a simple fix that will allow clients with existing streaming multipart parsers to get the continuation at the end.

_EDIT_: This also fixes a bug where an error would not terminate the multipart body.

``` shell
$ curl localhost:8098/buckets/kqllhzklroqm/index/field1_bin/val0/val5?stream=true\&max_results=3 -i
HTTP/1.1 200 OK
Vary: Accept-Encoding
Transfer-Encoding: chunked
Server: MochiWeb/1.1 WebMachine/1.10.0 (never breaks eye contact)
Date: Tue, 02 Jul 2013 01:35:14 GMT
Content-Type: multipart/mixed;boundary=1G4Fv6rUewvlAQt22mocVUjcHyA


--1G4Fv6rUewvlAQt22mocVUjcHyA
Content-Type: application/json

{"keys":["owdhxphpsezk","tozqrrtrjdnn","bkmmcbnmluvh"]}
--1G4Fv6rUewvlAQt22mocVUjcHyA--
Content-Type: application/json

{"continuation":"g2gCbQAAAAR2YWwzbQAAAAxia21tY2JubWx1dmg="}
--1G4Fv6rUewvlAQt22mocVUjcHyA--
```
