### PR TITLE
Streaming 2i Query Performance Penalty in 1.4

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -287,7 +287,7 @@
 ]}.
 
 %% @doc Default for 2i sort on results. If your application relies
-%% on the undocumented sorted order of results introduced in 1.4.2 and made
+%% on the sorted order of results introduced in 1.4 with pagination and made
 %% optional and off by default in 1.4.4, and you are not able to change your
 %% to override the sort order, uncomment this value and set to true.
 {mapping, "secondary_index_sort_default", "riak_kv.secondary_index_sort_default", [

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -285,3 +285,13 @@
   {commented, "1d"}, %% no default, it's undefined.
   {level, advanced}
 ]}.
+
+%% @doc Default for 2i sort on results. If your application relies
+%% on the undocumented sorted order of results introduced in 1.4.2 and made
+%% optional and off by default in 1.4.4, and you are not able to change your
+%% to override the sort order, uncomment this value and set to true.
+{mapping, "secondary_index_sort_default", "riak_kv.secondary_index_sort_default", [
+  {datatype, {enum, [true, false]}},
+  {default, false},
+  {commented, false}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -17,6 +17,6 @@
         {eper, ".*", {git, "git://github.com/basho/eper.git", {branch, "develop"}}},
         {sext, ".*", {git, "git://github.com/uwiger/sext.git", {tag, "1.1-3-g3af5478"}}},
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {branch, "develop"}}},
-        {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {branch, "develop"}}},
+        {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {branch, "feature/2i-sort-optional"}}},
         {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {branch, "develop"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -17,6 +17,6 @@
         {eper, ".*", {git, "git://github.com/basho/eper.git", {branch, "develop"}}},
         {sext, ".*", {git, "git://github.com/uwiger/sext.git", {tag, "1.1-3-g3af5478"}}},
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {branch, "develop"}}},
-        {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {branch, "feature/2i-sort-optional"}}},
+        {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {branch, "develop"}}},
         {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {branch, "develop"}}}
        ]}.

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -670,9 +670,10 @@ get_index(Bucket, Query, {?MODULE, [_Node, _ClientId]}=THIS) ->
 get_index(Bucket, Query, Opts, {?MODULE, [Node, _ClientId]}) ->
     Timeout = proplists:get_value(timeout, Opts, ?DEFAULT_TIMEOUT),
     MaxResults = proplists:get_value(max_results, Opts, all),
+    Order = proplists:get_value(order, Opts, unsorted),
     Me = self(),
     ReqId = mk_reqid(),
-    riak_kv_index_fsm_sup:start_index_fsm(Node, [{raw, ReqId, Me}, [Bucket, none, Query, Timeout, MaxResults]]),
+    riak_kv_index_fsm_sup:start_index_fsm(Node, [{raw, ReqId, Me}, [Bucket, none, Query, Timeout, MaxResults, Order]]),
     wait_for_query_results(ReqId, Timeout).
 
 %% @doc Run the provided index query, return a stream handle.
@@ -689,13 +690,14 @@ stream_get_index(Bucket, Query, {?MODULE, [_Node, _ClientId]}=THIS) ->
 stream_get_index(Bucket, Query, Opts, {?MODULE, [Node, _ClientId]}) ->
     Timeout = proplists:get_value(timeout, Opts, ?DEFAULT_TIMEOUT),
     MaxResults = proplists:get_value(max_results, Opts, all),
+    Order = proplists:get_value(order, Opts, unsorted),
     Me = self(),
     ReqId = mk_reqid(),
     case riak_kv_index_fsm_sup:start_index_fsm(Node,
                                                [{raw, ReqId, Me},
                                                 [Bucket, none,
                                                  Query, Timeout,
-                                                 MaxResults]]) of
+                                                 MaxResults, Order]]) of
         {ok, Pid} ->
             {ok, ReqId, Pid};
         {error, Reason} ->

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -670,10 +670,10 @@ get_index(Bucket, Query, {?MODULE, [_Node, _ClientId]}=THIS) ->
 get_index(Bucket, Query, Opts, {?MODULE, [Node, _ClientId]}) ->
     Timeout = proplists:get_value(timeout, Opts, ?DEFAULT_TIMEOUT),
     MaxResults = proplists:get_value(max_results, Opts, all),
