### PR TITLE
Add ack_execute to the put FSM's execute state for forwarded coordinator

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -180,6 +180,10 @@ start(_Type, _StartArgs) ->
                                           [[pncounter],[]],
                                           []),
 
+            riak_core_capability:register({riak_kv, put_fsm_ack_execute},
+                                          [enabled, disabled],
+                                          disabled),
+
             HealthCheckOn = app_helper:get_env(riak_kv, enable_health_checks, false),
             %% Go ahead and mark the riak_kv service as up in the node watcher.
             %% The riak_core_ring_handler blocks until all vnodes have been started

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -157,7 +157,6 @@ start_link(From, Object, PutOptions) ->
     end.
 
 set_put_coordinator_failure_timeout(MS) when is_integer(MS), MS >= 0 ->
-    %% mochiglobal:put(put_coordinator_failure_timeout, MS);
     application:set_env(riak_kv, put_coordinator_failure_timeout, MS);
 set_put_coordinator_failure_timeout(Bad) ->
     lager:error("~s:set_put_coordinator_failure_timeout(~p) invalid",
@@ -165,7 +164,6 @@ set_put_coordinator_failure_timeout(Bad) ->
     set_put_coordinator_failure_timeout(3000).
 
 get_put_coordinator_failure_timeout() ->
-    %% mochiglobal:get(put_coordinator_failure_timeout).
     app_helper:get_env(riak_kv, put_coordinator_failure_timeout, 3000).
 
 make_ack_options(Options) ->

--- a/src/riak_kv_put_fsm_sup.erl
+++ b/src/riak_kv_put_fsm_sup.erl
@@ -41,10 +41,6 @@ start_link() ->
 %% @spec init([]) -> SupervisorTree
 %% @doc supervisor callback.
 init([]) ->
-    %% Mochiglobal used this way is far slower than the application app ETS
-    %% CoordTimeout = app_helper:get_env(riak_kv, put_coordinator_failure_timeout, 3000),
-    %% riak_kv_put_fsm:set_put_coordinator_failure_timeout(CoordTimeout),
-
     PutFsmSpec = {undefined,
                {riak_kv_put_fsm, start_link, []},
                temporary, 5000, worker, [riak_kv_put_fsm]},

--- a/src/riak_kv_put_fsm_sup.erl
+++ b/src/riak_kv_put_fsm_sup.erl
@@ -41,6 +41,10 @@ start_link() ->
 %% @spec init([]) -> SupervisorTree
 %% @doc supervisor callback.
 init([]) ->
+    %% Mochiglobal used this way is far slower than the application app ETS
+    %% CoordTimeout = app_helper:get_env(riak_kv, put_coordinator_failure_timeout, 3000),
+    %% riak_kv_put_fsm:set_put_coordinator_failure_timeout(CoordTimeout),
+
     PutFsmSpec = {undefined,
                {riak_kv_put_fsm, start_link, []},
                temporary, 5000, worker, [riak_kv_put_fsm]},


### PR DESCRIPTION
When a put operation has been forwarded to a remote coordinator node,
When the remote put FSM enters the execute state, it sends an ack_execute
message back to the put FSM on the source node.  In the event that the
source node does not receive the ack_execute message, it will choose a
new coordinator node.  The hardcoded timeout is 3 seconds.
