### PR TITLE
remove ebloom from rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,6 @@
         {sidejob, ".*", {git, "git://github.com/basho/sidejob.git", {branch, "develop"}}},
         {erlang_js, ".*", {git, "git://github.com/basho/erlang_js.git", {branch, "develop"}}},
         {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {branch, "develop"}}},
-        {ebloom, ".*", {git, "git://github.com/basho/ebloom.git", {branch, "develop"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", {branch, "develop"}}},
         {sext, ".*", {git, "git://github.com/uwiger/sext.git", {tag, "1.1-3-g3af5478"}}},
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {branch, "develop"}}},


### PR DESCRIPTION
Remove the ebloom dependency, as it's not used anywhere in riak_kv.
