### PR TITLE
Fix include path.

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -72,7 +72,7 @@
 
 -include_lib("riak_kv_vnode.hrl").
 -include_lib("riak_kv_map_phase.hrl").
--include_lib("riak_core/include/riak_core_pb.hrl").
+-include_lib("riak_core_pb.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
This resolves compilation errors on develop/riak_kv.

@engelsanchez @seancribbs 
