### PR TITLE
Generic AAE status

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -293,7 +293,7 @@ reload_file(Filename) ->
     end.
 
 aae_status([]) ->
-    ExchangeInfo = riak_kv_entropy_info:compute_exchange_info(),
+    ExchangeInfo = riak_kv_entropy_info:compute_exchange_info(riak_kv),
     aae_exchange_status(ExchangeInfo),
     io:format("~n"),
     aae_tree_status(),
@@ -330,7 +330,7 @@ aae_repair_status(ExchangeInfo) ->
     ok.
 
 aae_tree_status() ->
-    TreeInfo = riak_kv_entropy_info:compute_tree_info(),
+    TreeInfo = riak_kv_entropy_info:compute_tree_info(riak_kv),
     io:format("~s~n", [string:centre(" Entropy Trees ", 79, $=)]),
     io:format("~-49s  Built (ago)~n", ["Index"]),
     io:format("~79..-s~n", [""]),

--- a/src/riak_kv_exchange_fsm.erl
+++ b/src/riak_kv_exchange_fsm.erl
@@ -284,6 +284,7 @@ next_state_with_timeout(StateName, State, Timeout) ->
     {next_state, StateName, State, Timeout}.
 
 exchange_complete({LocalIdx, _}, {RemoteIdx, RemoteNode}, IndexN, Repaired) ->
-    riak_kv_entropy_info:exchange_complete(LocalIdx, RemoteIdx, IndexN, Repaired),
+    riak_kv_entropy_info:exchange_complete(riak_kv, LocalIdx, RemoteIdx,
+                                           IndexN, Repaired),
     rpc:call(RemoteNode, riak_kv_entropy_info, exchange_complete,
-             [RemoteIdx, LocalIdx, IndexN, Repaired]).
+             [riak_kv, RemoteIdx, LocalIdx, IndexN, Repaired]).

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -51,7 +51,8 @@
          stop/1,
          destroy/1]).
 
--export([poke/1]).
+-export([poke/1,
+         get_build_time/1]).
 
 -type index() :: non_neg_integer().
 -type index_n() :: {index(), pos_integer()}.

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -477,7 +477,7 @@ do_build_finished(State=#state{index=Index, built=_Pid}) ->
     BuildTime = get_build_time(Tree0),
     hashtree:write_meta(<<"built">>, <<1>>, Tree0),
     hashtree:write_meta(<<"build_time">>, term_to_binary(BuildTime), Tree0),
-    riak_kv_entropy_info:tree_built(Index, BuildTime),
+    riak_kv_entropy_info:tree_built(riak_kv, Index, BuildTime),
     State#state{built=true, build_time=BuildTime}.
 
 %% Determine the build time for all trees associated with this


### PR DESCRIPTION
This pull request makes AAE entropy info parameterized on type.  This allows both KV and Yokozuna to share almost all the same status code without copy pasta.
- Add a `Type` to entropy info.  It represents the type of AAE being performed.  Currently `riak_kv` or `yokozuna` but could be other things in the future.
- Export the `get_build_time` function as it can be reused by Yokozuna.
- Parameterize the module and function name used to compute all exchanges.  KV has inter-partition exchange whereas Yokozuna is purely intra.  I.e. Yokozuna exchange is always between the same partition, different services.  By parameterizing the "all exchanges" calculation can let different services have different exchange patterns.
