### PR TITLE
2i term regex filter 1.4

### DIFF
--- a/include/riak_kv_index.hrl
+++ b/include/riak_kv_index.hrl
@@ -32,4 +32,16 @@
           return_body=false ::boolean() %% Note, only for riak cs bucket folds
          }).
 
--define(KV_INDEX_Q, #riak_kv_index_v2).
+-record(riak_kv_index_v3, {
+          start_key= <<>> :: binary(),
+          filter_field :: binary() | undefined,
+          start_term :: binary() | undefined, %% Note, in a $key query, start_key==start_term
+          end_term :: binary() | undefined, %% Note, in an eq query, start==end
+          return_terms=true :: boolean(), %% Note, should be false for an equals query
+          term_regex :: binary() | undefined,
+          start_inclusive=true :: boolean(),
+          end_inclusive=true :: boolean(),
+          return_body=false ::boolean() %% Note, only for riak cs bucket folds
+         }).
+
+-define(KV_INDEX_Q, #riak_kv_index_v3).

--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -32,9 +32,8 @@
          format_failure_reason/1,
          normalize_index_field/1,
          timestamp/0,
+         to_index_query/1,
          to_index_query/2,
-         to_index_query/3,
-         to_index_query/6,
          make_continuation/1,
          return_terms/2,
          return_body/1,
@@ -52,6 +51,7 @@
 -define(TIMEOUT, 30000).
 -define(BUCKETFIELD, <<"$bucket">>).
 -define(KEYFIELD, <<"$key">>).
+-define(CURRENT_2I_VERSION, v3).
 
 %% See GH610, this default is for backwards compat, so 2i behaves as
 %% it did before the FSM timeout bug was "fixed"
@@ -73,6 +73,7 @@
 -type key() :: binary().
 -opaque continuation() :: binary(). %% encoded last_result().
 
+-type query_version() :: v1 | v2 | v3.
 mapred_index(Dest, Args) ->
     mapred_index(Dest, Args, ?TIMEOUT).
 mapred_index(_Pipe, [Bucket, Query], Timeout) ->
@@ -243,89 +244,89 @@ timestamp() ->
     {MegaSeconds,Seconds,MilliSeconds}=os:timestamp(),
     (MegaSeconds * 1000000000000) + (Seconds * 1000000) + MilliSeconds.
 
-%% @spec to_index_query(binary(), [binary()]) ->
-%%         {ok, {atom(), binary(), list(binary())}} | {error, Reasons}.
-%% @doc Given an IndexOp, IndexName, and Args, construct and return a
-%%      valid query, or a list of errors if the query is malformed.
-to_index_query(IndexField, Args) ->
-    %% Normalize the index field...
-    IndexField1 = riak_index:normalize_index_field(IndexField),
+parse_field_if_defined(_, undefined) ->
+    {ok, undefined};
+parse_field_if_defined(Field, Val) ->
+    parse_field(Field, Val, field_types()).
 
-    %% Normalize the arguments...
-    case riak_index:parse_fields([{IndexField1, X} || X <- Args]) of
-        {ok, []} ->
-            {error, {too_few_arguments, Args}};
+to_index_query(?CURRENT_2I_VERSION, Args) ->
+    Defaults = ?KV_INDEX_Q{},
+    [Field1, Start, StartInc, End1, EndInc,
+     TermRegex, ReturnBody, Cont
+    ] =
+        [proplists:get_value(F, Args, Default) ||
+            {F, Default} <-
+            [{field, Defaults?KV_INDEX_Q.filter_field},
+             {start_term, Defaults?KV_INDEX_Q.start_term},
+             {start_inclusive, Defaults?KV_INDEX_Q.start_inclusive},
+             {end_term, Defaults?KV_INDEX_Q.end_term},
+             {end_inclusive, Defaults?KV_INDEX_Q.end_inclusive},
+             {term_regex, Defaults?KV_INDEX_Q.term_regex},
+             {return_body, Defaults?KV_INDEX_Q.return_body},
+             {continuation, undefined}]],
+    End = case End1 of undefined -> Start; _ -> End1 end,
+    Field = normalize_index_field(Field1),
+    SKeyDefault = case Field of
+        ?KEYFIELD -> Start;
+        _ -> Defaults?KV_INDEX_Q.start_key
+    end,
+    StartKey = proplists:get_value(start_key, Args, SKeyDefault),
+    %% Internal return terms, not to be confused with user facing
+    %% return terms in the external clients.
+    ReturnTerms = proplists:get_value(end_term, Args) =/= undefined andalso
+                  Field =/= ?KEYFIELD,
 
-        {ok, [{_, Value}]} ->
-            %% One argument == exact match query
-            {ok, {eq, IndexField1, Value}};
-
-        {ok, [{_, Start}, {_, End}]} ->
-            %% Two arguments == range query
-            case End > Start of
-                true ->
-                    {ok, {range, IndexField1, Start, End}};
-                false ->
-                    {error, {invalid_range, Args}}
+    case {parse_field_if_defined(Field, Start),
+          parse_field_if_defined(Field, End)} of
+        {{ok, NormStart}, {ok, NormEnd}} ->
+            Req1 = ?KV_INDEX_Q{
+                    start_key=StartKey,
+                    filter_field=Field,
+                    start_term=NormStart,
+                    end_term=NormEnd,
+                    return_terms=ReturnTerms,
+                    term_regex=TermRegex,
+                    start_inclusive=StartInc,
+                    end_inclusive=EndInc,
+                    return_body=ReturnBody},
+            case Cont of
+                undefined ->
+                    {ok, Req1};
+                _ ->
+                    apply_continuation(Req1, decode_continuation(Cont))
             end;
-
-        {ok, _} ->
-            {error, {too_many_arguments, Args}};
-
-        {error, FailureReasons} ->
-            {error, FailureReasons}
+        {{error, _} = Err, _} ->
+            Err;
+        {_, {error, _} = Err} ->
+            Err
+    end;
+to_index_query(OldVersion, Args) ->
+    case to_index_query(?CURRENT_2I_VERSION, Args) of
+        {ok, Req} ->
+            downgrade_query(OldVersion, Req);
+        Err ->
+            Err
     end.
 
-%% v2 2i queries
-%% @doc Create an index query of the current highest version supported by
-%% cluster capability.
-%% This 6 arity version is for the new (temporarily unsupported) `return_body' feature
-%% for CS.
-%% @see riak_kv_pb_csbucket
-to_index_query(IndexField, Args, Continuation, ReturnBody, {Start, StartInc}, {End, EndInc}) ->
-    BaseQuery = ?KV_INDEX_Q{return_body=ReturnBody,
-                            start_key=Start, start_inclusive=StartInc,
-                            end_term=End, end_inclusive=EndInc},
-    to_index_query(IndexField, Args, Continuation, BaseQuery).
-
-%% @doc Create an index quey of the current highest version supported by
-%% cluster capability.
-%% `IndexField' is either a user supplied term or one of
-%% the inbuilt indexes (`<<"$key">>' and `<<"$bucket">>').
-%% `Args' is a list or either a start and end for a range, or a single
-%% value for equality.
-%% `Continuation' is the opaque continuation that may have been
-%% returned from a previous query, or `undefined'.
-%% @see make_continuation/1
-to_index_query(IndexField, Args, Continuation) ->
-    to_index_query(IndexField, Args, Continuation, ?KV_INDEX_Q{}).
-
-to_index_query(IndexField, Args, Continuation, BaseQuery) ->
+to_index_query(Args) ->
     Version = riak_core_capability:get({riak_kv, secondary_index_version}, v1),
-    Query = to_index_query(IndexField, Args),
-    case {Version, Query} of
-        {_Any, {error, _Reason}=Error} -> Error;
-        {v1, OKQ} -> OKQ;
-        {v2, {ok, V1Q}} ->
-            {ok, V2Q} = make_v2_query(V1Q, BaseQuery),
-            apply_continuation(V2Q, decode_continuation(Continuation))
-    end.
+    to_index_query(Version, Args).
 
 %% @doc upgrade a V1 Query to a v2 Query
-make_v2_query({eq, ?BUCKETFIELD, _Bucket}, Q) ->
+make_query({eq, ?BUCKETFIELD, _Bucket}, Q) ->
     {ok, Q?KV_INDEX_Q{filter_field=?BUCKETFIELD, return_terms=false}};
-make_v2_query({eq, ?KEYFIELD, Value}, Q) ->
+make_query({eq, ?KEYFIELD, Value}, Q) ->
     {ok, Q?KV_INDEX_Q{filter_field=?KEYFIELD, start_key=Value, start_term=Value,
                  end_term=Value, return_terms=false}};
-make_v2_query({eq, Field, Value}, Q) ->
+make_query({eq, Field, Value}, Q) ->
     {ok, Q?KV_INDEX_Q{filter_field=Field, start_term=Value, end_term=Value, return_terms=false}};
-make_v2_query({range, ?KEYFIELD, Start, End}, Q) ->
+make_query({range, ?KEYFIELD, Start, End}, Q) ->
     {ok, Q?KV_INDEX_Q{filter_field=?KEYFIELD, start_term=Start, start_key=Start,
                 end_term=End, return_terms=false}};
-make_v2_query({range, Field, Start, End}, Q) ->
+make_query({range, Field, Start, End}, Q) ->
     {ok, Q?KV_INDEX_Q{filter_field=Field, start_term=Start,
                  end_term=End}};
-make_v2_query(V1Q, _) ->
+make_query(V1Q, _) ->
     {error, {invalid_v1_query, V1Q}}.
 
 %% @doc if a continuation is specified, use it to update the query
@@ -346,9 +347,50 @@ apply_continuation(Q, C) ->
 %% @doc upgrade a query to the current latest version
 upgrade_query(Q=?KV_INDEX_Q{}) ->
     Q;
+upgrade_query(#riak_kv_index_v2{
+                start_key=StartKey,
+                filter_field=Field,
+                start_term=StartTerm,
+                end_term=EndTerm,
+                return_terms=ReturnTerms,
+                start_inclusive=StartInclusive,
+                end_inclusive=EndInclusive,
+                return_body=ReturnBody}) ->
+    ?KV_INDEX_Q{
+        start_key=StartKey,
+        filter_field=Field,
+        start_term=StartTerm,
+        end_term=EndTerm,
+        return_terms=ReturnTerms,
+        start_inclusive=StartInclusive,
+        end_inclusive=EndInclusive,
+        return_body=ReturnBody};
 upgrade_query(Q) when is_tuple(Q) ->
-    {ok, V2Q} = make_v2_query(Q, ?KV_INDEX_Q{}),
-    V2Q.
+    {ok, Q2} = make_query(Q, ?KV_INDEX_Q{}),
+    Q2.
+
+%% @doc Downgrade a lastest version query record to a previous version.
+-spec downgrade_query(V :: query_version(), ?KV_INDEX_Q{}) ->
+    {ok, tuple() | #riak_kv_index_v2{}} | {error, any()}.
+downgrade_query(v1, ?KV_INDEX_Q{
+                filter_field=Field, start_term=Start, end_term=undefined}) ->
+    {ok, {eq, Field, Start}};
+downgrade_query(v1, ?KV_INDEX_Q{
+                filter_field=Field, start_term=Start, end_term=End}) ->
+    {ok, {range, Field, Start, End}};
+downgrade_query(v2, ?KV_INDEX_Q{
+                filter_field=Field, start_key=StartKey,
+                start_term=StartTerm, start_inclusive=StartInc,
+                end_term=EndTerm, end_inclusive=EndInc,
+                return_terms=ReturnTerms, return_body=ReturnBody}) ->
+    {ok, #riak_kv_index_v2{
+            filter_field = Field, start_key=StartKey,
+            start_term=StartTerm, start_inclusive=StartInc,
+            end_term=EndTerm, end_inclusive=EndInc,
+            return_terms=ReturnTerms, return_body=ReturnBody
+            }};
+downgrade_query(V, Q) ->
+    {error, {downgrade_not_supported, V, Q}}.
 
 %% @doc Should index terms be returned in a result
 %% to the client. Requires both that they are wanted (arg1)
@@ -383,9 +425,31 @@ index_key_in_range(_, _, _) ->
     false.
 
 %% @doc Is a {bucket, key} pair in range for an index query
-object_key_in_range({Bucket, Key}=OK, Bucket, Q=?KV_INDEX_Q{end_term=undefined}) ->
-    ?KV_INDEX_Q{start_key=Start, start_inclusive=StartInc} = Q,
+object_key_in_range({Bucket, Key} = OK, Bucket,
+                    ?KV_INDEX_Q{filter_field=Field,
+                                end_term=End,
+                                start_key=Start,
+                                start_inclusive=StartInc})
+        when Field =:= ?BUCKETFIELD orelse
+        End =:= undefined ->
     in_range(gt(StartInc, Key, Start), true, OK);
+object_key_in_range({Bucket, Key}=OK, Bucket,
+                    ?KV_INDEX_Q{filter_field=?KEYFIELD,
+                                start_key=Start,
+                                term_regex=TermRe,
+                                start_inclusive=StartInc,
+                                end_term=End,
+                                end_inclusive=EndInc})
+        when TermRe =/= undefined ->
+    case in_range(gt(StartInc, Key, Start), gt(EndInc, End, Key), OK) of
+        {true, OK} ->
+            case re:run(Key, TermRe) of
+                nomatch -> {skip, OK};
+                _ -> {true, OK}
+            end;
+        Other ->
+            Other
+    end;
 object_key_in_range({Bucket, Key}=OK, Bucket, Q) ->
     ?KV_INDEX_Q{start_key=Start, start_inclusive=StartInc,
                 end_term=End, end_inclusive=EndInc} = Q,

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -169,7 +169,7 @@ start(_Type, _StartArgs) ->
                                           v0),
 
             riak_core_capability:register({riak_kv, secondary_index_version},
-                                          [v2, v1],
+                                          [v3, v2, v1],
                                           v1),
 
             riak_core_capability:register({riak_kv, vclock_data_encoding},

--- a/src/riak_kv_pb_csbucket.erl
+++ b/src/riak_kv_pb_csbucket.erl
@@ -67,7 +67,15 @@ process(Req=#rpbcsbucketreq{}, State) ->
     #rpbcsbucketreq{bucket=Bucket, start_key=StartKey,
                     start_incl=StartIncl, continuation=Continuation,
                     end_key=EndKey, end_incl=EndIncl} = Req,
-    Query = riak_index:to_index_query(<<"$bucket">>, [Bucket], Continuation, true, {StartKey, StartIncl}, {EndKey, EndIncl}),
+    Query = riak_index:to_index_query([
+                {field,<<"$bucket">>},
+                {start_term, Bucket},
+                {start_inclusive, StartIncl},
+                {end_term, EndKey},
+                {end_inclusive, EndIncl},
+                {start_key, StartKey},
+                {continuation, Continuation}
+                ]),
     maybe_perform_query(Query, Req, State).
 
 maybe_perform_query({error, Reason}, _Req, State) ->

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -37,6 +37,7 @@
 -module(riak_kv_pb_index).
 
 -include_lib("riak_pb/include/riak_kv_pb.hrl").
+-include("riak_kv_index.hrl").
 
 -behaviour(riak_api_pb_service).
 
@@ -63,17 +64,43 @@ decode(Code, Bin) ->
 encode(Message) ->
     {ok, riak_pb_codec:encode(Message)}.
 
+validate_request(#rpbindexreq{qtype=QType, key=SKey,
+                              range_min=Min, range_max=Max,
+                              term_regex=TermRe} = Req) ->
+    {ValRe, ValErr} = case TermRe of
+        undefined ->
+            {undefined, undefined};
+        _ ->
+            re:compile(TermRe)
+    end,
+
+    if
+        QType == eq andalso not is_binary(SKey) ->
+            {error, {format, "Invalid equality query ~p", [SKey]}};
+        QType == range andalso not(is_binary(Min) andalso is_binary(Max)) ->
+            {error, {format, "Invalid range query: ~p -> ~p", [Min, Max]}};
+        ValRe =:= error ->
+            {error, {format, "Invalid term regular expression ~p : ~p",
+                     [TermRe, ValErr]}};
+        true ->
+            Query = riak_index:to_index_query(query_params(Req)),
+            case Query of
+                {ok, ?KV_INDEX_Q{start_term=Start, term_regex=Re}} when is_integer(Start)
+                       andalso Re =/= undefined ->
+                    {error, "Can not use term regular expression in integer query"};
+                _ ->
+                    Query
+            end
+    end.
+
 %% @doc process/2 callback. Handles an incoming request message.
-process(#rpbindexreq{qtype=eq, key=SKey}, State)
-  when not is_binary(SKey) ->
-    {error, {format, "Invalid equality query ~p", [SKey]}, State};
-process(#rpbindexreq{qtype=range, range_min=Min, range_max=Max}, State)
-  when not (is_binary(Min) andalso is_binary(Max)) ->
-    {error, {format, "Invalid range query: ~p -> ~p", [Min, Max]}, State};
-process(Req=#rpbindexreq{}, State) ->
-    {Index, Args, Continuation} = query_params(Req),
-    Query = riak_index:to_index_query(Index, Args, Continuation),
-    maybe_perform_query(Query, Req, State).
+process(#rpbindexreq{} = Req, State) ->
+    case validate_request(Req) of
+        {error, Err} ->
+            {error, Err, State};
+        QueryVal ->
+            maybe_perform_query(QueryVal, Req, State)
+    end.
 
 maybe_perform_query({error, Reason}, _Req, State) ->
     {error, {format, Reason}, State};
@@ -100,10 +127,14 @@ handle_query_results(ReturnTerms, MaxResults,  {ok, Results}, State) ->
     Resp = encode_results(ReturnTerms, Results, Cont),
     {reply, Resp, State}.
 
-query_params(#rpbindexreq{qtype=eq, index=Index, key=Value, continuation=Continuation}) ->
-    {Index, [Value], Continuation};
-query_params(#rpbindexreq{index=Index, range_min=Min, range_max=Max, continuation=Continuation}) ->
-    {Index, [Min, Max], Continuation}.
+query_params(#rpbindexreq{qtype=eq, index=Index, key=Value,
+                          term_regex=Re, continuation=Continuation}) ->
+    [{field, Index}, {start_term, Value}, {term_regex, Re},
+     {continuation, Continuation}];
+query_params(#rpbindexreq{index=Index, range_min=Min, range_max=Max,
+                          term_regex=Re, continuation=Continuation}) ->
+     [{field, Index}, {start_term, Min}, {end_term, Max},
+      {term_regex, Re}, {continuation, Continuation}].
 
 encode_results(true, Results0, Continuation) ->
     Results = [encode_result(Res) || Res <- Results0],

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -74,6 +74,7 @@
 -export([handoff_data_encoding_method/0]).
 
 -include_lib("riak_kv_vnode.hrl").
+-include_lib("riak_kv_index.hrl").
 -include_lib("riak_kv_map_phase.hrl").
 -include_lib("riak_core/include/riak_core_pb.hrl").
 
@@ -678,6 +679,13 @@ handle_coverage(?KV_INDEX_REQ{bucket=Bucket,
     handle_coverage_index(Bucket, ItemFilter, Query,
                           FilterVNodes, Sender, State, fun result_fun_ack/2).
 
+prepare_index_query(#riak_kv_index_v3{term_regex=RE} = Q) when
+        RE =/= undefined ->
+    {ok, CompiledRE} = re:compile(RE),
+    Q#riak_kv_index_v3{term_regex=CompiledRE};
+prepare_index_query(Q) ->
+    Q.
+
 handle_coverage_index(Bucket, ItemFilter, Query,
                       FilterVNodes, Sender,
                       State=#state{mod=Mod,
@@ -691,7 +699,7 @@ handle_coverage_index(Bucket, ItemFilter, Query,
             riak_kv_stat:update(vnode_index_read),
 
             ResultFun = ResultFunFun(Bucket, Sender),
-            Opts = [{index, Bucket, Query},
+            Opts = [{index, Bucket, prepare_index_query(Query)},
                     {bucket, Bucket}],
             %% @HACK
             %% Really this should be decided in the backend

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -55,6 +55,7 @@
 
 -include_lib("webmachine/include/webmachine.hrl").
 -include("riak_kv_wm_raw.hrl").
+-include("riak_kv_index.hrl").
 
 %% @spec init(proplist()) -> {ok, context()}
 %% @doc Initialize this resource.
@@ -98,16 +99,48 @@ malformed_request(RD, Ctx) ->
     ReturnTerms = normalize_boolean(string:to_lower(ReturnTerms0)),
     MaxResults0 = wrq:get_qs_value(?Q_2I_MAX_RESULTS, ?ALL_2I_RESULTS, RD),
     Continuation = wrq:get_qs_value(?Q_2I_CONTINUATION, undefined, RD),
+    TermRegex = wrq:get_qs_value(?Q_2I_TERM_REGEX, undefined, RD),
     Timeout0 =  wrq:get_qs_value("timeout", undefined, RD),
+    {Start, End} = case Args2 of
+        [] -> {undefined, undefined};
+        [S] -> {S, undefined};
+        [S, E] -> {S, E}
+    end,
+    QRes = riak_index:to_index_query([
+                {field, IndexField}, {start_term, Start}, {end_term, End},
+                {return_terms, ReturnTerms}, {continuation, Continuation},
+                {term_regex, TermRegex}
+                ]),
+    ValRe = case TermRegex of
+        undefined ->
+            ok;
+        _ ->
+            re:compile(TermRegex)
+    end,
 
-    case {ReturnTerms, validate_timeout(Timeout0), validate_max(MaxResults0), riak_index:to_index_query(IndexField, Args2, Continuation)} of
-        {malformed, _, _, _} ->
+    case {ReturnTerms, validate_timeout(Timeout0), validate_max(MaxResults0),
+          QRes, ValRe} of
+        {malformed, _, _, _, _} ->
              {true,
              wrq:set_resp_body(io_lib:format("Invalid ~p. ~p is not a boolean",
                                              [?Q_2I_RETURNTERMS, ReturnTerms0]),
                                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx};
-        {_, {true, Timeout}, {true, MaxResults}, {ok, Query}} ->
+        {_, _, _, {ok, ?KV_INDEX_Q{start_term=NormStart}}, {ok, _CompiledRe}}
+         when is_integer(NormStart) ->
+            {true,
+             wrq:set_resp_body("Can not use term regular expressions"
+                               " on integer queries",
+                               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx};
+        {_, _, _, _, {error, ReError}} ->
+            {true,
+             wrq:set_resp_body(
+                    io_lib:format("Invalid term regular expression ~p : ~p",
+                                  [TermRegex, ReError]),
+                    wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx};
+        {_, {true, Timeout}, {true, MaxResults}, {ok, Query}, _} ->
             %% Request is valid.
             ReturnTerms1 = riak_index:return_terms(ReturnTerms, Query),
             NewCtx = Ctx#ctx{
@@ -118,19 +151,19 @@ malformed_request(RD, Ctx) ->
                        timeout=Timeout
                       },
             {false, RD, NewCtx};
-        {_, _, _, {error, Reason}} ->
+        {_, _, _, {error, Reason}, _} ->
             {true,
              wrq:set_resp_body(
                io_lib:format("Invalid query: ~p~n", [Reason]),
                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx};
-        {_, _, {false, BadVal}, _} ->
+        {_, _, {false, BadVal}, _, _} ->
             {true,
              wrq:set_resp_body(io_lib:format("Invalid ~p. ~p is not a positive integer",
                                              [?Q_2I_MAX_RESULTS, BadVal]),
                                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx};
-        {_, {error, Input}, _, _} ->
+        {_, {error, Input}, _, _, _} ->
             {true, wrq:append_to_resp_body(io_lib:format("Bad timeout "
                                                            "value ~p. Must be a non-negative integer~n",
                                                            [Input]),

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -64,6 +64,7 @@
 -define(Q_RETURNBODY, "returnbody").
 -define(Q_2I_RETURNTERMS, "return_terms").
 -define(Q_2I_MAX_RESULTS, "max_results").
+-define(Q_2I_TERM_REGEX, "term_regex").
 -define(Q_2I_CONTINUATION, "continuation").
 -define(Q_RESULTS,  "results").
 -define(Q_RETURNVALUE, "returnvalue").


### PR DESCRIPTION
Backport the 2i term regex filter to the 1.4 series.

For convenience, the feature/2i-regex-filter-1.4 branch exists in top riak and other repos so this can be built and run with the right dependencies.

/cc @russelldb 
