### PR TITLE
Added Mutators to support changing object on read/write

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -187,6 +187,9 @@ start(_Type, _StartArgs) ->
                                           [enabled, disabled],
                                           disabled),
 
+            % get/put mutator is supported, but not all nodes may have it
+            riak_core_capability:register({riak_kv, mutators}, [true, false], false),
+
             HealthCheckOn = app_helper:get_env(riak_kv, enable_health_checks, false),
             %% Go ahead and mark the riak_kv service as up in the node watcher.
             %% The riak_core_ring_handler blocks until all vnodes have been started

--- a/src/riak_kv_mutator.erl
+++ b/src/riak_kv_mutator.erl
@@ -90,8 +90,12 @@ mutate_get(Object) ->
 mutate_get(Object, []) ->
     Object;
 mutate_get(Object, [Mutator | Tail]) ->
-    Object2 = Mutator:mutate_get(Object),
-    mutate_get(Object2, Tail).
+    case Mutator:mutate_get(Object) of
+        notfound ->
+            notfound;
+        Object2 ->
+            mutate_get(Object2, Tail)
+    end.
 
 mutate_put(Object, BucketProps) ->
     Contents = riak_object:get_contents(Object),

--- a/src/riak_kv_mutator.erl
+++ b/src/riak_kv_mutator.erl
@@ -32,18 +32,22 @@
 
 -module(riak_kv_mutator).
 
--export([register/1, unregister/1]).
+-export([register/1, register/2, unregister/1]).
 -export([get/0]).
 -export([mutate_put/2, mutate_get/1]).
 
+-define(DEFAULT_PRIORITY, 0).
+
 register(Module) ->
+    ?MODULE:register(Module, ?DEFAULT_PRIORITY).
+
+register(Module, Priority) ->
     Modifier = fun
         (undefined) ->
-            [Module];
+            [{Module, Priority}];
         (Values) ->
-            Values2 = lists:filter(fun erlang:is_list/1, Values),
-            Values3 = ordsets:union(Values2),
-            ordsets:add_element(Module, Values3)
+            Values2 = merge_values(Values),
+            orddict:store(Module, Priority, Values2)
     end,
     riak_core_metadata:put({riak_kv, mutators}, list, Modifier).
 
@@ -52,18 +56,20 @@ unregister(Module) ->
         (undefined) ->
             [];
         (Values) ->
-            Values2 = lists:filter(fun erlang:is_list/1, Values),
-            Values3 = ordsets:union(Values2),
-            ordsets:del_element(Module, Values3)
+            Values2 = merge_values(Values),
+            orddict:erase(Module, Values2)
     end,
     riak_core_metadata:put({riak_kv, mutators}, list, Modifier, []).
 
 get() ->
     Resolver = fun(Values) ->
         Values2 = lists:filter(fun erlang:is_list/1, Values),
-        ordsets:union(Values2)
+        merge_values(Values2)
     end,
-    Modules = riak_core_metadata:get({riak_kv, mutators}, list, [{default, []}, {resolver, Resolver}]),
+    ModulesAndPriors = riak_core_metadata:get({riak_kv, mutators}, list, [{default, []}, {resolver, Resolver}]),
+    Flipped = [{P, M} || {M, P} <- ModulesAndPriors],
+    Sorted = lists:sort(Flipped),
+    Modules = [M || {_P, M} <- Sorted],
     {ok, Modules}.
 
 mutate_get(Object) ->
@@ -91,3 +97,26 @@ mutate_put(Object, BucketProps) ->
     Meta2 = dict:store(mutators_applied, Modules, Meta),
     Object3 = riak_object:update_metadata(Object2, Meta2),
     riak_object:apply_updates(Object3).
+
+merge_values([]) ->
+    [];
+
+merge_values(Values) ->
+    case lists:filter(fun erlang:is_list/1, Values) of
+        [] ->
+            [];
+        [Head | Tail] ->
+            merge_values(Tail, Head)
+    end.
+
+merge_values([], Acc) ->
+    Acc;
+
+merge_values([Head | Tail], Acc) ->
+    Acc2 = orddict:merge(fun merge_fun/3, Acc, Head),
+    merge_values(Tail, Acc2).
+
+merge_fun(_Key, P1, P2) when P1 < P2 ->
+    P1;
+merge_fun(_Key, _P1, P2) ->
+    P2.

