### PR TITLE
use yokozuna or riak_search for {search, ...} MR inputs

### DIFF
--- a/src/riak_kv_mrc_pipe.erl
+++ b/src/riak_kv_mrc_pipe.erl
@@ -618,11 +618,21 @@ send_inputs(Pipe, {index, Bucket, Index, StartKey, EndKey}, Timeout) ->
             send_inputs(Pipe, NewInput, Timeout)
     end;
 send_inputs(Pipe, {search, Bucket, Query}, Timeout) ->
-    NewInput = {modfun, riak_search, mapred_search, [Bucket, Query, []]},
-    send_inputs(Pipe, NewInput, Timeout);
+    case search_module() of
+        {ok, Mod} ->
+            NewInput = {modfun, Mod, mapred_search, [Bucket, Query, []]},
+            send_inputs(Pipe, NewInput, Timeout);
+        {error, _}=Error ->
+            Error
+    end;
 send_inputs(Pipe, {search, Bucket, Query, Filter}, Timeout) ->
-    NewInput = {modfun, riak_search, mapred_search, [Bucket, Query, Filter]},
-    send_inputs(Pipe, NewInput, Timeout);
+    case search_module() of
+        {ok, Mod} ->
+            NewInput = {modfun, Mod, mapred_search, [Bucket, Query, Filter]},
+            send_inputs(Pipe, NewInput, Timeout);
+        {error, _}=Error ->
+            Error
+    end;
 send_inputs(Pipe, {modfun, Mod, Fun, Arg} = Modfun, Timeout) ->
     try Mod:Fun(Pipe, Arg, Timeout) of
         {ok, Bucket, ReqId} ->
@@ -633,6 +643,34 @@ send_inputs(Pipe, {modfun, Mod, Fun, Arg} = Modfun, Timeout) ->
         X:Y ->
             {Modfun, X, Y, erlang:get_stacktrace()}
     end.
+
+%% decide whether yokozuna or riak_search should be used for
+%% {search, ...} inputs
+search_module() ->
+    case {enabled(yokozuna), enabled(riak_search)} of
+        {true, true} ->
+            case application:get_env(riak_kv, mapred_search) of
+                %% being explicit here to help find typo errors earlier
+                {ok, yokozuna} ->
+                    {ok, yokozuna};
+                {ok, riak_search} ->
+                    {ok, riak_search};
+                undefined ->
+                    {error, "riak_kv:mapred_provider not defined"};
+                Other ->
+                    {error, {unknown_mapred_provider, Other}}
+            end;
+        {true, _} ->
+            {ok, yokozuna};
+        {_, true} ->
+            {ok, riak_search};
+        _ ->
+            {error, "search not enabled"}
+    end.
+
+%% riak_search and yokozuna both use an `enabled' appenv setting
+enabled(App) ->
+    {ok, true} == application:get_env(App, enabled).
 
 %% @doc Helper function used to redirect the results of
 %% index/search/etc. queries into the MapReduce pipe.  The function


### PR DESCRIPTION
_Note_: this should probably be considered non-merge-able until bucket-types land, since that has the potential for significant conflict, and redefinition of bucket-index mapping for yokozuna. I'm opening the PR now for comment and backup purposes.

There are two ways to use riak_search inputs for MapReduce:
- specify a {modfun, ...} input ({"module":...,"function":...} in json)
- specify a {search, ...} input ({"bucket":...,"query":...} in json)

This patch allows yokozuna to power the second type instead of
riak_search. The value of the "bucket" field is used as the name of the
yokozuna index.

This patch does not convert the modfun version, to keep from surprising
users, and to allow an escape hatch for people that need to use both.

If only one of riak_search or yokozuna is enabled, that system is chosen
to power search MR inputs.

If both are enabled, then the riak_kv's appenv 'mapred_search' must also
be defined as either 'riak_search' or 'yokozuna'. If it is not defined,
or it is defined as something else, and error will be returned from the MR.

If neither is enabled, an error is returned from the MR.

The automatic nature of the switch is intended to keep configuration as
minimal as possible: the extra riak_kv setting is only needed if _both_
riak_search and yokozuna are to be used, _and_ the user wants to use the
non-modfun forms. If only one search system is enabled, or only modfun
input forms are used, the correct thing just happens.

A test for this behavior is defined by `mapred_search_switch` in basho/riak_test#373.
