### PR TITLE
Add #riak_core_fold_req_v2 record (part 2 of 2), use new options for AAE tree building

### DIFF
--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -395,13 +395,14 @@ hash_object({Bucket, Key}, RObjBin) ->
 %% key/hash pair will be ignored.
 -spec fold_keys(index(), pid()) -> ok.
 fold_keys(Partition, Tree) ->
-    Req = ?FOLD_REQ{foldfun=fun(BKey={Bucket,Key}, RObj, _) ->
-                                    IndexN = riak_kv_util:get_index_n({Bucket, Key}),
-                                    insert(IndexN, term_to_binary(BKey), hash_object(BKey, RObj),
-                                           Tree, [if_missing]),
-                                    ok
-                            end,
-                    acc0=ok},
+    Req = riak_core_util:make_fold_req(
+            fun(BKey={Bucket,Key}, RObj, _) ->
+                    IndexN = riak_kv_util:get_index_n({Bucket, Key}),
+                    insert(IndexN, term_to_binary(BKey), hash_object(BKey, RObj),
+                           Tree, [if_missing]),
+                    ok
+            end,
+            ok, false, [aae_reconstruction]),
     riak_core_vnode_master:sync_command({Partition, node()},
                                         Req,
                                         riak_kv_vnode_master, infinity),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -467,7 +467,7 @@ handle_command(?KV_VCLOCK_REQ{bkeys=BKeys}, _Sender, State) ->
 handle_command(#riak_core_fold_req_v1{} = ReqV1,
                Sender, State) ->
     %% Use make_fold_req() to upgrade to the most recent ?FOLD_REQ
-    handle_command(riak_core_util:make_fold_req(ReqV1), Sender, State);
+    handle_command(riak_core_util:make_newest_fold_req(ReqV1), Sender, State);
 handle_command(?FOLD_REQ{foldfun=FoldFun, acc0=Acc0,
                          forwardable=_Forwardable, opts=Opts}, Sender, State) ->
     %% The riak_core layer takes care of forwarding/not forwarding, so


### PR DESCRIPTION
NOTE: This PR is incomplete.  I've created it for ease of discussion this week in Cambridge.

Add `aae_reconstruction` annotation to the fold request sent by
riak_kv_index_hashtree:fold_keys().

Also add not-forwardable annotation to the AAE hash tree fold,
to address GitHub issue #621.

If riak_kv_vnode:handle_command() gets a #riak_core_fold_req_v1 command,
that command is converted to a v2 command before continuing.  The
?FOLD_REQ.opts proplist is appended to the end of the `Opts` proplist
that is passed to the KV storage manager's Mod:fold_objects/4 function.