--- a/src/riak_kv_mutator.erl
+++ b/src/riak_kv_mutator.erl
@@ -1,0 +1,72 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_mutators - Storage and retrieval for get/put mutation
+%% functions
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc There are circumstances where the object stored on disk is not
+%% the object to return; and there are times the object written to the
+%% data storage backend is not meant to be the object given. An
+%% example would be storing only meta data for an object on a remote
+%% cluster. This module is an interface to register mutators that will
+%% can be run.
+%%
+%% This doubles as a behavior defining module for the mutators.
+
+-module(riak_kv_mutator).
+
+-define(ets, riak_kv_mutators_registry).
+
+-export([create/0, destroy/0]).
+-export([register/1, unregister/1]).
+-export([get/0]).
+-export([mutate_put/2, mutate_get/2]).
+
+create() ->
+    Ets = ets:new(?ets, [named_table, {read_concurrency, true}, public]),
+    {ok, Ets}.
+
+destroy() ->
+    ets:delete(?ets),
+    ok.
+
+register(Module) ->
+    ets:insert(?ets, {Module}),
+    ok.
+
+unregister(Module) ->
+    ets:delete(?ets, Module),
+    ok.
+
+get() ->
+    List = ets:match(?ets, {'$1'}),
+    {ok, lists:flatten(List)}.
+
+mutate_get(Object, BucketProps) ->
+    mutate(Object, BucketProps, mutate_get).
+
+mutate_put(Object, BucketProps) ->
+    mutate(Object, BucketProps, mutate_put).
+
+mutate(Object, BucketProps, Func) ->
+    FoldFun = fun({Module}, Obj) ->
+        Module:Func(Obj, BucketProps)
+    end,
+    ets:foldl(FoldFun, Object, ?ets).

--- a/src/riak_kv_mutator.erl
+++ b/src/riak_kv_mutator.erl
@@ -34,7 +34,7 @@
 
 -export([register/1, unregister/1]).
 -export([get/0]).
--export([mutate_put/2, mutate_get/2]).
+-export([mutate_put/2, mutate_get/1]).
 
 register(Module) ->
     Modifier = fun
@@ -66,7 +66,7 @@ get() ->
     Modules = riak_core_metadata:get({riak_kv, mutators}, list, [{default, []}, {resolver, Resolver}]),
     {ok, Modules}.
 
-mutate_get(Object, BucketProps) ->
+mutate_get(Object) ->
     Meta = riak_object:get_metadata(Object),
     {AppliedMutators, Meta2} = case dict:find(mutators_applied, Meta) of
         error ->
@@ -77,7 +77,7 @@ mutate_get(Object, BucketProps) ->
     Object2 = riak_object:update_metadata(Object, Meta2),
     Object3 = riak_object:apply_updates(Object2),
     FoldFun = fun(Module, Obj) ->
-        Module:mutate_get(Obj, BucketProps)
+        Module:mutate_get(Obj)
     end,
     lists:foldl(FoldFun, Object3, AppliedMutators).
 

--- a/src/riak_kv_mutator.erl
+++ b/src/riak_kv_mutator.erl
@@ -79,7 +79,7 @@ mutate_get(Object) ->
     FoldFun = fun(Module, Obj) ->
         Module:mutate_get(Obj)
     end,
-    lists:foldl(FoldFun, Object3, AppliedMutators).
+    lists:foldl(FoldFun, Object3, lists:reverse(AppliedMutators)).
 
 mutate_put(Object, BucketProps) ->
     FoldFun = fun(Module, Obj) ->

--- a/src/riak_kv_mutator.erl
+++ b/src/riak_kv_mutator.erl
@@ -26,7 +26,7 @@
 %% data storage backend is not meant to be the object given. An
 %% example would be storing only meta data for an object on a remote
 %% cluster. This module is an interface to register mutators that will
-%% can be run.
+%% be run.
 %%
 %% This doubles as a behavior defining module for the mutators.
 %%
@@ -92,7 +92,7 @@ register(Module) ->
     ?MODULE:register(Module, ?DEFAULT_PRIORITY).
 
 %% @doc Register a module as a mutator with the given priority. Modules with
-%% equal priority are done in sort sort (alphabetical) order. A module
+%% equal priority are done in default (alphabetical) order. A module
 %% can only be registered once. When there is a conflict (two different
 %% lists), those lists are merged.
 -spec register(Module :: atom(), Priority :: term()) -> 'ok'.

