### PR TITLE
Avoid mutator code path when necessary.

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1198,7 +1198,16 @@ perform_put({true, Obj},
                      bprops=BProps,
                      reqid=ReqID,
                      index_specs=IndexSpecs}) ->
-    {Obj2, Fake} = riak_kv_mutator:mutate_put(Obj, BProps),
+
+    %% Avoid the riak_kv_mutator code path is no mutators are
+    %% registered.
+    {Obj2, Fake} = case riak_kv_mutator:get() of
+        {ok, []} ->
+            {Obj, Obj};
+        {ok, Mutators} ->
+            riak_kv_mutator:mutate_put(Obj, BProps, Mutators)
+    end,
+
     {Reply, State2} = actual_put(BKey, Obj2, Fake, IndexSpecs, RB, ReqID, State),
     {Reply, State2}.
 


### PR DESCRIPTION
Avoid the mutator code path completely when there are no registered
mutators, which prevents the mutators_applied item from being added to
the metadata dictionary when there are no mutators.

@Vagabond @engelsanchez @lordnull 
