### PR TITLE
Coerce the datatype property into an atom.

### DIFF
--- a/src/riak_kv_pb_crdt.erl
+++ b/src/riak_kv_pb_crdt.erl
@@ -187,7 +187,15 @@ get_key(K) ->
 
 bucket_type_to_type(Bucket, BType) ->
     BProps = riak_core_bucket:get_bucket({BType, Bucket}),
-    DataType = proplists:get_value(datatype, BProps),
+    DataType = case proplists:get_value(datatype, BProps) of
+                   Atom when is_atom(Atom) -> Atom;
+                   Bin when is_binary(Bin) ->
+                       try binary_to_existing_atom(Bin, utf8) of
+                           Atom -> Atom
+                       catch
+                           _:_ -> undefined
+                       end
+               end,
     AllowMult = proplists:get_value(allow_mult, BProps),
     {AllowMult, DataType}.
 

--- a/src/riak_kv_pb_crdt.erl
+++ b/src/riak_kv_pb_crdt.erl
@@ -187,15 +187,7 @@ get_key(K) ->
 
 bucket_type_to_type(Bucket, BType) ->
     BProps = riak_core_bucket:get_bucket({BType, Bucket}),
-    DataType = case proplists:get_value(datatype, BProps) of
-                   Atom when is_atom(Atom) -> Atom;
-                   Bin when is_binary(Bin) ->
-                       try binary_to_existing_atom(Bin, utf8) of
-                           Atom -> Atom
-                       catch
-                           _:_ -> undefined
-                       end
-               end,
+    DataType = proplists:get_value(datatype, BProps),
     AllowMult = proplists:get_value(allow_mult, BProps),
     {AllowMult, DataType}.
 

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -53,6 +53,7 @@
 -define(JSON_ALLOW_MULT, <<"allow_mult">>).
 -define(JSON_EXTRACT, <<"search_extractor">>).
 -define(JSON_EXTRACT_LEGACY, <<"rs_extractfun">>).
+-define(JSON_DATATYPE, <<"datatype">>).
 
 %% Names of HTTP query parameters
 -define(Q_PROPS, "props").

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -340,6 +340,8 @@ jsonify_bucket_prop({Prop, Value}) ->
 %%          {Property::atom(), erlpropvalue()}
 %% @doc The reverse of jsonify_bucket_prop/1.  Converts JSON representation
 %%      of bucket properties to their Erlang form.
+erlify_bucket_prop({?JSON_DATATYPE, Type}) when is_binary(Type) ->
+    {datatype, binary_to_existing_atom(Type, utf8)};
 erlify_bucket_prop({?JSON_LINKFUN, {struct, Props}}) ->
     case {proplists:get_value(?JSON_MOD, Props),
           proplists:get_value(?JSON_FUN, Props)} of


### PR DESCRIPTION
When creating a bucket-type from the command-line, the `datatype`
property might not be an atom, so we should try to convert it to one
before passing it to the CRDT code.
