### PR TITLE
added secure_referer_check to riak_kv schema

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -286,7 +286,7 @@
   {level, advanced}
 ]}.
 
-%% @doc In Riak 1.2 we added some measures to counteract cross-site scripting 
+%% @doc Measures were added to Riak 1.2 to counteract cross-site scripting 
 %% and request-forgery attacks. Some reverse-proxies cannot remove the Referer 
 %% header and makes serving data directly from Riak impossible. Turning
 %% secure_referer_check = off disables this security check

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -285,3 +285,24 @@
   {commented, "1d"}, %% no default, it's undefined.
   {level, advanced}
 ]}.
+
+%% @doc In Riak 1.2 we added some measures to counteract cross-site scripting 
+%% and request-forgery attacks. Some reverse-proxies cannot remove the Referer 
+%% header and makes serving data directly from Riak impossible. Turning
+%% secure_referer_check = off disables this security check
+{mapping, "secure_referer_check", "riak_kv.secure_referer_check", [
+  {datatype, {enum, [on, off]}},
+  {default, on},
+  {level, advanced}
+]}.
+
+{translation,
+ "riak_kv.secure_referer_check",
+ fun(Conf) ->
+  case cuttlefish_util:conf_get_value("secure_referer_check", Conf) of
+    off -> false;
+    on -> true;
+    _ -> true
+  end
+ end
+}.

--- a/test/riak_kv_schema_tests.erl
+++ b/test/riak_kv_schema_tests.erl
@@ -42,6 +42,8 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_kv.multi_backend_default", undefined),
     cuttlefish_unit:assert_config(Config, "riak_kv.multi_backend", undefined),
 
+    cuttlefish_unit:assert_config(Config, "riak_kv.secure_referer_check", true),
+
     ok.
 
 override_non_multi_backend_schema_test() ->
@@ -74,7 +76,8 @@ override_non_multi_backend_schema_test() ->
         {["retry_put_coordinator_failure"], off},
         {["object_format"], v0},
         {["memory_backend", "max_memory"], "8GB"},
-        {["memory_backend", "ttl"], "1d"}
+        {["memory_backend", "ttl"], "1d"},
+        {["secure_referer_check"], off}
     ],
 
     Config = cuttlefish_unit:generate_templated_config(
@@ -111,6 +114,7 @@ override_non_multi_backend_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_kv.multi_backend_default", undefined),
     cuttlefish_unit:assert_config(Config, "riak_kv.multi_backend", undefined),
 
+    cuttlefish_unit:assert_config(Config, "riak_kv.secure_referer_check", false),
     ok.
 
 multi_backend_test() ->
@@ -153,6 +157,7 @@ multi_backend_test() ->
     cuttlefish_unit:assert_config(Config, "riak_kv.memory_backend.max_memory", 4096),
     cuttlefish_unit:assert_config(Config, "riak_kv.memory_backend.ttl", undefined),
 
+    cuttlefish_unit:assert_config(Config, "riak_kv.secure_referer_check", true),
     %% make sure multi backend is not on by shell_default
     cuttlefish_unit:assert_config(Config, "riak_kv.multi_backend_default", <<"backend_one">>),
 


### PR DESCRIPTION
A community user reported this setting missing from the schema.