--- a/src/riak_kv_mutator.erl
+++ b/src/riak_kv_mutator.erl
@@ -237,7 +237,7 @@ merge_values([{Priority, Module} = Mutator | Tail], Acc) ->
         {P1, _} when P1 < Priority ->
             Acc;
         Else ->
-            ordsets:all_element(Mutator, ordsets:del_element(Else))
+            ordsets:add_element(Mutator, ordsets:del_element(Else))
     end,
     merge_values(Tail, Acc2).
 

--- a/src/riak_kv_mutator.erl
+++ b/src/riak_kv_mutator.erl
@@ -93,7 +93,8 @@ register(Module) ->
 
 %% @doc Register a module as a mutator with the given priority. Modules with
 %% equal priority are done in sort sort (alphabetical) order. A module
-%% can only be registered once.
+%% can only be registered once. When there is a conflict (two different
+%% lists), those lists are merged.
 -spec register(Module :: atom(), Priority :: term()) -> 'ok'.
 register(Module, Priority) ->
     Modifier = fun

--- a/src/riak_kv_mutator.erl
+++ b/src/riak_kv_mutator.erl
@@ -123,7 +123,7 @@ unregister(Module) ->
 -spec get() -> [atom()].
 get() ->
     Resolver = fun
-        ('$deleted', '$delete') ->
+        ('$deleted', '$deleted') ->
             [];
         ('$deleted', Values) ->
             Values;

--- a/src/riak_kv_mutator.erl
+++ b/src/riak_kv_mutator.erl
@@ -76,8 +76,6 @@
 
 -module(riak_kv_mutator).
 
--include_lib("eunit/include/eunit.hrl").
-
 -export([register/1, register/2, unregister/1]).
 -export([get/0]).
 -export([mutate_put/2, mutate_get/1]).

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1213,8 +1213,12 @@ do_get(_Sender, BKey, ReqID,
 do_get_term({Bucket, Key}, Mod, ModState) ->
     case do_get_object(Bucket, Key, Mod, ModState) of
         {ok, Obj, _UpdModState} ->
-            Obj2 = riak_kv_mutator:mutate_get(Obj),
-            {ok, Obj2};
+            case riak_kv_mutator:mutate_get(Obj) of
+                notfound ->
+                    {error, notfound};
+                Obj2 ->
+                    {ok, Obj2}
+            end;
         %% @TODO Eventually it would be good to
         %% make the use of not_found or notfound
         %% consistent throughout the code.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1107,14 +1107,14 @@ perform_put({true, Obj},
                      bprops=BProps,
                      reqid=ReqID,
                      index_specs=IndexSpecs}) ->
-    Obj2 = riak_kv_mutator:mutate_put(Obj, BProps),
+    {Obj2, Fake} = riak_kv_mutator:mutate_put(Obj, BProps),
     case encode_and_put(Obj2, Mod, Bucket, Key, IndexSpecs, ModState) of
         {{ok, UpdModState}, EncodedVal} ->
             update_hashtree(Bucket, Key, EncodedVal, State),
             ?INDEX(Obj, put, Idx),
             case RB of
                 true ->
-                    Reply = {dw, Idx, Obj, ReqID};
+                    Reply = {dw, Idx, Fake, ReqID};
                 false ->
                     Reply = {dw, Idx, ReqID}
             end;