-    Order = proplists:get_value(order, Opts, unsorted),
+    Sort = proplists:get_value(sort, Opts),
     Me = self(),
     ReqId = mk_reqid(),
-    riak_kv_index_fsm_sup:start_index_fsm(Node, [{raw, ReqId, Me}, [Bucket, none, Query, Timeout, MaxResults, Order]]),
+    riak_kv_index_fsm_sup:start_index_fsm(Node, [{raw, ReqId, Me}, [Bucket, none, Query, Timeout, MaxResults, Sort]]),
     wait_for_query_results(ReqId, Timeout).
 
 %% @doc Run the provided index query, return a stream handle.
@@ -690,14 +690,14 @@ stream_get_index(Bucket, Query, {?MODULE, [_Node, _ClientId]}=THIS) ->
 stream_get_index(Bucket, Query, Opts, {?MODULE, [Node, _ClientId]}) ->
     Timeout = proplists:get_value(timeout, Opts, ?DEFAULT_TIMEOUT),
     MaxResults = proplists:get_value(max_results, Opts, all),
-    Order = proplists:get_value(order, Opts, unsorted),
+    Sort = proplists:get_value(sort, Opts),
     Me = self(),
     ReqId = mk_reqid(),
     case riak_kv_index_fsm_sup:start_index_fsm(Node,
                                                [{raw, ReqId, Me},
                                                 [Bucket, none,
                                                  Query, Timeout,
-                                                 MaxResults, Order]]) of
+                                                 MaxResults, Sort]]) of
         {ok, Pid} ->
             {ok, ReqId, Pid};
         {error, Reason} ->

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -83,18 +83,25 @@ process(Req=#rpbindexreq{}, State) ->
 maybe_perform_query({error, Reason}, _Req, State) ->
     {error, {format, Reason}, State};
 maybe_perform_query({ok, Query}, Req=#rpbindexreq{stream=true}, State) ->
-    #rpbindexreq{type = T, bucket=B, max_results=MaxResults, timeout=Timeout} = Req,
+    #rpbindexreq{type = T, bucket=B, max_results=MaxResults, timeout=Timeout,
+                sort=Sort} = Req,
     #state{client=Client} = State,
     Bucket = maybe_bucket_type(T, B),
-    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults}]),
+    Order = case Sort of true -> sorted; _ -> unsorted end,
+    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults},
+                                                {order, Order}]),
     {ok, ReqId, _FSMPid} = Client:stream_get_index(Bucket, Query, Opts),
     ReturnTerms = riak_index:return_terms(Req#rpbindexreq.return_terms, Query),
     {reply, {stream, ReqId}, State#state{req_id=ReqId, req=Req#rpbindexreq{return_terms=ReturnTerms}}};
 maybe_perform_query({ok, Query}, Req, State) ->
-    #rpbindexreq{type = T, bucket=B, max_results=MaxResults, return_terms=ReturnTerms0, timeout=Timeout} = Req,
+    #rpbindexreq{type = T, bucket=B, max_results=MaxResults,
+                 return_terms=ReturnTerms0, timeout=Timeout,
+                sort=Sort} = Req,
     #state{client=Client} = State,
     Bucket = maybe_bucket_type(T, B),
-    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults}]),
+    Order = case Sort of true -> sorted; _ -> unsorted end,
+    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults},
+                                                {order, Order}]),
     ReturnTerms =  riak_index:return_terms(ReturnTerms0, Query),
     QueryResult = Client:get_index(Bucket, Query, Opts),
     handle_query_results(ReturnTerms, MaxResults, QueryResult , State).

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -84,24 +84,22 @@ maybe_perform_query({error, Reason}, _Req, State) ->
     {error, {format, Reason}, State};
 maybe_perform_query({ok, Query}, Req=#rpbindexreq{stream=true}, State) ->
     #rpbindexreq{type = T, bucket=B, max_results=MaxResults, timeout=Timeout,
-                sort=Sort} = Req,
+                 sort=Sort} = Req,
     #state{client=Client} = State,
     Bucket = maybe_bucket_type(T, B),
