### PR TITLE
Move json encoding out of riak_object

### DIFF
--- a/src/riak_kv_js_vm.erl
+++ b/src/riak_kv_js_vm.erl
@@ -104,7 +104,7 @@ handle_call({batch_dispatch, _JobId, {_Sender, {map, {jsanon, JS}, Reduced, Arg}
 handle_call({batch_dispatch, _JobId, {_Sender, {map, {jsfun, JS}, _Reduced, Arg},
                                       Value, KeyData, _BKey}},
                                      _From, #state{ctx=Ctx}=State) ->
-    JsonValue = riak_object:to_json(Value),
+    JsonValue = riak_object_json:encode(Value),
     JsonArg = jsonify_arg(Arg),
     Reply = invoke_js(Ctx, JS, [JsonValue, KeyData, JsonArg]),
     {reply, Reply, State};
@@ -146,7 +146,7 @@ handle_call({dispatch, _JobId, {{jsfun, JS}, Args}}, _From,
     {reply, Reply, State};
 %% Pre-commit hook with named function
 handle_call({dispatch, _JobId, {{jsfun, JS}, Obj}}, _From, #state{ctx=Ctx}=State) ->
-    Reply = invoke_js(Ctx, JS, [riak_object:to_json(Obj)]),
+    Reply = invoke_js(Ctx, JS, [riak_object_json:encode(Obj)]),
     maybe_idle(State),
     {reply, Reply, State};
 handle_call(Request, _From, State) ->
@@ -162,7 +162,7 @@ handle_cast(reload, #state{ctx=Ctx, pool=Pool}=State) ->
 handle_cast({batch_dispatch, JobId, {Sender, {map, {jsanon, JS}, Arg, _Acc},
                                             Value,
                                             KeyData, _BKey}}, State) ->
-    JsonValue = riak_object:to_json(Value),
+    JsonValue = riak_object_json:encode(Value),
     JsonArg = jsonify_arg(Arg),
     {Result, UpdatedState} = define_invoke_anon_js(JS, [JsonValue, KeyData, JsonArg], State),
     FinalState = case Result of
@@ -179,7 +179,7 @@ handle_cast({batch_dispatch, JobId, {Sender, {map, {jsanon, JS}, Arg, _Acc},
 handle_cast({batch_dispatch, JobId, {Sender, {map, {jsfun, JS}, Arg, _Acc},
                                             Value,
                                             KeyData, _BKey}}, #state{ctx=Ctx}=State) ->
-    JsonValue = riak_object:to_json(Value),
+    JsonValue = riak_object_json:encode(Value),
     JsonArg = jsonify_arg(Arg),
     case invoke_js(Ctx, JS, [JsonValue, KeyData, JsonArg]) of
         {ok, R} ->
@@ -193,7 +193,7 @@ handle_cast({batch_dispatch, JobId, {Sender, {map, {jsfun, JS}, Arg, _Acc},
 handle_cast({dispatch, _Requestor, JobId, {Sender, {map, {jsanon, JS}, Arg, _Acc},
                                             Value,
                                             KeyData, _BKey}}, State) ->
-    JsonValue = riak_object:to_json(Value),
+    JsonValue = riak_object_json:encode(Value),
     JsonArg = jsonify_arg(Arg),
     {Result, UpdatedState} = define_invoke_anon_js(JS, [JsonValue, KeyData, JsonArg], State),
     FinalState = case Result of
@@ -211,7 +211,7 @@ handle_cast({dispatch, _Requestor, JobId, {Sender, {map, {jsanon, JS}, Arg, _Acc
 handle_cast({dispatch, _Requestor, JobId, {Sender, {map, {jsfun, JS}, Arg, _Acc},
                                             Value,
                                             KeyData, _BKey}}, #state{ctx=Ctx}=State) ->
-    JsonValue = riak_object:to_json(Value),
+    JsonValue = riak_object_json:encode(Value),
     JsonArg = jsonify_arg(Arg),
     case invoke_js(Ctx, JS, [JsonValue, KeyData, JsonArg]) of
         {ok, R} ->

--- a/src/riak_kv_mrc_map.erl
+++ b/src/riak_kv_mrc_map.erl
@@ -187,7 +187,7 @@ map_js(_JS, _Arg, {{error, notfound}, {Bucket, Key}, KeyData}) ->
            {Bucket, Key},
            KeyData}]};
 map_js(JS, Arg, {ok, Input, KeyData}) ->
-    JSArgs = [riak_object:to_json(Input), KeyData, Arg],
+    JSArgs = [riak_object_json:encode(Input), KeyData, Arg],
     JSCall = {JS, JSArgs},
     case riak_kv_js_manager:blocking_dispatch(
            ?JSPOOL_MAP, JSCall, ?DEFAULT_JS_RESERVE_ATTEMPTS) of

--- a/src/riak_object_json.erl
+++ b/src/riak_object_json.erl
@@ -1,0 +1,183 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc JSON encoding/decoding utilities for riak_object
+
+
+-module(riak_object_json).
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+-include("riak_kv_wm_raw.hrl").
+
+-export([encode/1,decode/1]).
+
+%% @spec to_json(riak_object()) -> {struct, list(any())}
+%% @doc Converts a riak_object into its JSON equivalent
+-spec encode(riak_object:riak_object()) -> {struct, list(any())}.
+encode(Obj) ->
+    {_,Vclock} = riak_object:vclock_header(Obj),
+    {struct, [{<<"bucket">>, riak_object:bucket(Obj)},
+              {<<"key">>, riak_object:key(Obj)},
+              {<<"vclock">>, list_to_binary(Vclock)},
+              {<<"values">>,
+               [{struct,
+                 [{<<"metadata">>, jsonify_metadata(MD)},
+                  {<<"data">>, V}]}
+                || {MD, V} <- riak_object:get_contents(Obj)
+               ]}]}.
+
+-spec decode(any()) -> riak_object:riak_object().
+decode({struct, Obj}) ->
+    decode(Obj);
+decode(Obj) ->
+    Bucket = proplists:get_value(<<"bucket">>, Obj),
+    Key = proplists:get_value(<<"key">>, Obj),
+    VClock0 = proplists:get_value(<<"vclock">>, Obj),
+    VClock = riak_object:decode_vclock(base64:decode(VClock0)),
+    [{struct, Values}] = proplists:get_value(<<"values">>, Obj),
+    RObj0 = riak_object:new(Bucket, Key, <<"">>),
+    RObj1 = riak_object:set_vclock(RObj0, VClock),
+    riak_object:set_contents(RObj1, dejsonify_values(Values, [])).
+
+jsonify_metadata(MD) ->
+    MDJS = fun({LastMod, Now={_,_,_}}) ->
+                   %% convert Now to JS-readable time string
+                   {LastMod, list_to_binary(
+                               httpd_util:rfc1123_date(
+                                 calendar:now_to_local_time(Now)))};
+              %% When the user metadata is empty, it should still be a struct
+              ({?MD_USERMETA, []}) ->
+                   {?MD_USERMETA, {struct, []}};
+              ({<<"Links">>, Links}) ->
+                   {<<"Links">>, [ [B, K, T] || {{B, K}, T} <- Links ]};
+              ({Name, List=[_|_]}) ->
+                   {Name, jsonify_metadata_list(List)};
+              ({Name, Value}) ->
+                   {Name, Value}
+           end,
+    {struct, lists:map(MDJS, dict:to_list(MD))}.
+
+%% @doc convert strings to binaries, and proplists to JSON objects
+jsonify_metadata_list([]) -> [];
+jsonify_metadata_list(List) ->
+    Classifier = fun({Key,_}, Type) when (is_binary(Key) orelse is_list(Key)),
+                                         Type /= array, Type /= string ->
+                         struct;
+                    (C, Type) when is_integer(C), C >= 0, C =< 256,
+                                   Type /= array, Type /= struct ->
+                         string;
+                    (_, _) ->
+                         array
+                 end,
+    case lists:foldl(Classifier, undefined, List) of
+        struct -> {struct, jsonify_proplist(List)};
+        string -> list_to_binary(List);
+        array -> List
+    end.
+
+%% @doc converts a proplist with potentially multiple values for the
+%%    same key into a JSON object with single or multi-valued keys.
+jsonify_proplist([]) -> [];
+jsonify_proplist(List) ->
+    dict:to_list(lists:foldl(fun({Key, Value}, Dict) ->
+                                     JSONKey = if is_list(Key) -> list_to_binary(Key);
+                                                  true -> Key
+                                               end,
+                                     JSONVal = if is_list(Value) -> jsonify_metadata_list(Value);
+                                                  true -> Value
+                                               end,
+                                     case dict:find(JSONKey, Dict) of
+                                         {ok, ListVal} when is_list(ListVal) ->
+                                             dict:append(JSONKey, JSONVal, Dict);
+                                         {ok, Other} ->
+                                             dict:store(JSONKey, [Other,JSONVal], Dict);
+                                         _ ->
+                                             dict:store(JSONKey, JSONVal, Dict)
+                                     end
+                             end, dict:new(), List)).
+
+dejsonify_values([], Accum) ->
+    lists:reverse(Accum);
+dejsonify_values([{<<"metadata">>, {struct, MD0}},
+                  {<<"data">>, D}|T], Accum) ->
+    Converter = fun({Key, Val}) ->
+                        case Key of
+                            <<"Links">> ->
+                                {Key, [{{B, K}, Tag} || [B, K, Tag] <- Val]};
+                            <<"X-Riak-Last-Modified">> ->
+                                {Key, os:timestamp()};
+                            _ ->
+                                {Key, if
+                                          is_binary(Val) ->
+                                              binary_to_list(Val);
+                                          true ->
+                                              dejsonify_meta_value(Val)
+                                      end}
+                        end
+                end,
+    MD = dict:from_list([Converter(KV) || KV <- MD0]),
+    dejsonify_values(T, [{MD, D}|Accum]).
+
+%% @doc convert structs back into proplists
+dejsonify_meta_value({struct, PList}) ->
+    lists:foldl(fun({Key, List}, Acc) when is_list(List) ->
+                        %% This reverses the {k,v},{k,v2} pattern that
+                        %% is possible in multi-valued indexes.
+                        [{Key, dejsonify_meta_value(L)} || L <- List] ++ Acc;
+                    ({Key, V}, Acc) ->
+                        [{Key, dejsonify_meta_value(V)}|Acc]
+                end, [], PList);
+dejsonify_meta_value(Value) -> Value.
+
+-ifdef(TEST).
+
+jsonify_multivalued_indexes_test() ->
+    Indexes = [{<<"test_bin">>, <<"one">>},
+               {<<"test_bin">>, <<"two">>},
+               {<<"test2_int">>, 4}],
+    ?assertEqual({struct, [{<<"test2_int">>,4},{<<"test_bin">>,[<<"one">>,<<"two">>]}]},
+                 jsonify_metadata_list(Indexes)).
+
+
+jsonify_round_trip_test() ->
+    Links = [{{<<"b">>,<<"k2">>},<<"tag">>},
+             {{<<"b2">>,<<"k2">>},<<"tag2">>}],
+    Indexes = [{<<"test_bin">>, <<"one">>},
+               {<<"test_bin">>, <<"two">>},
+               {<<"test2_int">>, 4}],
+    Meta = [{<<"foo">>, <<"bar">>}, {<<"baz">>, <<"quux">>}],
+    MD = dict:from_list([{?MD_USERMETA, Meta},
+                         {?MD_CTYPE, "application/json"},
+                         {?MD_INDEX, Indexes},
+                         {?MD_LINKS, Links}]),
+    O = riak_object:new(<<"b">>, <<"k">>, <<"{\"a\":1}">>, MD),
+    O2 = decode(encode(O)),
+    ?assertEqual(riak_object:bucket(O), riak_object:bucket(O2)),
+    ?assertEqual(riak_object:key(O), riak_object:key(O2)),
+    ?assert(vclock:equal(riak_object:vclock(O), riak_object:vclock(O2))),
+    ?assertEqual(lists:sort(Meta),
+                 lists:sort(dict:fetch(?MD_USERMETA,
+                                       riak_object:get_metadata(O2)))),
+    ?assertEqual(Links, dict:fetch(?MD_LINKS, riak_object:get_metadata(O2))),
+    ?assertEqual(lists:sort(Indexes), lists:sort(riak_object:index_data(O2))),
+    ?assertEqual(riak_object:get_contents(O), riak_object:get_contents(O2)).
+
+-endif.


### PR DESCRIPTION
Revisiting https://github.com/basho/riak_kv/pull/88
But using riak_object_json encode/decode and leaving old methods in
riak_object.erl with a deprecation warning.
