### PR TITLE
Add bucket types support to HTTP.

### DIFF
--- a/src/riak_kv_mapred_json.erl
+++ b/src/riak_kv_mapred_json.erl
@@ -72,6 +72,9 @@ parse_request(Req) ->
             {error, not_json}
     end.
 
+parse_inputs([Type, Bucket]) when is_binary(Type),
+                                  is_binary(Bucket) ->
+    {ok, {Type, Bucket}};
 parse_inputs(Bucket) when is_binary(Bucket) ->
     {ok, Bucket};
 parse_inputs(Targets) when is_list(Targets) ->
@@ -147,6 +150,10 @@ parse_inputs([], Accum) ->
 parse_inputs([[Bucket, Key]|T], Accum) when is_binary(Bucket),
                                              is_binary(Key) ->
     parse_inputs(T, [{Bucket, Key}|Accum]);
+parse_inputs([[Type, Bucket, Key, KeyData]|T], Accum) when is_binary(Type),
+                                                           is_binary(Bucket),
+                                                           is_binary(Key) ->
+    parse_inputs(T, [{{{Type,Bucket}, Key}, KeyData}|Accum]);
 parse_inputs([[Bucket, Key, KeyData]|T], Accum) when is_binary(Bucket),
                                                       is_binary(Key) ->
     parse_inputs(T, [{{Bucket, Key}, KeyData}|Accum]);
@@ -208,7 +215,7 @@ is_index_input(Inputs) when is_list(Inputs)->
 is_index_input(_) -> false.
 
 parse_index_input(Inputs) ->
-    Bucket   = proplists:get_value(<<"bucket">>, Inputs),
+    Bucket   = normalize_bucket_and_type(proplists:get_value(<<"bucket">>, Inputs)),
     Index    = proplists:get_value(<<"index">>, Inputs),
     Key      = proplists:get_value(<<"key">>, Inputs),
     StartKey = proplists:get_value(<<"start">>, Inputs),
@@ -235,6 +242,12 @@ parse_index_input(Inputs) ->
             invalid_input_error(Inputs)
     end.
 
+normalize_bucket_and_type(Bucket) when is_binary(Bucket) ->
+    Bucket;
+normalize_bucket_and_type([Type, Bucket]) when is_binary(Bucket),
+                                               is_binary(Type) ->
+    {Type, Bucket}.
+
 is_keyfilter_input(Inputs) when is_list(Inputs) ->
     HasBucket = proplists:get_value(<<"bucket">>, Inputs) /= undefined,
     HasKeyFilters = proplists:get_value(<<"key_filters">>, Inputs) /= undefined,
@@ -242,7 +255,7 @@ is_keyfilter_input(Inputs) when is_list(Inputs) ->
 is_keyfilter_input(_) -> false.
 
 parse_keyfilter_input(Inputs) ->
-    Bucket = proplists:get_value(<<"bucket">>, Inputs),
+    Bucket = normalize_bucket_and_type(proplists:get_value(<<"bucket">>, Inputs)),
     KeyFilters = proplists:get_value(<<"key_filters">>, Inputs),
 
     case length(KeyFilters) >= 1 of
@@ -324,6 +337,9 @@ jsonify_bkeys(Results, HasMRQuery) when HasMRQuery == true ->
     Results;
 jsonify_bkeys(Results, HasMRQuery) when HasMRQuery == false ->
     jsonify_bkeys_1(Results, []).
+
+jsonify_bkeys_1([{{{T,B},K},D}|Rest], Acc) ->
+    jsonify_bkeys_1(Rest, [[T,B,K,D]|Acc]);
 jsonify_bkeys_1([{{B, K},D}|Rest], Acc) ->
     jsonify_bkeys_1(Rest, [[B,K,D]|Acc]);
 jsonify_bkeys_1([{B, K}|Rest], Acc) ->
@@ -558,7 +574,16 @@ key_input_test() ->
                       {{<<"b2">>, <<"k2">>}, <<"v2">>},
                       {{<<"b3">>, <<"k3">>}, <<"v3">>}
                      ]},
-    ?assertEqual(Expected2, parse_inputs(mochijson2:decode(JSON2))).
+    ?assertEqual(Expected2, parse_inputs(mochijson2:decode(JSON2))),
+
+    %% Test parsing bucket types
+    JSON3 = <<"[[\"t1\", \"b1\", \"k1\", \"v1\"], [\"t2\", \"b2\", \"k2\", \"v2\"], [\"t3\", \"b3\", \"k3\", \"v3\"]]">>,
+    Expected3 = {ok, [
+                      {{{<<"t1">>, <<"b1">>}, <<"k1">>}, <<"v1">>},
+                      {{{<<"t2">>, <<"b2">>}, <<"k2">>}, <<"v2">>},
+                      {{{<<"t3">>, <<"b3">>}, <<"k3">>}, <<"v3">>}
+                     ]},
+    ?assertEqual(Expected3, parse_inputs(mochijson2:decode(JSON3))).
 
 modfun_input_test() ->
     JSON = <<"{\"module\":\"mymod\",\"function\":\"myfun\",\"arg\":[1,2,3]}">>,
@@ -581,12 +606,21 @@ index_input_test() ->
 
     JSON2 = <<"{\"bucket\":\"mybucket\",\"index\":\"myindex_bin\", \"start\":\"vala\", \"end\":\"valb\"}">>,
     Expected2 = {ok, {index, <<"mybucket">>, <<"myindex_bin">>, <<"vala">>, <<"valb">>}},
-    ?assertEqual(Expected2, parse_inputs(mochijson2:decode(JSON2))).
+    ?assertEqual(Expected2, parse_inputs(mochijson2:decode(JSON2))),
+
+    JSON3 = <<"{\"bucket\":[\"mytype\",\"mybucket\"],\"index\":\"myindex_bin\", \"start\":\"vala\", \"end\":\"valb\"}">>,
+    Expected3 = {ok, {index, {<<"mytype">>,<<"mybucket">>}, <<"myindex_bin">>, <<"vala">>, <<"valb">>}},
+    ?assertEqual(Expected3, parse_inputs(mochijson2:decode(JSON3))).
 
 keyfilter_input_test() ->
     JSON = <<"{\"bucket\":\"mybucket\",\"key_filters\":[[\"match\", \"key.*\"]]}">>,
     Expected = {ok, {<<"mybucket">>, [[<<"match">>, <<"key.*">>]]}},
-    ?assertEqual(Expected, parse_inputs(mochijson2:decode(JSON))).
+    ?assertEqual(Expected, parse_inputs(mochijson2:decode(JSON))),
+
+    JSON2 = <<"{\"bucket\":[\"mytype\", \"mybucket\"],\"key_filters\":[[\"match\", \"key.*\"]]}">>,
+    Expected2 = {ok, {{<<"mytype">>,<<"mybucket">>}, [[<<"match">>, <<"key.*">>]]}},
+    ?assertEqual(Expected2, parse_inputs(mochijson2:decode(JSON2))).
+
 
 -define(DISCRETE_ERLANG_JOB, <<"{\"inputs\": [[\"foo\", \"bar\"]], \"query\":[{\"map\":{\"language\":\"erlang\","
                               "\"module\":\"foo\", \"function\":\"bar\", \"keep\": false}}]}">>).

--- a/src/riak_kv_web.erl
+++ b/src/riak_kv_web.erl
@@ -77,6 +77,9 @@ raw_dispatch(Name) ->
       riak_kv_wm_link_walker, Props1}
     ] ++
 
