### PR TITLE
Eas fix wm 2i timeout

### DIFF
--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -77,7 +77,7 @@ mapred_index(Dest, Args) ->
     mapred_index(Dest, Args, ?TIMEOUT).
 mapred_index(_Pipe, [Bucket, Query], Timeout) ->
     {ok, C} = riak:local_client(),
-    {ok, ReqId} = C:stream_get_index(Bucket, Query, [{timeout, Timeout}]),
+    {ok, ReqId, _} = C:stream_get_index(Bucket, Query, [{timeout, Timeout}]),
     {ok, Bucket, ReqId}.
 
 %% @spec parse_object_hook(riak_object:riak_object()) ->

--- a/src/riak_kv_pb_csbucket.erl
+++ b/src/riak_kv_pb_csbucket.erl
@@ -76,7 +76,7 @@ maybe_perform_query({ok, Query}, Req, State) ->
     #rpbcsbucketreq{bucket=Bucket, max_results=MaxResults, timeout=Timeout} = Req,
     #state{client=Client} = State,
     Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults}]),
-    {ok, ReqId} = Client:stream_get_index(Bucket, Query, Opts),
+    {ok, ReqId, _FSMPid} = Client:stream_get_index(Bucket, Query, Opts),
     {reply, {stream, ReqId}, State#state{req_id=ReqId, req=Req}}.
 
 %% @doc process_stream/3 callback. Handle streamed responses

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -81,7 +81,7 @@ maybe_perform_query({ok, Query}, Req=#rpbindexreq{stream=true}, State) ->
     #rpbindexreq{bucket=Bucket, max_results=MaxResults, timeout=Timeout} = Req,
     #state{client=Client} = State,
     Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults}]),
-    {ok, ReqId} = Client:stream_get_index(Bucket, Query, Opts),
+    {ok, ReqId, _FSMPid} = Client:stream_get_index(Bucket, Query, Opts),
     ReturnTerms = riak_index:return_terms(Req#rpbindexreq.return_terms, Query),
     {reply, {stream, ReqId}, State#state{req_id=ReqId, req=Req#rpbindexreq{return_terms=ReturnTerms}}};
 maybe_perform_query({ok, Query}, Req, State) ->

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -258,12 +258,10 @@ whack_index_fsm(ReqID, Pid) ->
     clear_index_fsm_msgs(ReqID).
 
 wait_for_death(Pid) ->
+    Ref = erlang:monitor(process, Pid),
     exit(Pid, kill),
-    case is_process_alive(Pid) of
-        true ->
-            timer:sleep(10),
-            wait_for_death(Pid);
-        false ->
+    receive
+        {'DOWN', Ref, process, Pid, _Info} ->
             ok
     end.
 

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -215,11 +215,11 @@ handle_streaming_index_query(RD, Ctx) ->
 
     Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults}]),
 
-    {ok, ReqID} =  Client:stream_get_index(Bucket, Query, Opts),
-    StreamFun = index_stream_helper(ReqID, Boundary, ReturnTerms, MaxResults, proplists:get_value(timeout, Opts), undefined, 0),
+    {ok, ReqID, FSMPid} =  Client:stream_get_index(Bucket, Query, Opts),
+    StreamFun = index_stream_helper(ReqID, FSMPid, Boundary, ReturnTerms, MaxResults, proplists:get_value(timeout, Opts), undefined, 0),
     {{stream, {<<>>, StreamFun}}, CTypeRD, Ctx}.
 
-index_stream_helper(ReqID, Boundary, ReturnTerms, MaxResults, Timeout, LastResult, Count) ->
+index_stream_helper(ReqID, FSMPid, Boundary, ReturnTerms, MaxResults, Timeout, LastResult, Count) ->
     fun() ->
             receive
                 {ReqID, done} ->
@@ -234,7 +234,7 @@ index_stream_helper(ReqID, Boundary, ReturnTerms, MaxResults, Timeout, LastResul
                             end,
                     {iolist_to_binary(Final), done};
                 {ReqID, {results, []}} ->
-                    {<<>>, index_stream_helper(ReqID, Boundary, ReturnTerms, MaxResults, Timeout, LastResult, Count)};
+                    {<<>>, index_stream_helper(ReqID, FSMPid, Boundary, ReturnTerms, MaxResults, Timeout, LastResult, Count)};
                 {ReqID, {results, Results}} ->
                     %% JSONify the results
                     JsonResults = encode_results(ReturnTerms, Results),
@@ -244,12 +244,36 @@ index_stream_helper(ReqID, Boundary, ReturnTerms, MaxResults, Timeout, LastResul
                     LastResult1 = last_result(Results),
                     Count1 = Count + length(Results),
                     {iolist_to_binary(Body),
-                     index_stream_helper(ReqID, Boundary, ReturnTerms, MaxResults, Timeout, LastResult1, Count1)};
+                     index_stream_helper(ReqID, FSMPid, Boundary, ReturnTerms, MaxResults, Timeout, LastResult1, Count1)};
                 {ReqID, Error} ->
                     stream_error(Error, Boundary)
             after Timeout ->
+                    whack_index_fsm(ReqID, FSMPid),
                     stream_error({error, timeout}, Boundary)
             end
+    end.
+
+whack_index_fsm(ReqID, Pid) ->
+    wait_for_death(Pid),
+    clear_index_fsm_msgs(ReqID).
+
+wait_for_death(Pid) ->
+    exit(Pid, kill),
+    case is_process_alive(Pid) of
+        true ->
+            timer:sleep(10),
+            wait_for_death(Pid);
+        false ->
+            ok
+    end.
+
+clear_index_fsm_msgs(ReqID) ->
+    receive
+        {ReqID, _} ->
+            clear_index_fsm_msgs(ReqID)
+    after
+        0 ->
+            ok
     end.
 
 stream_error(Error, Boundary) ->


### PR DESCRIPTION
When the webmachine process handling the 2i request times out, it was
returning an error message, but messages from the index FSM could still
arrive at this process later in a different context (in mochiweb)
causing it to send error messages to the client, which at that point
could be sending another request down the same connection. That
unrelated request was failing with a 400 "unexpected data" message.
This fix uses a big hammer: on a timeout in the wm process, it will try
to kill the index FSM and consume any messages sent from it before
returning a timeout error message to the client.
