### PR TITLE
Transform deserialization errors and CRC check failures into not_founds for 1.4

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -145,6 +145,10 @@ get(Bucket, Key, #state{ref=Ref}=State) ->
             {ok, Value, State};
         not_found  ->
             {error, not_found, State};
+        {error, bad_crc}  ->
+            lager:warning("Unreadable object ~p/~p discarded",
+                          [Bucket,Key]),
+            {error, not_found, State};
         {error, nofile}  ->
             {error, not_found, State};
         {error, Reason} ->

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -382,9 +382,14 @@ load_built(#state{trees=Trees}) ->
 -spec hash_object({riak_object:bucket(), riak_object:key()}, riak_object_t2b()) -> binary().
 hash_object({Bucket, Key}, RObjBin) ->
     %% Normalize the `riak_object' vector clock before hashing
-    RObj = riak_object:from_binary(Bucket, Key, RObjBin),
-    Hash = riak_object:hash(RObj),
-    term_to_binary(Hash).
+    try
+        RObj = riak_object:from_binary(Bucket, Key, RObjBin),
+        Hash = riak_object:hash(RObj),
+        term_to_binary(Hash)
+    catch _:_ ->
+            Null = erlang:phash2(<<>>),
+            term_to_binary(Null)
+    end.
 
 %% Fold over a given vnode's data, inserting each object into the appropriate
 %% hashtree. Use the `if_missing' option to only insert the key/hash pair if

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -780,29 +780,34 @@ handoff_finished(_TargetNode, State) ->
     {ok, State}.
 
 handle_handoff_data(BinObj, State) ->
-    case (catch decode_binary_object(BinObj)) of 
-        {'EXIT', _} ->
-            {reply, {error, bad_object}, State};
-        {BKey, Val} ->
-            {B, K} = BKey,
-            case do_diffobj_put(BKey, riak_object:from_binary(B, K, Val), 
-                                State) of
-                {ok, UpdModState} ->
-                    {reply, ok, State#state{modstate=UpdModState}};
-                {error, Reason, UpdModState} ->
-                    {reply, {error, Reason}, State#state{modstate=UpdModState}};
-                Err ->
-                    {reply, {error, Err}, State}
-            end
+    try
+        {BKey, Val} = decode_binary_object(BinObj),
+        {B, K} = BKey,
+        case do_diffobj_put(BKey, riak_object:from_binary(B, K, Val), 
+                            State) of
+            {ok, UpdModState} ->
+                {reply, ok, State#state{modstate=UpdModState}};
+            {error, Reason, UpdModState} ->
+                {reply, {error, Reason}, State#state{modstate=UpdModState}};
+            Err ->
+                {reply, {error, Err}, State}
+        end
+    catch _:_ ->
+            lager:warning("Unreadable object discarded in handoff"),
+            {reply, ok, State}
     end.
 
 encode_handoff_item({B, K}, V) ->
     %% before sending data to another node change binary version
     %% to one supported by the cluster. This way we don't send
     %% unsupported formats to old nodes
-    ObjFmt = riak_core_capability:get({riak_kv, object_format}, v0),
-    Value  = riak_object:to_binary_version(ObjFmt, B, K, V),
-    encode_binary_object(B, K, Value).
+    try
+        ObjFmt = riak_core_capability:get({riak_kv, object_format}, v0),
+        Value  = riak_object:to_binary_version(ObjFmt, B, K, V),
+        encode_binary_object(B, K, Value)
+    catch _:_ ->
+            corrupted
+    end.
 
 is_empty(State=#state{mod=Mod, modstate=ModState}) ->
     IsEmpty = Mod:is_empty(ModState),
@@ -970,8 +975,7 @@ prepare_put(State=#state{vnodeid=VId,
         false ->
             prepare_put(State, PutArgs, IndexBackend)
     end.
-prepare_put(#state{idx=Idx,
-                   vnodeid=VId,
+prepare_put(#state{vnodeid=VId,
                    mod=Mod,
                    modstate=ModState},
             PutArgs=#putargs{bkey={Bucket, Key},
@@ -986,13 +990,6 @@ prepare_put(#state{idx=Idx,
     GetReply =
         case do_get_object(Bucket, Key, Mod, ModState) of
             {error, not_found, _UpdModState} ->
-                ok;
-            % NOTE: bad_crc is NOT an official backend response. It is
-            % specific to bitcask currently and handling it may be changed soon.
-            % A standard set of responses will be agreed on
-            % https://github.com/basho/riak_kv/issues/496
-            {error, bad_crc, _UpdModState} ->
-                lager:info("Bad CRC detected while reading Partition=~p, Bucket=~p, Key=~p", [Idx, Bucket, Key]),
                 ok;
             {ok, TheOldObj, _UpdModState} ->
                 {ok, TheOldObj}
@@ -1207,11 +1204,17 @@ do_get_object(Bucket, Key, Mod, ModState) ->
         false ->
             case do_get_binary(Bucket, Key, Mod, ModState) of
                 {ok, ObjBin, _UpdModState} ->
-                    case riak_object:from_binary(Bucket, Key, ObjBin) of
-                        {error, R} ->
-                            throw(R);
-                        RObj ->
-                            {ok, RObj, _UpdModState}
+                    try
+                        case riak_object:from_binary(Bucket, Key, ObjBin) of
+                            {error, Reason} ->
+                                throw(Reason);
+                            RObj ->
+                                {ok, RObj, _UpdModState}
+                        end
+                    catch _:_ ->
+                            lager:warning("Unreadable object ~p/~p discarded",
+                                          [Bucket,Key]),
+                            {error, not_found, _UpdModState}
                     end;
                 Else ->
                     Else


### PR DESCRIPTION
1.4 version of the corruption filtering changes for kv.

riak_test PR here: https://github.com/basho/riak_test/pull/353

required core PR here: https://github.com/basho/riak_core/pull/359

cc @engelsanchez 
