### PR TITLE
leveldb fold hardening for 1.4

### DIFF
--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -377,6 +377,8 @@ index_key_in_range({Bucket, Key, Field, Term}=IK, Bucket,
   when Term >= StartTerm,
        Term =< EndTerm ->
     in_range(gt(StartInc, {Term, Key}, {StartTerm, StartKey}), true, IK);
+index_key_in_range(ignore, _, _) ->
+    {skip, ignore};
 index_key_in_range(_, _, _) ->
     false.
 
@@ -388,6 +390,8 @@ object_key_in_range({Bucket, Key}=OK, Bucket, Q) ->
     ?KV_INDEX_Q{start_key=Start, start_inclusive=StartInc,
                 end_term=End, end_inclusive=EndInc} = Q,
     in_range(gt(StartInc, Key, Start), gt(EndInc, End, Key), OK);
+object_key_in_range(ignore, _, _) ->
+    {skip, ignore};
 object_key_in_range(_, _, _) ->
     false.
 


### PR DESCRIPTION
moved to 1.4 and adapted for changes there.  Requires the same tests.  Adding filtering to the index seemed like the minimal change to the code, but I can see the argument for handling it in the backend for separation-of-concerns reasons.  If it bothers you, please let me know.