-    Order = case Sort of true -> sorted; _ -> unsorted end,
-    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults},
-                                                {order, Order}]),
+    Opts0 = [{max_results, MaxResults}] ++ [{sort, Sort} || Sort /= undefined],
+    Opts = riak_index:add_timeout_opt(Timeout, Opts0),
     {ok, ReqId, _FSMPid} = Client:stream_get_index(Bucket, Query, Opts),
     ReturnTerms = riak_index:return_terms(Req#rpbindexreq.return_terms, Query),
     {reply, {stream, ReqId}, State#state{req_id=ReqId, req=Req#rpbindexreq{return_terms=ReturnTerms}}};
 maybe_perform_query({ok, Query}, Req, State) ->
     #rpbindexreq{type = T, bucket=B, max_results=MaxResults,
                  return_terms=ReturnTerms0, timeout=Timeout,
-                sort=Sort} = Req,
+                 sort=Sort} = Req,
     #state{client=Client} = State,
     Bucket = maybe_bucket_type(T, B),
-    Order = case Sort of true -> sorted; _ -> unsorted end,
-    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults},
-                                                {order, Order}]),
+    Opts0 = [{max_results, MaxResults}] ++ [{sort, Sort} || Sort /= undefined],
+    Opts = riak_index:add_timeout_opt(Timeout, Opts0),
     ReturnTerms =  riak_index:return_terms(ReturnTerms0, Query),
     QueryResult = Client:get_index(Bucket, Query, Opts),
     handle_query_results(ReturnTerms, MaxResults, QueryResult , State).

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -44,6 +44,9 @@
 %%   * return_terms=true
 %%         when querying with a range, returns the value of the index
 %%         along with the key.
+%%   * sort=true|false
+%%         whether the results will be sorted. Ignored when max_results
+%%         is set, as pagination requires sorted results.
 
 -module(riak_kv_wm_index).
 
@@ -70,6 +73,7 @@
           max_results :: all | pos_integer(), %% maximum number of 2i results to return, the page size.
           return_terms = false :: boolean(), %% should the index values be returned
           timeout :: non_neg_integer() | undefined | infinity,
+          order :: sorted | unsorted,
           security        %% security context
          }).
 
@@ -153,41 +157,55 @@ malformed_request(RD, Ctx) ->
     Args2 = [list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, X)) || X <- Args1],
     ReturnTerms0 = wrq:get_qs_value(?Q_2I_RETURNTERMS, "false", RD),
     ReturnTerms = normalize_boolean(string:to_lower(ReturnTerms0)),
+    Sorted0 = wrq:get_qs_value(?Q_2I_SORT, "false", RD),
+    Sorted = normalize_boolean(string:to_lower(Sorted0)),
     MaxResults0 = wrq:get_qs_value(?Q_2I_MAX_RESULTS, ?ALL_2I_RESULTS, RD),
     Continuation = wrq:get_qs_value(?Q_2I_CONTINUATION, undefined, RD),
     Timeout0 =  wrq:get_qs_value("timeout", undefined, RD),
 