--- a/test/fsm_eqc_util.erl
+++ b/test/fsm_eqc_util.erl
@@ -44,7 +44,7 @@ non_blank_string() ->
 %% with utf8 conversion.
 lower_char() ->
     choose(16#20, 16#7f).
-    
+
 
 vclock() ->
     ?LET(VclockSym, vclock_sym(), eval(VclockSym)).
@@ -80,10 +80,10 @@ maybe_tombstone() ->
 %%  brother   sister otherbrother
 %%       \     |    /
 %%         current
-%%    
+%%
 lineage() ->
     elements([current, ancestor, brother, sister, otherbrother]).
- 
+
 merge(ancestor, Lineage) -> Lineage;  % order should match Clocks list in riak_objects
 merge(Lineage, ancestor) -> Lineage;  % as last modified is used as tie breaker with
 merge(_, current)        -> current;  % allow_mult=false
@@ -111,9 +111,9 @@ partvals() ->
     not_empty(fsm_eqc_util:longer_list(2, partval())).
 
 %% Generate 5 riak objects with the same bkey
-%% 
+%%
 riak_objects() ->
-    ?LET({{Bucket,Key},AncestorVclock0,Tombstones}, 
+    ?LET({{Bucket,Key},AncestorVclock0,Tombstones},
          {noshrink(bkey()),vclock(),vector(5, maybe_tombstone())},
     begin
         AncestorVclock = vclock:increment(<<"dad">>, AncestorVclock0),
@@ -144,7 +144,7 @@ add_tombstone(Obj) ->
     [{M,V}] = riak_object:get_contents(Obj),
     NewM = dict:store(<<"X-Riak-Deleted">>, true, M),
     riak_object:set_contents(Obj, [{NewM, V}]).
-                
+
 
 some_up_node_status(NumNodes) ->
     at_least_one_up(nodes_status(NumNodes)).
@@ -186,6 +186,7 @@ start_mock_servers() ->
     start_fake_get_put_monitor(),
     riak_core_stat_cache:start_link(),
     riak_kv_stat:register_stats(),
+    riak_core_metadata_manager:start_link([{data_dir, "fsm_eqc_test_data"}]),
     riak_core_ring_events:start_link(),
     riak_core_node_watcher_events:start_link(),
     riak_core_node_watcher:start_link(),
@@ -194,6 +195,7 @@ start_mock_servers() ->
 
 cleanup_mock_servers() ->
     stop_fake_get_put_monitor(),
+    riak_kv_test_util:stop_process(riak_core_metadata_manager),
     application:stop(folsom),
     application:stop(riak_core).
 

--- a/test/riak_kv_mutator_tests.erl
+++ b/test/riak_kv_mutator_tests.erl
@@ -55,6 +55,27 @@ functionaltiy_test_() ->
             ?assertEqual({ok, Expected}, Got1)
         end} end,
 
+        fun(_) -> {"register a mutator with a priority", fun() ->
+            Got1 = riak_kv_mutator:register(fake_module, 3),
+            ?assertEqual(ok, Got1),
+            Got2 = riak_kv_mutator:get(),
+            ?assertEqual({ok, [fake_module]}, Got2)
+        end} end,
+
+        fun(_) -> {"register a mutator twice, differing priorities", fun() ->
+            ok = riak_kv_mutator:register(fake_module, 3),
+            ok = riak_kv_mutator:register(fake_module, 7),
+            Got = riak_kv_mutator:get(),
+            ?assertEqual({ok, [fake_module]}, Got)
+        end} end,
+
+        fun(_) -> {"priority determines mutator order", fun() ->
+            ok = riak_kv_mutator:register(fake_module, 7),
+            ok = riak_kv_mutator:register(fake_module_2, 2),
+            Got = riak_kv_mutator:get(),
+            ?assertEqual({ok, [fake_module_2, fake_module]}, Got)
+        end} end,
+
         fun(_) -> {"mutate a put", fun() ->
             Object = riak_object:new(<<"bucket">>, <<"key">>, <<"original_data">>, dict:from_list([{<<"mutations">>, 0}])),
             riak_kv_mutator:register(?MODULE),

--- a/test/riak_kv_mutator_tests.erl
+++ b/test/riak_kv_mutator_tests.erl
@@ -5,7 +5,7 @@
 
 -export([mutate_put/2, mutate_get/1]).
 
-functionaltiy_test_() ->
+functionality_test_() ->
     {foreach, fun() ->
         purge_data_dir(),
         {ok, Pid} = riak_core_metadata_manager:start_link([{data_dir, "test_data"}]),

--- a/test/riak_kv_mutator_tests.erl
+++ b/test/riak_kv_mutator_tests.erl
@@ -34,6 +34,11 @@ functionaltiy_test_() ->
             ?assertEqual({ok, [fake_module, fake_module_2]}, Got)
         end} end,
 
+        fun(_) -> {"retrieve an empty list of mutators", fun() ->
+            Got = riak_kv_mutator:get(),
+            ?assertEqual({ok, []}, Got)
+        end} end,
+
         fun(_) -> {"unregister", fun() ->
             ok = riak_kv_mutator:register(fake_module),
             Got1 = riak_kv_mutator:unregister(fake_module),

--- a/test/riak_kv_mutator_tests.erl
+++ b/test/riak_kv_mutator_tests.erl
@@ -1,0 +1,98 @@
+-module(riak_kv_mutator_tests).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+-export([mutate_put/2, mutate_get/2]).
+
+creation_destruction_test() ->
+    Got = riak_kv_mutator:create(),
+    ?assertMatch({ok, _Ref}, Got),
+    Got2 = riak_kv_mutator:destroy(),
+    ?assertEqual(ok, Got2).
+
+functionaltiy_test_() ->
+    {foreach, fun() ->
+        riak_kv_mutator:create()
+    end,
+    fun(_) ->
+        riak_kv_mutator:destroy()
+    end, [
+
+        fun(_) -> {"register a mutator", fun() ->
+            Got = riak_kv_mutator:register(fake_module),
+            ?assertEqual(ok, Got)
+        end} end,
+
+        fun(_) -> {"retrieve mutators", fun() ->
+            ok = riak_kv_mutator:register(fake_module),
+            ok = riak_kv_mutator:register(fake_module_2),
+            Got = riak_kv_mutator:get(),
+            ?assertEqual({ok, [fake_module, fake_module_2]}, Got)
+        end} end,
+
+        fun(_) -> {"unregister", fun() ->
+            ok = riak_kv_mutator:register(fake_module),
+            Got1 = riak_kv_mutator:unregister(fake_module),
+            ?assertEqual(ok, Got1),
+            Got2 = riak_kv_mutator:get(),
+            ?assertEqual({ok, []}, Got2)
+        end} end,
+
+        fun(_) -> {"mutate a put", fun() ->
+            Object = riak_object:new(<<"bucket">>, <<"key">>, <<"original_data">>, dict:from_list([{<<"mutations">>, 0}])),
+            riak_kv_mutator:register(?MODULE),
+            Got = riak_kv_mutator:mutate_put(Object, [{<<"bucket_prop">>, <<"bprop">>}]),
+            ExpectedVal = <<"mutatedbprop">>,
+            ExpectedMetaMutations = 1,
+            ?assertEqual(ExpectedVal, riak_object:get_value(Got)),
+            ?assertEqual(ExpectedMetaMutations, dict:fetch(<<"mutations">>, riak_object:get_metadata(Got)))
+        end} end,
+
+        fun(_) -> {"mutate a get", fun() ->
+            Object = riak_object:new(<<"bucket">>, <<"key">>, <<"original_data">>, dict:from_list([{<<"mutations">>, 7}])),
+            riak_kv_mutator:register(?MODULE),
+            Got = riak_kv_mutator:mutate_get(Object, [{<<"bucket_prop">>, <<"warble">>}]),
+            ExpectedVal = <<"mutatedwarble">>,
+            ExpectedMetaMutations = 8,
+            ?assertEqual(ExpectedVal, riak_object:get_value(Got)),
+            ?assertEqual(ExpectedMetaMutations, dict:fetch(<<"mutations">>, riak_object:get_metadata(Got)))
+        end} end
+
+    ]}.
+
+mutate_put(Object, BucketProps) ->
+    mutate(Object, BucketProps).
+
+mutate_get(Object, BucketProps) ->
+    mutate(Object, BucketProps).
+
+mutate(Object, BucketProps) ->
+    ?debugMsg("bing"),
+    NewVal = case proplists:get_value(<<"bucket_prop">>, BucketProps) of
+        BProp when is_binary(BProp) ->
+    ?debugMsg("bing"),
+            <<"mutated", BProp/binary>>;
+        undefined ->
+    ?debugMsg("bing"),
+            <<"mutated">>
+    end,
+    ?debugMsg("bing"),
+    Meta = riak_object:get_metadata(Object),
+    Mutations = case dict:find(<<"mutations">>, Meta) of
+        {ok, N} when is_integer(N) ->
+    ?debugMsg("bing"),
+            N + 1;
+        _ ->
+    ?debugMsg("bing"),
+            0
+    end,
+    ?debugMsg("bing"),
+    Meta2 = dict:store(<<"mutations">>, Mutations, Meta),
+    ?debugMsg("bing"),
+    Object2 = riak_object:update_value(Object, NewVal),
+    ?debugMsg("bing"),
+    Object3 = riak_object:update_metadata(Object2, Meta2),
+    riak_object:apply_updates(Object3).
+
+-endif.


### PR DESCRIPTION
This is to support https://github.com/basho/riak_repl/issues/223 .

This implements a 'mutator' interface. A mutator callback module can alter an object to be stored and after it has been retrieved from a storage backend.

Note this has been recently rebased and force-pushed (sept 26) to account for changes from develop.
