### PR TITLE
Add metadata cache

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -254,6 +254,19 @@
   {datatype, {enum, [v0, v1]}}
 ]}.
 
+%% @doc md_cache_size controls how large the md cache is allowed to be
+%% it defaults to 1MB, set to 0 to disable the cache.  This shouldn't 
+%% be neccessary on-disk based backends, but can help performance in some
+%% cases (i.e. memory backend, data fits in block cache, etc).
+%% note that this is the size of the ETS table, rather than the actual data,
+%% to keep the size calculation simple, thus more space may be used than 
+%% the simple size * vnode_count calculation would imply.
+{mapping, "md_cache_size", "riak_kv.vnode_md_cache_size", [
+  {datatype, bytesize},
+  {default, "512KB"}
+]}.
+
+
 %%%% Memory backend section
 
 {mapping, "memory_backend.max_memory", "riak_kv.memory_backend.max_memory", [

--- a/src/riak_kv.app.src
+++ b/src/riak_kv.app.src
@@ -41,6 +41,9 @@
          %% Disable active anti-entropy by default
          {anti_entropy, {off, []}},
 
+         %% size of the vclock/indices cache per vnode 
+         {vnode_md_cache_size, 1048576},
+
          %% Allow Erlang MapReduce functions to be specified as
          %% strings.
          %%

--- a/src/riak_kv.app.src
+++ b/src/riak_kv.app.src
@@ -41,9 +41,6 @@
          %% Disable active anti-entropy by default
          {anti_entropy, {off, []}},
 
-         %% size of the vclock/indices cache per vnode 
-         {vnode_md_cache_size, 1048576},
-
          %% Allow Erlang MapReduce functions to be specified as
          %% strings.
          %%

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -74,7 +74,7 @@
 -export([merge/2, apply_updates/1, syntactic_merge/2]).
 -export([to_json/1, from_json/1]).
 -export([index_data/1]).
--export([index_specs/1, diff_index_specs/2]).
+-export([index_specs/1, diff_index_specs/2, diff_specs_direct/2]).
 -export([to_binary/2, from_binary/3, to_binary_version/4, binary_version/1]).
 -export([set_contents/2, set_vclock/2]). %% INTERNAL, only for riak_*
 
@@ -393,6 +393,17 @@ diff_index_specs(Obj, OldObj) ->
     OldIndexSet = ordsets:from_list(OldIndexes),
     AllIndexes = index_data(Obj),
     AllIndexSet = ordsets:from_list(AllIndexes),
+    diff_specs_core(AllIndexSet, OldIndexSet).
+
+diff_specs_direct(AllList, OldList) ->
+    AllIndexes =  [{Index, Value} || {_Op, Index, Value} <- AllList],
+    OldIndexes =  [{Index, Value} || {_Op, Index, Value} <- OldList],
+    AllIndexSet = ordsets:from_list(AllIndexes),
+    OldIndexSet = ordsets:from_list(OldIndexes),    
+    diff_specs_core(AllIndexSet, OldIndexSet).
+
+
+diff_specs_core(AllIndexSet, OldIndexSet) ->
     NewIndexSet = ordsets:subtract(AllIndexSet, OldIndexSet),
     RemoveIndexSet =
         ordsets:subtract(OldIndexSet, AllIndexSet),


### PR DESCRIPTION
NB: this patch has merged https://github.com/basho/riak_kv/pull/695 and should not be merged until after that patch has landed (and rebased if that patch changes).

This change adds an ETS table per vnode to act as a cache for the vclocks and index specs of any values that have recently been gotten or put.  This is meant to save round-trips to the disk in common get-then-put workflows on slower disks.

The cache is size limited, and setting the size to 0 will disable it, since it is a slight performance hit in certain situations (e.g. using the memory backend, when all of your data fits into RAM, etc).
