### PR TITLE
Avoid t2b/b2t between vnode and get FSM

### DIFF
--- a/include/riak_kv_vnode.hrl
+++ b/include/riak_kv_vnode.hrl
@@ -11,6 +11,10 @@
           bkey :: {binary(), binary()},
           req_id :: non_neg_integer()}).
 
+-record(riak_kv_get_bin_req_v1, {
+          bkey :: {binary(), binary()},
+          req_id :: non_neg_integer()}).
+
 -record(riak_kv_listkeys_req_v2, {
           bucket :: binary()|'_'|tuple(),
           req_id :: non_neg_integer(),
@@ -57,6 +61,7 @@
 
 -define(KV_PUT_REQ, #riak_kv_put_req_v1).
 -define(KV_GET_REQ, #riak_kv_get_req_v1).
+-define(KV_GET_BIN_REQ, #riak_kv_get_bin_req_v1).
 -define(KV_LISTBUCKETS_REQ, #riak_kv_listbuckets_req_v1).
 -define(KV_LISTKEYS_REQ, #riak_kv_listkeys_req_v4).
 -define(KV_INDEX_REQ, #riak_kv_index_req_v2).

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -277,7 +277,12 @@ execute(timeout, StateData0=#state{timeout=Timeout,req_id=ReqId,
     Preflist = [IndexNode || {IndexNode, _Type} <- Preflist2],
     Ps = preflist_for_tracing(Preflist),
     ?DTRACE(?C_GET_FSM_PREFLIST, [], Ps),
-    riak_kv_vnode:get_bin(Preflist, BKey, ReqId),
+    case riak_core_capability:get({riak_kv, get_fsm_bin}) of
+        true ->
+            riak_kv_vnode:get_bin(Preflist, BKey, ReqId);
+        false ->
+            riak_kv_vnode:get(Preflist, BKey, ReqId)
+    end,
     StateData = StateData0#state{tref=TRef},
     new_state(waiting_vnode_r, StateData).
 


### PR DESCRIPTION
This is a port of Krestenkrab's PR :
https://github.com/basho/riak_kv/pull/83
Avoids doing a binary to term on an object that is sent from a vnode to
the get FSM requesting it. This means that the FSM will have to do it on
that side, but it avoids the implicit term_to_binary/binary_to_term when
the object is sent through disterl.  Some tests using a memory backend
on OSX show a decent improvement (~5% in throughput and more in
latency).
The get_fsm fake vnode had to be updated to support the get binary
request.