+   [ {["types", bucket_type, "props"], riak_kv_wm_bucket_type,
+      [{api_version, 3}|raw_props(Name)]} ] ++
+
    lists:flatten([
     [
      %% NEW API

--- a/src/riak_kv_web.erl
+++ b/src/riak_kv_web.erl
@@ -53,9 +53,8 @@ raw_dispatch() ->
 
 raw_dispatch(Name) ->
     Props1 = [{bucket_type, <<"default">>}, {api_version, 1}|raw_props(Name)],
-    Props2 = [{api_version, 2}|raw_props(Name)],
-    Props3 = [ {["types", bucket_type], Props2},
-               {[], [{bucket_type, <<"default">>}|Props2]}],
+    Props2 = [ {["types", bucket_type], [{api_version, 3}|raw_props(Name)]},
+               {[], [{bucket_type, <<"default">>}, {api_version, 2}|raw_props(Name)]}],
 
     [
      %% OLD API
@@ -105,7 +104,7 @@ raw_dispatch(Name) ->
      %% crdts
      {Prefix ++ ["buckets", bucket, crdt, key], {riak_kv_wm_crdt, known_type},
       riak_kv_wm_crdt, Props}
-    ] || {Prefix, Props} <- Props3 ]).
+    ] || {Prefix, Props} <- Props2 ]).
 
 is_post(Req) ->
     wrq:method(Req) == 'POST'.

--- a/src/riak_kv_web.erl
+++ b/src/riak_kv_web.erl
@@ -52,8 +52,11 @@ raw_dispatch() ->
     end.
 
 raw_dispatch(Name) ->
-    Props1 = [{api_version, 1}|raw_props(Name)],
+    Props1 = [{bucket_type, <<"default">>}, {api_version, 1}|raw_props(Name)],
     Props2 = [{api_version, 2}|raw_props(Name)],
+    Props3 = [ {["types", bucket_type], Props2},
+               {[], [{bucket_type, <<"default">>}|Props2]}],
+
     [
      %% OLD API
      {[Name],
@@ -72,34 +75,37 @@ raw_dispatch(Name) ->
       riak_kv_wm_object, Props1},
 
      {[Name, bucket, key, '*'],
-      riak_kv_wm_link_walker, Props1},
+      riak_kv_wm_link_walker, Props1}
+    ] ++
 
+   lists:flatten([
+    [
      %% NEW API
-     {["buckets"],
-      riak_kv_wm_buckets, Props2},
+     {Prefix ++ ["buckets"],
+      riak_kv_wm_buckets, Props},
 
-     {["buckets", bucket, "props"],
-      riak_kv_wm_props, Props2},
+     {Prefix ++ ["buckets", bucket, "props"],
+      riak_kv_wm_props, Props},
 
-     {["buckets", bucket, "keys"], fun is_post/1,
-      riak_kv_wm_object, Props2},
+     {Prefix ++ ["buckets", bucket, "keys"], fun is_post/1,
+      riak_kv_wm_object, Props},
 
-     {["buckets", bucket, "keys"],
-      riak_kv_wm_keylist, Props2},
+     {Prefix ++ ["buckets", bucket, "keys"],
+      riak_kv_wm_keylist, Props},
 
-     {["buckets", bucket, "keys", key],
-      riak_kv_wm_object, Props2},
+     {Prefix ++ ["buckets", bucket, "keys", key],
+      riak_kv_wm_object, Props},
 
-     {["buckets", bucket, "keys", key, '*'],
-      riak_kv_wm_link_walker, Props2},
+     {Prefix ++ ["buckets", bucket, "keys", key, '*'],
+      riak_kv_wm_link_walker, Props},
 
-     {["buckets", bucket, "index", field, '*'],
-      riak_kv_wm_index, Props2},
+     {Prefix ++ ["buckets", bucket, "index", field, '*'],
+      riak_kv_wm_index, Props},
 
      %% crdts
-     {["buckets", bucket, crdt, key], {riak_kv_wm_crdt, known_type},
-      riak_kv_wm_crdt, Props2}
-    ].
+     {Prefix ++ ["buckets", bucket, crdt, key], {riak_kv_wm_crdt, known_type},
+      riak_kv_wm_crdt, Props}
+    ] || {Prefix, Props} <- Props3 ]).
 
 is_post(Req) ->
     wrq:method(Req) == 'POST'.

