### PR TITLE
Sort AAE differences before acting upon them via read-repair

### DIFF
--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -117,6 +117,7 @@
          local_compare/2,
          compare/2,
          compare/3,
+         compare/4,
          top_hash/1,
          get_bucket/3,
          key_hashes/2,
@@ -401,7 +402,10 @@ compare(Tree, Remote) ->
 
 -spec compare(hashtree(), remote_fun(), acc_fun(X)) -> X.
 compare(Tree, Remote, AccFun) ->
-    compare(1, 0, Tree, Remote, AccFun, []).
+    compare(Tree, Remote, AccFun, []).
+
+compare(Tree, Remote, AccFun, Acc) ->
+    compare(1, 0, Tree, Remote, AccFun, Acc).
 
 -spec levels(hashtree()) -> pos_integer().
 levels(#state{levels=L}) ->

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -90,14 +90,14 @@
 %% to LevelDB using a single batch write. Writes are flushed whenever the
 %% buffer becomes full, as well as before updating the hashtree.
 %%
-%% Tree exchange is provided by the ``compare/2'' and ``compare/3'' functions.
-%% The behavior of these functions is determined through a provided function
+%% Tree exchange is provided by the ``compare/4'' function.
+%% The behavior of this function is determined through a provided function
 %% that implements logic to get buckets and segments for a given remote tree,
 %% as well as a callback invoked as key differences are determined. This
 %% generic interface allows for tree exchange to be implemented in a variety
 %% of ways, including directly against to local hash tree instances, over
 %% distributed Erlang, or over a custom protocol over a TCP socket. See
-%% ``local_compare/2'' and ``do_remote/1'' for examples.
+%% ``local_compare/2'' and ``do_remote/1'' for examples (-ifdef(TEST) only).
 
 -module(hashtree).
 
@@ -114,9 +114,6 @@
          destroy/1,
          read_meta/2,
          write_meta/3,
-         local_compare/2,
-         compare/2,
-         compare/3,
          compare/4,
          top_hash/1,
          get_bucket/3,
@@ -126,6 +123,7 @@
          width/1,
          mem_levels/1]).
 
+-ifdef(TEST).
 -export([run_local/0,
          run_local/1,
          run_concurrent_build/0,
@@ -134,6 +132,7 @@
          run_multiple/2,
          run_remote/0,
          run_remote/1]).
+-endif. % TEST
 
 -ifdef(EQC).
 -export([prop_correct/0]).
@@ -383,26 +382,6 @@ rehash_perform(State) ->
 -spec top_hash(hashtree()) -> [] | [{0, binary()}].
 top_hash(State) ->
     get_bucket(1, 0, State).
-
--spec local_compare(hashtree(), hashtree()) -> [keydiff()].
-local_compare(T1, T2) ->
-    Remote = fun(get_bucket, {L, B}) ->
-                     get_bucket(L, B, T2);
-                (key_hashes, Segment) ->
-                     [{_, KeyHashes2}] = key_hashes(T2, Segment),
-                     KeyHashes2
-             end,
-    compare(T1, Remote).
-
--spec compare(hashtree(), remote_fun()) -> [keydiff()].
-compare(Tree, Remote) ->
-    compare(Tree, Remote, fun(Keys, KeyAcc) ->
-                                  Keys ++ KeyAcc
-                          end).
-
--spec compare(hashtree(), remote_fun(), acc_fun(X)) -> X.
-compare(Tree, Remote, AccFun) ->
-    compare(Tree, Remote, AccFun, []).
 
 compare(Tree, Remote, AccFun, Acc) ->
     compare(1, 0, Tree, Remote, AccFun, Acc).
@@ -897,6 +876,8 @@ expand(V, N, Acc) ->
 %%% Experiments
 %%%===================================================================
 
+-ifdef(TEST).
+
 run_local() ->
     run_local(10000).
 run_local(N) ->
@@ -1050,7 +1031,25 @@ peval(L) ->
 %%% EUnit
 %%%===================================================================
 
--ifdef(TEST).
+-spec local_compare(hashtree(), hashtree()) -> [keydiff()].
+local_compare(T1, T2) ->
+    Remote = fun(get_bucket, {L, B}) ->
+                     get_bucket(L, B, T2);
+                (key_hashes, Segment) ->
+                     [{_, KeyHashes2}] = key_hashes(T2, Segment),
+                     KeyHashes2
+             end,
+    compare(T1, Remote).
+
+-spec compare(hashtree(), remote_fun()) -> [keydiff()].
+compare(Tree, Remote) ->
+    compare(Tree, Remote, fun(Keys, KeyAcc) ->
+                                  Keys ++ KeyAcc
+                          end).
+
+-spec compare(hashtree(), remote_fun(), acc_fun(X)) -> X.
+compare(Tree, Remote, AccFun) ->
+    compare(Tree, Remote, AccFun, []).
 
 %% Verify that `update_tree/1' generates a snapshot of the underlying
 %% LevelDB store that is used by `compare', therefore isolating the

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -159,8 +159,8 @@
 
 -type keydiff() :: {missing | remote_missing | different, binary()}.
 
