### PR TITLE
Fix counter protobuf message codes

### DIFF
--- a/src/riak_kv_pb_counter.erl
+++ b/src/riak_kv_pb_counter.erl
@@ -24,15 +24,15 @@
 %% following request messages:</p>
 %%
 %% <pre>
-%%  29 - RpbCounterUpdateReq
-%%  31 - RpbCounterGetReq
+%%  50 - RpbCounterUpdateReq
+%%  52 - RpbCounterGetReq
 %% </pre>
 %%
 %% <p>This service produces the following responses:</p>
 %%
 %% <pre>
-%%  30 - RpbCounterUpdateResp - 0 length
-%%  32 - RpbCounterGetResp
+%%  51 - RpbCounterUpdateResp - 0 length
+%%  53 - RpbCounterGetResp
 %% </pre>
 %%
 %% @end


### PR DESCRIPTION
According to [this line](https://github.com/basho/riak_kv/blob/319e96717d5f4ee8afe6c47f65355f79035311f9/src/riak_kv_app.erl#L35) and my testing, these codes are the correct ones.

Is there a reason why they are not in the docs and `riak_pb` README?