--- a/src/riak_kv_wm_bucket_type.erl
+++ b/src/riak_kv_wm_bucket_type.erl
@@ -1,0 +1,273 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_wm_bucket_type: Webmachine resource for bucket type properties
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Resource for serving Riak bucket properties over HTTP.
+%%
+%% Available operations:
+%%
+%% GET /types/Type/props
+%%   Get information about the named Type, in JSON form:
+%%     {"props":{Prop1:Val1,Prop2:Val2,...}}
+%%   Each bucket-type property will be included in the "props" object.
+%%   "linkfun" and "chash_keyfun" properties will be encoded as
+%%   JSON objects of the form:
+%%     {"mod":ModuleName,
+%%      "fun":FunctionName}
+%%   Where ModuleName and FunctionName are each strings representing
+%%   a module and function.
+%%
+%% GET /types/Type/props
+%%   Modify bucket-type properties.
+%%   Content-type must be application/json, and the body must have
+%%   the form:
+%%     {"props":{Prop:Val}}
+%%   Where the "props" object takes the same form as returned from
+%%   a GET of the same resource.
+%%
+%% DELETE /types/Bucket/props
+%%   Reset bucket-type properties back to the default settings
+
+-module(riak_kv_wm_bucket_type).
+
+%% webmachine resource exports
+-export([
+         init/1,
+         service_available/2,
+         is_authorized/2,
+         forbidden/2,
+         allowed_methods/2,
+         malformed_request/2,
+         content_types_provided/2,
+         encodings_provided/2,
+         content_types_accepted/2,
+         resource_exists/2,
+         produce_bucket_type_body/2,
+         accept_bucket_type_body/2,
+         delete_resource/2
+        ]).
+
+%% @type context() = term()
+-record(ctx, {bucket_type,  %% binary() - Bucket type (from uri)
+              client,       %% riak_client() - the store client
+              prefix,       %% string() - prefix for resource uris
+              riak,         %% local | {node(), atom()} - params for riak client
+              bucketprops,  %% proplist() - properties of the bucket
+              method,       %% atom() - HTTP method for the request
+              api_version,  %% non_neg_integer() - old or new http api
+              security     %% security context
+             }).
+
+-include_lib("webmachine/include/webmachine.hrl").
+-include("riak_kv_wm_raw.hrl").
+
+%% @spec init(proplist()) -> {ok, context()}
+%% @doc Initialize this resource.  This function extracts the
+%%      'prefix' and 'riak' properties from the dispatch args.
+init(Props) ->
+    {ok, #ctx{
+            prefix=proplists:get_value(prefix, Props),
+            riak=proplists:get_value(riak, Props),
+            api_version=proplists:get_value(api_version,Props),
+            bucket_type=proplists:get_value(bucket_type, Props)
+           }}.
+
+%% @spec service_available(reqdata(), context()) ->
+%%          {boolean(), reqdata(), context()}
+%% @doc Determine whether or not a connection to Riak can be
+%%      established.  This function also takes this opportunity to extract
+%%      the 'bucket' bindings from the dispatch.
+service_available(RD, Ctx0=#ctx{riak=RiakProps}) ->
+    Ctx = riak_kv_wm_utils:ensure_bucket_type(RD, Ctx0, #ctx.bucket_type),
+    case riak_kv_wm_utils:get_riak_client(RiakProps, riak_kv_wm_utils:get_client_id(RD)) of
+        {ok, C} ->
+            {true, RD, Ctx#ctx{method=wrq:method(RD), client=C}};
+        Error ->
+            {false,
+             wrq:set_resp_body(
+               io_lib:format("Unable to connect to Riak: ~p~n", [Error]),
+               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx}
+    end.
+
+is_authorized(ReqData, Ctx) ->
+    case riak_api_web_security:is_authorized(ReqData) of
+        false ->
+            {"Basic realm=\"Riak\"", ReqData, Ctx};
+        {true, SecContext} ->
+            {true, ReqData, Ctx#ctx{security=SecContext}};
+        insecure ->
+            %% XXX 301 may be more appropriate here, but since the http and
+            %% https port are different and configurable, it is hard to figure
+            %% out the redirect URL to serve.
+            {{halt, 426}, wrq:append_to_resp_body(<<"Security is enabled and "
+                    "Riak does not accept credentials over HTTP. Try HTTPS "
+                    "instead.">>, ReqData), Ctx}
+    end.
+
+forbidden(RD, Ctx = #ctx{security=undefined}) ->
+    {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx};
+forbidden(RD, Ctx=#ctx{security=Security}) ->
+    case riak_kv_wm_utils:is_forbidden(RD) of
+        true ->
+            {true, RD, Ctx};
+        false ->
+            Perm = case Ctx#ctx.method of
+                'PUT' ->
+                    "riak_core.set_bucket_type";
+                'GET' ->
+                    "riak_core.get_bucket_type";
+                'HEAD' ->
+                    "riak_core.get_bucket_type";
+                'DELETE' ->
+                    "riak_core.set_bucket_type"
+            end,
+
+            Res = riak_core_security:check_permission({Perm, Ctx#ctx.bucket_type}, Security),
+            case Res of
+                {false, Error, _} ->
+                    RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
+                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD1), Ctx};
+                {true, _} ->
+                    forbidden_check_bucket_type(RD, Ctx)
+            end
+    end.
+
+%% @doc Detects whether the requested bucket-type exists.
+forbidden_check_bucket_type(RD, #ctx{method=M}=Ctx) when M =:= 'PUT'; 
+                                                         M =:= 'DELETE' ->
+    %% If the bucket type doesn't exist, we want to bail early so that
+    %% users cannot PUT/DELETE bucket types that don't exist.
+    case riak_kv_wm_utils:bucket_type_exists(Ctx#ctx.bucket_type) of
+        true ->
+            {false, RD, Ctx};
+        false ->
+            {{halt, 404},
+             wrq:set_resp_body(
+               io_lib:format("Cannot modify unknown bucket type: ~p", [Ctx#ctx.bucket_type]),
+               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx}
+    end;
+forbidden_check_bucket_type(RD, Ctx) ->
+    {false, RD, Ctx}.
+
+
+%% @spec allowed_methods(reqdata(), context()) ->
+%%          {[method()], reqdata(), context()}
+%% @doc Get the list of methods this resource supports.
+%%      Properties allows HEAD, GET, and PUT.
+allowed_methods(RD, Ctx) when Ctx#ctx.api_version =:= 3 ->
+    {['HEAD', 'GET', 'PUT', 'DELETE'], RD, Ctx}.
+
+%% @spec malformed_request(reqdata(), context()) ->
+%%          {boolean(), reqdata(), context()}
+%% @doc Determine whether query parameters, request headers,
+%%      and request body are badly-formed.
+%%      Body format is checked to be valid JSON, including
+%%      a "props" object for a bucket-PUT.
+malformed_request(RD, Ctx) when Ctx#ctx.method =:= 'PUT' ->
+    malformed_props(RD, Ctx);
+malformed_request(RD, Ctx) ->
+    {false, RD, Ctx}.
+
+%% @spec malformed_bucket_put(reqdata(), context()) ->
+%%          {boolean(), reqdata(), context()}
+%% @doc Check the JSON format of a bucket-level PUT.
+%%      Must be a valid JSON object, containing a "props" object.
+malformed_props(RD, Ctx) ->
+    case catch mochijson2:decode(wrq:req_body(RD)) of
+        {struct, Fields} ->
+            case proplists:get_value(?JSON_PROPS, Fields) of
+                {struct, Props} ->
+                    {false, RD, Ctx#ctx{bucketprops=Props}};
+                _ ->
+                    {true, props_format_message(RD), Ctx}
+            end;
+        _ ->
+            {true, props_format_message(RD), Ctx}
+    end.
+
+%% @spec bucket_format_message(reqdata()) -> reqdata()
+%% @doc Put an error about the format of the bucket-PUT body
+%%      in the response body of the reqdata().
+props_format_message(RD) ->
+    wrq:append_to_resp_body(
+      ["bucket type PUT must be a JSON object of the form:\n",
+       "{\"",?JSON_PROPS,"\":{...bucket properties...}}"],
+      wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)).
+
+
+resource_exists(RD, Ctx) ->
+    {riak_kv_wm_utils:bucket_type_exists(Ctx#ctx.bucket_type), RD, Ctx}.
+
+%% @spec content_types_provided(reqdata(), context()) ->
+%%          {[{ContentType::string(), Producer::atom()}], reqdata(), context()}
+%% @doc List the content types available for representing this resource.
+%%      "application/json" is the content-type for props requests.
+content_types_provided(RD, Ctx) ->
+    {[{"application/json", produce_bucket_type_body}], RD, Ctx}.
+
+%% @spec encodings_provided(reqdata(), context()) ->
+%%          {[{Encoding::string(), Producer::function()}], reqdata(), context()}
+%% @doc List the encodings available for representing this resource.
+%%      "identity" and "gzip" are available for props requests.
+encodings_provided(RD, Ctx) ->
+    {riak_kv_wm_utils:default_encodings(), RD, Ctx}.
+
+%% @spec content_types_accepted(reqdata(), context()) ->
+%%          {[{ContentType::string(), Acceptor::atom()}],
+%%           reqdata(), context()}
+%% @doc Get the list of content types this resource will accept.
+%%      "application/json" is the only type accepted for props PUT.
+content_types_accepted(RD, Ctx) ->
+    {[{"application/json", accept_bucket_type_body}], RD, Ctx}.
+
+%% @spec produce_bucket_body(reqdata(), context()) -> {binary(), reqdata(), context()}
+%% @doc Produce the bucket properties as JSON.
+produce_bucket_type_body(RD, Ctx) ->
+    Props = riak_core_bucket_type:get(Ctx#ctx.bucket_type),
+    JsonProps = mochijson2:encode(
+                  {struct, 
+                   [
+                    {?JSON_PROPS, 
+                     [ riak_kv_wm_utils:jsonify_bucket_prop(P) || P <- Props ]}
+                   ]}),
+    {JsonProps, RD, Ctx}.
+
+%% @spec accept_bucket_body(reqdata(), context()) -> {true, reqdata(), context()}
+%% @doc Modify the bucket properties according to the body of the
+%%      bucket-level PUT request.
+accept_bucket_type_body(RD, Ctx=#ctx{bucket_type=T, bucketprops=Props}) ->
+    ErlProps = lists:map(fun riak_kv_wm_utils:erlify_bucket_prop/1, Props),
+    case riak_core_bucket_type:update(T, ErlProps) of
+        ok ->
+            {true, RD, Ctx};
+        {error, Details} ->
+            JSON = mochijson2:encode(Details),
+            RD2 = wrq:append_to_resp_body(JSON, RD),
+            {{halt, 400}, RD2, Ctx}
+    end.
+
+%% @spec delete_resource(reqdata(), context()) -> {boolean, reqdata(), context()}
+%% @doc Reset the bucket properties back to the default values
+delete_resource(RD, Ctx=#ctx{bucket_type=T}) ->
+    ok = riak_core_bucket_type:reset(T),
+    {true, RD, Ctx}.

--- a/src/riak_kv_wm_buckets.erl
+++ b/src/riak_kv_wm_buckets.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_kv_wm_buckets - Webmachine resource for listing buckets.
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -24,10 +24,15 @@
 %%
 %% Available operations:
 %%
-%% GET /buckets?buckets=true (NEW) 
+%% GET /types/Type/buckets?buckets=true (with bucket-type)
+%% GET /types/Type/buckets?buckets=stream
+%% GET /buckets?buckets=true (NEW)
+%% GET /buckets?buckets=stream
 %% GET /Prefix?buckets=true
 %%   Get information about available buckets. Note that generating the
-%%   bucket list is expensive, so we require the "buckets=true" arg.
+%%   bucket list is expensive, so we require the "buckets=true" or
+%%   "buckets=stream" arg.
+%%
 
 -module(riak_kv_wm_buckets).
 
@@ -84,9 +89,9 @@ service_available(RD, Ctx0=#ctx{riak=RiakProps}) ->
     Ctx = riak_kv_wm_utils:ensure_bucket_type(RD, Ctx0, #ctx.bucket_type),
     case riak_kv_wm_utils:get_riak_client(RiakProps, riak_kv_wm_utils:get_client_id(RD)) of
         {ok, C} ->
-            {true, 
+            {true,
              RD,
-             Ctx#ctx{ 
+             Ctx#ctx{
                method=wrq:method(RD),
                client=C
               }};
@@ -159,7 +164,7 @@ malformed_timeout_param(RD, Ctx) ->
     case wrq:get_qs_value("timeout", none, RD) of
         none ->
             {false, RD, Ctx};
-        TimeoutStr -> 
+        TimeoutStr ->
             try
                 Timeout = list_to_integer(TimeoutStr),
                 {false, RD, Ctx#ctx{timeout=Timeout}}
@@ -169,7 +174,7 @@ malformed_timeout_param(RD, Ctx) ->
                      wrq:append_to_resp_body(io_lib:format("Bad timeout "
                                                            "value ~p~n",
                                                            [TimeoutStr]),
-                                             wrq:set_resp_header(?HEAD_CTYPE, 
+                                             wrq:set_resp_header(?HEAD_CTYPE,
                                                                  "text/plain", RD)),
                      Ctx}
             end
@@ -185,7 +190,7 @@ resource_exists(RD, #ctx{bucket_type=BType}=Ctx) ->
 produce_bucket_list(RD, #ctx{client=Client,
                              timeout=Timeout0,
                              bucket_type=BType}=Ctx) ->
-    Timeout = 
+    Timeout =
         case Timeout0 of
             undefined -> ?DEFAULT_TIMEOUT;
             Set -> Set
@@ -194,7 +199,7 @@ produce_bucket_list(RD, #ctx{client=Client,
         ?Q_TRUE ->
             %% Get the buckets.
             {ok, Buckets} = Client:list_buckets(none, Timeout, BType),
-            {mochijson2:encode({struct, [{?JSON_BUCKETS, Buckets}]}), 
+            {mochijson2:encode({struct, [{?JSON_BUCKETS, Buckets}]}),
              RD, Ctx};
         ?Q_STREAM ->
             F = fun() ->
@@ -208,15 +213,14 @@ produce_bucket_list(RD, #ctx{client=Client,
 
 stream_buckets(ReqId) ->
     receive
-        {ReqId, done} -> 
-                {mochijson2:encode({struct, 
+        {ReqId, done} ->
+                {mochijson2:encode({struct,
                                     [{<<"buckets">>, []}]}), done};
         {ReqId, _From, {buckets_stream, Buckets}} ->
-            {mochijson2:encode({struct, [{<<"buckets">>, Buckets}]}), 
+            {mochijson2:encode({struct, [{<<"buckets">>, Buckets}]}),
              fun() -> stream_buckets(ReqId) end};
         {ReqId, {buckets_stream, Buckets}} ->
             {mochijson2:encode({struct, [{<<"buckets">>, Buckets}]}),
              fun() -> stream_buckets(ReqId) end};
         {ReqId, timeout} -> {mochijson2:encode({struct, [{error, timeout}]}), done}
     end.
-

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_kv_wm_index - Webmachine resource for running index queries.
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -24,8 +24,26 @@
 %%
 %% Available operations:
 %%
-%% GET /buckets/bucket/indexes/index/op/arg1...
+%% GET /buckets/Bucket/index/IndexName/Key
+%% GET /buckets/Bucket/index/IndexName/Start/End
 %%   Run an index lookup, return the results as JSON.
+%%
+%% GET /types/Type/buckets/Bucket/index/IndexName/Key
+%% GET /types/Type/buckets/Bucket/index/IndexName/Start/End
+%%   Run an index lookup over the Bucket in BucketType, returning the
+%%   results in JSON.
+%%
+%% Both URL formats support the following query-string options:
+%%   * max_results=Integer
+%%         limits the number of results returned
+%%   * stream=true
+%%         streams the results back in multipart/mixed chunks
+%%   * continuation=C
+%%         the continuation returned from the last query, used to
+%%         fetch the next "page" of results.
+%%   * return_terms=true
+%%         when querying with a range, returns the value of the index
+%%         along with the key.
 
 -module(riak_kv_wm_index).
 

--- a/src/riak_kv_wm_keylist.erl
+++ b/src/riak_kv_wm_keylist.erl
@@ -3,7 +3,7 @@
 %% riak_kv_wm_keylist - Webmachine resource for listing
 %%                      the keys in a bucket.
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -25,6 +25,7 @@
 %%
 %% Available operations:
 %%
+%% GET /types/Type/buckets/Bucket/keys?keys=true|stream (with bucket-type)
 %% GET /buckets/Bucket/keys?keys=true|stream (NEW)
 %% GET /Prefix/Bucket?keys=true|stream (OLD)
 %%   Get the keys for a bucket. This is an expensive operation.
@@ -38,6 +39,7 @@
 %%   the user can also specify a 'props=true' to include props in the
 %%   JSON response. This provides backward compatibility with the
 %%   old HTTP API.
+%%
 
 -module(riak_kv_wm_keylist).
 
@@ -173,7 +175,7 @@ malformed_timeout_param(RD, Ctx) ->
     case wrq:get_qs_value("timeout", none, RD) of
         none ->
             {false, RD, Ctx};
-        TimeoutStr -> 
+        TimeoutStr ->
             try
                 Timeout = list_to_integer(TimeoutStr),
                 {false, RD, Ctx#ctx{timeout=Timeout}}
@@ -183,7 +185,7 @@ malformed_timeout_param(RD, Ctx) ->
                      wrq:append_to_resp_body(io_lib:format("Bad timeout "
                                                            "value ~p~n",
                                                            [TimeoutStr]),
-                                             wrq:set_resp_header(?HEAD_CTYPE, 
+                                             wrq:set_resp_header(?HEAD_CTYPE,
                                                                  "text/plain", RD)),
                      Ctx}
             end
@@ -219,7 +221,7 @@ produce_bucket_body(RD, #ctx{client=Client,
         ?Q_STREAM ->
             %% Start streaming the keys...
             F = fun() ->
-                        {ok, ReqId} = Client:stream_list_keys(Bucket, 
+                        {ok, ReqId} = Client:stream_list_keys(Bucket,
                                                               Timeout),
                         stream_keys(ReqId)
                 end,

--- a/src/riak_kv_wm_keylist.erl
+++ b/src/riak_kv_wm_keylist.erl
@@ -231,7 +231,7 @@ produce_bucket_body(RD, #ctx{client=Client,
                 case Ctx#ctx.api_version of
                     1 ->
                         mochijson2:encode({struct, BucketPropsJson});
-                    2 ->
+                    Two when Two >= 2 ->
                         []
                 end,
             {{stream, {FirstResult, F}}, RD, Ctx};

--- a/src/riak_kv_wm_link_walker.erl
+++ b/src/riak_kv_wm_link_walker.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_kv_wm_link_walker: HTTP access to Riak link traversal
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/riak_kv_wm_link_walker.erl
+++ b/src/riak_kv_wm_link_walker.erl
@@ -141,6 +141,7 @@
 -record(ctx, {api_version, %% integer() - Determine which version of the API to use.
               prefix,      %% string() - prefix for resource urls
               riak,        %% local | {node(), atom()} - params for riak client
+              bucket_type, %% string() - bucket type (from uri)
               bucket,      %% binary() - Bucket name (from uri)
               key,         %% binary() - Key (from uri),
               linkquery,
@@ -200,7 +201,8 @@ init(Props) ->
     {ok, #ctx{api_version=proplists:get_value(api_version, Props),
               prefix=proplists:get_value(prefix, Props),
               riak=proplists:get_value(riak, Props),
-              cache_secs=proplists:get_value(cache_secs, Props, 600)
+              cache_secs=proplists:get_value(cache_secs, Props, 600),
+              bucket_type=proplists:get_value(bucket_type, Props)
              }}.
 
 %% @spec malformed_request(reqdata(), context()) ->
@@ -229,7 +231,8 @@ malformed_request(RD, Ctx) ->
 %%      can be established.  This function also takes this
 %%      opportunity to extract the 'bucket' and 'key' path
 %%      bindings from the dispatch.
-service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
+service_available(RD, Ctx0=#ctx{riak=RiakProps}) ->
+    Ctx = riak_kv_wm_utils:ensure_bucket_type(RD, Ctx0, #ctx.bucket_type),
     case riak_kv_wm_utils:get_riak_client(RiakProps, riak_kv_wm_utils:get_client_id(RD)) of
         {ok, C} ->
             CtxBucket =
@@ -252,7 +255,16 @@ service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
     end.
 
 forbidden(RD, Ctx) ->
-    {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx}.
+    case Ctx#ctx.bucket_type of
+        <<"default">> ->
+            {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx};
+        _Other ->
+            RD1 = wrq:set_resp_header(?HEAD_CTYPE, "text/plain"),
+            {true,
+             wrq:set_resp_body("Link-walking is not allowed on keys stored in "
+                               "bucket-types.", RD1),
+             Ctx}
+    end.
 
 %% @spec allowed_methods(reqdata(), context()) ->
 %%          {[method()], reqdata(), context()}

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_kv_wm_mapred: webmachine resource for mapreduce requests
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -215,7 +215,7 @@ pipe_mapred(RD,
                     pipe_mapred_nonchunked(RD, State, Mrc)
             end;
         {error, {Fitting, Reason}} ->
-            {{halt, 400}, 
+            {{halt, 400},
              send_error({error, [{phase, Fitting},
                                  {error, iolist_to_binary(Reason)}]}, RD),
              State}
@@ -274,7 +274,7 @@ pipe_mapred_chunked(RD, State, Mrc) ->
      BoundaryState}.
 
 pipe_stream_mapred_results(RD,
-                           #state{boundary=Boundary}=State, 
+                           #state{boundary=Boundary}=State,
                            Mrc) ->
     case riak_kv_mrc_pipe:receive_sink(Mrc) of
         {ok, Done, Outputs} ->

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -124,6 +124,7 @@
 
 %% @type context() = term()
 -record(ctx, {api_version,  %% integer() - Determine which version of the API to use.
+              bucket_type,  %% binary() - Bucket type (from uri)
               bucket,       %% binary() - Bucket name (from uri)
               key,          %% binary() - Key (from uri)
               client,       %% riak_client() - the store client
@@ -161,7 +162,8 @@
 init(Props) ->
     {ok, #ctx{api_version=proplists:get_value(api_version, Props),
               prefix=proplists:get_value(prefix, Props),
-              riak=proplists:get_value(riak, Props)}}.
+              riak=proplists:get_value(riak, Props),
+              bucket_type=proplists:get_value(bucket_type, Props)}}.
 
 %% @spec service_available(reqdata(), context()) ->
 %%          {boolean(), reqdata(), context()}
@@ -170,7 +172,8 @@ init(Props) ->
 %%      opportunity to extract the 'bucket' and 'key' path
 %%      bindings from the dispatch, as well as any vtag
 %%      query parameter.
-service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
+service_available(RD, Ctx0=#ctx{riak=RiakProps}) ->
+    Ctx = riak_kv_wm_utils:ensure_bucket_type(RD, Ctx0, #ctx.bucket_type),
     case riak_kv_wm_utils:get_riak_client(RiakProps, riak_kv_wm_utils:get_client_id(RD)) of
         {ok, C} ->
             {true,
@@ -217,12 +220,12 @@ forbidden(RD, Ctx=#ctx{security=undefined}) ->
             {true, RD, Ctx};
         false ->
             %% If it is a put or a post, don't require the object to already
-            %% exist.
+            %% exist, but the bucket type must exist.
             case Ctx#ctx.method of
                 'POST' ->
-                    {false, RD, Ctx};
+                    forbidden_check_bucket_type(RD, Ctx);
                 'PUT' ->
-                    {false, RD, Ctx};
+                    forbidden_check_bucket_type(RD, Ctx);
                 _ ->
                     forbidden_check_doc(RD, Ctx)
             end
@@ -246,7 +249,7 @@ forbidden(RD, Ctx=#ctx{security=Security}) ->
             end,
 
             Res = riak_core_security:check_permission({Perm,
-                                                           {<<"default">>,
+                                                           {Ctx#ctx.bucket_type,
                                                             Ctx#ctx.bucket}},
                                                            Security),
             case Res of
@@ -262,12 +265,13 @@ forbidden(RD, Ctx=#ctx{security=Security}) ->
                             %% assumes that the key is present.
                             forbidden_check_doc(RD, Ctx);
                         _ ->
-                            {false, RD, Ctx}
+                            %% Ensure the bucket type exists, otherwise 404 early.
+                            forbidden_check_bucket_type(RD, Ctx)
                     end
             end
     end.
 
-%% @doc Detects whether fetching the requeste object results in an
+%% @doc Detects whether fetching the requested object results in an
 %% error.
 forbidden_check_doc(RD, Ctx) ->
     DocCtx = ensure_doc(Ctx),
@@ -276,6 +280,15 @@ forbidden_check_doc(RD, Ctx) ->
             handle_common_error(Reason, RD, DocCtx);
         _ ->
             {false, RD, DocCtx}
+    end.
+
+%% @doc Detects whether the requested object's bucket-type exists.
+forbidden_check_bucket_type(RD, Ctx) ->
+    case riak_kv_wm_utils:bucket_type_exists(Ctx#ctx.bucket_type) of
+        true ->
+            {false, RD, Ctx};
+        false ->
+            handle_common_error(bucket_type_unknown, RD, Ctx)
     end.
 
 %% @spec allowed_methods(reqdata(), context()) ->
@@ -668,11 +681,11 @@ post_is_create(RD, Ctx) ->
 %% @doc Choose the Key for the document created during a bucket-level POST.
 %%      This function also sets the Location header to generate a
 %%      201 Created response.
-create_path(RD, Ctx=#ctx{prefix=P, bucket=B, api_version=V}) ->
+create_path(RD, Ctx=#ctx{prefix=P, bucket_type=T, bucket=B, api_version=V}) ->
     K = riak_core_util:unique_id_62(),
     {K,
      wrq:set_resp_header("Location",
-                         riak_kv_wm_utils:format_uri(B, K, P, V),
+                         riak_kv_wm_utils:format_uri(T, B, K, P, V),
                          RD),
      Ctx#ctx{key=list_to_binary(K)}}.
 
@@ -685,10 +698,10 @@ process_post(RD, Ctx) -> accept_doc_body(RD, Ctx).
 %% @doc Store the data the client is PUTing in the document.
 %%      This function translates the headers and body of the HTTP request
 %%      into their final riak_object() form, and executes the Riak put.
-accept_doc_body(RD, Ctx=#ctx{bucket=B, key=K, client=C, links=L, index_fields=IF}) ->
-    Doc0 = case Ctx#ctx.doc of
+accept_doc_body(RD, Ctx=#ctx{bucket_type=T, bucket=B, key=K, client=C, links=L, index_fields=IF}) ->
+    Doc0 = case {Ctx#ctx.doc, T} of
                {ok, D} -> D;
-               _       -> riak_object:new(B, K, <<>>)
+               _       -> riak_object:new(maybe_bucket_type(T,B), K, <<>>)
            end,
     VclockDoc = riak_object:set_vclock(Doc0, decode_vclock_header(RD)),
     {CType, Charset} = extract_content_type(RD),
@@ -944,23 +957,28 @@ decode_vclock_header(RD) ->
 %%      worry about the order of executing of those places.
 ensure_doc(Ctx=#ctx{doc=undefined, key=undefined}) ->
     Ctx#ctx{doc={error, notfound}};
-ensure_doc(Ctx=#ctx{doc=undefined, bucket=B, key=K, client=C,
+ensure_doc(Ctx=#ctx{doc=undefined, bucket_type=T, bucket=B, key=K, client=C,
                     basic_quorum=Quorum, notfound_ok=NotFoundOK}) ->
-    Options0 = [deletedvclock, {basic_quorum, Quorum},
-                {notfound_ok, NotFoundOK}],
-    Options = make_options(Options0, Ctx),
-    Ctx#ctx{doc=C:get(B, K, Options)};
+    case riak_kv_wm_utils:bucket_type_exists(T) of
+        true ->
+            Options0 = [deletedvclock, {basic_quorum, Quorum},
+                        {notfound_ok, NotFoundOK}],
+            Options = make_options(Options0, Ctx),
+            Ctx#ctx{doc=C:get(maybe_bucket_type(T,B), K, Options)};
+        false ->
+            Ctx#ctx{doc={error, bucket_type_unknown}}
+    end;
 ensure_doc(Ctx) -> Ctx.
 
 %% @spec delete_resource(reqdata(), context()) -> {true, reqdata(), context()}
 %% @doc Delete the document specified.
-delete_resource(RD, Ctx=#ctx{bucket=B, key=K, client=C}) ->
+delete_resource(RD, Ctx=#ctx{bucket_type=T, bucket=B, key=K, client=C}) ->
     Options = make_options([], Ctx),
     Result = case wrq:get_req_header(?HEAD_VCLOCK, RD) of
         undefined ->
-            C:delete(B,K,Options);
+            C:delete(maybe_bucket_type(T,B),K,Options);
         _ ->
-            C:delete_vclock(B,K,decode_vclock_header(RD),Options)
+            C:delete_vclock(maybe_bucket_type(T,B),K,decode_vclock_header(RD),Options)
     end,
     case Result of
         {error, Reason} ->
@@ -989,7 +1007,7 @@ generate_etag(RD, Ctx) ->
             {dict:fetch(?MD_VTAG, MD), RD, Ctx};
         multiple_choices ->
             {ok, Doc} = Ctx#ctx.doc,
-            <<ETag:128/integer>> = 
+            <<ETag:128/integer>> =
                 md5(term_to_binary(riak_object:vclock(Doc))),
             {riak_core_util:integer_to_list(ETag, 62), RD, Ctx}
     end.
@@ -1046,7 +1064,8 @@ get_link_heads(RD, Ctx) ->
                 {ok, BucketRegex} = re:compile("</" ++ Prefix ++ "/([^/]+)>; ?rel=\"([^\"]+)\""),
                 {ok, KeyRegex} = re:compile("</" ++ Prefix ++ "/([^/]+)/([^/]+)>; ?riaktag=\"([^\"]+)\""),
                 extract_links(LinkHeaders1, BucketRegex, KeyRegex);
-            2 ->
+            %% @todo Handle links in API Version 3?
+            Two when Two >= 2 ->
                 {ok, BucketRegex} = re:compile("</buckets/([^/]+)>; ?rel=\"([^\"]+)\""),
                 {ok, KeyRegex} = re:compile("</buckets/([^/]+)/keys/([^/]+)>; ?riaktag=\"([^\"]+)\""),
                 extract_links(LinkHeaders1, BucketRegex, KeyRegex)
@@ -1139,6 +1158,12 @@ handle_common_error(Reason, RD, Ctx) ->
                         io_lib:format("not found~n",[]),
                         RD)),
                 Ctx};
+        {error, bucket_type_unknown} ->
+            {{halt, 404},
+             wrq:set_resp_body(
+               io_lib:format("Unknown bucket type: ~p", [Ctx#ctx.bucket_type]),
+               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx};
         {error, {deleted, _VClock}} ->
             {{halt, 404},
                 wrq:set_resp_header("Content-Type", "text/plain",
@@ -1195,3 +1220,12 @@ make_options(Prev, Ctx) ->
     NewOpts = [ {Opt, Val} || {Opt, Val} <- NewOpts0,
                               Val /= undefined, Val /= default ],
     Prev ++ NewOpts.
+
+%% Construct a {Type, Bucket} tuple, if not working with the default bucket
+%% @todo factor this into another module, copied from riak_kv_pb_object
+maybe_bucket_type(undefined, B) ->
+    B;
+maybe_bucket_type(<<"default">>, B) ->
+    B;
+maybe_bucket_type(T, B) ->
+    {T, B}.

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -1161,7 +1161,7 @@ handle_common_error(Reason, RD, Ctx) ->
         {error, bucket_type_unknown} ->
             {{halt, 404},
              wrq:set_resp_body(
-               io_lib:format("Unknown bucket type: ~p", [Ctx#ctx.bucket_type]),
+               io_lib:format("Unknown bucket type: ~s", [Ctx#ctx.bucket_type]),
                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx};
         {error, {deleted, _VClock}} ->

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -978,7 +978,7 @@ delete_resource(RD, Ctx=#ctx{bucket_type=T, bucket=B, key=K, client=C}) ->
         undefined ->
             C:delete(riak_kv_wm_utils:maybe_bucket_type(T,B),K,Options);
         _ ->
-            C:delete_vclock(riak_kv_wm_utils:maybe_bucket_type(T,B),xK,decode_vclock_header(RD),Options)
+            C:delete_vclock(riak_kv_wm_utils:maybe_bucket_type(T,B),K,decode_vclock_header(RD),Options)
     end,
     case Result of
         {error, Reason} ->

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_kv_wm_object: Webmachine resource for KV object level operations.
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -24,11 +24,13 @@
 %%
 %% Available operations:
 %%
+%% POST /types/Type/buckets/Bucket/keys (with bucket-type)
 %% POST /buckets/Bucket/keys (NEW)
 %% POST /Prefix/Bucket (OLD)
 %%   Equivalent to "PUT /Prefix/Bucket/Key" where Key is chosen
 %%   by the server.
 %%
+%% GET /types/Type/buckets/Bucket/keys/Key (with bucket-type)
 %% GET /buckets/Bucket/keys/Key (NEW)
 %% GET /Prefix/Bucket/Key (OLD)
 %%   Get the data stored in the named Bucket under the named Key.
@@ -54,6 +56,7 @@
 %%   sibling, include the query param "vtag=V", where V is the vtag
 %%   of the sibling you want.
 %%
+%% PUT /types/Type/buckets/Bucket/keys/Key (with bucket-type)
 %% PUT /buckets/Bucket/keys/Key (NEW)
 %% PUT /Prefix/Bucket/Key (OLD)
 %%   Store new data in the named Bucket under the named Key.
@@ -81,11 +84,13 @@
 %%   to determine whether or not the resource exists). A default
 %%   r-value of 2 will be used if none is specified.
 %%
+%% POST /types/Type/buckets/Bucket/keys/Key (with bucket-type)
 %% POST /buckets/Bucket/keys/Key (NEW)
 %% POST /Prefix/Bucket/Key (OLD)
 %%   Equivalent to "PUT /Prefix/Bucket/Key" (useful for clients that
 %%   do not support the PUT method).
 %%
+%% DELETE /types/Type/buckets/Bucket/keys/Key (with bucket-type)
 %% DELETE /buckets/Bucket/keys/Key (NEW)
 %% DELETE /Prefix/Bucket/Key (OLD)
 %%   Delete the data stored in the named Bucket under the named Key.

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -699,7 +699,7 @@ process_post(RD, Ctx) -> accept_doc_body(RD, Ctx).
 %%      This function translates the headers and body of the HTTP request
 %%      into their final riak_object() form, and executes the Riak put.
 accept_doc_body(RD, Ctx=#ctx{bucket_type=T, bucket=B, key=K, client=C, links=L, index_fields=IF}) ->
-    Doc0 = case {Ctx#ctx.doc, T} of
+    Doc0 = case Ctx#ctx.doc of
                {ok, D} -> D;
                _       -> riak_object:new(riak_kv_wm_utils:maybe_bucket_type(T,B), K, <<>>)
            end,

--- a/src/riak_kv_wm_ping.erl
+++ b/src/riak_kv_wm_ping.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_kv_wm_ping: simple Webmachine resource for availability test
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/riak_kv_wm_props.erl
+++ b/src/riak_kv_wm_props.erl
@@ -1,8 +1,8 @@
 %% -------------------------------------------------------------------
 %%
-%% raw_http_resource: Webmachine resource for listing bucket properties.
+%% riak_kv_wm_props: Webmachine resource for listing bucket properties.
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -24,6 +24,7 @@
 %%
 %% Available operations:
 %%
+%% GET /types/Type/buckets/Bucket/props (with bucket-type)
 %% GET /buckets/Bucket/props (NEW)
 %% GET /Prefix/Bucket (OLD)
 %%   Get information about the named Bucket, in JSON form:
@@ -36,7 +37,8 @@
 %%   Where ModuleName and FunctionName are each strings representing
 %%   a module and function.
 %%
-%% GET /buckets/Bucket/props
+%% PUT /types/Type/buckets/Bucket/props (with bucket-type)
+%% PUT /buckets/Bucket/props
 %% PUT /Prefix/Bucket (OLD)
 %%   Modify bucket properties.
 %%   Content-type must be application/json, and the body must have
@@ -45,6 +47,7 @@
 %%   Where the "props" object takes the same form as returned from
 %%   a GET of the same resource.
 %%
+%% DELETE /types/Type/buckets/Bucket/props (with bucket-type)
 %% DELETE /buckets/Bucket/props
 %%   Reset bucket properties back to the default settings
 %%   not supported by the OLD API

--- a/src/riak_kv_wm_props.erl
+++ b/src/riak_kv_wm_props.erl
@@ -172,7 +172,8 @@ forbidden(RD, Ctx=#ctx{security=Security}) ->
 %%      Properties allows HEAD, GET, and PUT.
 allowed_methods(RD, Ctx) when Ctx#ctx.api_version =:= 1 ->
     {['HEAD', 'GET', 'PUT'], RD, Ctx};
-allowed_methods(RD, Ctx) when Ctx#ctx.api_version =:= 2 ->
+allowed_methods(RD, Ctx) when Ctx#ctx.api_version =:= 2;
+                              Ctx#ctx.api_version =:= 3 ->
     {['HEAD', 'GET', 'PUT', 'DELETE'], RD, Ctx}.
 
 %% @spec malformed_request(reqdata(), context()) ->
@@ -242,7 +243,7 @@ content_types_accepted(RD, Ctx) ->
 %% @doc Produce the bucket properties as JSON.
 produce_bucket_body(RD, Ctx) ->
     Client = Ctx#ctx.client,
-    Bucket = {Ctx#ctx.bucket_type, Ctx#ctx.bucket},
+    Bucket = riak_kv_wm_utils:maybe_bucket_type(Ctx#ctx.bucket_type, Ctx#ctx.bucket),
     JsonProps1 = get_bucket_props_json(Client, Bucket),
     JsonProps2 = {struct, [JsonProps1]},
     JsonProps3 = mochijson2:encode(JsonProps2),

--- a/src/riak_kv_wm_stats.erl
+++ b/src/riak_kv_wm_stats.erl
@@ -1,8 +1,8 @@
 %% -------------------------------------------------------------------
 %%
-%% stats_http_resource: publishing Riak runtime stats via HTTP
+%% riak_kv_wm_stats: publishing Riak runtime stats via HTTP
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -154,12 +154,12 @@ format_links([{{Bucket,Key}, Tag}|Rest], Prefix, APIVersion, Acc) ->
 format_links([{Bucket, Tag}|Rest], Prefix, APIVersion, Acc) ->
     Bucket1 = mochiweb_util:quote_plus(Bucket),
     Tag1 = mochiweb_util:quote_plus(Tag),
-    Val = 
+    Val =
         case APIVersion of
             1 ->
                 io_lib:format("</~s/~s>; rel=\"~s\"",
                               [Prefix, Bucket1, Tag1]);
-            2 -> 
+            2 ->
                 io_lib:format("</buckets/~s>; rel=\"~s\"",
                               [Bucket1, Tag1])
         end,
@@ -229,7 +229,7 @@ any_to_bool(V) when is_boolean(V) ->
     V.
 
 is_forbidden(RD) ->
-    is_null_origin(RD) or 
+    is_null_origin(RD) or
     (app_helper:get_env(riak_kv,secure_referer_check,true) and not is_valid_referer(RD)).
 
 %% @doc Check if the Origin header is "null". This is useful to look for attempts

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -304,9 +304,9 @@ referer_tuple(RD) ->
 %%         "fun":FunctionNameAsString}
 jsonify_bucket_prop({linkfun, {modfun, Module, Function}}) ->
     {?JSON_LINKFUN, {struct, [{?JSON_MOD,
-                               list_to_binary(atom_to_list(Module))},
+                               atom_to_binary(Module, utf8)},
                               {?JSON_FUN,
-                               list_to_binary(atom_to_list(Function))}]}};
+                               atom_to_binary(Function, utf8)}]}};
 jsonify_bucket_prop({linkfun, {qfun, _}}) ->
     {?JSON_LINKFUN, <<"qfun">>};
 jsonify_bucket_prop({linkfun, {jsfun, Name}}) ->
@@ -319,37 +319,38 @@ jsonify_bucket_prop({linkfun, {jsanon, Source}}) ->
     {?JSON_LINKFUN, {struct, [{?JSON_JSANON, Source}]}};
 jsonify_bucket_prop({chash_keyfun, {Module, Function}}) ->
     {?JSON_CHASH, {struct, [{?JSON_MOD,
-                             list_to_binary(atom_to_list(Module))},
+                             atom_to_binary(Module, utf8)},
                             {?JSON_FUN,
-                             list_to_binary(atom_to_list(Function))}]}};
+                             atom_to_binary(Function, utf8)}]}};
 %% TODO Remove Legacy extractor prop in future version
 jsonify_bucket_prop({rs_extractfun, {modfun, M, F}}) ->
     {?JSON_EXTRACT_LEGACY, {struct, [{?JSON_MOD,
-                                      list_to_binary(atom_to_list(M))},
+                                      atom_to_binary(M, utf8)},
                                      {?JSON_FUN,
-                                      list_to_binary(atom_to_list(F))}]}};
+                                      atom_to_binary(F, utf8)}]}};
 jsonify_bucket_prop({rs_extractfun, {{modfun, M, F}, Arg}}) ->
     {?JSON_EXTRACT_LEGACY, {struct, [{?JSON_MOD,
-                                      list_to_binary(atom_to_list(M))},
+                                      atom_to_binary(M, utf8)},
                                      {?JSON_FUN,
-                                      list_to_binary(atom_to_list(F))},
+                                      atom_to_binary(F, utf8)},
                                      {?JSON_ARG, Arg}]}};
 jsonify_bucket_prop({search_extractor, {struct, _}=S}) ->
     {?JSON_EXTRACT, S};
 jsonify_bucket_prop({search_extractor, {M, F}}) ->
     {?JSON_EXTRACT, {struct, [{?JSON_MOD,
-                             list_to_binary(atom_to_list(M))},
+                             atom_to_binary(M, utf8)},
                               {?JSON_FUN,
-                               list_to_binary(atom_to_list(F))}]}};
+                               atom_to_binary(F, utf8)}]}};
 jsonify_bucket_prop({search_extractor, {M, F, Arg}}) ->
     {?JSON_EXTRACT, {struct, [{?JSON_MOD,
-                               list_to_binary(atom_to_list(M))},
+                               atom_to_binary(M, utf8)},
                               {?JSON_FUN,
-                               list_to_binary(atom_to_list(F))},
+                               atom_to_binary(F, utf8)},
                               {?JSON_ARG, Arg}]}};
-
+jsonify_bucket_prop({name, {_T, B}}) ->
+    {<<"name">>, B};
 jsonify_bucket_prop({Prop, Value}) ->
-    {list_to_binary(atom_to_list(Prop)), Value}.
+    {atom_to_binary(Prop, utf8), Value}.
 
 %% @spec erlify_bucket_prop({Property::binary(), jsonpropvalue()}) ->
 %%          {Property::atom(), erlpropvalue()}

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -40,7 +40,8 @@
          jsonify_bucket_prop/1,
          erlify_bucket_prop/1,
          ensure_bucket_type/3,
-         bucket_type_exists/1
+         bucket_type_exists/1,
+         maybe_bucket_type/2
         ]).
 
 -include_lib("webmachine/include/webmachine.hrl").
@@ -406,3 +407,11 @@ ensure_bucket_type(RD, Ctx, FNum) ->
 bucket_type_exists(<<"default">>) -> true;
 bucket_type_exists(Type) ->
     riak_core_bucket_type:get(Type) /= undefined.
+
+%% Construct a {Type, Bucket} tuple, if not working with the default bucket
+maybe_bucket_type(undefined, B) ->
+    B;
+maybe_bucket_type(<<"default">>, B) ->
+    B;
+maybe_bucket_type(T, B) ->
+    {T, B}.

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -161,7 +161,7 @@ format_links([{Bucket, Tag}|Rest], Prefix, APIVersion, Acc) ->
             1 ->
                 io_lib:format("</~s/~s>; rel=\"~s\"",
                               [Prefix, Bucket1, Tag1]);
-            2 ->
+            Two when Two >= 2 ->
                 io_lib:format("</buckets/~s>; rel=\"~s\"",
                               [Bucket1, Tag1])
         end,

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -31,6 +31,7 @@
          multipart_encode_body/4,
          format_links/3,
          format_uri/4,
+         format_uri/5,
          encode_value/1,
          accept_value/2,
          any_to_list/1,
@@ -181,6 +182,17 @@ format_uri(Bucket, Key, Prefix, 1) ->
     io_lib:format("/~s/~s/~s", [Prefix, Bucket, Key]);
 format_uri(Bucket, Key, _Prefix, 2) ->
     io_lib:format("/buckets/~s/keys/~s", [Bucket, Key]).
+
+
+%% @doc Format the URI for a type/bucket/key correctly for the api version
+%% used. (APIVersion is the final parameter.)
+format_uri(_Type, Bucket, Key, Prefix, 1) ->
+    format_uri(Bucket, Key, Prefix, 1);
+format_uri(_Type, Bucket, Key, Prefix, 2) ->
+    format_uri(Bucket, Key, Prefix, 2);
+format_uri(Type, Bucket, Key, _Prefix, 3) ->
+    io_lib:format("/types/~s/buckets/~s/keys/~s", [Type, Bucket, Key]).
+
 
 %% @spec get_ctype(dict(), term()) -> string()
 %% @doc Work out the content type for this object - use the metadata if provided

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_kv_wm_utils: Common functions used by riak_kv_wm_* modules.
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file


### PR DESCRIPTION
This supports the proposed API from basho/riak#362.

Notes:
- Linkwalking is not supported over keys stored in bucket-types. Similarly, links can only be used between keys in the default type, as described in the proposal.
- JSON MapReduce was adjusted to support `[Type, Bucket]` as inputs for full-bucket jobs, and `[ [Type, Bucket, Key, KeyData], ...]` for specific keys. Note that the `KeyData` is required in this form, even if it is null/undefined.
- Bucket-type properties resources were added so that there is parity with the existing PB feature. Whether clients _should_ be able to modify those properties is still under debate. /cc @jrwest @Vagabond 

A riak_test and support in the Erlang HTTP client cover these new features.
