### PR TITLE
Fix keys fsm EQC test

### DIFF
--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -118,11 +118,16 @@ start(Partition, Config) ->
     TTL = riak_kv_util:get_backend_config(ttl, Config, memory_backend),
     MemoryMB = riak_kv_util:get_backend_config(max_memory, Config, memory_backend),
     %% leave this one alone, it is only for testing
+    NormalTableOpts = [ordered_set],
+    TestTableOpts = app_helper:get_prop_or_env(test_table_opts,
+                                               Config,
+                                               memory_backend,
+                                               [named_table, public]),
     TableOpts = case app_helper:get_prop_or_env(test, Config, memory_backend) of
                     true ->
-                        [ordered_set, public];
+                        NormalTableOpts ++ TestTableOpts;
                     _ ->
-                        [ordered_set]
+                        NormalTableOpts
                 end,
     case MemoryMB of
         undefined ->
@@ -632,8 +637,8 @@ object_size(Object) ->
 -ifdef(TEST).
 
 simple_test_() ->
-    application:set_env(memory_backend, test, true),
-    riak_kv_backend:standard_test(?MODULE, []).
+    Config = [{test, true}, {test_table_opts, [public]}],
+    riak_kv_backend:standard_test(?MODULE, Config).
 
 ttl_test_() ->
     Config = [{ttl, 15}],


### PR DESCRIPTION
The keys FSM EQC test was failing with lists of actual keys having many
duplicates for each key and failing to match.
The test relies on the memory backend tables to be named to be able to
wipe them out in between generated runs, which may and will use
different bucket n_val values, placing replicas in different sets of
vnodes each time. This was changed recently, so
adding named_table option at ETS creation time.

Make memory table options configurable to allow the keys_fsm_eqc test,
that relies on tables being named so it can clear them all between
runs and some memory_backend tests that will
break if they are named, as they create multiple ones with the same
partition number. This should allow them both to succeed.
