### PR TITLE
Set text/plain as content-type for permission errors

### DIFF
--- a/src/riak_kv_wm_buckets.erl
+++ b/src/riak_kv_wm_buckets.erl
@@ -121,7 +121,8 @@ forbidden(RD, Ctx) ->
                                                       Ctx#ctx.security),
             case Res of
                 {false, Error, _} ->
-                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD), Ctx};
+                    RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
+                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD1), Ctx};
                 {true, _} ->
                     {false, RD, Ctx}
             end

--- a/src/riak_kv_wm_crdt.erl
+++ b/src/riak_kv_wm_crdt.erl
@@ -197,7 +197,8 @@ forbidden(RD, Ctx=#ctx{security=Security}) ->
                                                            Security),
             case Res of
                 {false, Error, _} ->
-                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD), Ctx};
+                    RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
+                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD1), Ctx};
                 {true, _} ->
                     {false, RD, Ctx}
             end

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -111,7 +111,8 @@ forbidden(RD, Ctx) ->
                                                       Ctx#ctx.security),
             case Res of
                 {false, Error, _} ->
-                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD), Ctx};
+                    RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
+                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD1), Ctx};
                 {true, _} ->
                     {false, RD, Ctx}
             end

--- a/src/riak_kv_wm_keylist.erl
+++ b/src/riak_kv_wm_keylist.erl
@@ -133,7 +133,8 @@ forbidden(RD, Ctx) ->
                                                       Ctx#ctx.security),
             case Res of
                 {false, Error, _} ->
-                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD), Ctx};
+                    RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
+                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD1), Ctx};
                 {true, _} ->
                     {false, RD, Ctx}
             end

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -75,8 +75,9 @@ forbidden(RD, State) ->
                                     State#state.security),
                             case Res of
                                 {false, Error, _} ->
+                                    RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
                                     {true, wrq:append_to_resp_body(
-                                             list_to_binary(Error), RD), State};
+                                             list_to_binary(Error), RD1), State};
                                 {true, _} ->
                                     {false, RD, State}
                             end;

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -251,7 +251,8 @@ forbidden(RD, Ctx=#ctx{security=Security}) ->
                                                            Security),
             case Res of
                 {false, Error, _} ->
-                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD), Ctx};
+                    RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
+                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD1), Ctx};
                 {true, _} ->
                     case Perm of
                         "riak_kv.get" ->

--- a/src/riak_kv_wm_props.erl
+++ b/src/riak_kv_wm_props.erl
@@ -155,7 +155,8 @@ forbidden(RD, Ctx=#ctx{security=Security}) ->
                                                            Security),
             case Res of
                 {false, Error, _} ->
-                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD), Ctx};
+                    RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
+                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD1), Ctx};
                 {true, _} ->
                     {false, RD, Ctx}
             end


### PR DESCRIPTION
cc @seancribbs 
