### PR TITLE
Add support for new riak_kv access methods get_object/4 and put_object/4

### DIFF
--- a/src/riak_kv_yessir_backend.erl
+++ b/src/riak_kv_yessir_backend.erl
@@ -179,12 +179,6 @@ start(_Partition, Config) ->
                    undefined -> 1024;
                    Count     -> Count
                end,
-    S = #state{aae_mode = AAE_Mode,
-               constant_r_object = riak_object:new(<<>>, <<>>, <<>>),
-               default_get = <<42:(DefaultLen*8)>>,
-               default_size = DefaultLen,
-               key_count = KeyCount},
-    io:format("~p\n", [S]),                     % QQQ DELETE ME
     {ok, #state{aae_mode = AAE_Mode,
                 constant_r_object = riak_object:new(<<>>, <<>>, <<>>),
                 default_get = <<42:(DefaultLen*8)>>,


### PR DESCRIPTION
On a 2 node test, 1 box load gen and 1 box a single Riak node with
all defaults (i.e. n_val=3 and ring size=64), when comparing to the
memory backend with 50% get/50% put op mix:
- 1 byte value size: this backend is slightly slower than the memory
  backend, by a few percentage points
- 20KB value size: this backend is 17% faster (5834.42 -> 6837.8)
  with a drop of 99.9% latency of 50msec -> 40msec
