### PR TITLE
Transform deserialization errors and CRC check failures into not_founds

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -145,6 +145,8 @@ get(Bucket, Key, #state{ref=Ref}=State) ->
             {error, not_found, State};
         {error, nofile}  ->
             {error, not_found, State};
+        {error, bad_crc}  ->
+            {error, not_found, State};
         {error, Reason} ->
             {error, Reason, State}
     end.

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -146,6 +146,7 @@ get(Bucket, Key, #state{ref=Ref}=State) ->
         {error, nofile}  ->
             {error, not_found, State};
         {error, bad_crc}  ->
+            lager:warning("Discarding corrupted value"),
             {error, not_found, State};
         {error, Reason} ->
             {error, Reason, State}

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1083,7 +1083,10 @@ perform_put({true, Obj},
     {Reply, State#state{modstate=UpdModState}}.
 
 do_reformat({Bucket, Key}=BKey, State=#state{mod=Mod, modstate=ModState}) ->
-    case do_get_object(Bucket, Key, Mod, ModState) of
+    case (catch do_get_object(Bucket, Key, Mod, ModState)) of
+        {'EXIT', {badarg, _}} -> 
+            Reply = {error, not_found},
+            UpdState = State;
         {error, not_found, _UpdModState} ->
             Reply = {error, not_found},
             UpdState = State;

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1075,7 +1075,7 @@ perform_put({true, Obj},
     {Reply, State#state{modstate=UpdModState}}.
 
 do_reformat({Bucket, Key}=BKey, State=#state{mod=Mod, modstate=ModState}) ->
-    case catch do_get_object(Bucket, Key, Mod, ModState) of
+    case do_get_object(Bucket, Key, Mod, ModState) of
         {error, not_found, _UpdModState} ->
             Reply = {error, not_found},
             UpdState = State;

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -962,8 +962,7 @@ prepare_put(State=#state{vnodeid=VId,
         false ->
             prepare_put(State, PutArgs, IndexBackend)
     end.
-prepare_put(#state{idx=Idx,
-                   vnodeid=VId,
+prepare_put(#state{vnodeid=VId,
                    mod=Mod,
                    modstate=ModState},
             PutArgs=#putargs{bkey={Bucket, Key},
@@ -978,13 +977,6 @@ prepare_put(#state{idx=Idx,
     GetReply =
         case do_get_object(Bucket, Key, Mod, ModState) of
             {error, not_found, _UpdModState} ->
-                ok;
-            % NOTE: bad_crc is NOT an official backend response. It is
-            % specific to bitcask currently and handling it may be changed soon.
-            % A standard set of responses will be agreed on
-            % https://github.com/basho/riak_kv/issues/496
-            {error, bad_crc, _UpdModState} ->
-                lager:info("Bad CRC detected while reading Partition=~p, Bucket=~p, Key=~p", [Idx, Bucket, Key]),
                 ok;
             {ok, TheOldObj, _UpdModState} ->
                 {ok, TheOldObj}
@@ -1083,11 +1075,7 @@ perform_put({true, Obj},
     {Reply, State#state{modstate=UpdModState}}.
 
 do_reformat({Bucket, Key}=BKey, State=#state{mod=Mod, modstate=ModState}) ->
-    case (catch do_get_object(Bucket, Key, Mod, ModState)) of
-        {'EXIT', _} -> 
-            lager:warning("Corrupted ancestor or sibling value discarded"),
-            Reply = {error, not_found},
-            UpdState = State;
+    case catch do_get_object(Bucket, Key, Mod, ModState) of
         {error, not_found, _UpdModState} ->
             Reply = {error, not_found},
             UpdState = State;
@@ -1203,9 +1191,17 @@ do_get_object(Bucket, Key, Mod, ModState) ->
         false ->
             case do_get_binary(Bucket, Key, Mod, ModState) of
                 {ok, ObjBin, _UpdModState} ->
-                    case riak_object:from_binary(Bucket, Key, ObjBin) of
-                        {error, R} ->
-                            throw(R);
+                    case (catch riak_object:from_binary(Bucket, Key, ObjBin)) of
+                        {'EXIT', _} ->
+                            lager:debug("Get on ~p/~p failed", [Bucket, Key]),
+                            lager:warning("Corrupted value discarded"),
+                            {error, not_found, _UpdModState};
+                        {error, Reason} ->
+                            lager:debug("Get on ~p/~p failed", [Bucket, Key]),
+                            lager:warning("Couldn't deserialize object, "
+                                          "discarding. Reason: ~p", 
+                                          [Reason]),
+                            {error, not_found, _UpdModState};
                         RObj ->
                             {ok, RObj, _UpdModState}
                     end;

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1084,7 +1084,8 @@ perform_put({true, Obj},
 
 do_reformat({Bucket, Key}=BKey, State=#state{mod=Mod, modstate=ModState}) ->
     case (catch do_get_object(Bucket, Key, Mod, ModState)) of
-        {'EXIT', {badarg, _}} -> 
+        {'EXIT', _} -> 
+            lager:warning("Corrupted ancestor or sibling value discarded"),
             Reply = {error, not_found},
             UpdState = State;
         {error, not_found, _UpdModState} ->


### PR DESCRIPTION
Backends should be lossy.  Since we typically have other replicas on the system, if we can't read something off the disk, or it seems to have been corrupted, we should drop it and count on read repair, AAE, or a subsequent write to put things right.
