### PR TITLE
add option to filter keys that are no longer in preflist during fold

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -453,7 +453,6 @@ handle_command(#riak_kv_listkeys_req_v2{bucket=Input, req_id=ReqId, caller=Calle
             end,
             BufferFun =
                 fun(Results) ->
-                        lager:info("RESULTS: ~p", [Results]),
                         Caller ! {ReqId, {kl, Idx, Results}}
                 end,
             Extras = fold_extras(keys, Idx, Bucket),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -440,7 +440,7 @@ handle_command(#riak_kv_listkeys_req_v2{bucket=Input, req_id=ReqId, caller=Calle
                         UniqueResults = lists:usort(Results),
                         Caller ! {ReqId, {kl, Idx, UniqueResults}}
                 end,
-            FoldFun = fold_fun(buckets, BufferMod, Filter),
+            FoldFun = fold_fun(buckets, BufferMod, Filter, undefined),
             ModFun = fold_buckets;
         _ ->
             {ok, Capabilities} = Mod:capabilities(Bucket, ModState),
@@ -453,9 +453,11 @@ handle_command(#riak_kv_listkeys_req_v2{bucket=Input, req_id=ReqId, caller=Calle
             end,
             BufferFun =
                 fun(Results) ->
+                        lager:info("RESULTS: ~p", [Results]),
                         Caller ! {ReqId, {kl, Idx, Results}}
                 end,
-            FoldFun = fold_fun(keys, BufferMod, Filter),
+            Extras = fold_extras(keys, Idx, Bucket),
+            FoldFun = fold_fun(keys, BufferMod, Filter, Extras),
             ModFun = fold_keys
     end,
     Buffer = BufferMod:new(BufferSize, BufferFun),
@@ -644,8 +646,9 @@ handle_coverage(?KV_LISTBUCKETS_REQ{item_filter=ItemFilter},
     %% Construct the filter function
     Filter = riak_kv_coverage_filter:build_filter(all, ItemFilter, undefined),
     BufferMod = riak_kv_fold_buffer,
+
     Buffer = BufferMod:new(BufferSize, result_fun(Sender)),
-    FoldFun = fold_fun(buckets, BufferMod, Filter),
+    FoldFun = fold_fun(buckets, BufferMod, Filter, undefined),
     FinishFun = finish_fun(BufferMod, Sender),
     {ok, Capabilities} = Mod:capabilities(ModState),
     AsyncBackend = lists:member(async_fold, Capabilities),
@@ -742,7 +745,8 @@ handle_coverage_fold(FoldType, Bucket, ItemFilter, ResultFun,
     Filter = riak_kv_coverage_filter:build_filter(Bucket, ItemFilter, FilterVNode),
     BufferMod = riak_kv_fold_buffer,
     Buffer = BufferMod:new(BufferSize, ResultFun),
-    FoldFun = fold_fun(keys, BufferMod, Filter),
+    Extras = fold_extras(keys, Index, Bucket),
+    FoldFun = fold_fun(keys, BufferMod, Filter, Extras),
     FinishFun = finish_fun(BufferMod, Sender),
     {ok, Capabilities} = Mod:capabilities(Bucket, ModState),
     AsyncBackend = lists:member(async_fold, Capabilities),
@@ -1268,11 +1272,11 @@ list(FoldFun, FinishFun, Mod, ModFun, ModState, Opts, Buffer) ->
     end.
 
 %% @private
-fold_fun(buckets, BufferMod, none) ->
+fold_fun(buckets, BufferMod, none, _Extra) ->
     fun(Bucket, Buffer) ->
             BufferMod:add(Bucket, Buffer)
     end;
-fold_fun(buckets, BufferMod, Filter) ->
+fold_fun(buckets, BufferMod, Filter, _Extra) ->
     fun(Bucket, Buffer) ->
             case Filter(Bucket) of
                 true ->
@@ -1281,16 +1285,41 @@ fold_fun(buckets, BufferMod, Filter) ->
                     Buffer
             end
     end;
-fold_fun(keys, BufferMod, none) ->
+fold_fun(keys, BufferMod, none, undefined) ->
     fun(_, Key, Buffer) ->
             BufferMod:add(Key, Buffer)
     end;
-fold_fun(keys, BufferMod, Filter) ->
+fold_fun(keys, BufferMod, none, {Bucket, Index, N, NumPartitions}) ->
+    fun(_, Key, Buffer) ->
+            Hash = riak_core_util:chash_key({Bucket, Key}),
+            case riak_core_ring:future_index(Hash, Index, N, NumPartitions, NumPartitions) of
+                Index ->
+                    BufferMod:add(Key, Buffer);
+                _ ->
+                    Buffer
+            end
+    end;
+fold_fun(keys, BufferMod, Filter, undefined) ->
     fun(_, Key, Buffer) ->
             case Filter(Key) of
                 true ->
                     BufferMod:add(Key, Buffer);
                 false ->
+                    Buffer
+            end
+    end;
+fold_fun(keys, BufferMod, Filter, {Bucket, Index, N, NumPartitions}) ->
+    fun(_, Key, Buffer) ->
+            Hash = riak_core_util:chash_key({Bucket, Key}),
+            case riak_core_ring:future_index(Hash, Index, N, NumPartitions, NumPartitions) of
+                Index ->
+                    case Filter(Key) of
+                        true ->
+                            BufferMod:add(Key, Buffer);
+                        false ->
+                            Buffer
+                    end;
+                _ ->
                     Buffer
             end
     end.
@@ -1306,6 +1335,23 @@ result_fun(Bucket, Sender) ->
     fun(Items) ->
             riak_core_vnode:reply(Sender, {Bucket, Items})
     end.
+
+fold_extras(keys, Index, Bucket) ->
+    case app_helper:get_env(riak_kv, fold_preflist_filter, false) of
+        true ->
+            {ok, R} = riak_core_ring_manager:get_my_ring(),
+            NValMap = nval_map(R),
+            N = case lists:keyfind(Bucket, 1, NValMap) of
+                    false -> riak_core_bucket:default_object_nval();
+                    {Bucket, NVal} -> NVal
+                end,
+            NumPartitions = riak_core_ring:num_partitions(R),
+            {Bucket, Index, N, NumPartitions};
+        false ->
+            undefined
+    end;
+fold_extras(_, _, _) ->
+    undefined.
 
 %% wait for acknowledgement that results were received before
 %% continuing, as a way of providing backpressure for processes that


### PR DESCRIPTION
In cases like reducing n-value and ring resizing Riak may leave additional
replicas on a partition that no longer is a member of a preflist for the
replica's key. Riak does not (yet) clean up this data, and even if it did,
there would be a window between the time the data was considered "straggling"
and when it was deleted. To prevent this a filter for user-facing folds (not handoff
folds -- via FOLD_REQ) has been added to check whether or not the key being folded
over has the partition as a member of its preflist.

This change, also, does not affect bucket folds because during these
folds the keys are not exposed and it would be expensive to verify if
at least one key in the bucket had the partition as a member of its
preflist.

This PR relies on https://github.com/basho/riak_core/pull/410

These changes are primarily meant to address a known issue with ring resizing (see rehashing in "The Rest of the Story [here](https://github.com/basho/riak_core/pull/301) and the last para of @jtuple's comment [here](https://github.com/basho/riak_pipe/pull/76#issuecomment-18715817)). Of course, it comes at a cost: primarily, hashing each key on every iteration of the fold. It is behind an option for this reason. We could perhaps make this better by storing the hash of the object in its metadata, but this PR does not include that.

A possible way to verify these changes is to:
1. populate Riak using [mapred_verify](https://github.com/basho/mapred_verify)
2. run [mapred_verify](https://github.com/basho/mapred_verify) tests to make sure they pass
3. run a ring resize to completion
4. run [mapred_verify](https://github.com/basho/mapred_verify) tests and watch some fail
5. `application:set_env(riak_kv, fold_preflist_filter, true)` on each node
6. run [mapred_verify](https://github.com/basho/mapred_verify) tests and watch them pass

Any other user facing fold functions like list keys or 2i would hit this as well.
