### PR TITLE
Transform an empty context to a `undefined` for the PB protocol

### DIFF
--- a/src/riak_kv_pb_crdt.erl
+++ b/src/riak_kv_pb_crdt.erl
@@ -259,6 +259,8 @@ return_value(true) ->
 return_value(_) ->
     [].
 
+get_context(<<>>, _) ->
+    undefined;
 get_context(_Ctx, false) ->
    undefined;
 get_context(Ctx, true) ->


### PR DESCRIPTION
As spotted by @broach in https://github.com/basho/riak-java-client/pull/332