--type remote_fun() :: fun((get_bucket | key_hashes,
-                           {integer(), integer()}) -> any()).
+-type remote_fun() :: fun((get_bucket | key_hashes | init | final,
+                           {integer(), integer()} | integer() | term()) -> any()).
 
 -type acc_fun(Acc) :: fun(([keydiff()], Acc) -> Acc).
 

--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -124,6 +124,7 @@
          mem_levels/1]).
 
 -ifdef(TEST).
+-export([local_compare/2]).
 -export([run_local/0,
          run_local/1,
          run_concurrent_build/0,

--- a/src/riak_kv_exchange_fsm.erl
+++ b/src/riak_kv_exchange_fsm.erl
@@ -171,11 +171,31 @@ key_exchange(timeout, State=#state{local=LocalVN,
     lager:debug("Starting key exchange between ~p and ~p", [LocalVN, RemoteVN]),
     lager:debug("Exchanging hashes for preflist ~p", [IndexN]),
 
-    Remote = fun(get_bucket, {L, B}) ->
+    TmpDir = app_helper:get_env(riak_core, platform_data_dir, "/tmp"),
+    {NA, NB, NC} = Now = WriteLog = now(),
+    LogFile1 = lists:flatten(io_lib:format("~s/~s/in.~p.~p.~p",
+                                           [TmpDir, ?MODULE, NA, NB, NC])),
+    ok = filelib:ensure_dir(LogFile1),
+    LogFile2 = lists:flatten(io_lib:format("~s/~s/out.~p.~p.~p",
+                                           [TmpDir, ?MODULE, NA, NB, NC])),
+    ok = filelib:ensure_dir(LogFile2),
+    Remote = fun(get_bucket, {L, B}=_X) ->
                      exchange_bucket(RemoteTree, IndexN, L, B);
                 (key_hashes, Segment) ->
                      exchange_segment(RemoteTree, IndexN, Segment);
-                (_, _) ->
+                (init, _Y) ->
+                     %% Our return value is ignored, so we can't return
+                     %% the disk log handle here.  However, disk_log is
+                     %% magically stateful, so we don't need to change
+                     %% the exchange API to accomodate us.
+                     {ok, _} = open_disk_log(Now, LogFile1, read_write),
+                     ok;
+                (final, _Y) ->
+                     ok = disk_log:sync(Now),
+                     ok = disk_log:close(Now),
+                     ok;
+                (_X, _Y) ->
+                     lager:error("~s LINE ~p: ~p ~p", [?MODULE, ?LINE, _X, _Y]),
                      ok
              end,
 
@@ -186,27 +206,53 @@ key_exchange(timeout, State=#state{local=LocalVN,
     %% entropy manager if needed.
     {ok, RC} = riak:local_client(),
     AccFun = fun(KeyDiff, Acc) ->
-                     lists:foldl(fun(Diff, Acc2) ->
-                                         read_repair_keydiff(RC, LocalVN, RemoteVN, Diff),
-                                         case Acc2 of
-                                             [] ->
-                                                 [1];
-                                             [Count] ->
-                                                 [Count+1]
-                                         end
+                     lists:foldl(fun({DiffReason, BKeyBin}, Count) ->
+                                         {B, K} = binary_to_term(BKeyBin),
+                                         T = {B, K, DiffReason},
+                                         if Count rem 5000 == 0 ->
+                                                 ok = disk_log:log(WriteLog, T);
+                                            true ->
+                                                 ok = disk_log:alog(WriteLog, T)
+                                         end,
+                                         Count+1
                                  end, Acc, KeyDiff)
              end,
     %% TODO: Add stats for AAE
-    case riak_kv_index_hashtree:compare(IndexN, Remote, AccFun, LocalTree) of
-        [] ->
-            exchange_complete(LocalVN, RemoteVN, IndexN, 0),
+    Count = riak_kv_index_hashtree:compare(IndexN, Remote, AccFun, 0, LocalTree),
+    if Count == 0 ->
             ok;
-        [Count] ->
-            exchange_complete(LocalVN, RemoteVN, IndexN, Count),
+       true ->
+            %% Sort the keys.  For vnodes that use backends that preserve
+            %% lexicographic sort order for BKeys, this is a big
+            %% improvement.  For backends that do not, e.g. Bitcask, sorting
+            %% by BKey is unlikely to be any worse.  For Riak CS's use
+            %% pattern, sorting may have some benefit since block N is
+            %% likely to be nearby on disk of block N+1.
+            StartTime = now(),
+            ok = sort_disk_log(LogFile1, LogFile2),
+            lager:debug("~s:key_exchange: sorting time = ~p seconds\n",
+                        [?MODULE, timer:now_diff(now(), StartTime) / 1000000]),
+            {ok, ReadLog} = open_disk_log(Now, LogFile2, read_only),
+            FoldRes =
+                fold_disk_log(fun(Diff, Acc) ->
+                                      read_repair_keydiff(RC, LocalVN, RemoteVN,
+                                                          Diff),
+                                      Acc + 1
+                              end, 0, ReadLog),
+            disk_log:close(ReadLog),
+            if Count == FoldRes ->
+                    ok;
+               true ->
+                    lager:error("~s:key_exchange: Count ~p /= FoldRes ~p\n",
+                                [?MODULE, Count, FoldRes])
+            end,
             lager:info("Repaired ~b keys during active anti-entropy exchange "
                        "of ~p between ~p and ~p",
                        [Count, IndexN, LocalVN, RemoteVN])
     end,
+    exchange_complete(LocalVN, RemoteVN, IndexN, Count),
+    _ = file:delete(LogFile1),
+    _ = file:delete(LogFile2),
     {stop, normal, State}.
 
 %%%===================================================================
@@ -222,8 +268,7 @@ exchange_segment(Tree, IndexN, Segment) ->
     riak_kv_index_hashtree:exchange_segment(IndexN, Segment, Tree).
 
 %% @private
-read_repair_keydiff(RC, LocalVN, RemoteVN, {_, KeyBin}) ->
-    {Bucket, Key} = binary_to_term(KeyBin),
+read_repair_keydiff(RC, LocalVN, RemoteVN, {Bucket, Key, _Reason}) ->
     %% TODO: Even though this is at debug level, it's still extremely
     %%       spammy. Should this just be removed? We can always use
     %%       redbug to trace read_repair_keydiff when needed. Of course,
@@ -287,3 +332,73 @@ exchange_complete({LocalIdx, _}, {RemoteIdx, RemoteNode}, IndexN, Repaired) ->
     riak_kv_entropy_info:exchange_complete(LocalIdx, RemoteIdx, IndexN, Repaired),
     rpc:call(RemoteNode, riak_kv_entropy_info, exchange_complete,
              [RemoteIdx, LocalIdx, IndexN, Repaired]).
+
+open_disk_log(Name, Path, RWorRO) ->
+    open_disk_log(Name, Path, RWorRO, [{type, halt}, {format, internal}]).
+
+open_disk_log(Name, Path, RWorRO, OtherOpts) ->
+    disk_log:open([{name, Name}, {file, Path}, {mode, RWorRO}|OtherOpts]).
+
+sort_disk_log(InputFile, OutputFile) ->
+    {ok, ReadLog} = open_disk_log(now(), InputFile, read_only),
+    _ = file:delete(OutputFile),
+    {ok, WriteLog} = open_disk_log(now(), OutputFile, read_write),
+    Input = sort_disk_log_input(ReadLog),
+    Output = sort_disk_log_output(WriteLog),
+    try
+        file_sorter:sort(Input, Output, {format, term})
+    after
+        ok = disk_log:close(ReadLog),
+        ok = disk_log:close(WriteLog)
+    end.
+
+sort_disk_log_input(ReadLog) ->
+    sort_disk_log_input(ReadLog, start).
+
+sort_disk_log_input(ReadLog, Cont) ->
+    fun(close) ->
+            ok;
+       (read) ->
+            case disk_log:chunk(ReadLog, Cont) of
+                {error, Reason} ->
+                    {error, Reason};
+                {Cont2, Terms} ->
+                    {Terms, sort_disk_log_input(ReadLog, Cont2)};
+                {Cont2, Terms, _Badbytes} ->
+                    {Terms, sort_disk_log_input(ReadLog, Cont2)};
+                eof ->
+                    end_of_input
+            end
+    end.
+
+sort_disk_log_output(WriteLog) ->
+    sort_disk_log_output(WriteLog, 1).
+
+sort_disk_log_output(WriteLog, Count) ->
+    fun(close) ->
+            ok;
+       (Terms) ->
+            %% Typical length of terms is on the order of 1-1500
+            %% e.g. [{Bucket1, Key1, missing|remote_missing|different}, ...]
+            if Count rem 100 == 0 ->
+                    disk_log:log_terms(WriteLog, Terms);
+                true ->
+                    disk_log:alog_terms(WriteLog, Terms)
+            end,
+            sort_disk_log_output(WriteLog, Count + 1)
+    end.
+
+fold_disk_log(Fun, Acc, DiskLog) ->
+    fold_disk_log(disk_log:chunk(DiskLog, start), Fun, Acc, DiskLog).
+
+fold_disk_log(eof, _Fun, Acc, _DiskLog) ->
+    Acc;
+fold_disk_log({Cont, Terms}, Fun, Acc, DiskLog) ->
+    Acc2 = try
+               lists:foldl(Fun, Acc, Terms)
+    catch X:Y ->
+            lager:error("~s:fold_disk_log: caught ~p ~p @ ~p\n",
+                        [?MODULE, X, Y, erlang:get_stacktrace()]),
+            Acc
+    end,
+    fold_disk_log(disk_log:chunk(DiskLog, Cont), Fun, Acc2, DiskLog).

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -39,6 +39,7 @@
 -export([get_lock/2,
          compare/3,
          compare/4,
+         compare/5,
          exchange_bucket/4,
          exchange_segment/3,
          update/2,
@@ -166,7 +167,14 @@ compare(Id, Remote, Tree) ->
 -spec compare(index_n(), hashtree:remote_fun(),
               undefined | hashtree:acc_fun(T), pid()) -> T.
 compare(Id, Remote, AccFun, Tree) ->
-    gen_server:call(Tree, {compare, Id, Remote, AccFun}, infinity).
+    compare(Id, Remote, AccFun, [], Tree).
+
+%% @doc A variant of {@link compare/3} that takes a key difference accumulator
+%%      function as an additional parameter.
+-spec compare(index_n(), hashtree:remote_fun(),
+              undefined | hashtree:acc_fun(T), any(), pid()) -> T.
+compare(Id, Remote, AccFun, Acc, Tree) ->
+    gen_server:call(Tree, {compare, Id, Remote, AccFun, Acc}, infinity).
 
 %% @doc Acquire the lock for the specified index_hashtree if not already
 %%      locked, and associate the lock with the calling process.
@@ -276,8 +284,8 @@ handle_call({exchange_segment, Id, Segment}, _From, State) ->
                end,
                State);
 
-handle_call({compare, Id, Remote, AccFun}, From, State) ->
-    do_compare(Id, Remote, AccFun, From, State),
+handle_call({compare, Id, Remote, AccFun, Acc}, From, State) ->
+    do_compare(Id, Remote, AccFun, Acc, From, State),
     {noreply, State};
 
 handle_call(destroy, _From, State) ->
@@ -589,8 +597,8 @@ tree_id(_) ->
     erlang:error(badarg).
 
 -spec do_compare(index_n(), hashtree:remote_fun(), hashtree:acc_fun(any()),
-                 term(), state()) -> ok.
-do_compare(Id, Remote, AccFun, From, State) ->
+                 any(), term(), state()) -> ok.
+do_compare(Id, Remote, AccFun, Acc, From, State) ->
     case orddict:find(Id, State#state.trees) of
         error ->
             %% This case shouldn't happen, but might as well safely handle it.
@@ -600,12 +608,8 @@ do_compare(Id, Remote, AccFun, From, State) ->
         {ok, Tree} ->
             spawn_link(fun() ->
                                Remote(init, self()),
-                               Result = case AccFun of
-                                            undefined ->
-                                                hashtree:compare(Tree, Remote);
-                                            _ ->
-                                                hashtree:compare(Tree, Remote, AccFun)
-                                        end,
+                               Result = hashtree:compare(Tree, Remote,
+                                                         AccFun, Acc),
                                Remote(final, self()),
                                gen_server:reply(From, Result)
                        end)

--- a/test/hashtree_eqc.erl
+++ b/test/hashtree_eqc.erl
@@ -11,9 +11,10 @@
 -include_lib("eunit/include/eunit.hrl").
 
 hashtree_test_() ->
-    {timeout, 30,
+    Timeout = 30,
+    {timeout, Timeout*2,
         fun() ->
-                ?assert(eqc:quickcheck(?QC_OUT(eqc:testing_time(29,
+                ?assert(eqc:quickcheck(?QC_OUT(eqc:testing_time(Timeout,
                             hashtree_eqc:prop_correct()))))
         end
     }.


### PR DESCRIPTION
```
        %% Sort the keys.  For vnodes that use backends that preserve
        %% lexicographic sort order for BKeys, this is a big
        %% improvement.  For backends that do not, e.g. Bitcask, sorting
        %% by BKey is unlikely to be any worse.  For Riak CS's use
        %% pattern, sorting may have some benefit since block N is
        %% likely to be adjacent on disk to block N+1.
```
