### PR TITLE
Fix MR/bucket types incompatibility

### DIFF
--- a/src/riak_kv_mapred_json.erl
+++ b/src/riak_kv_mapred_json.erl
@@ -596,7 +596,7 @@ key_input_test() ->
     ?assertEqual(Expected2, parse_inputs(mochijson2:decode(JSON2))),
 
     %% Test parsing bucket types
-    JSON3 = <<"[[\"t1\", \"b1\", \"k1\", \"v1\"], [\"t2\", \"b2\", \"k2\", \"v2\"], [\"t3\", \"b3\", \"k3\", \"v3\"]]">>,
+    JSON3 = <<"[[\"b1\", \"k1\", \"v1\", \"t1\"], [\"b2\", \"k2\", \"v2\", \"t2\"], [\"b3\", \"k3\", \"v3\", \"t3\"]]">>,
     Expected3 = {ok, [
                       {{{<<"t1">>, <<"b1">>}, <<"k1">>}, <<"v1">>},
                       {{{<<"t2">>, <<"b2">>}, <<"k2">>}, <<"v2">>},

--- a/src/riak_kv_mapred_json.erl
+++ b/src/riak_kv_mapred_json.erl
@@ -338,8 +338,16 @@ jsonify_bkeys(Results, HasMRQuery) when HasMRQuery == true ->
 jsonify_bkeys(Results, HasMRQuery) when HasMRQuery == false ->
     jsonify_bkeys_1(Results, []).
 
+%% @doc Translate undefined to null, which mochijson will translate to JS null 
+maybe_null(undefined) ->
+    null;
+maybe_null(V) ->
+    V.
+
 jsonify_bkeys_1([{{{T,B},K},D}|Rest], Acc) ->
-    jsonify_bkeys_1(Rest, [[T,B,K,D]|Acc]);
+    jsonify_bkeys_1(Rest, [[B,K,maybe_null(D),T]|Acc]);
+jsonify_bkeys_1([{{B, K}, undefined}|Rest], Acc) ->
+    jsonify_bkeys_1(Rest, [[B,K]|Acc]);
 jsonify_bkeys_1([{{B, K},D}|Rest], Acc) ->
     jsonify_bkeys_1(Rest, [[B,K,D]|Acc]);
 jsonify_bkeys_1([{B, K}|Rest], Acc) ->

--- a/src/riak_kv_pipe_get.erl
+++ b/src/riak_kv_pipe_get.erl
@@ -164,7 +164,14 @@ make_req_id() ->
 bkey({{_,_}=Bkey,_}) -> Bkey;
 bkey({_,_}=Bkey)     -> Bkey;
 bkey([Bucket,Key])   -> {Bucket, Key};
-bkey([Bucket,Key,_]) -> {Bucket, Key}.
+bkey([Bucket,Key,_]) -> {Bucket, Key};
+bkey([Bucket,Key,_, BType]) -> {{BType, Bucket}, Key}.
+
+%% @doc Translate JS null to standard Erlang undefined
+null2undefined(null) ->
+    undefined;
+null2undefined(V) ->
+    V.
 
 %% @doc Extract KeyData from input.  The atom `undefined' is returned
 %%      if no keydata is specified.
@@ -172,7 +179,8 @@ bkey([Bucket,Key,_]) -> {Bucket, Key}.
 keydata({{_,_},KeyData}) -> KeyData;
 keydata({_,_})           -> undefined;
 keydata([_,_])           -> undefined;
-keydata([_,_,KeyData])   -> KeyData.
+keydata([_,_,KeyData])   -> null2undefined(KeyData);
+keydata([_,_,KeyData,_])   -> null2undefined(KeyData).
 
 %% @doc Compute the KV hash of the input.
 -spec bkey_chash(riak_kv_mrc_pipe:key_input()) -> chash:index().

--- a/src/riak_kv_pipe_index.erl
+++ b/src/riak_kv_pipe_index.erl
@@ -104,8 +104,15 @@ keysend_loop(ReqId, Partition, FittingDetails) ->
 keysend(_Bucket, [], _Partition, _FittingDetails) ->
     ok;
 keysend(Bucket, [Key | Keys], Partition, FittingDetails) ->
+    SKey = strip_index(Key),
+    Out = if
+        is_tuple(Bucket) ->
+            {{Bucket, SKey}, undefined};
+        true ->
+            {Bucket, SKey}
+    end,
     case riak_pipe_vnode_worker:send_output(
-           {{Bucket, strip_index(Key)}, undefined}, Partition, FittingDetails) of
+           Out, Partition, FittingDetails) of
         ok ->
             keysend(Bucket, Keys, Partition, FittingDetails);
         ER ->

--- a/src/riak_kv_pipe_listkeys.erl
+++ b/src/riak_kv_pipe_listkeys.erl
@@ -119,8 +119,14 @@ keysend_loop(ReqId, Partition, FittingDetails) ->
 keysend(_Bucket, [], _Partition, _FittingDetails) ->
     ok;
 keysend(Bucket, [Key | Keys], Partition, FittingDetails) ->
+    Out = if
+        is_tuple(Bucket) ->
+            {{Bucket, Key}, undefined};
+        true ->
+            {Bucket, Key}
+    end,
     case riak_pipe_vnode_worker:send_output(
-           {{Bucket, Key}, undefined}, Partition, FittingDetails) of
+           Out, Partition, FittingDetails) of
         ok ->
             keysend(Bucket, Keys, Partition, FittingDetails);
         ER ->


### PR DESCRIPTION
This adds a special case to keep the old format for bkey streams when
using the default bucket.  It also changes the order of jsonified lists
for bkey/keydata items that have a bucket type, moving the bucket type
last.  That should make all existing JS and Erlang MR reduce functions
compatible as long as they don't have to deal with bucket types (within
the same bucket, etc). The functions will only need updating to deal
with bucket types by accessing the 4th item in the list. This is
compatible with the old format, as it will be null in pre-bucket types
Riak. That way no complicated checks for list length are needed to
determine the order of the items.  Keydata, the 3rd item in the list,
will be null when a bucket type is present as a 4th member. Erlang
reduce functions will need a new clause if bucket types will be present,
but not if only default. All MR riak tests should pass with this now.

/cc @Vagabond @beerriot 
