### PR TITLE
Fix consistent_object mixed-mode failure.

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -826,6 +826,8 @@ consistent_object(Node, Bucket) when Node =:= node() ->
     riak_kv_util:consistent_object(Bucket);
 consistent_object(Node, Bucket) ->
     case rpc:call(Node, riak_kv_util, consistent_object, [Bucket]) of
+        {badrpc, {'EXIT', {undef, _}}} ->
+            false;
         {badrpc, _}=Err ->
             {error, Err};
         Result ->


### PR DESCRIPTION
Ensure that if we attempt to call consistent_object on a remote node
and get a undefined function error back, this most likely means that
the node contacted is running an earlier version of Riak, in which
case strong consistency is not available.

It appears that in addition to this, we probably should have a
capability for this.

This fixes the current failure on `verify_basic_upgrade.`
