### PR TITLE
Fix rebar.config to use {branch, "name"}

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,17 +10,16 @@
                   ]}.
 
 {deps, [
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core", "develop"}},
-        {sidejob, ".*", {git, "git://github.com/basho/sidejob", "develop"}},
-        {erlang_js, ".*", {git, "git://github.com/basho/erlang_js", "develop"}},
-        {bitcask, ".*", {git, "git://github.com/basho/bitcask", "develop"}},
-        {ebloom, ".*", {git, "git://github.com/basho/ebloom", "develop"}},
-        {eper, ".*", {git, "git://github.com/basho/eper.git", "develop"}},
-        {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git",
-                          "master"}},
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core", {branch, "develop"}}},
+        {sidejob, ".*", {git, "git://github.com/basho/sidejob", {branch, "develop"}}},
+        {erlang_js, ".*", {git, "git://github.com/basho/erlang_js", {branch, "develop"}}},
+        {bitcask, ".*", {git, "git://github.com/basho/bitcask", {branch, "develop"}}},
+        {ebloom, ".*", {git, "git://github.com/basho/ebloom", {branch, "develop"}}},
+        {eper, ".*", {git, "git://github.com/basho/eper.git", {branch, "develop"}}},
+        {eleveldb, ".*", {git, "git://github.com/basho/eleveldb.git", {branch, "master"}}},
         {sext, ".*", {git, "git://github.com/uwiger/sext", {tag, "1.1-3-g3af5478"}}},
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git",
-                                "develop"}},
-        {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", "develop"}},
-        {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", "develop"}}
+                                {branch, "develop"}}},
+        {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {branch, "develop"}}},
+        {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {branch, "develop"}}}
        ]}.


### PR DESCRIPTION
The rebar.config file currently is using "develop" by itself, which does
not make rebar actually update that branch on update-deps.
