### PR TITLE
Add warning/max object limits

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1234,10 +1234,20 @@ do_get_binary(Bucket, Key, Mod, ModState) ->
 do_get_object(Bucket, Key, Mod, ModState) ->
     case uses_r_object(Mod, ModState, Bucket) of
         true ->
+            %% Non binary returns do not trigger size warnings
             Mod:get_object(Bucket, Key, false, ModState);
         false ->
             case do_get_binary(Bucket, Key, Mod, ModState) of
                 {ok, ObjBin, _UpdModState} ->
+                    BinSize = size(ObjBin),
+                    WarnSize = app_helper:get_env(riak_kv, warn_object_size),
+                    case BinSize > WarnSize of
+                        true ->
+                            lager:warning("Read large object ~p/~p (~p bytes)",
+                                          [Bucket, Key, BinSize]);
+                        false ->
+                            ok
+                    end,
                     try
                         case riak_object:from_binary(Bucket, Key, ObjBin) of
                             {error, Reason} ->
@@ -1701,13 +1711,55 @@ return_encoded_binary_object(Method, EncodedObject) ->
            {{error, Reason::term(), UpdModState::term()}, EncodedObj::binary()}.
 
 encode_and_put(Obj, Mod, Bucket, Key, IndexSpecs, ModState) ->
+    NumSiblings = riak_object:value_count(Obj),
+    case NumSiblings > app_helper:get_env(riak_kv, max_siblings) of
+        true ->
+            lager:error("Too many siblings for object ~p/~p (~p)",
+                        [Bucket, Key, NumSiblings]),
+            {{error, {too_many_siblings, NumSiblings}, ModState},
+             undefined};
+        false ->
+            case NumSiblings > app_helper:get_env(riak_kv, warn_siblings) of
+                true ->
+                    lager:warning("Too many siblings for object ~p/~p (~p)",
+                                  [Bucket, Key, NumSiblings]);
+                false ->
+                    ok
+            end,
+            encode_and_put_no_sib_check(Obj, Mod, Bucket, Key, IndexSpecs, ModState)
+    end.
+
+encode_and_put_no_sib_check(Obj, Mod, Bucket, Key, IndexSpecs, ModState) ->
     case uses_r_object(Mod, ModState, Bucket) of
         true ->
+            %% Non binary returning backends will have to handle size warnings
+            %% and errors themselves.
             Mod:put_object(Bucket, Key, IndexSpecs, Obj, ModState);
         false ->
             ObjFmt = riak_core_capability:get({riak_kv, object_format}, v0),
             EncodedVal = riak_object:to_binary(ObjFmt, Obj),
-            {Mod:put(Bucket, Key, IndexSpecs, EncodedVal, ModState), EncodedVal}
+            BinSize = size(EncodedVal),
+            %% Report or fail on large objects
+            case BinSize > app_helper:get_env(riak_kv, max_object_size) of
+                true ->
+                    lager:error("Object too large to write: ~p/~p ~p bytes",
+                                [Bucket, Key, BinSize]),
+                    {{error, {too_large, BinSize}, ModState},
+                     EncodedVal};
+                false ->
+                    WarnSize = app_helper:get_env(riak_kv, warn_object_size),
+                    case BinSize > WarnSize of
+                       true ->
+                            lager:warning("Writing very large object " ++
+                                          "(~p bytes) to ~p/~p",
+                                          [BinSize, Bucket, Key]);
+                        false ->
+                            ok
+                    end,
+                    PutRet = Mod:put(Bucket, Key, IndexSpecs, EncodedVal,
+                                     ModState),
+                    {PutRet, EncodedVal}
+            end
     end.
 
 uses_r_object(Mod, ModState, Bucket) ->


### PR DESCRIPTION
CSEs have wanted more visibility into sibling and object size explosions for a while. A warning threshold would make sure that the logs can be used to pinpoint or event prevent size and sibling number explosions.

We have also discussed putting hard limits on size and sibling number. Writes would fail for very large objects or objects with too many siblings. This should only be used as a last resort to prevent a cluster from experiencing severe performance problems that can result in cascaded deaths even
