### PR TITLE
Improve logging so we can tell which vnode failed to start up.

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -378,13 +378,13 @@ init([Index]) ->
                     {ok, State}
             end;
         {error, Reason} ->
-            lager:error("Failed to start index ~p backend ~p error: ~p",
-                        [Index, Mod, Reason]),
+            lager:error("Failed to start ~p backend for index ~p error: ~p",
+                        [Mod, Index, Reason]),
             riak:stop("backend module failed to start."),
             {error, Reason};
         {'EXIT', Reason1} ->
-            lager:error("Failed to start index ~p backend ~p crash: ~p",
-                        [Index, Mod, Reason1]),
+            lager:error("Failed to start ~p backend for index ~p crash: ~p",
+                        [Mod, Index, Reason1]),
             riak:stop("backend module failed to start."),
             {error, Reason1}
     end.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -378,13 +378,13 @@ init([Index]) ->
                     {ok, State}
             end;
         {error, Reason} ->
-            lager:error("Failed to start ~p Reason: ~p",
-                        [Mod, Reason]),
+            lager:error("Failed to start index ~p backend ~p error: ~p",
+                        [Index, Mod, Reason]),
             riak:stop("backend module failed to start."),
             {error, Reason};
         {'EXIT', Reason1} ->
-            lager:error("Failed to start ~p Reason: ~p",
-                        [Mod, Reason1]),
+            lager:error("Failed to start index ~p backend ~p crash: ~p",
+                        [Index, Mod, Reason1]),
             riak:stop("backend module failed to start."),
             {error, Reason1}
     end.


### PR DESCRIPTION
Was an issue resolving zd://6200.

Output after

```
2013-10-02 13:13:45.244 [error] <0.491.0>@riak_kv_vnode:init:381 Failed to start index 365375409332725729550921208179070754913983135744 backend riak_kv_bitcask_backend error: eacces
2013-10-02 13:13:45.249 [notice] <0.491.0>@riak:stop:43 "backend module failed to start."
```
