### PR TITLE
Additions to Counters for Yokozuna

### DIFF
--- a/src/riak_kv_counter.erl
+++ b/src/riak_kv_counter.erl
@@ -36,7 +36,7 @@
 
 -module(riak_kv_counter).
 
--export([update/3, merge/1, value/1, new/2, to_binary/1, from_binary/1, supported/0]).
+-export([update/3, merge/1, value/1, sibling_value/1, new/2, to_binary/1, from_binary/1, supported/0]).
 
 -include("riak_kv_wm_raw.hrl").
 -include_lib("riak_kv_types.hrl").
@@ -91,6 +91,17 @@ value(RObj) ->
         undefined -> 0;
         _ ->
             riak_kv_pncounter:value(Counter)
+    end.
+
+%% @doc Turn a single sibling into a counter value. Used by the YZ Extractor.
+-spec sibling_value(binary()) -> {ok, integer()} | {error, term()}.
+sibling_value(Sibling) ->
+    try
+        PNCounter = riak_kv_counter:from_binary(Sibling),
+        Value = riak_pn_counter:value(PNCounter),
+        {ok, Value};
+    catch
+        _:_ -> {error, not_counter}
     end.
 
 %% Merge contents _AND_ meta

--- a/src/riak_kv_counter.erl
+++ b/src/riak_kv_counter.erl
@@ -102,7 +102,7 @@ value(RObj) ->
 sibling_value(Sibling) ->
     try
         PNCounter = riak_kv_counter:from_binary(Sibling),
-        Value = riak_pn_counter:value(PNCounter),
+        Value = riak_kv_pncounter:value(PNCounter),
         {ok, Value}
     catch
         _:_ -> {error, not_counter}


### PR DESCRIPTION
This is associated with the work in basho/yokozuna#135 - and hence will have to wait until yokozuna supports 1.4.

Firstly, the Yokozuna extractor extracts on a sibling-by-sibling basis, not the entire riak object. Hence it's useful to have a method in `riak_kv_counter` that can give the counter value from a single sibling.

Secondly, we require that Yokozuna merges all CRDTs before doing extraction, so that the most up to date value of the counter is merged. `riak_kv_counter:merge/1` is "safe" to call on a riak_object without counter siblings (ie it won't affect anything), but is quite a heavyweight thing to do. We include a simple check to see if any siblings could be a counter, before merging. This probably needs (micro-)benchmarking to see if it really does increase performance.
