### PR TITLE
Add millisecond timemout parameter to API 2i endpoints

### DIFF
--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -40,7 +40,8 @@
          return_body/1,
          upgrade_query/1,
          object_key_in_range/3,
-         index_key_in_range/3
+         index_key_in_range/3,
+         add_timeout_opt/2
         ]).
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -51,6 +52,10 @@
 -define(TIMEOUT, 30000).
 -define(BUCKETFIELD, <<"$bucket">>).
 -define(KEYFIELD, <<"$key">>).
+
+%% See GH610, this default is for backwards compat, so 2i behaves as
+%% it did before the FSM timeout bug was "fixed"
+-define(DEFAULT_TIMEOUT, infinity).
 
 %% @type data_type_defs()  :: [data_type_def()].
 %% @type data_type_def()   :: {MatchFunction::function(), ParseFunction::function()}.
@@ -418,6 +423,22 @@ decode_continuation(undefined) ->
     undefined;
 decode_continuation(Bin) ->
     binary_to_term(base64:decode(Bin)).
+
+%% @doc add the `timeout' option tuple to the
+%% `Opts' proplist. if `Timeout' is undefined
+%% then the `app.config' property
+%% `{riak_kv, seconady_index timeout}' is used
+%% If that config property is defined, then
+%% a default of `infinity'  is used.
+%% We use `infinity' as the default to
+%% match the behavior pre 1.4
+add_timeout_opt(undefined, Opts) ->
+    Timeout = app_helper:get_env(riak_kv, secondary_index_timeout, ?DEFAULT_TIMEOUT),
+    [{timeout, Timeout} | Opts];
+add_timeout_opt(0, Opts) ->
+    [{timeout, infinity} | Opts];
+add_timeout_opt(Timeout, Opts) ->
+    [{timeout, Timeout} | Opts].
 
 %% @spec field_types() -> data_type_defs().
 %%

--- a/src/riak_kv_pb_csbucket.erl
+++ b/src/riak_kv_pb_csbucket.erl
@@ -73,11 +73,11 @@ process(Req=#rpbcsbucketreq{}, State) ->
 maybe_perform_query({error, Reason}, _Req, State) ->
     {error, {format, Reason}, State};
 maybe_perform_query({ok, Query}, Req, State) ->
-    #rpbcsbucketreq{bucket=Bucket, max_results=MaxResults} = Req,
+    #rpbcsbucketreq{bucket=Bucket, max_results=MaxResults, timeout=Timeout} = Req,
     #state{client=Client} = State,
-    {ok, ReqId} = Client:stream_get_index(Bucket, Query, [{max_results, MaxResults}]),
+    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults}]),
+    {ok, ReqId} = Client:stream_get_index(Bucket, Query, Opts),
     {reply, {stream, ReqId}, State#state{req_id=ReqId, req=Req}}.
-
 
 %% @doc process_stream/3 callback. Handle streamed responses
 process_stream({ReqId, done}, ReqId, State=#state{req_id=ReqId,


### PR DESCRIPTION
Accepts non_neg_integer milliseconds (zero for inifinty)
Add support for an app.config setting for 2i timeouts

Depends on https://github.com/basho/riak_pb/pull/50
