### PR TITLE
Fix HTTP MR error reporting

### DIFF
--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -208,9 +208,10 @@ pipe_mapred_nonchunked(RD, State, Mrc) ->
         {error, timeout} ->
             riak_kv_mrc_pipe:destroy_sink(Mrc),
             {{halt, 500}, send_error({error, timeout}, RD), State};
-        {error, {_From, {Error, _Input}}} ->
+        {error, {From, Info}} ->
             riak_kv_mrc_pipe:destroy_sink(Mrc),
-            {{halt, 500}, send_error({error, Error}, RD), State}
+            Json = riak_kv_mapred_json:jsonify_pipe_error(From, Info),
+            {{halt, 500}, send_error({error, Json}, RD), State}
     end.
 
 pipe_mapred_chunked(RD, State, Mrc) ->
@@ -265,9 +266,10 @@ pipe_stream_mapred_results(RD,
             %% detroyed the pipe
             riak_kv_mrc_pipe:cleanup_sink(Mrc),
             {format_error(Error), done};
-        {error, {_From, {Error, _Input}}, _} ->
+        {error, {From, Info}, _} ->
             riak_kv_mrc_pipe:destroy_sink(Mrc),
-            {format_error({error, Error}), done}
+            Json = riak_kv_mapred_json:jsonify_pipe_error(From, Info),
+            {format_error({error, Json}), done}
     end.
 
 result_part({PhaseId, Results}, HasMRQuery, Boundary) ->


### PR DESCRIPTION
Someone pointed out that MR errors over HTTP currently look like this:

```
<html><head><title>500 Internal Server Error</title></head><body><h1>Internal Server Error</h1>The server encountered an error while processing this request:<br><pre>{error,
    {error,
        {case_clause,
            {error,
                {0,
                 [{module,riak_kv_mrc_map},
                  {partition,433883298582611803841718934712646521460354973696},
                  {details,
                      [{fitting,
                           {fitting,<0.1576.0>,#Ref<0.0.0.3917>,follow,1}},
                       {name,0},
                       {module,riak_kv_mrc_map},
                       {arg,
                           {{modfun,riak_kv_mapreduce,map_object_value},none}},
                       {output,
                           {fitting,<0.1573.0>,#Ref<0.0.0.3917>,sink,
                               undefined}},
                       {options,
                           [{log,sink},
                            {trace,[error]},
                            {sink,
                                {fitting,<0.1573.0>,#Ref<0.0.0.3917>,sink,
                                    undefined}},
                            {sink_type,{fsm,10,infinity}}]},
                       {q_limit,64}]},
                  {type,error},
                  {error,function_clause},
                  {input,{{error,notfound},{<<"foo">>,<<"bar">>},undefined}},
                  {modstate,
                      {state,
                          433883298582611803841718934712646521460354973696,
                          {fitting_details,
                              {fitting,<0.1576.0>,#Ref<0.0.0.3917>,follow,1},
                              0,riak_kv_mrc_map,
                              {{modfun,riak_kv_mapreduce,map_object_value},
                               none},
                              {fitting,<0.1573.0>,#Ref<0.0.0.3917>,sink,
                                  undefined},
                              [{log,sink},
                               {trace,[error]},
                               {sink,
                                   {fitting,<0.1573.0>,#Ref<0.0.0.3917>,sink,
                                       undefined}},
                               {sink_type,{fsm,10,infinity}}],
                              64},
                          {modfun,riak_kv_mapreduce,map_object_value},
                          none}},
                  {stack,
                      [{riak_kv_mapreduce,notfound_map_action,
                           [{error,notfound},undefined,none],
                           [{file,"src/riak_kv_mapreduce.erl"},{line,124}]},
                       {riak_kv_mrc_map,map,3,
                           [{file,"src/riak_kv_mrc_map.erl"},{line,164}]},
                       {riak_kv_mrc_map,process,3,
                           [{file,"src/riak_kv_mrc_map.erl"},{line,140}]},
                       {riak_pipe_vnode_worker,process_input,3,
                           [{file,"src/riak_pipe_vnode_worker.erl"},
                            {line,444}]},
                       {riak_pipe_vnode_worker,wait_for_input,2,
                           [{file,"src/riak_pipe_vnode_worker.erl"},
                            {line,376}]},
                       {gen_fsm,handle_msg,7,
                           [{file,"gen_fsm.erl"},{line,494}]},
                       {proc_lib,init_p_do_apply,3,
                           [{file,"proc_lib.erl"},{line,227}]}]}]}}},
        [{riak_kv_wm_mapred,pipe_mapred_nonchunked,3,
             [{file,"src/riak_kv_wm_mapred.erl"},{line,180}]},
         {webmachine_resource,resource_call,3,
             [{file,"src/webmachine_resource.erl"},{line,183}]},
         {webmachine_resource,do,3,
             [{file,"src/webmachine_resource.erl"},{line,141}]},
         {webmachine_decision_core,resource_call,1,
             [{file,"src/webmachine_decision_core.erl"},{line,48}]},
         {webmachine_decision_core,decision,1,
             [{file,"src/webmachine_decision_core.erl"},{line,481}]},
         {webmachine_decision_core,handle_request,2,
             [{file,"src/webmachine_decision_core.erl"},{line,33}]},
         {webmachine_mochiweb,loop,1,
             [{file,"src/webmachine_mochiweb.erl"},{line,97}]},
         {mochiweb_http,parse_headers,5,
             [{file,"src/mochiweb_http.erl"},{line,180}]}]}}</pre><P><HR><ADDRESS>mochiweb+webmachine web server</ADDRESS></body></html>
```

…or even worse in one of riak's logs, where you get about the first 12 lines (through the `arg` tuple) smushed together, with none of the useful stuff that follows it.

The HTTP error response is supposed to look like this:

```
{
  "phase": 0,
  "error": "function_clause",
  "input": "{{error,notfound},{<<\"foo\">>,<<\"bar\">>},undefined}",
  "type": "error",
  "stack": "[{riak_kv_mapreduce,notfound_map_action,[{error,notfound},undefined,none],[{file,\"src/riak_kv_mapreduce.erl\"},{line,124}]},{riak_kv_mrc_map,map,3,[{file,\"src/riak_kv_mrc_map.erl\"},{line,164}]},{riak_kv_mrc_map,process,3,[{file,\"src/riak_kv_mrc_map.erl\"},{line,140}]},{riak_pipe_vnode_worker,process_input,3,[{file,\"src/riak_pipe_vnode_worker.erl\"},{line,445}]},{riak_pipe_vnode_worker,wait_for_input,2,[{file,\"src/riak_pipe_vnode_worker.erl\"},{line,377}]},{gen_fsm,handle_msg,7,[{file,\"gen_fsm.e...\"},...]},...]"
}
```

This PR fixes the situation, which appears like it may have been broken since about the 1.3 release. The commit in this PR should be trivially portable to the 1.4 and 1.3 branches, since `riak_kv_wm_mapred.erl` hasn't changed since 2012.

A `riak_test` has been written to trigger this issue: basho/riak_test#355. To trigger without using `riak_test`, use this curl (note that the key `foo/bar` must not exist in order to trigger the error):

```
curl -X POST -H "content-type: application/json" http://localhost:10018/mapred --data "{\"inputs\":[[\"foo\",\"bar\"]],\"query\":[{\"map\":{\"language\":\"erlang\",\"module\":\"riak_kv_mapreduce\",\"function\":\"map_object_value\"}}]}"
```
