### PR TITLE
Support for strongly consistent Riak

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
                   ]}.
 
 {deps, [
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core", {branch, "jdb-strong-2.0-wip"}}},
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core", {branch, "develop"}}},
         {sidejob, ".*", {git, "git://github.com/basho/sidejob.git", {branch, "develop"}}},
         {erlang_js, ".*", {git, "git://github.com/basho/erlang_js.git", {branch, "develop"}}},
         {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {branch, "develop"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,6 @@
                   ]}.
 
 {deps, [
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core", {branch, "develop"}}},
         {sidejob, ".*", {git, "git://github.com/basho/sidejob.git", {branch, "develop"}}},
         {erlang_js, ".*", {git, "git://github.com/basho/erlang_js.git", {branch, "develop"}}},
         {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {branch, "develop"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
                   ]}.
 
 {deps, [
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core", {tag, "1.4.2"}}},
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core", {branch, "jdb-strong-1.4.2"}}},
         {sidejob, ".*", {git, "git://github.com/basho/sidejob", {tag, "0.2.0"}}},
         {erlang_js, ".*", {git, "git://github.com/basho/erlang_js", {tag, "1.2.2"}}},
         {bitcask, ".*", {git, "git://github.com/basho/bitcask", {tag, "1.6.3"}}},

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -220,7 +220,12 @@ consistent_put_type(RObj, Options) ->
        IfMissing ->
             put_once;
        true ->
-            overwrite
+            %% Defaulting to put_once here for safety.
+            %% Our client API makes it too easy to accidently send requests
+            %% without a provided vector clock and clobber your data.
+            %% overwrite
+            %% TODO: Expose client option to explicitly request overwrite
+            put_once
     end.
 
 %% @spec put(RObj :: riak_object:riak_object(), riak_kv_put_fsm::options(), riak_client()) ->

--- a/src/riak_kv_ensemble_backend.erl
+++ b/src/riak_kv_ensemble_backend.erl
@@ -1,0 +1,169 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc
+%% Implementation of {@link riak_ensemble_backend} behavior that
+%% connects riak_ensemble to riak_kv vnodes. 
+%%
+%% TODO: Move to riak_kv. Before PR, document more.
+
+-module(riak_kv_ensemble_backend).
+-behaviour(riak_ensemble_backend).
+
+-export([init/3, new_obj/4]).
+-export([obj_epoch/1, obj_seq/1, obj_key/1, obj_value/1]).
+-export([set_obj_epoch/2, set_obj_seq/2, set_obj_value/2]).
+-export([get/3, put/4, tick/5]).
+-export([reply/2]).
+
+-include_lib("riak_ensemble/include/riak_ensemble_types.hrl").
+
+-record(state, {ensemble  :: ensemble_id(),
+                id        :: peer_id(),
+                proxy     :: atom()}).
+
+-type obj()    :: riak_object:riak_object().
+-type state()  :: #state{}.
+-type key()    :: {_,_}.
+-type value()  :: any().
+
+%%===================================================================
+
+-spec init(ensemble_id(), peer_id(), [any()]) -> state().
+init(Ensemble, Id, []) ->
+    {{kv, _PL, _N, Idx}, _} = Id,
+    Proxy = riak_core_vnode_proxy:reg_name(riak_kv_vnode, Idx),
+    #state{ensemble=Ensemble,
+           id=Id,
+           proxy=Proxy}.
+
+%%===================================================================
+
+-spec new_obj(epoch(), seq(), key(), value()) -> obj().
+new_obj(Epoch, Seq, {B,K}, Value) ->
+    case riak_object:is_robject(Value) of
+        true ->
+            set_epoch_seq(Epoch, Seq, Value);
+        false ->
+            RObj = riak_object:new(B, K, Value),
+            set_epoch_seq(Epoch, Seq, RObj)
+    end.
+
+set_epoch_seq(Epoch, Seq, RObj) ->
+    EpochSeq = (Epoch bsl 32) + Seq,
+    %% riak_object:set_vclock(RObj, vclock:fresh(Epoch, Seq)),
+    RObj2 = riak_object:set_vclock(RObj, vclock:fresh(eseq, EpochSeq)),
+    RObj3 = riak_object:update_last_modified(RObj2),
+    riak_object:apply_updates(RObj3).
+
+get_epoch_seq(RObj) ->
+    EpochSeq = vclock:get_counter(eseq, riak_object:vclock(RObj)),
+    <<Epoch:32/integer, Seq:32/integer>> = <<EpochSeq:64/integer>>,
+    {Epoch, Seq}.
+
+%%===================================================================
+
+-spec obj_epoch(obj()) -> epoch().
+obj_epoch(RObj) ->
+    {Epoch, _} = get_epoch_seq(RObj),
+    Epoch.
+
+-spec obj_seq(obj()) -> seq().
+obj_seq(RObj) ->
+    {_, Seq} = get_epoch_seq(RObj),
+    Seq.
+
+-spec obj_key(obj()) -> key().
+obj_key(RObj) ->
+    {riak_object:bucket(RObj), riak_object:key(RObj)}.
+
+-spec obj_value(obj()) -> value().
+obj_value(RObj) ->
+    riak_object:get_value(RObj).
+
+%%===================================================================
+
+-spec set_obj_epoch(epoch(), obj()) -> obj().
+set_obj_epoch(Epoch, RObj) ->
+    {_, Seq} = get_epoch_seq(RObj),
+    set_epoch_seq(Epoch, Seq, RObj).
+
+-spec set_obj_seq(seq(), obj()) -> obj().
+set_obj_seq(Seq, RObj) ->
+    {Epoch, _} = get_epoch_seq(RObj),
+    set_epoch_seq(Epoch, Seq, RObj).
+
+-spec set_obj_value(value(), obj()) -> obj().
+set_obj_value(Value, RObj) ->
+    case riak_object:is_robject(Value) of
+        true ->
+            Contents = riak_object:get_contents(Value),
+            riak_object:set_contents(RObj, Contents);
+        false ->
+            riak_object:apply_updates(riak_object:update_value(RObj, Value))
+    end.
+
+%%===================================================================
+
+-spec get(key(), riak_ensemble_backend:from(), state()) -> state().
+get(Key, From, State=#state{proxy=Proxy}) ->
+    ok = send_msg(Proxy, From, {ensemble_get, Key}),
+    State.
+
+-spec put(key(), obj(), riak_ensemble_backend:from(), state()) -> state().
+put(Key, Obj, From, State=#state{proxy=Proxy}) ->
+    ok = send_msg(Proxy, From, {ensemble_put, Key, Obj}),
+    State.
+
+-spec send_msg(atom(), riak_ensemble_backend:from(), any()) -> ok.
+send_msg(Proxy, From, Msg) ->
+    Msg2 = erlang:append_element(Msg, From),
+    catch Proxy ! Msg2,
+    ok.
+
+-spec reply(riak_ensemble_backend:from(), any()) -> ok.
+reply(From, Reply) ->
+    riak_ensemble_backend:reply(From, Reply),
+    ok.
+
+%%===================================================================
+
+-spec tick(epoch(), seq(), peer_id(), views(), state()) -> state().
+tick(_Epoch, _Seq, _Leader, Views, State=#state{id=Id}) ->
+    {{kv, Idx, N, _}, _} = Id,
+    Latest = hd(Views),
+    {ok, CHBin} = riak_core_ring_manager:get_chash_bin(),
+    {PL, _} = chashbin:itr_pop(N, chashbin:exact_iterator(Idx, CHBin)),
+    %% TODO: Make ensembles/peers use ensemble/peer as actual peer name so this is unneeded
+    Peers = [{{kv, Idx, N, Idx2}, Node} || {Idx2, Node} <- PL],
+    Add = Peers -- Latest,
+    Del = Latest -- Peers,
+    Changes = [{add, Peer} || Peer <- Add] ++ [{del, Peer} || Peer <- Del],
+    case Changes of
+        [] ->
+            ok;
+        _ ->
+            io:format("~p~n", [Changes]),
+            spawn(fun() ->
+                          riak_ensemble_peer:update_members(self(), Changes, 5000)
+                  end),
+            ok
+    end,
+    State.

--- a/src/riak_kv_ensembles.erl
+++ b/src/riak_kv_ensembles.erl
@@ -1,0 +1,118 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc
+%% This gen_server is reponsible for bootstrapping consensus ensembles
+%% used by riak_kv to provide strong consistency. The server polls the
+%% ring periodically and registers any missing ensembles with the
+%% riak_ensemble_manager.
+
+-module(riak_kv_ensembles).
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-record(state, {last_ring_id :: term()}).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([]) ->
+    schedule_tick(),
+    {ok, #state{last_ring_id = undefined}}.
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(tick, State) ->
+    State2 = tick(State),
+    {noreply, State2};
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+schedule_tick() ->
+    erlang:send_after(10000, ?MODULE, tick).
+
+tick(State=#state{last_ring_id=LastID}) ->
+    case riak_core_ring_manager:get_ring_id() of
+        LastID ->
+            State;
+        RingID ->
+            {ok, Ring, CHBin} = riak_core_ring_manager:get_raw_ring_chashbin(),
+            maybe_bootstrap_ensembles(Ring, CHBin),
+            schedule_tick(),
+            State#state{last_ring_id=RingID}
+    end.
+
+maybe_bootstrap_ensembles(Ring, CHBin) ->
+    IsClaimant = (riak_core_ring:claimant(Ring) == node()),
+    IsReady = riak_core_ring:ring_ready(Ring),
+    case IsClaimant and IsReady of
+        true ->
+            bootstrap_preflists(Ring, CHBin);
+        false ->
+            ok
+    end.
+
+bootstrap_preflists(Ring, CHBin) ->
+    AllN = riak_core_bucket:all_n(Ring),
+    Owners = riak_core_ring:all_owners(Ring),
+    AllPL = [{Idx, N} || {Idx, _} <- Owners,
+                         N <- AllN],
+    Ensembles = riak_ensemble_manager:rget(ensembles, []),
+    Known = [{Idx, N} || {{kv, Idx, N}, _} <- Ensembles],
+    Need = AllPL -- Known,
+    io:format("All: ~p~nKnown ~p~nNeed: ~p~n", [AllPL, Known, Need]),
+    [begin
+         {PL, _} = chashbin:itr_pop(N, chashbin:exact_iterator(Idx, CHBin)),
+         %% TODO: Make ensembles/peers use ensemble/peer as actual peer name so this is unneeded
+         Peers = [{{kv, Idx, N, Idx2}, Node} || {Idx2, Node} <- PL],
+         riak_ensemble_manager:create_ensemble({kv, Idx, N}, undefined, Peers,
+                                               riak_kv_ensemble_backend, []),
+         ok
+     end || {Idx, N} <- Need],
+    ok.

--- a/src/riak_kv_ensembles.erl
+++ b/src/riak_kv_ensembles.erl
@@ -113,7 +113,7 @@ bootstrap_preflists(Ring, CHBin) ->
     Ensembles = riak_ensemble_manager:rget(ensembles, []),
     Known = [{Idx, N} || {{kv, Idx, N}, _} <- Ensembles],
     Need = AllPL -- Known,
-    io:format("All: ~p~nKnown ~p~nNeed: ~p~n", [AllPL, Known, Need]),
+    %% io:format("All: ~p~nKnown ~p~nNeed: ~p~n", [AllPL, Known, Need]),
     L = [begin
              {PL, _} = chashbin:itr_pop(N, chashbin:exact_iterator(Idx, CHBin)),
              %% TODO: Make ensembles/peers use ensemble/peer as actual peer name so this is unneeded

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -626,7 +626,7 @@ handle_options([], State) ->
 handle_options([{update_last_modified, false}|T], State) ->
     handle_options(T, State);
 handle_options([{update_last_modified, true}|T], State = #state{robj = RObj}) ->
-    handle_options(T, State#state{robj = update_last_modified(RObj)});
+    handle_options(T, State#state{robj = riak_object:update_last_modified(RObj)});
 handle_options([{returnbody, true}|T], State) ->
     VnodeOpts = [{returnbody, true} | State#state.vnode_options],
     %% Force DW>0 if requesting return body to ensure the dw event
@@ -672,42 +672,6 @@ init_putcore(State = #state{n = N, w = W, pw = PW, dw = DW, allowmult = AllowMul
 %% Apply any pending updates to robj
 apply_updates(State = #state{robj = RObj}) ->
     State#state{robj = riak_object:apply_updates(RObj)}.
-
-%%
-%% Update X-Riak-VTag and X-Riak-Last-Modified in the object's metadata, if
-%% necessary.
-%%
-%% @private
-update_last_modified(RObj) ->
-    MD0 = case dict:find(clean, riak_object:get_update_metadata(RObj)) of
-              {ok, true} ->
-                  %% There have been no changes to updatemetadata. If we stash the
-                  %% last modified in this dict, it will cause us to lose existing
-                  %% metadata (bz://508). If there is only one instance of metadata,
-                  %% we can safely update that one, but in the case of multiple siblings,
-                  %% it's hard to know which one to use. In that situation, use the update
-                  %% metadata as is.
-                  case riak_object:get_metadatas(RObj) of
-                      [MD] ->
-                          MD;
-                      _ ->
-                          riak_object:get_update_metadata(RObj)
-                  end;
-               _ ->
-                  riak_object:get_update_metadata(RObj)
-          end,
-    %% Post-0.14.2 changed vtags to be generated from node/now rather the vclocks.
-    %% The vclock has not been updated at this point.  Vtags/etags should really
-    %% be an external interface concern and are only used for sibling selection
-    %% and if-modified type tests so they could be generated on retrieval instead.
-    %% This changes from being a hash on the value to a likely-to-be-unique value
-    %% which should serve the same purpose.  It was possible to generate two
-    %% objects with the same vclock on 0.14.2 if the same clientid was used in
-    %% the same second.  It can be revisited post-1.0.0.
-    Now = os:timestamp(),
-    NewMD = dict:store(?MD_VTAG, riak_kv_util:make_vtag(Now),
-                       dict:store(?MD_LASTMOD, Now, MD0)),
-    riak_object:update_metadata(RObj, NewMD).
 
 %% Invokes the hook and returns a tuple of
 %% {Lang, Called, Result}

--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -88,6 +88,10 @@ init([]) ->
                       {riak_kv_entropy_manager, start_link, []},
                       permanent, 30000, worker, [riak_kv_entropy_manager]},
 
+    EnsemblesKV =  {riak_kv_ensembles,
+                    {riak_kv_ensembles, start_link, []},
+                    permanent, 30000, worker, [riak_kv_ensembles]},
+
     % Figure out which processes we should run...
     HasStorageBackend = (app_helper:get_env(riak_kv, storage_backend) /= undefined),
 
@@ -102,6 +106,7 @@ init([]) ->
         KeysFsmSup,
         IndexFsmSup,
         EntropyManager,
+        EnsemblesKV,
         JSSup,
         MapJSPool,
         ReduceJSPool,

--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -106,7 +106,7 @@ init([]) ->
         KeysFsmSup,
         IndexFsmSup,
         EntropyManager,
-        EnsemblesKV,
+        [EnsemblesKV || riak_core_sup:ensembles_enabled()],
         JSSup,
         MapJSPool,
         ReduceJSPool,

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -43,6 +43,7 @@
          puts_active/0,
          exact_puts_active/0,
          gets_active/0,
+         consistent_object/1,
          overload_reply/1]).
 
 -include_lib("riak_kv_vnode.hrl").
@@ -158,6 +159,16 @@ normalize_rw_value(one, _N) -> 1;
 normalize_rw_value(quorum, N) -> erlang:trunc((N/2)+1);
 normalize_rw_value(all, N) -> N;
 normalize_rw_value(_, _) -> error.
+
+consistent_object(Bucket) ->
+    case Bucket of
+        <<"c#", _/binary>> ->
+            true;
+        <<"c~", _/binary>> ->
+            true;
+        _ ->
+            false
+    end.
 
 %% ===================================================================
 %% Preflist utility functions

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -161,14 +161,13 @@ normalize_rw_value(quorum, N) -> erlang:trunc((N/2)+1);
 normalize_rw_value(all, N) -> N;
 normalize_rw_value(_, _) -> error.
 
+-spec consistent_object(binary() | {binary(),binary()}) -> true | false | {error,_}.
 consistent_object(Bucket) ->
-    case Bucket of
-        <<"c#", _/binary>> ->
-            true;
-        <<"c~", _/binary>> ->
-            true;
-        _ ->
-            false
+    case riak_core_bucket:get_bucket(Bucket) of
+        Props when is_list(Props) ->
+            lists:member({consistent, true}, Props);
+        {error, _}=Err ->
+            Err
     end.
 
 %% ===================================================================

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -72,6 +72,7 @@
          handle_info/2]).
 
 -export([handoff_data_encoding_method/0]).
+-export([set_vnode_forwarding/2]).
 
 -include_lib("riak_kv_vnode.hrl").
 -include_lib("riak_kv_map_phase.hrl").
@@ -98,6 +99,8 @@
                 key_buf_size :: pos_integer(),
                 async_folding :: boolean(),
                 in_handoff = false :: boolean(),
+                handoff_target :: node(),
+                forward :: node() | [{integer(), node()}],
                 hashtrees :: pid() }).
 
 -type index_op() :: add | remove.
@@ -770,14 +773,14 @@ request_hash(?KV_DELETE_REQ{bkey=BKey}) ->
 request_hash(_Req) ->
     undefined.
 
-handoff_starting(_TargetNode, State) ->
-    {true, State#state{in_handoff=true}}.
+handoff_starting({_HOType, TargetNode}, State) ->
+    {true, State#state{in_handoff=true, handoff_target=TargetNode}}.
 
 handoff_cancelled(State) ->
-    {ok, State#state{in_handoff=false}}.
+    {ok, State#state{in_handoff=false, handoff_target=undefined}}.
 
 handoff_finished(_TargetNode, State) ->
-    {ok, State}.
+    {ok, State#state{in_handoff=false, handoff_target=undefined}}.
 
 handle_handoff_data(BinObj, State) ->
     try
@@ -811,6 +814,9 @@ encode_handoff_item({B, K}, V) ->
                           [Error,Reason]),
             corrupted
     end.
+
+set_vnode_forwarding(Forward, State) ->
+    State#state{forward=Forward}.
 
 is_empty(State=#state{mod=Mod, modstate=ModState}) ->
     IsEmpty = Mod:is_empty(ModState),
@@ -852,18 +858,46 @@ terminate(_Reason, #state{mod=Mod, modstate=ModState}) ->
     Mod:stop(ModState),
     ok.
 
-handle_info({ensemble_get, Key, From}, State) ->
-    {reply, {r, Retval, _, _}, State2} = do_get(undefined, Key, undefined, State),
-    Reply = case Retval of
-                {ok, Obj} ->
-                    Obj;
-                _ ->
-                    notfound
-            end,
-    riak_kv_ensemble_backend:reply(From, Reply),
-    {ok, State2};
+handle_info({ensemble_get, Key, From}, State=#state{idx=Idx, forward=Fwd}) ->
+    case Fwd of
+        undefined ->
+            {reply, {r, Retval, _, _}, State2} = do_get(undefined, Key, undefined, State),
+            Reply = case Retval of
+                        {ok, Obj} ->
+                            Obj;
+                        _ ->
+                            notfound
+                    end,
+            riak_kv_ensemble_backend:reply(From, Reply),
+            {ok, State2};
+        Fwd when is_atom(Fwd) ->
+            forward_get({Idx, Fwd}, Key, From),
+            {ok, State}
+    end;
 
-handle_info({ensemble_put, Key, Obj, From}, State) ->
+handle_info({ensemble_put, Key, Obj, From}, State=#state{handoff_target=HOTarget,
+                                                         idx=Idx,
+                                                         forward=Fwd}) ->
+    case Fwd of
+        undefined ->
+            {Result, State2} = actual_put(Key, Obj, [], false, undefined, State),
+            Reply = case Result of
+                        {dw, _Idx, _Obj, _ReqID} ->
+                            Obj;
+                        {dw, _Idx, _ReqID} ->
+                            Obj;
+                        {fail, _Idx, _ReqID} ->
+                            failed
+                    end,
+            ((Reply =/= failed) and (HOTarget =/= undefined)) andalso raw_put(HOTarget, Key, Obj),
+            riak_kv_ensemble_backend:reply(From, Reply),
+            {ok, State2};
+        Fwd when is_atom(Fwd) ->
+            forward_put({Idx, Fwd}, Key, Obj, From),
+            {ok, State}
+    end;
+
+handle_info({raw_forward_put, Key, Obj, From}, State) ->
     {Result, State2} = actual_put(Key, Obj, [], false, undefined, State),
     Reply = case Result of
                 {dw, _Idx, _Obj, _ReqID} ->
@@ -874,6 +908,19 @@ handle_info({ensemble_put, Key, Obj, From}, State) ->
                     failed
             end,
     riak_kv_ensemble_backend:reply(From, Reply),
+    {ok, State2};
+handle_info({raw_forward_get, Key, From}, State) ->
+    {reply, {r, Retval, _, _}, State2} = do_get(undefined, Key, undefined, State),
+    Reply = case Retval of
+                {ok, Obj} ->
+                    Obj;
+                _ ->
+                    notfound
+            end,
+    riak_kv_ensemble_backend:reply(From, Reply),
+    {ok, State2};
+handle_info({raw_put, Key, Obj}, State) ->
+    {_, State2} = actual_put(Key, Obj, [], false, undefined, State),
     {ok, State2};
 
 handle_info(retry_create_hashtree, State=#state{hashtrees=undefined}) ->
@@ -918,6 +965,25 @@ handle_exit(_Pid, Reason, State) ->
     %% queue and never being processed.
     lager:error("Linked process exited. Reason: ~p", [Reason]),
     {stop, linked_process_crash, State}.
+
+%% @private
+forward_put({Idx, Node}, Key, Obj, From) ->
+    Proxy = riak_core_vnode_proxy:reg_name(riak_kv_vnode, Idx, Node),
+    riak_core_send_msg:bang_unreliable(Proxy, {raw_forward_put, Key, Obj, From}),
+    ok.
+
+%% @private
+forward_get({Idx, Node}, Key, From) ->
+    Proxy = riak_core_vnode_proxy:reg_name(riak_kv_vnode, Idx, Node),
+    riak_core_send_msg:bang_unreliable(Proxy, {raw_forward_get, Key, From}),
+    ok.
+
+%% @private
+raw_put({Idx, Node}, Key, Obj) ->
+    Proxy = riak_core_vnode_proxy:reg_name(riak_kv_vnode, Idx, Node),
+    %% Note: This cannot be bang_unreliable. Don't change.
+    Proxy ! {raw_put, Key, Obj},
+    ok.
 
 %% @private
 %% upon receipt of a client-initiated put


### PR DESCRIPTION
This is the `riak_kv` related pull-request for on-going work to add strong consistency to Riak.

Primarily, this pull-request integrates with [riak_ensemble](http://github.com/basho/riak_ensemble) that provides most of the heavy lifting.

This pull-request is provides a `riak_ensemble_backend` implementation that integrates with K/V vnodes, registers ensembles (consensus groups) for each distinct replica set (preflist/n-val) in Riak, and maps the existing client API onto `riak_ensemble_client` against these new K/V ensembles.

---

Objects written under a bucket type with property `consistent = true` are consistent objects and use the consistent code path, everything else uses the normal Riak code path.

Consistent operations are conditional single key atomic updates:
- If you write a key, the next successful read is guaranteed to show that write (or the result of a future write that saw the write).
- If you get/modify/put an object, Riak ensures that the object didn't change since you read it. In other words, the request will fail if a concurrent write occurred and changed the object.
- In general, timeouts are indistinguishable from partial writes in a distributed system. Thus, consistent Riak resolves partial write ambiguity at read time. If you try to write a value, and that write times out, the current state of the key is unknown -- it could be the prior value or the attempted to write value. However, the next successful read of the key tells you which occurred and ensures that decision does not change in the future. 
- For example, if you partially write to 1 replica which then becomes partitioned/goes offline. Subsequently, perform a successful read that shows the old value. It's guaranteed the old value wins. The partitioned failed--to-write value is essentially rolled back. Even once that replica comes back online and propagates the failed-to-write value, the old value still wins. Of course, in a slightly different scenario, it's entirely possible for the initial read-after-failed-write to return the new value instead. Again, either option is possible on the next read. But, after that read, things do not change.

Internally, `riak_ensemble` supports three types of writes: `put_once`, `modify`, and `overwrite`.
- A `put_once` operation only succeeds if the key doesn't already exist.
- A `modify` operation is used as the `put` in a get/modify/put sequence. A `modify` operation fails the write if the object no longer matches the base object returned in the `get` part of the sequence.
- A `overwrite` operation is a fast, unsafe, unchecked operation. `overwrite` operations overwrite the key without regard to it's existing value. This is useful when bulk loading data.

For Riak, the existing K/V API is mapped to a subset of these operations. Client puts that are missing a vector clock are mapped to `put_once` operations, while those that provide a vector clock are mapped to `modify`. There is currently no mapping to `overwrite`.

A previous version of this code mapped operations w/o vector clocks to `overwrite`, and puts with `if_none_matched` to `put_once`, but it is too easy for a client to accidentally not send vector clock data and mapping that to `overwrite` made it too easy for users to clobber data. Hence the safer mapping above.

Delete operations are similar. Riak client deletes map to a unchecked (similar to overwrite) ensemble delete. Whereas client delete_vclock operations map to safe deletes that are similar to `modify`. Specifically, the safe variant is used in the sequence: `Obj = get(), delete(Obj)` where Riak fails the delete if the object has changed since the get.

Note: All mentions of "vector clock" above are slightly different than normal Riak. Consider them opaque contexts passed back/forth to the client. In general, vector clocks for consistent data aren't really the same as with normal Riak operations. We don't main normal vector clocks at all. The consistent subsystem maintains it's own logical clock per ensemble (eg. per preflist) which is used for all consistent operations. However, for compatibility this value is converted into a "vector clock" thus the object and client requests formats stays the same.

---

Known limitations/issues (TODO: file issues)
- Consistent data does not currently support secondary indexes.
- Consistent data does not currently support object mutators.
- Consistent operations do not yet fire any stats-related events, nor keep any stats of their own.
- Consistent operations currently bypass the overload protection system and need their own overload protection to be added.
- Deleting consistent data leaves around tombstones that are not currently harvested. 
- Consistent reads currently do not use read repair, nor does normal AAE currently heal missing consistent data.
- The consensus subsystem (riak_ensemble) requires implementing modules to provide a `sync` behavior that heals potentially diverted/corrupted replicas. The plan is to use AAE for this in `riak_kv`. However, this currently is not done and will be done in a future pull-request.

Sibling pull-requests: basho/riak_core#441, basho/riak_ensemble#1
