### PR TITLE
bucket type console functions

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -37,7 +37,13 @@
          aae_status/1,
          reformat_indexes/1,
          reformat_objects/1,
-         reload_code/1]).
+         reload_code/1,
+         bucket_type_status/1,
+         bucket_type_activate/1,
+         bucket_type_create/1,
+         bucket_type_update/1,
+         bucket_type_reset/1,
+         bucket_type_list/1]).
 
 join([NodeStr]) ->
     join(NodeStr, fun riak_core:join/1,
@@ -434,6 +440,109 @@ run_reformat(M, F, A) ->
         Err:Reason ->
             lager:error("index reformat crashed with error type ~p and reason: ~p",
                         [Err, Reason])
+    end.
+
+bucket_type_status([TypeStr]) ->
+    Type = list_to_binary(TypeStr),
+    bucket_type_print_status(Type, riak_core_bucket_type:status(Type)),
+    bucket_type_print_props(riak_core_claimant:get_bucket_type(Type, undefined, false)).
+
+bucket_type_print_status(Type, undefined) ->
+    io:format("~s is not an existing bucket type~n", [Type]);
+bucket_type_print_status(Type, created) ->
+    io:format("~s has been created but cannot be activated yet~n", [Type]);
+bucket_type_print_status(Type, ready) ->
+    io:format("~s has been created and may be activated~n", [Type]);
+bucket_type_print_status(Type, active) ->
+    io:format("~s is active~n", [Type]).
+
+bucket_type_print_props(undefined) ->
+    ok;
+bucket_type_print_props(Props) ->
+    io:format("~n"),
+    [io:format("~p: ~p~n", [K, V]) || {K, V} <- Props].
+
+bucket_type_activate([TypeStr]) ->
+    Type = list_to_binary(TypeStr),
+    bucket_type_print_activate_result(Type, riak_core_bucket_type:activate(Type)).
+
+bucket_type_print_activate_result(Type, ok) ->
+    io:format("~s has been activated~n", [Type]);
+bucket_type_print_activate_result(Type, {error, undefined}) ->
+    bucket_type_print_status(Type, undefined);
+bucket_type_print_activate_result(Type, {error, not_ready}) ->
+    bucket_type_print_status(Type, created).
+
+bucket_type_create([TypeStr, PropsStr]) ->
+    Type = list_to_binary(TypeStr),
+    bucket_type_create(Type, catch mochijson2:decode(PropsStr)).
+
+bucket_type_create(Type, {struct, Fields}) ->
+    case proplists:get_value(<<"props">>, Fields) of
+        {struct, Props} ->
+            bucket_type_print_create_result(Type, riak_core_bucket_type:create(Type, Props));
+        _ ->
+            io:format("Cannot create bucket type ~s: no props field found in json~n", [Type]),
+            error
+    end;
+bucket_type_create(Type, _) ->
+    io:format("Cannot create bucket type ~s: invalid json~n", [Type]),
+    error.
+
+bucket_type_print_create_result(Type, ok) ->
+    io:format("~s created~n", [Type]);
+bucket_type_print_create_result(Type, {error, Reason}) ->
+    io:format("Error creating bucket type ~s: ~p~n", [Type, Reason]),
+    error.
+
+bucket_type_update([TypeStr, PropsStr]) ->
+    Type = list_to_binary(TypeStr),
+    bucket_type_update(Type, catch mochijson2:decode(PropsStr)).
+
+bucket_type_update(Type, {struct, Fields}) ->
+    case proplists:get_value(<<"props">>, Fields) of
+        {struct, Props} ->
+            bucket_type_print_update_result(Type, riak_core_bucket_type:update(Type, Props));
+        _ ->
+            io:format("Cannot create bucket type ~s: no props field found in json~n", [Type]),
+            error
+    end;
+bucket_type_update(Type, _) ->
+    io:format("Cannot update bucket type: ~s: invalid json~n", [Type]),
+    error.
+
+bucket_type_print_update_result(Type, ok) ->
+    io:format("~s updated~n", [Type]);
+bucket_type_print_update_result(Type, {error, Reason}) ->
+    io:format("Error updating bucket type ~s: ~p~n", [Type, Reason]),
+    error.
+
+bucket_type_reset([TypeStr]) ->
+    Type = list_to_binary(TypeStr),
+    bucket_type_print_reset_result(Type, riak_core_bucket_type:reset(Type)).
+
+bucket_type_print_reset_result(Type, ok) ->
+    io:format("~s reset~n", [Type]);
+bucket_type_print_reset_result(Type, {error, Reason}) ->
+    io:format("Error updating bucket type ~s: ~p~n", [Type, Reason]),
+    error.
+
+bucket_type_list([]) ->
+    It = riak_core_bucket_type:iterator(),
+    bucket_type_print_list(It).
+
+bucket_type_print_list(It) ->
+    case riak_core_bucket_type:itr_done(It) of
+        true ->
+            riak_core_bucket_type:itr_close(It);
+        false ->
+            {Type, Props} = riak_core_bucket_type:itr_value(It),
+            ActiveStr = case proplists:get_value(active, Props, false) of
+                            true -> "active";
+                            false -> "not active"
+                        end,
+            io:format("~s (~s)~n", [Type, ActiveStr]),
+            bucket_type_print_list(riak_core_bucket_type:itr_next(It))
     end.
 
 %%%===================================================================

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -480,7 +480,8 @@ bucket_type_create([TypeStr, PropsStr]) ->
 bucket_type_create(Type, {struct, Fields}) ->
     case proplists:get_value(<<"props">>, Fields) of
         {struct, Props} ->
-            bucket_type_print_create_result(Type, riak_core_bucket_type:create(Type, Props));
+            ErlProps = [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props],
+            bucket_type_print_create_result(Type, riak_core_bucket_type:create(Type, ErlProps));
         _ ->
             io:format("Cannot create bucket type ~s: no props field found in json~n", [Type]),
             error
@@ -502,7 +503,8 @@ bucket_type_update([TypeStr, PropsStr]) ->
 bucket_type_update(Type, {struct, Fields}) ->
     case proplists:get_value(<<"props">>, Fields) of
         {struct, Props} ->
-            bucket_type_print_update_result(Type, riak_core_bucket_type:update(Type, Props));
+            ErlProps = [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props],
+            bucket_type_print_update_result(Type, riak_core_bucket_type:update(Type, ErlProps));
         _ ->
             io:format("Cannot create bucket type ~s: no props field found in json~n", [Type]),
             error

--- a/src/riak_kv_wm_props.erl
+++ b/src/riak_kv_wm_props.erl
@@ -243,14 +243,14 @@ produce_bucket_body(RD, Ctx) ->
 
 get_bucket_props_json(Client, Bucket) ->
     Props1 = Client:get_bucket(Bucket),
-    Props2 = lists:map(fun jsonify_bucket_prop/1, Props1),
+    Props2 = lists:map(fun riak_kv_wm_utils:jsonify_bucket_prop/1, Props1),
     {?JSON_PROPS, {struct, Props2}}.
 
 %% @spec accept_bucket_body(reqdata(), context()) -> {true, reqdata(), context()}
 %% @doc Modify the bucket properties according to the body of the
 %%      bucket-level PUT request.
 accept_bucket_body(RD, Ctx=#ctx{bucket=B, client=C, bucketprops=Props}) ->
-    ErlProps = lists:map(fun erlify_bucket_prop/1, Props),
+    ErlProps = lists:map(fun riak_kv_wm_utils:erlify_bucket_prop/1, Props),
     case C:set_bucket(B, ErlProps) of
         ok ->
             {true, RD, Ctx};
@@ -265,105 +265,3 @@ accept_bucket_body(RD, Ctx=#ctx{bucket=B, client=C, bucketprops=Props}) ->
 delete_resource(RD, Ctx=#ctx{bucket=B, client=C}) ->
     C:reset_bucket(B),
     {true, RD, Ctx}.
-
-%% @spec jsonify_bucket_prop({Property::atom(), erlpropvalue()}) ->
-%%           {Property::binary(), jsonpropvalue()}
-%% @type erlpropvalue() = integer()|string()|boolean()|
-%%                        {modfun, atom(), atom()}|{atom(), atom()}
-%% @type jsonpropvalue() = integer()|string()|boolean()|{struct,[jsonmodfun()]}
-%% @type jsonmodfun() = {mod_binary(), binary()}|{fun_binary(), binary()}
-%% @doc Convert erlang bucket properties to JSON bucket properties.
-%%      Property names are converted from atoms to binaries.
-%%      Integer, string, and boolean property values are left as integer,
-%%      string, or boolean JSON values.
-%%      {modfun, Module, Function} or {Module, Function} values of the
-%%      linkfun and chash_keyfun properties are converted to JSON objects
-%%      of the form:
-%%        {"mod":ModuleNameAsString,
-%%         "fun":FunctionNameAsString}
-jsonify_bucket_prop({linkfun, {modfun, Module, Function}}) ->
-    {?JSON_LINKFUN, {struct, [{?JSON_MOD,
-                               list_to_binary(atom_to_list(Module))},
-                              {?JSON_FUN,
-                               list_to_binary(atom_to_list(Function))}]}};
-jsonify_bucket_prop({linkfun, {qfun, _}}) ->
-    {?JSON_LINKFUN, <<"qfun">>};
-jsonify_bucket_prop({linkfun, {jsfun, Name}}) ->
-    {?JSON_LINKFUN, {struct, [{?JSON_JSFUN, Name}]}};
-jsonify_bucket_prop({linkfun, {jsanon, {Bucket, Key}}}) ->
-    {?JSON_LINKFUN, {struct, [{?JSON_JSANON,
-                               {struct, [{?JSON_JSBUCKET, Bucket},
-                                         {?JSON_JSKEY, Key}]}}]}};
-jsonify_bucket_prop({linkfun, {jsanon, Source}}) ->
-    {?JSON_LINKFUN, {struct, [{?JSON_JSANON, Source}]}};
-jsonify_bucket_prop({chash_keyfun, {Module, Function}}) ->
-    {?JSON_CHASH, {struct, [{?JSON_MOD,
-                             list_to_binary(atom_to_list(Module))},
-                            {?JSON_FUN,
-                             list_to_binary(atom_to_list(Function))}]}};
-%% TODO Remove Legacy extractor prop in future version
-jsonify_bucket_prop({rs_extractfun, {modfun, M, F}}) ->
-    {?JSON_EXTRACT_LEGACY, {struct, [{?JSON_MOD,
-                                      list_to_binary(atom_to_list(M))},
-                                     {?JSON_FUN,
-                                      list_to_binary(atom_to_list(F))}]}};
-jsonify_bucket_prop({rs_extractfun, {{modfun, M, F}, Arg}}) ->
-    {?JSON_EXTRACT_LEGACY, {struct, [{?JSON_MOD,
-                                      list_to_binary(atom_to_list(M))},
-                                     {?JSON_FUN,
-                                      list_to_binary(atom_to_list(F))},
-                                     {?JSON_ARG, Arg}]}};
-jsonify_bucket_prop({search_extractor, {struct, _}=S}) ->
-    {?JSON_EXTRACT, S};
-jsonify_bucket_prop({search_extractor, {M, F}}) ->
-    {?JSON_EXTRACT, {struct, [{?JSON_MOD,
-                             list_to_binary(atom_to_list(M))},
-                              {?JSON_FUN,
-                               list_to_binary(atom_to_list(F))}]}};
-jsonify_bucket_prop({search_extractor, {M, F, Arg}}) ->
-    {?JSON_EXTRACT, {struct, [{?JSON_MOD,
-                               list_to_binary(atom_to_list(M))},
-                              {?JSON_FUN,
-                               list_to_binary(atom_to_list(F))},
-                              {?JSON_ARG, Arg}]}};
-
-jsonify_bucket_prop({Prop, Value}) ->
-    {list_to_binary(atom_to_list(Prop)), Value}.
-
-%% @spec erlify_bucket_prop({Property::binary(), jsonpropvalue()}) ->
-%%          {Property::atom(), erlpropvalue()}
-%% @doc The reverse of jsonify_bucket_prop/1.  Converts JSON representation
-%%      of bucket properties to their Erlang form.
-erlify_bucket_prop({?JSON_LINKFUN, {struct, Props}}) ->
-    case {proplists:get_value(?JSON_MOD, Props),
-          proplists:get_value(?JSON_FUN, Props)} of
-        {Mod, Fun} when is_binary(Mod), is_binary(Fun) ->
-            {linkfun, {modfun,
-                       list_to_existing_atom(binary_to_list(Mod)),
-                       list_to_existing_atom(binary_to_list(Fun))}};
-        {undefined, undefined} ->
-            case proplists:get_value(?JSON_JSFUN, Props) of
-                Name when is_binary(Name) ->
-                    {linkfun, {jsfun, Name}};
-                undefined ->
-                    case proplists:get_value(?JSON_JSANON, Props) of
-                        {struct, Bkey} ->
-                            Bucket = proplists:get_value(?JSON_JSBUCKET, Bkey),
-                            Key = proplists:get_value(?JSON_JSKEY, Bkey),
-                            %% bomb if malformed
-                            true = is_binary(Bucket) andalso is_binary(Key),
-                            {linkfun, {jsanon, {Bucket, Key}}};
-                        Source when is_binary(Source) ->
-                            {linkfun, {jsanon, Source}}
-                    end
-            end
-    end;
-erlify_bucket_prop({?JSON_CHASH, {struct, Props}}) ->
-    {chash_keyfun, {list_to_existing_atom(
-                      binary_to_list(
-                        proplists:get_value(?JSON_MOD, Props))),
-                    list_to_existing_atom(
-                      binary_to_list(
-                        proplists:get_value(?JSON_FUN, Props)))}};
-erlify_bucket_prop({Prop, Value}) ->
-    {list_to_existing_atom(binary_to_list(Prop)), Value}.


### PR DESCRIPTION
these live in kv because they rely on mochijson2 which is no longer in riak_core

This PR relies on https://github.com/basho/riak_core/pull/402 and https://github.com/basho/riak_kv/pull/673
