### PR TITLE
Use the deep equality check for riak_objects.

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1179,7 +1179,7 @@ put_merge(false, true, _CurObj, UpdObj, _VId, _StartTime) -> % coord=false, LWW=
     {newobj, UpdObj};
 put_merge(false, false, CurObj, UpdObj, _VId, _StartTime) -> % coord=false, LWW=false
     ResObj = riak_object:syntactic_merge(CurObj, UpdObj),
-    case ResObj =:= CurObj of
+    case riak_object:equal(ResObj, CurObj) of
         true ->
             {oldobj, CurObj};
         false ->


### PR DESCRIPTION
Since some of the objects stored in the r_object are items like dicts,
etc where the internal representation can change; ensure that we perform
the deep equality check.
