### PR TITLE
Add Yokozuna index hook

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -79,6 +79,15 @@
 -export([put_merge/6]). %% For fsm_eqc_vnode
 -endif.
 
+%% N.B. The ?INDEX macro should be called any time the object bytes on
+%% disk are modified.
+-ifdef(TEST).
+%% Use values so that test compile doesn't give 'unused vars' warning.
+-define(INDEX(A,B,C), _=element(1,{A,B,C}), ok).
+-else.
+-define(INDEX(Obj, Reason, Partition), yz_kv:index(Obj, Reason, Partition)).
+-endif.
+
 -record(mrjob, {cachekey :: term(),
                 bkey :: term(),
                 reqid :: term(),
@@ -913,7 +922,9 @@ do_put(Sender, {Bucket,_Key}=BKey, RObj, ReqID, StartTime, Options, State) ->
     update_index_write_stats(UpdPutArgs#putargs.is_index, UpdPutArgs#putargs.index_specs),
     UpdState.
 
-do_backend_delete(BKey, RObj, State = #state{mod = Mod, modstate = ModState}) ->
+do_backend_delete(BKey, RObj, State = #state{idx = Idx,
+                                             mod = Mod,
+                                             modstate = ModState}) ->
     %% object is a tombstone or all siblings are tombstones
     %% Calculate the index specs to remove...
     %% JDM: This should just be a tombstone by this point, but better
@@ -924,6 +935,7 @@ do_backend_delete(BKey, RObj, State = #state{mod = Mod, modstate = ModState}) ->
     {Bucket, Key} = BKey,
     case Mod:delete(Bucket, Key, IndexSpecs, ModState) of
         {ok, UpdModState} ->
+            ?INDEX(RObj, delete, Idx),
             riak_kv_index_hashtree:delete(BKey, State#state.hashtrees),
             update_index_delete_stats(IndexSpecs),
             State#state{modstate = UpdModState};
@@ -1071,6 +1083,7 @@ perform_put({true, Obj},
     case encode_and_put(Obj, Mod, Bucket, Key, IndexSpecs, ModState) of
         {{ok, UpdModState}, EncodedVal} ->
             update_hashtree(Bucket, Key, EncodedVal, State),
+            ?INDEX(Obj, put, Idx),
             case RB of
                 true ->
                     Reply = {dw, Idx, Obj, ReqID};
@@ -1397,6 +1410,7 @@ do_diffobj_put({Bucket, Key}, DiffObj,
                     update_hashtree(Bucket, Key, EncodedVal, StateData),
                     update_index_write_stats(IndexBackend, IndexSpecs),
                     update_vnode_stats(vnode_put, Idx, StartTS),
+                    ?INDEX(DiffObj, handoff, Idx),
                     InnerRes;
                 {InnerRes, _Val} ->
                     InnerRes
@@ -1422,6 +1436,7 @@ do_diffobj_put({Bucket, Key}, DiffObj,
                             update_hashtree(Bucket, Key, EncodedVal, StateData),
                             update_index_write_stats(IndexBackend, IndexSpecs),
                             update_vnode_stats(vnode_put, Idx, StartTS),
+                            ?INDEX(AMObj, handoff, Idx),
                             InnerRes;
                         {InnerRes, _EncodedVal} ->
                             InnerRes


### PR DESCRIPTION
Add a low-level hook in the vnode for the purposes of indexing objects
in Yokozuna.  This hook provides a notification to Yokozuna _any time_
an object's bytes are modified on disk.
