### PR TITLE
fix riak_kv_backend standard tests

### DIFF
--- a/src/riak_kv_backend.erl
+++ b/src/riak_kv_backend.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_kv_backend: Riak backend behaviour
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -76,6 +76,7 @@ standard_test(BackendMod, Config) ->
     {spawn,
      [
       {setup,
+       local,
        fun() -> setup({BackendMod, Config}) end,
        fun cleanup/1,
        fun(X) ->
@@ -92,16 +93,14 @@ standard_test(BackendMod, Config) ->
 basic_store_and_fetch({Backend, State}) ->
     {"basic store and fetch test",
      fun() ->
-             [
-              ?_assertMatch({ok, _},
-                            Backend:put(<<"b1">>, <<"k1">>, [], <<"v1">>, State)),
-              ?_assertMatch({ok, _},
-                            Backend:put(<<"b2">>, <<"k2">>, [], <<"v2">>, State)),
-              ?_assertMatch({ok,<<"v2">>, _},
-                            Backend:get(<<"b2">>, <<"k2">>, State)),
-              ?_assertMatch({error, not_found, _},
-                            Backend:get(<<"b1">>, <<"k3">>, State))
-             ]
+             ?assertMatch({ok, _},
+                          Backend:put(<<"b1">>, <<"k1">>, [], <<"v1">>, State)),
+             ?assertMatch({ok, _},
+                          Backend:put(<<"b2">>, <<"k2">>, [], <<"v2">>, State)),
+             ?assertMatch({ok,<<"v2">>, _},
+                          Backend:get(<<"b2">>, <<"k2">>, State)),
+             ?assertMatch({error, not_found, _},
+                          Backend:get(<<"b1">>, <<"k3">>, State))
      end
     }.
 
@@ -113,7 +112,7 @@ fold_buckets({Backend, State}) ->
                          [Bucket | Acc]
                  end,
 
-             ?_assertEqual([<<"b1">>, <<"b2">>],
+             ?assertEqual([<<"b1">>, <<"b2">>],
                            begin
                                {ok, Buckets1} =
                                    Backend:fold_buckets(FoldBucketsFun,
@@ -154,52 +153,49 @@ fold_keys({Backend, State}) ->
                                  [Key | Acc]
                          end
                  end,
-             [
-              ?_assertEqual([{<<"b1">>, <<"k1">>}, {<<"b2">>, <<"k2">>}],
-                            begin
-                                {ok, Keys1} =
-                                    Backend:fold_keys(FoldKeysFun,
-                                                      [],
-                                                      [],
-                                                      State),
-                                lists:sort(Keys1)
-                            end),
-              ?_assertEqual({ok, [<<"k1">>]},
-                            Backend:fold_keys(FoldKeysFun1,
-                                              [],
-                                              [{bucket, <<"b1">>}],
-                                              State)),
-              ?_assertEqual([<<"k2">>],
-                            Backend:fold_keys(FoldKeysFun1,
-                                              [],
-                                              [{bucket, <<"b2">>}],
-                                              State)),
-              ?_assertEqual({ok, [<<"k1">>]},
-                            Backend:fold_keys(FoldKeysFun2, [], [], State)),
-              ?_assertEqual({ok, [<<"k1">>]},
-                            Backend:fold_keys(FoldKeysFun2,
-                                              [],
-                                              [{bucket, <<"b1">>}],
-                                              State)),
-              ?_assertEqual({ok, [<<"k2">>]},
-                            Backend:fold_keys(FoldKeysFun3, [], [], State)),
-              ?_assertEqual({ok, []},
-                            Backend:fold_keys(FoldKeysFun3,
-                                              [],
-                                              [{bucket, <<"b1">>}],
-                                              State))
-             ]
+
+             ?assertEqual([{<<"b1">>, <<"k1">>}, {<<"b2">>, <<"k2">>}],
+                          begin
+                              {ok, Keys1} =
+                                  Backend:fold_keys(FoldKeysFun,
+                                                    [],
+                                                    [],
+                                                    State),
+                              lists:sort(Keys1)
+                          end),
+             ?assertEqual({ok, [<<"k1">>]},
+                          Backend:fold_keys(FoldKeysFun1,
+                                            [],
+                                            [{bucket, <<"b1">>}],
+                                            State)),
+             ?assertEqual({ok, [<<"k2">>]},
+                          Backend:fold_keys(FoldKeysFun1,
+                                            [],
+                                            [{bucket, <<"b2">>}],
+                                            State)),
+             ?assertEqual({ok, [<<"k1">>]},
+                          Backend:fold_keys(FoldKeysFun2, [], [], State)),
+             ?assertEqual({ok, [<<"k1">>]},
+                          Backend:fold_keys(FoldKeysFun2,
+                                            [],
+                                            [{bucket, <<"b1">>}],
+                                            State)),
+             ?assertEqual({ok, [<<"k2">>]},
+                          Backend:fold_keys(FoldKeysFun3, [], [], State)),
+             ?assertEqual({ok, []},
+                          Backend:fold_keys(FoldKeysFun3,
+                                            [],
+                                            [{bucket, <<"b1">>}],
+                                            State))
      end
     }.
 
 delete_object({Backend, State}) ->
     {"object deletion test",
      fun() ->
-             [
-              ?_assertMatch({ok, _}, Backend:delete(<<"b2">>, <<"k2">>, State)),
-              ?_assertMatch({error, not_found, _},
-                            Backend:get(<<"b2">>, <<"k2">>, State))
-             ]
+             ?assertMatch({ok, _}, Backend:delete(<<"b2">>, <<"k2">>, [], State)),
+             ?assertMatch({error, not_found, _},
+                          Backend:get(<<"b2">>, <<"k2">>, State))
      end
     }.
 
@@ -214,51 +210,47 @@ fold_objects({Backend, State}) ->
                  fun(Bucket, Key, Value, Acc) ->
                          [{{Bucket, Key}, Value} | Acc]
                  end,
-             [
-              ?_assertEqual([{<<"b1">>, <<"k1">>}],
-                            begin
-                                {ok, Keys} =
-                                    Backend:fold_keys(FoldKeysFun,
-                                                      [],
-                                                      [],
-                                                      State),
-                                lists:sort(Keys)
-                            end),
+             ?assertEqual([{<<"b1">>, <<"k1">>}],
+                          begin
+                              {ok, Keys} =
+                                  Backend:fold_keys(FoldKeysFun,
+                                                    [],
+                                                    [],
+                                                    State),
+                              lists:sort(Keys)
+                          end),
 
-              ?_assertEqual([{{<<"b1">>,<<"k1">>}, <<"v1">>}],
-                            begin
-                                {ok, Objects1} =
-                                    Backend:fold_objects(FoldObjectsFun,
-                                                         [],
-                                                         [],
-                                                         State),
-                                lists:sort(Objects1)
-                            end),
-              ?_assertMatch({ok, _},
-                            Backend:put(<<"b3">>, <<"k3">>, [], <<"v3">>, State)),
-              ?_assertEqual([{{<<"b1">>,<<"k1">>},<<"v1">>},
-                             {{<<"b3">>,<<"k3">>},<<"v3">>}],
-                            begin
-                                {ok, Objects} =
-                                    Backend:fold_objects(FoldObjectsFun,
-                                                         [],
-                                                         [],
-                                                         State),
-                                lists:sort(Objects)
-                            end)
-             ]
+             ?assertEqual([{{<<"b1">>,<<"k1">>}, <<"v1">>}],
+                          begin
+                              {ok, Objects1} =
+                                  Backend:fold_objects(FoldObjectsFun,
+                                                       [],
+                                                       [],
+                                                       State),
+                              lists:sort(Objects1)
+                          end),
+             ?assertMatch({ok, _},
+                          Backend:put(<<"b3">>, <<"k3">>, [], <<"v3">>, State)),
+             ?assertEqual([{{<<"b1">>,<<"k1">>},<<"v1">>},
+                           {{<<"b3">>,<<"k3">>},<<"v3">>}],
+                          begin
+                              {ok, Objects} =
+                                  Backend:fold_objects(FoldObjectsFun,
+                                                       [],
+                                                       [],
+                                                       State),
+                              lists:sort(Objects)
+                          end)
      end
     }.
 
 empty_check({Backend, State}) ->
     {"is_empty test",
      fun() ->
-             [
-              ?_assertEqual(false, Backend:is_empty(State)),
-              ?_assertMatch({ok, _}, Backend:delete(<<"b1">>,<<"k1">>, State)),
-              ?_assertMatch({ok, _}, Backend:delete(<<"b3">>,<<"k3">>, State)),
-              ?_assertEqual(true, Backend:is_empty(State))
-             ]
+             ?assertEqual(false, Backend:is_empty(State)),
+             ?assertMatch({ok, _}, Backend:delete(<<"b1">>,<<"k1">>, [], State)),
+             ?assertMatch({ok, _}, Backend:delete(<<"b3">>,<<"k3">>, [], State)),
+             ?assertEqual(true, Backend:is_empty(State))
      end
     }.
 

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_memory_backend: storage engine using ETS tables
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -120,7 +120,7 @@ start(Partition, Config) ->
     %% leave this one alone, it is only for testing
     TableOpts = case app_helper:get_prop_or_env(test, Config, memory_backend) of
                     true ->
-                        [ordered_set, public, named_table];
+                        [ordered_set, public];
                     _ ->
                         [ordered_set]
                 end,
@@ -632,6 +632,7 @@ object_size(Object) ->
 -ifdef(TEST).
 
 simple_test_() ->
+    application:set_env(memory_backend, test, true),
     riak_kv_backend:standard_test(?MODULE, []).
 
 ttl_test_() ->


### PR DESCRIPTION
The riak_kv_backend standard tests, which are invoked by riak backend
tests, were not actually testing anything. The standard_test/2 function was
coded as an eunit test generator but it was returning functions that
themselves were returning lists of test generators. Unfortunately eunit
won't work through that many levels of test generator indirection so the
tests weren't actually running.

Change the standard tests to use regular assertMatch rather than the test
generator form _assertMatch so that the tests actually run. Due to
bitcask's use of the process dictionary, add the local test directive to
the top test spec to execute the tests in the same process where the
backend initialization function runs. Fix one of the fold_keys tests to
expect the correct result. Change all the delete/3 calls to delete/4 calls,
as that's what backends now implement. Modify the memory backend test setup
to ensure its ets tables are created appropriately for testing.
