### PR TITLE
Add security to Riak

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -187,7 +187,8 @@ start(_Type, _StartArgs) ->
             riak_core:register(riak_kv, [
                 {vnode_module, riak_kv_vnode},
                 {bucket_validator, riak_kv_bucket},
-                {stat_mod, riak_kv_stat}
+                {stat_mod, riak_kv_stat},
+                {permissions, [get, put, delete]}
             ]
             ++ [{health_check, {?MODULE, check_kv_health, []}} || HealthCheckOn]),
 

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -188,7 +188,8 @@ start(_Type, _StartArgs) ->
                 {vnode_module, riak_kv_vnode},
                 {bucket_validator, riak_kv_bucket},
                 {stat_mod, riak_kv_stat},
-                {permissions, [get, put, delete]}
+                {permissions, [get, put, delete, list_keys, list_buckets,
+                               mapreduce, index]}
             ]
             ++ [{health_check, {?MODULE, check_kv_health, []}} || HealthCheckOn]),
 

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -57,7 +57,12 @@ init() ->
 
 %% @doc decode/2 callback. Decodes an incoming message.
 decode(Code, Bin) ->
-    {ok, riak_pb_codec:decode(Code, Bin)}.
+    Msg = riak_pb_codec:decode(Code, Bin),
+    case Msg of
+        #rpbindexreq{type=T, bucket=B} ->
+            Bucket = bucket_type(T, B),
+            {ok, Msg, {"riak_kv.index", Bucket}}
+    end.
 
 %% @doc encode/1 callback. Encodes an outgoing response message.
 encode(Message) ->
@@ -163,4 +168,10 @@ maybe_bucket_type(undefined, B) ->
 maybe_bucket_type(<<"default">>, B) ->
     B;
 maybe_bucket_type(T, B) ->
+    {T, B}.
+
+%% always construct {Type, Bucket} tuple, filling in default type if needed
+bucket_type(undefined, B) ->
+    {<<"default">>, B};
+bucket_type(T, B) ->
     {T, B}.

--- a/src/riak_kv_pb_object.erl
+++ b/src/riak_kv_pb_object.erl
@@ -79,7 +79,17 @@ init() ->
 
 %% @doc decode/2 callback. Decodes an incoming message.
 decode(Code, Bin) ->
