### PR TITLE
Issue/665 retry put coordinator failure

### DIFF
--- a/src/riak_kv_pb_crdt.erl
+++ b/src/riak_kv_pb_crdt.erl
@@ -134,6 +134,7 @@ process(#dtupdatereq{bucket=B, key=K, type=BType,
                            make_option(timeout, timeout(Timeout)) ++
                            make_option(sloppy_quorum, SloppyQ) ++
                            make_option(n_val, NVal) ++
+                           make_option(retry_put_coordinator_failure, false) ++
                            Options) of
                 ok ->
                     {reply, #dtupdateresp{key=ReturnKey}, State};

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -167,10 +167,14 @@ get_put_coordinator_failure_timeout() ->
     app_helper:get_env(riak_kv, put_coordinator_failure_timeout, 3000).
 
 make_ack_options(Options) ->
-    case riak_core_capability:get({riak_kv, put_fsm_ack_execute}, disabled) of
-        disabled ->
+    case (riak_core_capability:get(
+            {riak_kv, put_fsm_ack_execute}, disabled) == disabled
+          orelse
+          app_helper:get_env(
+            riak_kv, retry_put_coordinator_failure, on) == off) of
+        true ->
             {false, Options};
-        enabled ->
+        false ->
             case proplists:get_value(retry_put_coordinator_failure, Options, true) of
                 true ->
                     {true, [{ack_execute, self()}|Options]};


### PR DESCRIPTION
Addresses #665 

I strongly disagree that the default should be 'off'.  This is Riak 2.0 and is a good time to introduce a behavior change that should've happened many releases ago.

There's a tentative cuttlefish thingie in one of the commit log messages.