-    case {ReturnTerms, validate_timeout(Timeout0), validate_max(MaxResults0), riak_index:to_index_query(IndexField, Args2, Continuation)} of
-        {malformed, _, _, _} ->
+    case {Sorted,
+          ReturnTerms,
+          validate_timeout(Timeout0),
+          validate_max(MaxResults0),
+          riak_index:to_index_query(IndexField, Args2, Continuation)} of
+        {malformed, _, _, _, _} ->
+             {true,
+             wrq:set_resp_body(io_lib:format("Invalid ~p. ~p is not a boolean",
+                                             [?Q_2I_SORT, Sorted0]),
+                               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx};
+        {_, malformed, _, _, _} ->
              {true,
              wrq:set_resp_body(io_lib:format("Invalid ~p. ~p is not a boolean",
                                              [?Q_2I_RETURNTERMS, ReturnTerms0]),
                                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx};
-        {_, {true, Timeout}, {true, MaxResults}, {ok, Query}} ->
+        {_, _, {true, Timeout}, {true, MaxResults}, {ok, Query}} ->
             %% Request is valid.
             ReturnTerms1 = riak_index:return_terms(ReturnTerms, Query),
+            Order = case Sorted of true -> sorted; false -> unsorted end,
             NewCtx = Ctx#ctx{
                        bucket = Bucket,
                        index_query = Query,
                        max_results = MaxResults,
                        return_terms = ReturnTerms1,
-                       timeout=Timeout
+                       timeout=Timeout,
+                       order = Order
                       },
             {false, RD, NewCtx};
-        {_, _, _, {error, Reason}} ->
+        {_, _, _, _, {error, Reason}} ->
             {true,
              wrq:set_resp_body(
                io_lib:format("Invalid query: ~p~n", [Reason]),
                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx};
-        {_, _, {false, BadVal}, _} ->
+        {_, _, _, {false, BadVal}, _} ->
             {true,
              wrq:set_resp_body(io_lib:format("Invalid ~p. ~p is not a positive integer",
                                              [?Q_2I_MAX_RESULTS, BadVal]),
                                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx};
-        {_, {error, Input}, _, _} ->
+        {_, _, {error, Input}, _, _} ->
             {true, wrq:append_to_resp_body(io_lib:format("Bad timeout "
                                                            "value ~p. Must be a non-negative integer~n",
                                                            [Input]),
@@ -265,6 +283,7 @@ handle_streaming_index_query(RD, Ctx) ->
     MaxResults = Ctx#ctx.max_results,
     ReturnTerms = Ctx#ctx.return_terms,
     Timeout = Ctx#ctx.timeout,
+    Order = Ctx#ctx.order,
 
     %% Create a new multipart/mixed boundary
     Boundary = riak_core_util:unique_id_62(),
@@ -273,7 +292,8 @@ handle_streaming_index_query(RD, Ctx) ->
                 "multipart/mixed;boundary="++Boundary,
                 RD),
 
-    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults}]),
+    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults},
+                                                {order, Order}]),
 
     {ok, ReqID, FSMPid} =  Client:stream_get_index(Bucket, Query, Opts),
     StreamFun = index_stream_helper(ReqID, FSMPid, Boundary, ReturnTerms, MaxResults, proplists:get_value(timeout, Opts), undefined, 0),
@@ -357,9 +377,11 @@ handle_all_in_memory_index_query(RD, Ctx) ->
     Query = Ctx#ctx.index_query,
     MaxResults = Ctx#ctx.max_results,
     ReturnTerms = Ctx#ctx.return_terms,
+    Order = Ctx#ctx.order,
     Timeout = Ctx#ctx.timeout,
 
-    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults}]),
+    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults},
+                                               {order, Order}]),
 
     %% Do the index lookup...
     case Client:get_index(Bucket, Query, Opts) of

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -73,7 +73,7 @@
           max_results :: all | pos_integer(), %% maximum number of 2i results to return, the page size.
           return_terms = false :: boolean(), %% should the index values be returned
           timeout :: non_neg_integer() | undefined | infinity,
-          order :: sorted | unsorted,
+          sort :: boolean() | undefined,
           security        %% security context
          }).
 
@@ -157,13 +157,16 @@ malformed_request(RD, Ctx) ->
     Args2 = [list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, X)) || X <- Args1],
     ReturnTerms0 = wrq:get_qs_value(?Q_2I_RETURNTERMS, "false", RD),
     ReturnTerms = normalize_boolean(string:to_lower(ReturnTerms0)),
-    Sorted0 = wrq:get_qs_value(?Q_2I_SORT, "false", RD),
-    Sorted = normalize_boolean(string:to_lower(Sorted0)),
+    Sort0 = wrq:get_qs_value(?Q_2I_SORT, RD),
+    Sort = case Sort0 of
+        undefined -> undefined;
+        _ -> normalize_boolean(string:to_lower(Sort0))
+    end,
     MaxResults0 = wrq:get_qs_value(?Q_2I_MAX_RESULTS, ?ALL_2I_RESULTS, RD),
     Continuation = wrq:get_qs_value(?Q_2I_CONTINUATION, undefined, RD),
     Timeout0 =  wrq:get_qs_value("timeout", undefined, RD),
 
