### PR TITLE
Move riak_core.proto from riak_core.

### DIFF
--- a/src/riak_core.proto
+++ b/src/riak_core.proto
@@ -1,0 +1,6 @@
+message RiakObject_PB {
+        required bytes bucket = 1;
+        required bytes key = 2;
+        required bytes val = 3;
+}
+


### PR DESCRIPTION
This protobuff definition is only used by KV. Whether we should
continue to use this encoding can be debated separately, but putting
the file in KV removes yet another dependency from Core. Third parties
who use Core can pull in protobuffs via riak_api or their own
applications. For KV, it is pulled as a dependency of riak_api.

/cc @Vagabond @evanmcc @jrwest

Pair of basho/riak_core#382 and should be considered together.