-    {ok, riak_pb_codec:decode(Code, Bin)}.
+    Msg = riak_pb_codec:decode(Code, Bin),
+    case Msg of
+        #rpbgetreq{} ->
+            {ok, Msg, {"riak_kv.get", Msg#rpbgetreq.bucket}};
+        #rpbputreq{} ->
+            {ok, Msg, {"riak_kv.put", Msg#rpbputreq.bucket}};
+        #rpbdelreq{} ->
+            {ok, Msg, {"riak_kv.delete", Msg#rpbdelreq.bucket}};
+        _ ->
+            {ok, Msg}
+    end.
 
 %% @doc encode/1 callback. Encodes an outgoing response message.
 encode(Message) ->

--- a/src/riak_kv_pb_object.erl
+++ b/src/riak_kv_pb_object.erl
@@ -82,11 +82,14 @@ decode(Code, Bin) ->
     Msg = riak_pb_codec:decode(Code, Bin),
     case Msg of
         #rpbgetreq{} ->
-            {ok, Msg, {"riak_kv.get", Msg#rpbgetreq.bucket}};
+            {ok, Msg, {"riak_kv.get", bucket_type(Msg#rpbgetreq.type,
+                                                        Msg#rpbgetreq.bucket)}};
         #rpbputreq{} ->
-            {ok, Msg, {"riak_kv.put", Msg#rpbputreq.bucket}};
+            {ok, Msg, {"riak_kv.put", bucket_type(Msg#rpbputreq.type,
+                                                        Msg#rpbputreq.bucket)}};
         #rpbdelreq{} ->
-            {ok, Msg, {"riak_kv.delete", Msg#rpbdelreq.bucket}};
+            {ok, Msg, {"riak_kv.delete", bucket_type(Msg#rpbdelreq.type,
+                                                           Msg#rpbdelreq.bucket)}};
         _ ->
             {ok, Msg}
     end.
@@ -348,6 +351,12 @@ maybe_bucket_type(undefined, B) ->
 maybe_bucket_type(<<"default">>, B) ->
     B;
 maybe_bucket_type(T, B) ->
+    {T, B}.
+
+%% always construct {Type, Bucket} tuple, filling in default type if needed
+bucket_type(undefined, B) ->
+    {<<"default">>, B};
+bucket_type(T, B) ->
     {T, B}.
 
 %% ===================================================================

--- a/src/riak_kv_wm_buckets.erl
+++ b/src/riak_kv_wm_buckets.erl
@@ -35,6 +35,7 @@
 -export([
          init/1,
          service_available/2,
+         is_authorized/2,
          forbidden/2,
          content_types_provided/2,
          encodings_provided/2,
@@ -49,7 +50,8 @@
           prefix,       %% string() - prefix for resource uris
           riak,         %% local | {node(), atom()} - params for riak client
           method,       %% atom() - HTTP method for the request
-          timeout       %% integer() - list buckets timeout
+          timeout,      %% integer() - list buckets timeout
+          security      %% security context
          }).
 
 -include_lib("webmachine/include/webmachine.hrl").
@@ -92,8 +94,38 @@ service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
              Ctx}
     end.
 
+is_authorized(ReqData, Ctx) ->
+    case riak_api_web_security:is_authorized(ReqData) of
+        false ->
+            {"Basic realm=\"Riak\"", ReqData, Ctx};
+        {true, SecContext} ->
+            {true, ReqData, Ctx#ctx{security=SecContext}};
+        insecure ->
+            %% XXX 301 may be more appropriate here, but since the http and
+            %% https port are different and configurable, it is hard to figure
+            %% out the redirect URL to serve.
+            {{halt, 426}, wrq:append_to_resp_body(<<"Security is enabled and "
+                    "Riak does not accept credentials over HTTP. Try HTTPS "
+                    "instead.">>, ReqData), Ctx}
+    end.
+
+forbidden(RD, Ctx = #ctx{security=undefined}) ->
+    {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx};
 forbidden(RD, Ctx) ->
-    {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx}.
+    case riak_kv_wm_utils:is_forbidden(RD) of
+        true ->
+            {true, RD, Ctx};
+        false ->
+            Res = riak_core_security:check_permission({"riak_kv.list_buckets",
+                                                       <<"default">>},
+                                                      Ctx#ctx.security),
+            case Res of
+                {false, Error, _} ->
+                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD), Ctx};
+                {true, _} ->
+                    {false, RD, Ctx}
+            end
+    end.
 
 %% @spec content_types_provided(reqdata(), context()) ->
 %%          {[{ContentType::string(), Producer::atom()}], reqdata(), context()}

--- a/src/riak_kv_wm_counter.erl
+++ b/src/riak_kv_wm_counter.erl
@@ -72,6 +72,7 @@
 -export([
          init/1,
          service_available/2,
+         is_authorized/2,
          forbidden/2,
          allowed_methods/2,
          malformed_request/2,
@@ -103,7 +104,8 @@
               doc,          %% {ok, riak_object()}|{error, term()} - the object found
               bucketprops,  %% proplist() - properties of the bucket
               method,       %% atom() - HTTP method for the request
-              counter_op    :: integer() | undefined %% The amount to add to the counter
+              counter_op   :: integer() | undefined, %% The amount to add to the counter
+              security      %% security context
              }).
 %% @type link() = {{Bucket::binary(), Key::binary()}, Tag::binary()}
 %% @type index_field() = {Key::string(), Value::string()}
@@ -152,8 +154,46 @@ service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
              Ctx}
     end.
 
-forbidden(RD, Ctx) ->
-    {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx}.
+is_authorized(ReqData, Ctx) ->
+    case riak_api_web_security:is_authorized(ReqData) of
+        false ->
+            {"Basic realm=\"Riak\"", ReqData, Ctx};
+        {true, SecContext} ->
+            {true, ReqData, Ctx#ctx{security=SecContext}};
+        insecure ->
+            %% XXX 301 may be more appropriate here, but since the http and
+            %% https port are different and configurable, it is hard to figure
+            %% out the redirect URL to serve.
+            {{halt, 426}, wrq:append_to_resp_body(<<"Security is enabled and "
+                    "Riak does not accept credentials over HTTP. Try HTTPS "
+                    "instead.">>, ReqData), Ctx}
+    end.
+
+forbidden(RD, Ctx = #ctx{security=undefined}) ->
+    {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx};
+forbidden(RD, Ctx=#ctx{security=Security}) ->
+    case riak_kv_wm_utils:is_forbidden(RD) of
+        true ->
+            {true, RD, Ctx};
+        false ->
+            Perm = case Ctx#ctx.method of
+                'POST' ->
+                    "riak_kv.put";
+                'GET' ->
+                    "riak_kv.get"
+            end,
+
+            Res = riak_core_security:check_permission({Perm,
+                                                           {<<"default">>,
+                                                            Ctx#ctx.bucket}},
+                                                           Security),
+            case Res of
+                {false, Error, _} ->
+                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD), Ctx};
+                {true, _} ->
+                    {false, RD, Ctx}
+            end
+    end.
 
 allowed_methods(RD, Ctx) ->
     {['GET', 'POST'], RD, Ctx}.

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -33,6 +33,7 @@
 -export([
          init/1,
          service_available/2,
+         is_authorized/2,
          forbidden/2,
          malformed_request/2,
          content_types_provided/2,
@@ -48,7 +49,8 @@
           index_query,   %% The query..
           max_results :: all | pos_integer(), %% maximum number of 2i results to return, the page size.
           return_terms = false :: boolean(), %% should the index values be returned
-          timeout :: non_neg_integer() | undefined | infinity
+          timeout :: non_neg_integer() | undefined | infinity,
+          security        %% security context
          }).
 
 -define(ALL_2I_RESULTS, all).
@@ -80,8 +82,40 @@ service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
              Ctx}
     end.
 
+is_authorized(ReqData, Ctx) ->
+    case riak_api_web_security:is_authorized(ReqData) of
+        false ->
+            {"Basic realm=\"Riak\"", ReqData, Ctx};
+        {true, SecContext} ->
+            {true, ReqData, Ctx#ctx{security=SecContext}};
+        insecure ->
+            %% XXX 301 may be more appropriate here, but since the http and
+            %% https port are different and configurable, it is hard to figure
+            %% out the redirect URL to serve.
+            {{halt, 426}, wrq:append_to_resp_body(<<"Security is enabled and "
+                    "Riak does not accept credentials over HTTP. Try HTTPS "
+                    "instead.">>, ReqData), Ctx}
+    end.
+
+forbidden(RD, Ctx = #ctx{security=undefined}) ->
+    {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx};
 forbidden(RD, Ctx) ->
-    {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx}.
+    case riak_kv_wm_utils:is_forbidden(RD) of
+        true ->
+            {true, RD, Ctx};
+        false ->
+            Bucket = list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, wrq:path_info(bucket, RD))),
+            Res = riak_core_security:check_permission({"riak_kv.index",
+                                                       {<<"default">>,
+                                                        Bucket}},
+                                                      Ctx#ctx.security),
+            case Res of
+                {false, Error, _} ->
+                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD), Ctx};
+                {true, _} ->
+                    {false, RD, Ctx}
+            end
+    end.
 
 %% @spec malformed_request(reqdata(), context()) ->
 %%          {boolean(), reqdata(), context()}

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -24,7 +24,7 @@
 
 -module(riak_kv_wm_mapred).
 
--export([init/1,allowed_methods/2, known_content_type/2, forbidden/2]).
+-export([init/1,allowed_methods/2, known_content_type/2, is_authorized/2, forbidden/2]).
 -export([malformed_request/2, process_post/2, content_types_provided/2]).
 -export([nop/2]).
 
@@ -36,14 +36,62 @@
 -define(DEFAULT_TIMEOUT, 60000).
 
 
--record(state, {inputs, timeout, mrquery, boundary}).
+-record(state, {inputs, timeout, mrquery, boundary, security}).
 -type state() :: #state{}.
 
 init(_) ->
     {ok, #state{}}.
 
+is_authorized(ReqData, State) ->
+    case riak_api_web_security:is_authorized(ReqData) of
+        false ->
+            {"Basic realm=\"Riak\"", ReqData, State};
+        {true, SecContext} ->
+            {true, ReqData, State#state{security=SecContext}};
+        insecure ->
+            %% XXX 301 may be more appropriate here, but since the http and
+            %% https port are different and configurable, it is hard to figure
+            %% out the redirect URL to serve.
+            {{halt, 426}, wrq:append_to_resp_body(<<"Security is enabled and "
+                    "Riak does not accept credentials over HTTP. Try HTTPS "
+                    "instead.">>, ReqData), State}
+    end.
+
+forbidden(RD, State = #state{security=undefined}) ->
+    {riak_kv_wm_utils:is_forbidden(RD), RD, State};
 forbidden(RD, State) ->
-    {riak_kv_wm_utils:is_forbidden(RD), RD, State}.
+    case riak_kv_wm_utils:is_forbidden(RD) of
+        true ->
+            {true, RD, State};
+        false ->
+            case {wrq:method(RD), wrq:req_body(RD)} of
+                {'POST', Body} when Body /= undefined ->
+                    case riak_kv_mapred_json:parse_request(Body) of
+                        {ok, ParsedInputs, _ParsedQuery, _Timeout} ->
+                            lager:info("MR inputs are ~p", [ParsedInputs]),
+                            Permissions = riak_kv_mapred_term:get_required_permissions(ParsedInputs,
+                                                                                       _ParsedQuery),
+                            lager:info("MR permissions are ~p",
+                                       [Permissions]),
+                            Res = riak_core_security:check_permissions(
+                                    Permissions,
+                                    State#state.security),
+                            case Res of
+                                {false, Error, _} ->
+                                    {true, wrq:append_to_resp_body(
+                                             list_to_binary(Error), RD), State};
+                                {true, _} ->
+                                    {false, RD, State}
+                            end;
+                        _ ->
+                            %% bad input, will be caught in verify_body
+                            {false, RD, State}
+                    end;
+                _ ->
+                    %% bad input, will be caught in verify_body
+                    {false, RD, State}
+            end
+    end.
 
 allowed_methods(RD, State) ->
     {['GET','HEAD','POST'], RD, State}.
@@ -123,6 +171,7 @@ check_body(RD, State) ->
 verify_body(Body, State) ->
     case riak_kv_mapred_json:parse_request(Body) of
         {ok, ParsedInputs, ParsedQuery, Timeout} ->
+            lager:info("MR inputs are ~p", [ParsedInputs]),
             {true, [], State#state{inputs=ParsedInputs,
                                    mrquery=ParsedQuery,
                                    timeout=Timeout}};

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -68,11 +68,8 @@ forbidden(RD, State) ->
                 {'POST', Body} when Body /= undefined ->
                     case riak_kv_mapred_json:parse_request(Body) of
                         {ok, ParsedInputs, _ParsedQuery, _Timeout} ->
-                            lager:info("MR inputs are ~p", [ParsedInputs]),
                             Permissions = riak_kv_mapred_term:get_required_permissions(ParsedInputs,
                                                                                        _ParsedQuery),
-                            lager:info("MR permissions are ~p",
-                                       [Permissions]),
                             Res = riak_core_security:check_permissions(
                                     Permissions,
                                     State#state.security),
@@ -171,7 +168,6 @@ check_body(RD, State) ->
 verify_body(Body, State) ->
     case riak_kv_mapred_json:parse_request(Body) of
         {ok, ParsedInputs, ParsedQuery, Timeout} ->
-            lager:info("MR inputs are ~p", [ParsedInputs]),
             {true, [], State#state{inputs=ParsedInputs,
                                    mrquery=ParsedQuery,
                                    timeout=Timeout}};

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -205,7 +205,8 @@ is_authorized(ReqData, Ctx) ->
                     case wrq:get_req_header("Authorization", ReqData) of
                         "Basic " ++ Base64 ->
                             UserPass = base64:decode_to_string(Base64),
-                            [User, Pass] = string:tokens(UserPass, ":"),
+                            [User, Pass] = [list_to_binary(X) || X <-
+                                                                 string:tokens(UserPass, ":")],
                             {ok, Peer} = inet_parse:address(wrq:peer(ReqData)),
                             case riak_core_security:authenticate(User, Pass,
                                     [{ip, Peer}])
@@ -268,7 +269,7 @@ forbidden(RD, Ctx=#ctx{security=Security}) ->
             end,
 
             {Res, _} = riak_core_security:check_permission(Perm,
-                                                           binary_to_list(Ctx#ctx.bucket),
+                                                           Ctx#ctx.bucket,
                                                            Security),
             case Res of
                 false ->

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -208,7 +208,7 @@ is_authorized(ReqData, Ctx) ->
                             [User, Pass] = string:tokens(UserPass, ":"),
                             {ok, Peer} = inet_parse:address(wrq:peer(ReqData)),
                             case riak_core_security:authenticate(User, Pass,
-                                    Peer)
+                                    [{ip, Peer}])
                                 of
                                 {ok, Sec} ->
                                     {true, Sec};

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -253,8 +253,6 @@ forbidden(RD, Ctx=#ctx{security=Security}) ->
                 {false, Error, _} ->
                     {true, wrq:append_to_resp_body(list_to_binary(Error), RD), Ctx};
                 {true, _} ->
-                    lager:info("authorized to ~p on ~p", [Perm,
-                                                          Ctx#ctx.bucket]),
                     case Perm of
                         "riak_kv.get" ->
                             %% Ensure the key is here, otherwise 404

--- a/src/riak_kv_wm_ping.erl
+++ b/src/riak_kv_wm_ping.erl
@@ -45,7 +45,8 @@ is_authorized(ReqData, Ctx) ->
                     case wrq:get_req_header("Authorization", ReqData) of
                         "Basic " ++ Base64 ->
                             UserPass = base64:decode_to_string(Base64),
-                            [User, Pass] = string:tokens(UserPass, ":"),
+                            [User, Pass] = [list_to_binary(X) || X <-
+                                                                 string:tokens(UserPass, ":")],
                             {ok, Peer} = inet_parse:address(wrq:peer(ReqData)),
                             case riak_core_security:authenticate(User, Pass,
                                                                  [{ip, Peer}])

--- a/src/riak_kv_wm_ping.erl
+++ b/src/riak_kv_wm_ping.erl
@@ -48,7 +48,7 @@ is_authorized(ReqData, Ctx) ->
                             [User, Pass] = string:tokens(UserPass, ":"),
                             {ok, Peer} = inet_parse:address(wrq:peer(ReqData)),
                             case riak_core_security:authenticate(User, Pass,
-                                    Peer)
+                                                                 [{ip, Peer}])
                                 of
                                 {ok, _} ->
                                     true;

--- a/src/riak_kv_wm_ping.erl
+++ b/src/riak_kv_wm_ping.erl
@@ -39,25 +39,30 @@ init([]) ->
 is_authorized(ReqData, Ctx) ->
     Res = case app_helper:get_env(riak_core, security, false) of
         true ->
-            lager:info("Auth header ~p",
-                       [wrq:get_req_header("Authorization", ReqData)]),
-            case wrq:get_req_header("Authorization", ReqData) of
-                "Basic " ++ Base64 ->
-                    UserPass = base64:decode_to_string(Base64),
-                    [User, Pass] = string:tokens(UserPass, ":"),
-                    {ok, Peer} = inet_parse:address(wrq:peer(ReqData)),
-                    lager:info("credentials ~p ~p from ~p", [User, Pass,
-                                                             Peer]),
-                    case riak_core_security:authenticate(User, Pass,
-                                                         Peer)
-                    of
-                        {ok, _} ->
-                            true;
-                        {error, _} ->
+            Scheme = wrq:scheme(ReqData),
+            case Scheme == https of
+                true ->
+                    case wrq:get_req_header("Authorization", ReqData) of
+                        "Basic " ++ Base64 ->
+                            UserPass = base64:decode_to_string(Base64),
+                            [User, Pass] = string:tokens(UserPass, ":"),
+                            {ok, Peer} = inet_parse:address(wrq:peer(ReqData)),
+                            case riak_core_security:authenticate(User, Pass,
+                                    Peer)
+                                of
+                                {ok, _} ->
+                                    true;
+                                {error, _} ->
+                                    false
+                            end;
+                        _ ->
                             false
                     end;
-                _ ->
-                    false
+                false ->
+                    %% security is enabled, but they're connecting over HTTP.
+                    %% which means if they authed, the credentials would be in
+                    %% plaintext
+                    insecure
             end;
         false ->
             true
@@ -66,7 +71,14 @@ is_authorized(ReqData, Ctx) ->
         false ->
             {"Basic realm=\"Riak\"", ReqData, Ctx};
         true ->
-            {true, ReqData, Ctx}
+            {true, ReqData, Ctx};
+        insecure ->
+            %% XXX 301 may be more appropriate here, but since the http and
+            %% https port are different and configurable, it is hard to figure
+            %% out the redirect URL to serve.
+            {{halt, 426}, wrq:append_to_resp_body(<<"Security is enabled and "
+                    "Riak does not accept credentials over HTTP. Try HTTPS "
+                    "instead.">>, ReqData), Ctx}
     end.
 
 to_html(ReqData, Ctx) ->

--- a/src/riak_kv_wm_props.erl
+++ b/src/riak_kv_wm_props.erl
@@ -55,6 +55,7 @@
 -export([
          init/1,
          service_available/2,
+         is_authorized/2,
          forbidden/2,
          allowed_methods/2,
          malformed_request/2,
@@ -74,7 +75,8 @@
               riak,         %% local | {node(), atom()} - params for riak client
               bucketprops,  %% proplist() - properties of the bucket
               method,       %% atom() - HTTP method for the request
-              api_version   %% non_neg_integer() - old or new http api
+              api_version,  %% non_neg_integer() - old or new http api
+              security      %% security context
              }).
 
 -include_lib("webmachine/include/webmachine.hrl").
@@ -116,8 +118,48 @@ service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
              Ctx}
     end.
 
-forbidden(RD, Ctx) ->
-    {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx}.
+is_authorized(ReqData, Ctx) ->
+    case riak_api_web_security:is_authorized(ReqData) of
+        false ->
+            {"Basic realm=\"Riak\"", ReqData, Ctx};
+        {true, SecContext} ->
+            {true, ReqData, Ctx#ctx{security=SecContext}};
+        insecure ->
+            %% XXX 301 may be more appropriate here, but since the http and
+            %% https port are different and configurable, it is hard to figure
+            %% out the redirect URL to serve.
+            {{halt, 426}, wrq:append_to_resp_body(<<"Security is enabled and "
+                    "Riak does not accept credentials over HTTP. Try HTTPS "
+                    "instead.">>, ReqData), Ctx}
+    end.
+
+forbidden(RD, Ctx = #ctx{security=undefined}) ->
+    {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx};
+forbidden(RD, Ctx=#ctx{security=Security}) ->
+    case riak_kv_wm_utils:is_forbidden(RD) of
+        true ->
+            {true, RD, Ctx};
+        false ->
+            Perm = case Ctx#ctx.method of
+                'PUT' ->
+                    "riak_core.set_bucket";
+                'GET' ->
+                    "riak_core.get_bucket";
+                'HEAD' ->
+                    "riak_core.get_bucket"
+            end,
+
+            Res = riak_core_security:check_permission({Perm,
+                                                           {<<"default">>,
+                                                            Ctx#ctx.bucket}},
+                                                           Security),
+            case Res of
+                {false, Error, _} ->
+                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD), Ctx};
+                {true, _} ->
+                    {false, RD, Ctx}
+            end
+    end.
 
 %% @spec allowed_methods(reqdata(), context()) ->
 %%          {[method()], reqdata(), context()}


### PR DESCRIPTION
This PR uses the new security APIs in riak_core to do permissions checking on various riak API endpoints.

It currently does not secure ALL of the APIs, specifically stats, link walking and the 'CS bucket' APIs are not covered.

See also basho/riak#355