-    case {Sorted,
+    case {Sort,
           ReturnTerms,
           validate_timeout(Timeout0),
           validate_max(MaxResults0),
@@ -171,7 +174,7 @@ malformed_request(RD, Ctx) ->
         {malformed, _, _, _, _} ->
              {true,
              wrq:set_resp_body(io_lib:format("Invalid ~p. ~p is not a boolean",
-                                             [?Q_2I_SORT, Sorted0]),
+                                             [?Q_2I_SORT, Sort0]),
                                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx};
         {_, malformed, _, _, _} ->
@@ -183,14 +186,13 @@ malformed_request(RD, Ctx) ->
         {_, _, {true, Timeout}, {true, MaxResults}, {ok, Query}} ->
             %% Request is valid.
             ReturnTerms1 = riak_index:return_terms(ReturnTerms, Query),
-            Order = case Sorted of true -> sorted; false -> unsorted end,
             NewCtx = Ctx#ctx{
                        bucket = Bucket,
                        index_query = Query,
                        max_results = MaxResults,
                        return_terms = ReturnTerms1,
                        timeout=Timeout,
-                       order = Order
+                       sort = Sort
                       },
             {false, RD, NewCtx};
         {_, _, _, _, {error, Reason}} ->
@@ -283,7 +285,7 @@ handle_streaming_index_query(RD, Ctx) ->
     MaxResults = Ctx#ctx.max_results,
     ReturnTerms = Ctx#ctx.return_terms,
     Timeout = Ctx#ctx.timeout,
-    Order = Ctx#ctx.order,
+    Sort = Ctx#ctx.sort,
 
     %% Create a new multipart/mixed boundary
     Boundary = riak_core_util:unique_id_62(),
@@ -292,8 +294,8 @@ handle_streaming_index_query(RD, Ctx) ->
                 "multipart/mixed;boundary="++Boundary,
                 RD),
 
-    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults},
-                                                {order, Order}]),
+    Opts0 = [{max_results, MaxResults}] ++ [{sort, Sort} || Sort /= undefined],
+    Opts = riak_index:add_timeout_opt(Timeout, Opts0), 
 
     {ok, ReqID, FSMPid} =  Client:stream_get_index(Bucket, Query, Opts),
     StreamFun = index_stream_helper(ReqID, FSMPid, Boundary, ReturnTerms, MaxResults, proplists:get_value(timeout, Opts), undefined, 0),
@@ -377,11 +379,11 @@ handle_all_in_memory_index_query(RD, Ctx) ->
     Query = Ctx#ctx.index_query,
     MaxResults = Ctx#ctx.max_results,
     ReturnTerms = Ctx#ctx.return_terms,
-    Order = Ctx#ctx.order,
+    Sort = Ctx#ctx.sort,
     Timeout = Ctx#ctx.timeout,
 
-    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults},
-                                               {order, Order}]),
+    Opts0 = [{max_results, MaxResults}] ++ [{sort, Sort} || Sort /= undefined],
+    Opts = riak_index:add_timeout_opt(Timeout, Opts0), 
 
     %% Do the index lookup...
     case Client:get_index(Bucket, Query, Opts) of

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -67,5 +67,6 @@
 -define(Q_2I_RETURNTERMS, "return_terms").
 -define(Q_2I_MAX_RESULTS, "max_results").
 -define(Q_2I_CONTINUATION, "continuation").
+-define(Q_2I_SORT, "sort").
 -define(Q_RESULTS,  "results").
 -define(Q_RETURNVALUE, "returnvalue").


### PR DESCRIPTION
In 1.4.2, the streaming merge sort which enables pagination creates a large performance hit to queries that might not require it (streaming). 

Making the sort optional on non-paginated 2i queries would provide greatly increased performance on queries that don't require deterministic ordering.

This issue is particularly visible when returning multi-million key results. 1-10million
