### PR TITLE
Add HTTP API for datatypes.

### DIFF
--- a/src/riak_kv_crdt.erl
+++ b/src/riak_kv_crdt.erl
@@ -23,8 +23,7 @@
 -module(riak_kv_crdt).
 
 -export([update/3, merge/1, value/2, new/3,
-         supported/1, parse_operation/2,
-         to_mod/1, from_mod/1]).
+         supported/1, to_mod/1, from_mod/1]).
 -export([to_binary/2, to_binary/1, from_binary/1]).
 
 -include("riak_kv_wm_raw.hrl").
@@ -384,18 +383,6 @@ to_record(?SET_TYPE, Val) ->
 %% @TODO what does this mean for Maps?
 supported(Mod) ->
     lists:member(Mod, riak_core_capability:get({riak_kv, crdt}, [])).
-
-%% @doc parse the operation from a binary
-%% Assume type is validated and supported
-%% This is where all the magic neds to be @TODO'd
-parse_operation(CRDTOp, OpBin) ->
-    try
-        {ok, Tokens, _} = erl_scan:string(binary_to_list(OpBin)),
-        {ok, Ops} = erl_parse:parse_term(Tokens),
-        {ok, CRDTOp?CRDT_OP{op=Ops}}
-    catch Class:Reason ->
-            {error, {Class, Reason}}
-    end.
 
 %% @doc turn a string token / atom into a
 %% CRDT type

--- a/src/riak_kv_crdt_json.erl
+++ b/src/riak_kv_crdt_json.erl
@@ -1,0 +1,431 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_crdt_json: Codec routines for CRDTs in JSON
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_kv_crdt_json).
+-export([update_request_from_json/3, fetch_response_to_json/4]).
+-compile([{inline, [bad_op/2, bad_field/1]}]).
+
+-define(FIELD_PATTERN, "^(.*)_(counter|set|register|flag|map)$").
+
+-ifdef(TEST).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+-include("riak_kv_types.hrl").
+-endif.
+
+-export_type([context/0]).
+
+%% Mostly copied from riak_pb_dt_codec
+%% Value types
+-opaque context() :: binary().
+-type map_field() :: {binary(), embedded_type()}.
+-type embedded_type() :: counter | set | register | flag | map.
+-type toplevel_type() :: counter | set | map.
+-type type_mappings() :: [{embedded_type(), module()}].
+
+%% Operations
+-type counter_op() :: increment | decrement | {increment | decrement, integer()}.
+-type simple_set_op() :: {add, binary()} | {remove, binary()} | {add_all, [binary()]} | {remove_all, [binary()]}.
+-type set_op() :: simple_set_op() | {update, [simple_set_op()]}.
+-type flag_op() :: enable | disable.
+-type register_op() :: {assign, binary()}.
+-type simple_map_op() :: {add, map_field()} | {remove, map_field()} | {update, map_field(), embedded_type_op()}.
+-type map_op() :: simple_map_op() | {update, [simple_map_op()]}.
+-type embedded_type_op() :: counter_op() | set_op() | register_op() | flag_op() | map_op().
+-type toplevel_op() :: counter_op() | set_op() | map_op().
+-type update() :: {toplevel_type(), toplevel_op(), context()}.
+
+%% @doc Encodes a fetch response as a JSON struct, ready for
+%% serialization with mochijson2.
+-spec fetch_response_to_json(toplevel_type(), term(), context(), type_mappings()) -> mochijson2:json_object().
+fetch_response_to_json(Type, Value, Context, Mods) ->
+    {struct, [{<<"type">>, atom_to_binary(Type, utf8)},
+              {<<"value">>, value_to_json(Type, Value, Mods)}] ++
+         [ {<<"context">>, base64:encode(Context)} || Context /= undefined, Context /= <<>> ]}.
+
+%% @doc Decodes a JSON value into an update operation.
+-spec update_request_from_json(toplevel_type(), mochijson2:json_term(), type_mappings()) -> update().
+update_request_from_json(Type, JSON0, Mods) ->
+    {JSON, Context} = extract_context(JSON0),
+    {Type, op_from_json(Type, JSON, Mods), Context}.
+
+%% NB we assume that the internal format is well-formed and don't guard it.
+value_to_json(counter, Int, _) -> Int;
+value_to_json(set, List, _) -> List;
+value_to_json(flag, Bool, _) -> Bool;
+value_to_json(register, Bin, _) -> Bin;
+value_to_json(map, Pairs, Mods) ->
+    {struct,
+     [ begin
+           JSONField = {_Name,Type} = field_to_type(Key, Mods),
+           {field_to_json(JSONField), value_to_json(Type, Value, Mods)}
+       end || {Key, Value} <- Pairs ]}.
+
+-spec extract_context(mochijson2:json_value()) -> {mochijson2:json_value(), undefined | context()}.
+extract_context({struct, Fields0}=JSON) ->
+    case lists:keytake(<<"context">>, 1, Fields0) of
+        {value, {<<"context">>, Ctx}, Fields} ->
+            {{struct, Fields}, decode_context(Ctx)};
+        false ->
+            {JSON, undefined}
+    end;
+extract_context(JSON) ->
+    %% We will allow non-object requests for counters, since they only
+    %% have 'increment' ops after all. {'increment':Int} is acceptable
+    %% as well.
+    {JSON, undefined}.
+
+-spec decode_context(base64:ascii_binary()) -> context().
+decode_context(Bin) when is_binary(Bin) ->
+    try
+        base64:decode(Bin)
+    catch
+        exit:_BadMatch ->
+            throw({invalid_context, Bin})
+    end.
+
+-spec field_to_mod({binary(), toplevel_type()}, type_mappings()) -> {binary(), module()}.
+field_to_mod({Name, Type}=Field, Mods) ->
+    case lists:keyfind(Type, 1, Mods) of
+        false ->
+            Field;
+        {Type, Mod} ->
+            {Name, Mod}
+    end.
+
+-spec field_to_type({binary(), module()}, type_mappings()) -> {binary(), toplevel_type()}.
+field_to_type({Name, Mod}=Field, Mods) ->
+    case lists:keyfind(Mod, 2, Mods) of
+        false ->
+            Field;
+        {Type, Mod} ->
+            {Name, Type}
+    end.
+
+-spec field_to_json(map_field()) -> binary().
+field_to_json({Name, Type}) when is_binary(Name), is_atom(Type) ->
+    BinType = atom_to_binary(Type, utf8),
+    <<Name/bytes, $_, BinType/bytes>>.
+
+-spec field_from_json(binary()) -> map_field().
+field_from_json(Bin) when is_binary(Bin) ->
+    case re:run(Bin, ?FIELD_PATTERN, [anchored, {capture, all_but_first, binary}]) of
+        {match, [Name, BinType]} ->
+            {Name, binary_to_existing_atom(BinType, utf8)};
+        _ ->
+            bad_field(Bin)
+    end.
+
+-spec op_from_json(embedded_type(), mochijson2:json_term(), type_mappings()) -> embedded_type_op().
+op_from_json(flag, Op, _Mods) -> flag_op_from_json(Op);
+op_from_json(register, Op, _Mods) -> register_op_from_json(Op);
+op_from_json(counter, Op, _Mods) -> counter_op_from_json(Op);
+op_from_json(set, Op, _Mods) -> set_op_from_json(Op);
+op_from_json(map, Op, Mods) -> map_op_from_json(Op, Mods).
+
+%% Map: {"update":{Field:Op, ...}}
+-spec map_op_from_json(mochijson2:json_object(), type_mappings()) -> map_op().
+map_op_from_json({struct, Ops0}=InOp, Mods) ->
+    Ops = lists:keymap(fun(<<"update">>) -> update;
+                          (<<"add">>) -> add;
+                          (<<"remove">>) -> remove;
+                          (Op) -> bad_op(map, Op)
+                       end, 1, Ops0),
+    {struct, Updates} = proplists:get_value(update, Ops, {struct, []}),
+    Adds = case proplists:get_value(add, Ops, []) of
+               AddBin when is_binary(AddBin) ->
+                   [AddBin];
+               AddList when is_list(AddList) -> AddList;
+               _ -> bad_op(map, InOp)
+           end,
+    Removes = case proplists:get_value(remove, Ops, []) of
+               RemoveBin when is_binary(RemoveBin) ->
+                   [RemoveBin];
+               RemoveList when is_list(RemoveList) -> RemoveList;
+               _ -> bad_op(map, InOp)
+           end,
+    {update, [ {remove, field_to_mod(field_from_json(Field), Mods)} || Field <- Removes ] ++
+             [ {add, field_to_mod(field_from_json(Field), Mods)} || Field <- Adds ] ++
+         [ map_update_op_from_json(Update, Mods) || Update <- Updates ]};
+map_op_from_json(Op, _Mods) ->
+    bad_op(map, Op).
+
+
+-spec map_update_op_from_json({mochijson2:json_string(), mochijson2:json_term()}, type_mappings()) ->
+                                     {update, map_field(), embedded_type_op()}.
+map_update_op_from_json({JSONField, Op}, Mods) ->
+    Field = {_Name, Type} = field_from_json(JSONField),
+    {update, field_to_mod(Field, Mods), op_from_json(Type, Op, Mods)}.
+
+-spec flag_op_from_json(binary()) -> flag_op().
+flag_op_from_json(<<"enable">>) -> enable;
+flag_op_from_json(<<"disable">>) -> disable;
+flag_op_from_json(Op) -> bad_op(flag, Op).
+
+-spec register_op_from_json(mochijson2:json_object()) -> register_op().
+register_op_from_json({struct, [{<<"assign">>, Value}]}) when is_binary(Value) -> {assign, Value};
+register_op_from_json(Value) when is_binary(Value) -> {assign, Value};
+register_op_from_json(Op) -> bad_op(register, Op).
+
+-spec counter_op_from_json(mochijson2:json_term()) -> counter_op().
+counter_op_from_json(Int) when is_integer(Int), Int >= 0 -> {increment, Int};
+counter_op_from_json(Int) when is_integer(Int), Int < 0 -> {decrement, -Int};
+counter_op_from_json(<<"increment">>) -> increment;
+counter_op_from_json(<<"decrement">>) -> decrement;
+counter_op_from_json({struct, [{<<"increment">>,Int}]}) when is_integer(Int) -> {increment, Int};
+counter_op_from_json({struct, [{<<"decrement">>,Int}]}) when is_integer(Int) -> {decrement, Int};
+counter_op_from_json(Op) -> bad_op(counter, Op).
+
+
+-spec set_op_from_json(mochijson2:json_term() |
+                       {mochijson2:json_string(), mochijson2:json_term()}) ->
+                              set_op().
+set_op_from_json({struct, Ops}) when is_list(Ops) ->
+    try
+        {update, [ set_op_from_json(Op) || Op <- Ops]}
+    catch
+        throw:{invalid_operation, {set, _}} ->
+            bad_op(set, {struct, Ops})
+    end;
+set_op_from_json({<<"add">>, Bin}) when is_binary(Bin) -> {add, Bin};
+set_op_from_json({<<"remove">>, Bin}) when is_binary(Bin) -> {remove, Bin};
+set_op_from_json({Verb, BinList}=Op) when is_list(BinList), (Verb == <<"add_all">> orelse
+                                                             Verb == <<"remove_all">>)->
+    case check_set_members(BinList) of
+        true ->
+            {binary_to_existing_atom(Verb, utf8), BinList};
+        false ->
+            bad_op(set, Op)
+    end;
+set_op_from_json({<<"update">>, {struct, Ops}}) when is_list(Ops) ->
+    {update, [ set_op_from_json(Op) || Op <- Ops]};
+set_op_from_json({<<"update">>, Ops}) when is_list(Ops) ->
+    {update, [ set_op_from_json(Op) || Op <- Ops]};
+set_op_from_json(Op) -> bad_op(set, Op).
+
+-spec check_set_members([term()]) -> boolean().
+check_set_members(BinList) ->
+    lists:all(fun erlang:is_binary/1, BinList).
+
+-spec bad_op(atom(), term()) -> no_return().
+bad_op(Type, Op) ->
+    throw({invalid_operation, {Type, Op}}).
+
+-spec bad_field(binary()) -> no_return().
+bad_field(Bin) ->
+    throw({invalid_field_name, Bin}).
+
+-ifdef(TEST).
+
+encode_fetch_response_test_() ->
+    [
+     {"encode counter",
+      fun() ->
+              {ok, Counter} = ?COUNTER_TYPE:update({increment, 5}, a, ?COUNTER_TYPE:new()),
+              ?assertEqual({struct, [{<<"type">>,<<"counter">>},
+                                     {<<"value">>, 5}]},
+                           fetch_response_to_json(counter, ?COUNTER_TYPE:value(Counter), undefined, ?MOD_MAP)),
+              ?assertEqual({struct, [{<<"type">>,<<"counter">>},
+                                     {<<"value">>, 5}]},
+                           fetch_response_to_json(counter, ?COUNTER_TYPE:value(Counter), <<>>, ?MOD_MAP))
+      end},
+     {"encode set",
+      fun() ->
+              {ok, Set} = ?SET_TYPE:update({add_all, [<<"a">>, <<"b">>, <<"c">>]}, a, ?SET_TYPE:new()),
+              ?assertEqual({struct, [{<<"type">>, <<"set">>},
+                                     {<<"value">>, [<<"a">>,<<"b">>,<<"c">>]}]},
+                           fetch_response_to_json(set, ?SET_TYPE:value(Set), undefined, ?MOD_MAP)),
+              ?assertMatch({struct, [_Type, _Value, {<<"context">>, Bin}]} when is_binary(Bin),
+                           fetch_response_to_json(set, ?SET_TYPE:value(Set),
+                                                  ?SET_TYPE:to_binary(?SET_TYPE:precondition_context(Set)),
+                                                  ?MOD_MAP))
+      end},
+     {"encode map",
+      fun() ->
+              {ok, Map} = ?MAP_TYPE:update({update,
+                                            [
+                                             {update, {<<"a">>, ?SET_TYPE},{add_all, [<<"a">>, <<"b">>, <<"c">>]}},
+                                             {update, {<<"b">>, ?FLAG_TYPE}, enable},
+                                             {update, {<<"c">>, ?REG_TYPE}, {assign, <<"sean">>}},
+                                             {update, {<<"d">>, ?MAP_TYPE},
+                                              {update, [{update, {<<"e">>, ?COUNTER_TYPE}, {increment,5}}]}}
+                                            ]}, a, ?MAP_TYPE:new()),
+              ?assertEqual({struct, [
+                                     {<<"type">>, <<"map">>},
+                                     {<<"value">>,
+                                      {struct,
+                                       [ % NB inverse order from the order of update-application
+                                        {<<"d_map">>, {struct, [{<<"e_counter">>, 5}]}},
+                                        {<<"c_register">>, <<"sean">>},
+                                        {<<"b_flag">>, true},
+                                        {<<"a_set">>, [<<"a">>, <<"b">>, <<"c">>]}]}}
+                                     ]},
+                           fetch_response_to_json(map, ?MAP_TYPE:value(Map), undefined, ?MOD_MAP)
+                           ),
+              ?assertMatch({struct, [_Type, _Value, {<<"context">>, Bin}]} when is_binary(Bin),
+                           fetch_response_to_json(map, ?MAP_TYPE:value(Map),
+                                                  ?MAP_TYPE:to_binary(?MAP_TYPE:precondition_context(Map)),
+                                                  ?MOD_MAP))
+      end}
+    ].
+
+decode_update_request_test_() ->
+    [
+     {"decode counter ops",
+      fun() ->
+              ?assertEqual({counter, increment, undefined},
+                           update_request_from_json(counter, <<"increment">>, ?MOD_MAP)),
+              ?assertEqual({counter, decrement, undefined},
+                           update_request_from_json(counter, <<"decrement">>, ?MOD_MAP)),
+              ?assertEqual({counter, {increment, 10}, undefined},
+                           update_request_from_json(counter, 10, ?MOD_MAP)),
+              ?assertEqual({counter, {decrement, 7}, undefined},
+                           update_request_from_json(counter, -7, ?MOD_MAP)),
+              ?assertEqual({counter, {decrement, 7}, undefined},
+                           update_request_from_json(counter, {struct, [{<<"decrement">>, 7}]}, ?MOD_MAP)),
+              ?assertEqual({counter, {increment, 10}, undefined},
+                           update_request_from_json(counter, {struct, [{<<"increment">>, 10}]}, ?MOD_MAP)),
+              %% Increment argument must be integer
+              ?assertThrow({invalid_operation, {counter, _}},
+                           update_request_from_json(counter, {struct, [{<<"increment">>, true}]}, ?MOD_MAP)),
+              %% Only one operation allowed, increment or decrement
+              ?assertThrow({invalid_operation, {counter, _}},
+                           update_request_from_json(counter, {struct, [{<<"increment">>, 5},{<<"decrement">>, 10}]}, ?MOD_MAP)),
+              %% Must have an operation, empty object invalid
+              ?assertThrow({invalid_operation, {counter, _}},
+                           update_request_from_json(counter, {struct, []}, ?MOD_MAP)),
+              %% Empty list is an invalid op
+              ?assertThrow({invalid_operation, {counter, _}},
+                           update_request_from_json(counter, [], ?MOD_MAP))
+      end},
+     {"decode set ops",
+      fun() ->
+              %% All single mutations
+              ?assertEqual({set, {update, [{add, <<"foo">>}]}, undefined},
+                           update_request_from_json(set, {struct, [{<<"add">>, <<"foo">>}]}, ?MOD_MAP)),
+              ?assertEqual({set, {update, [{add_all, [<<"foo">>, <<"bar">>]}]}, undefined},
+                           update_request_from_json(set, {struct, [{<<"add_all">>, [<<"foo">>,<<"bar">>]}]}, ?MOD_MAP)),
+              ?assertEqual({set, {update, [{remove, <<"foo">>}]}, undefined},
+                           update_request_from_json(set, {struct, [{<<"remove">>, <<"foo">>}]}, ?MOD_MAP)),
+              ?assertEqual({set, {update, [{remove_all, [<<"foo">>,<<"bar">>]}]}, undefined},
+                           update_request_from_json(set, {struct, [{<<"remove_all">>, [<<"foo">>,<<"bar">>]}]}, ?MOD_MAP)),
+              %% Multiple ops may be passed at once
+              ?assertEqual({set, {update, [{add, <<"foo">>}, {remove_all, [<<"baz">>,<<"quux">>]}]}, undefined},
+                           update_request_from_json(set, {struct, [{<<"add">>, <<"foo">>}, {<<"remove_all">>, [<<"baz">>,<<"quux">>]}]}, ?MOD_MAP)),
+              %% All members must be binaries
+              ?assertThrow({invalid_operation, {set, _}},
+                           update_request_from_json(set, {struct, [{<<"add">>, <<"foo">>}, {<<"remove_all">>, [<<"bar">>,true]}]}, ?MOD_MAP)),
+              %% Only valid operations are add/remove/add_all/remove_all
+              ?assertThrow({invalid_operation, {set, _}},
+                           update_request_from_json(set, {struct, [{<<"increment">>, 5}]}, ?MOD_MAP)),
+              %% Context should be extracted properly
+              {ok, Set} = ?SET_TYPE:update({add_all, [<<"a">>, <<"b">>, <<"c">>]}, a, ?SET_TYPE:new()),
+              BinContext = ?SET_TYPE:to_binary(?SET_TYPE:precondition_context(Set)),
+              {struct, [_Type, _Value, {<<"context">>, JSONCtx}]} = fetch_response_to_json(set, ?SET_TYPE:value(Set),
+                                                                                       BinContext,
+                                                                                       ?MOD_MAP),
+              ?assertMatch({set, {update, [{remove, <<"a">>}]}, BinContext},
+                           update_request_from_json(set, {struct, [{<<"remove">>, <<"a">>}, {<<"context">>, JSONCtx}]}, ?MOD_MAP))
+      end},
+     {"decode map ops",
+      fun() ->
+              %% Simple ops
+              ?assertEqual({map, {update, [{add, {<<"a">>, ?COUNTER_TYPE}}]}, undefined},
+                           update_request_from_json(map, {struct, [{<<"add">>, <<"a_counter">>}]}, ?MOD_MAP)),
+              ?assertEqual({map, {update, [{add, {<<"a">>, ?COUNTER_TYPE}}, {add, {<<"a">>, ?SET_TYPE}}]}, undefined},
+                           update_request_from_json(map, {struct, [{<<"add">>, [<<"a_counter">>, <<"a_set">>]}]}, ?MOD_MAP)),
+              ?assertEqual({map, {update, [{remove, {<<"a">>, ?COUNTER_TYPE}}]}, undefined},
+                           update_request_from_json(map, {struct, [{<<"remove">>, <<"a_counter">>}]}, ?MOD_MAP)),
+              ?assertEqual({map, {update, [{remove, {<<"a">>, ?COUNTER_TYPE}}, {remove, {<<"a">>, ?SET_TYPE}}]}, undefined},
+                           update_request_from_json(map, {struct, [{<<"remove">>, [<<"a_counter">>, <<"a_set">>]}]}, ?MOD_MAP)),
+              %% Removes get ordered before adds, multiple ops extracted
+              ?assertEqual({map, {update, [{remove, {<<"a">>, ?COUNTER_TYPE}}, {add, {<<"a">>, ?SET_TYPE}}]}, undefined},
+                           update_request_from_json(map, {struct, [{<<"add">>, [<<"a_set">>]}, {<<"remove">>, [<<"a_counter">>]}]}, ?MOD_MAP)),
+              %% Nested updates
+              ?assertEqual({map, {update, [{update, {<<"a">>, ?COUNTER_TYPE}, increment}]}, undefined},
+                           update_request_from_json(map, {struct, [{<<"update">>, {struct, [{<<"a_counter">>, <<"increment">>}]}}]}, ?MOD_MAP)),
+
+              ?assertEqual({map, {update, [{update, {<<"b">>, ?MAP_TYPE}, 
+                                            {update, [{update, {<<"c">>, ?REG_TYPE}, {assign, <<"foo">>}}]}}]}, undefined},
+                           update_request_from_json(map, {struct, [{<<"update">>, 
+                                                                    {struct, [{<<"b_map">>, 
+                                                                               {struct, [{<<"update">>, 
+                                                                                          {struct, [{<<"c_register">>, <<"foo">>}]}}]}}]}}]}, 
+                                                    ?MOD_MAP)),
+              ?assertEqual({map, {update, [{update, {<<"b">>, ?MAP_TYPE}, 
+                                            {update, [{update, {<<"c">>, ?FLAG_TYPE}, enable}]}}]}, undefined},
+                           update_request_from_json(map, {struct, [{<<"update">>, 
+                                                                    {struct, [{<<"b_map">>, 
+                                                                               {struct, [{<<"update">>, 
+                                                                                          {struct, [{<<"c_flag">>, <<"enable">>}]}}]}}]}}]}, 
+                                                    ?MOD_MAP)),
+
+              %% Extract context
+              {ok, Map} = ?MAP_TYPE:update({update,
+                                            [
+                                             {update, {<<"a">>, ?SET_TYPE},{add_all, [<<"a">>, <<"b">>, <<"c">>]}},
+                                             {update, {<<"b">>, ?FLAG_TYPE}, enable},
+                                             {update, {<<"c">>, ?REG_TYPE}, {assign, <<"sean">>}},
+                                             {update, {<<"d">>, ?MAP_TYPE},
+                                              {update, [{update, {<<"e">>, ?COUNTER_TYPE}, {increment,5}}]}}
+                                            ]}, a, ?MAP_TYPE:new()),
+              BinContext = ?MAP_TYPE:to_binary(?MAP_TYPE:precondition_context(Map)),
+              {struct, [_Type, _Value, {<<"context">>, JSONCtx}]} = fetch_response_to_json(set, ?MAP_TYPE:value(Map),
+                                                                                           BinContext,
+                                                                                           ?MOD_MAP),
+              ?assertMatch({map, {update, [{remove, {<<"a">>, ?SET_TYPE}}]}, BinContext},
+                           update_request_from_json(map, {struct, [{<<"remove">>, <<"a_set">>}, {<<"context">>, JSONCtx}]}, ?MOD_MAP)),
+                           
+              %% Invalid field names
+              ?assertThrow({invalid_field_name, <<"a_hash">>}, update_request_from_json(map, {struct, [{<<"add">>, <<"a_hash">>}]}, ?MOD_MAP)),
+              ?assertThrow({invalid_field_name, <<"foo">>}, update_request_from_json(map, {struct, [{<<"remove">>, <<"foo">>}]}, ?MOD_MAP)),
+              ?assertThrow({invalid_field_name, <<"b_blob">>}, 
+                           update_request_from_json(map, {struct, 
+                                                          [{<<"update">>, 
+                                                            {struct, [{<<"a_map">>, 
+                                                                       {struct, [{<<"remove">>, <<"b_blob">>}]}}]}}]}, ?MOD_MAP)),
+              %% Invalid operations for maps
+              ?assertThrow({invalid_operation, {map, _}},
+                           update_request_from_json(map, <<"increment">>, ?MOD_MAP)),
+              ?assertThrow({invalid_operation, {map, _}},
+                           update_request_from_json(map, {struct, [{<<"increment">>, 5}]}, ?MOD_MAP)),
+              ?assertThrow({invalid_operation, {map, _}},
+                           update_request_from_json(map, {struct, [{<<"add_all">>, [<<"foo">>]}]}, ?MOD_MAP)),
+              %% Invalid operations for nested types
+              ?assertThrow({invalid_operation, {counter, _}},
+                           update_request_from_json(map, 
+                                                    {struct, [{<<"update">>, {struct, [{<<"a_counter">>, <<"poke">>}]}}]}, ?MOD_MAP)),
+              ?assertThrow({invalid_operation, {flag, _}},
+                           update_request_from_json(map, 
+                                                    {struct, [{<<"update">>, {struct, [{<<"a_flag">>, 5}]}}]}, ?MOD_MAP)),
+              ?assertThrow({invalid_operation, {register, _}},
+                           update_request_from_json(map, 
+                                                    {struct, [{<<"update">>, {struct, [{<<"a_register">>, true}]}}]}, ?MOD_MAP)),
+              ?assertThrow({invalid_operation, {set, _}},
+                           update_request_from_json(map, 
+                                                    {struct, [{<<"update">>, {struct, [{<<"a_set">>, {struct, [{<<"delete">>, <<"bar">>}]}}]}}]}, ?MOD_MAP)),
+              ?assertThrow({invalid_operation, {map, _}},
+                           update_request_from_json(map, 
+                                                    {struct, [{<<"update">>, {struct, [{<<"a_map">>, {struct, [{<<"delete">>, <<"bar">>}]}}]}}]}, ?MOD_MAP))
+
+      end}
+    ].
+-endif.

--- a/src/riak_kv_web.erl
+++ b/src/riak_kv_web.erl
@@ -32,6 +32,7 @@
 
 -export([dispatch_table/0]).
 -include("riak_kv_wm_raw.hrl").
+-include("riak_kv_types.hrl").
 
 dispatch_table() ->
     MapredProps = mapred_props(),
@@ -58,7 +59,7 @@ raw_dispatch(Name) ->
                {[], APIv2Props}],
 
     [
-     %% OLD API
+     %% OLD API, remove in v2.2
      {[Name],
       riak_kv_wm_buckets, Props1},
 
@@ -80,7 +81,11 @@ raw_dispatch(Name) ->
     ] ++
 
    [ {["types", bucket_type, "props"], riak_kv_wm_bucket_type,
-      [{api_version, 3}|raw_props(Name)]} ] ++
+      [{api_version, 3}|raw_props(Name)]},
+     {["types", bucket_type, "buckets", bucket, "datatypes"], fun is_post/1,
+      riak_kv_wm_crdt, [{api_version, 3}]},
+     {["types", bucket_type, "buckets", bucket, "datatypes", key],
+      riak_kv_wm_crdt, [{api_version, 3}]}] ++
 
         [ %% v1.4 counters @TODO REMOVE at v2.2
           %% NOTE: no (default) bucket prefix only

--- a/src/riak_kv_wm_crdt.erl
+++ b/src/riak_kv_wm_crdt.erl
@@ -1,8 +1,8 @@
 %% -------------------------------------------------------------------
 %%
-%% riak_kv_wm_counter: Webmachine resource for counters
+%% riak_kv_wm_crdt: Webmachine resource for convergent data types
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -19,148 +19,155 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
-
-%% @doc Resource for serving Counters over HTTP.
+%% @doc Resource for serving data-types over HTTP.
 %%
 %% Available operations:
 %%
-%% POST /buckets/Bucket/counters/Key
-%%   Increment the counter at `Bucket', `Key' by
-%%   the integer amount of the request body. If the request body cannot be
-%%   parsed (by erlang `list_to_integer/1') then a `400 bad request'
-%%   is the result.
+%% GET /types/BucketType/buckets/Bucket/datatypes/Key
+%%   Get the current value of the data-type at `BucketType', `Bucket', `Key'.
+%%   Result is a JSON body with a structured value, or `404 Not Found' if no
+%%   datatype exists at that resource location.
+%%
+%%   The format of the JSON response will be roughly
+%%   <code>{"type":..., "value":..., "context":...}</code>, where the
+%%   `type' is a string designating which data-type is presented, the
+%%   `value' is a representation of the data-type's value (see below),
+%%   and the `context' is the opaque context, if needed or requested.
+%%
+%%   The type and structure of the `value' field in the response
+%%   depends on the `type' field.
+%%   <dl>
+%%     <dt>counter</dt><dd>an integer</dd>
+%%     <dt>set</dt><dd>an array of strings</dd>
+%%     <dt>map</dt><dd>an object where the fields are as described below.</dd>
+%%   </dl>
+%%
+%%   The format of a field name in the map value determines both the
+%%   name of the entry and the type, joined with an underscore. For
+%%   example, a `register' with name `firstname' would be
+%%   `"firstname_register"'. Valid types embeddable in a map are
+%%   `counter', `flag', `register', `set', and `map'.
+%%
+%%   The following query params are accepted:
+%%
+%%   <dl>
+%%     <dt>r</dt><dd>Read quorum. See below for defaults and values.</dd>
+%%     <dt>pr</dt><dd>Primary read quorum. See below for defaults and values.</dd>
+%%     <dt>basic_quorum</dt><dd>Boolean. Return as soon as a quorum of responses are received
+%%                              if true. Default is the bucket default, if absent.</dd>
+%%     <dt>notfound_ok</dt><dd>Boolean. A `not_found` response from a vnode counts toward
+%%                             `r' quorum if true. Default is the bucket default, if absent.</dd>
+%%     <dt>include_context</dt><dd>Boolean. If the datatype requires the opaque "context" for
+%%                                 safe removal, include it in the response. Defaults to `true'.</dd>
+%%   </dl>
+%%
+%% POST /types/BucketType/buckets/Bucket/datatypes
+%% POST /types/BucketType/buckets/Bucket/datatypes/Key
+%%   Mutate the data-type at `BucketType', `Bucket', `Key' by applying
+%%   the submitted operation contained in a JSON payload. If `Key' is
+%%   not specified, one will be generated for the client and included
+%%   in the returned `Location' header.
+%%
+%%   The format of the operation payload depends on the data-type.
+%%   <dl>
+%%     <dt>counter</dt><dd>An integer, or an object containing a single field, either
+%%                         `"increment"' or `"decrement"', and an associated integer value.</dd>
+%%     <dt>set</dt><dd>An object containing any combination of `"add"', `"add_all"',
+%%                     `"remove"', `"remove_all"' fields. `"add"' and `"remove"' should refer to
+%%                     single string values, while `"add_all"' and `"remove_all"' should be arrays
+%%                     of strings. The `"context"' field may be included.</dd>
+%%     <dt>map</dt><dd>An object containing any of the fields `"add"', `"remove"', or `"update"'.
+%%                     `"add"' and `"remove"' should be lists of field names as described above.
+%%                     `"update"` should be an object containing fields and the operation to apply
+%%                     to the type associated with the field.</dd>
+%%     <dt>register (embedded in map only)</dt><dd>`{"assign":Value}' where `Value' is the new string
+%%                                                 value of the register.</dd>
+%%     <dt>flag (embedded in map only)</dt><dd>The string "enable" or "disable".</dd>
+%%   </dl>
+%%
 %%   The following query params are accepted (@see `riak_kv_wm_object' docs, too):
 %%
 %%   <dl>
 %%     <dt>w</dt><dd>The write quorum. See below for defaults and values.</dd>
 %%     <dt>pw</dt><dd>The primary write quorum. See below for defaults and values.</dd>
 %%     <dt>dw</dt><dd>The durable write quorum. See below for default and values.</dd>
-%%     <dt>returnvalue</dt><dd>Boolean. Default is `false' if not provided. When `true'
-%%                             the response body will be the value of the counter.</dd>
+%%     <dt>returnbody</dt><dd>Boolean. Default is `false' if not provided. When `true'
+%%                             the response body will be the value of the datatype.</dd>
+%%     <dt>include_context</dt><dd>Boolean. Default is `true' if not provided. When `true'
+%%                             and `returnbody' is `true', the opaque context will be included.</dd>
 %%   </dl>
-%%
-%%  GET /buckets/Bucket/counters/Key
-%%    Get the current value of the counter at `Bucket', `Key'. Result is a text/plain
-%%    body with an integer value, or `not_found' if no counter exists at that resource location.
-%%    The following query params are accepted:
-%%
-%%    <dl>
-%%      <dt>r</dt><dd>Read quorum. See below for defaults and values.</dd>
-%%      <dt>pr</dt><dd>Primary read quorum. See below for defaults and values.</dd>
-%%      <dt>basic_quorum</dt><dd>Boolean. Return as soon as a quorum of responses are received
-%%                               if true. Default is the bucket default, if absent.</dd>
-%%      <dt>notfound_ok</dt><dd>Boolean. A `not_found` response from a vnode counts toward
-%%                              `r' quorum if true. Default is the bucket default, if absent.</dd>
-%%    </dl>
 %%
 %%   Quorum values (r/pr/w/pw/dw):
 %%     <dl>
-%%       <dt>default</dt<dd>Whatever the bucket default is. This is the value used
+%%      <dt>default</dt<dd>Whatever the bucket default is. This is the value used
 %%                          for any absent value.</dd>
 %%      <dt>quorum</dt><dd>(Bucket N val / 2) + 1</dd>
 %%      <dt>all</dt><dd>All replicas must respond</dd>
 %%      <dt>one</dt><dd>Any one response is enough</dd>
 %%      <dt>Integer</dt><dd>That specific number of vnodes must respond. Must be =< N</dd>
 %%    </dl>
-%% Please see http://docs.basho.com for details of all the quorum values and there effect.
-
-
+%%
+%% Please see http://docs.basho.com for details of all the quorum values and their effects.
 
 -module(riak_kv_wm_crdt).
+-record(ctx, {
+          api_version,
+          client, %% riak:local_client()
+          bucket_type,
+          bucket,
+          key,
+          crdt_type,
+          data,
+          module,
+          r,
+          w,
+          dw,
+          rw,
+          pr,
+          pw,
+          basic_quorum,
+          notfound_ok,
+          include_context,
+          returnbody,
+          method,
+          timeout,
+          security
+         }).
+-include("riak_kv_wm_raw.hrl").
+-include("riak_kv_types.hrl").
 
-%% webmachine resource exports
 -export([
          init/1,
          service_available/2,
+         malformed_request/2,
          is_authorized/2,
          forbidden/2,
          allowed_methods/2,
-         malformed_request/2,
-         resource_exists/2,
          content_types_provided/2,
-         post_is_create/2,
-         process_post/2,
-         accept_doc_body/2,
-         to_text/2,
-         known_type/1
+         encodings_provided/2,
+         resource_exists/2,
+         process_post/2,           %% POST handler
+         produce_json/2           %% GET/HEAD handler
         ]).
 
-%% @type context() = term()
--record(ctx, {api_version,  %% integer() - Determine which version of the API to use.
-              bucket,       %% binary() - Bucket name (from uri)
-              key,          %% binary() - Key (from uri)
-              client,       %% riak_client() - the store client
-              r,            %% integer() - r-value for reads
-              w,            %% integer() - w-value for writes
-              dw,           %% integer() - dw-value for writes
-              rw,           %% integer() - rw-value for deletes
-              pr,           %% integer() - number of primary nodes required in preflist on read
-              pw,           %% integer() - number of primary nodes required in preflist on write
-              basic_quorum, %% boolean() - whether to use basic_quorum
-              notfound_ok,  %% boolean() - whether to treat notfounds as successes
-              prefix,       %% string() - prefix for resource uris
-              riak,         %% local | {node(), atom()} - params for riak client
-              doc,          %% {ok, riak_object()}|{error, term()} - the object found
-              bucketprops,  %% proplist() - properties of the bucket
-              method,       %% atom() - HTTP method for the request
-              crdt_op    :: term() | undefined, %% A parsed CRDT Op
-              security      %% security context
-             }).
-%% @type link() = {{Bucket::binary(), Key::binary()}, Tag::binary()}
-%% @type index_field() = {Key::string(), Value::string()}
-
 -include_lib("webmachine/include/webmachine.hrl").
--include("riak_kv_wm_raw.hrl").
--include_lib("riak_kv_types.hrl").
 
-%% @spec init(proplist()) -> {ok, context()}
-%% @doc Initialize this resource.  This function extracts the
-%%      'prefix' and 'riak' properties from the dispatch args.
 init(Props) ->
-    {ok, #ctx{api_version=proplists:get_value(api_version, Props),
-              prefix=proplists:get_value(prefix, Props),
-              riak=proplists:get_value(riak, Props)}}.
+    {ok, #ctx{api_version=proplists:get_value(api_version, Props)}}.
 
-service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
-    Type = riak_kv_crdt:to_mod(wrq:path_info(crdt, RD)),
-    OpCtx = get_op_context(wrq:get_req_header(?HEAD_CRDT_CONTEXT, RD)),
-    case riak_kv_crdt:supported(Type) of
-        true ->
-            case riak_kv_wm_utils:get_riak_client(RiakProps, riak_kv_wm_utils:get_client_id(RD)) of
-                {ok, C} ->
-                    {true,
-                     RD,
-                     Ctx#ctx{
-                       method=wrq:method(RD),
-                       client=C,
-                       bucket=case wrq:path_info(bucket, RD) of
-                                  undefined -> undefined;
-                                  B -> list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, B))
-                              end,
-                       key=case wrq:path_info(key, RD) of
-                               undefined -> undefined;
-                               K -> list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, K))
-                           end,
-                       crdt_op=?CRDT_OP{mod=Type, ctx=OpCtx}
-                      }};
-                Error ->
-                    {false,
-                     wrq:set_resp_body(
-                       io_lib:format("Unable to connect to Riak: ~p~n", [Error]),
-                       wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
-                     Ctx}
-            end;
-        false  ->
-            {false,
-             wrq:set_resp_body(io_lib:format("~p are not supported.~n", [Type]),
-               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
-             Ctx}
-    end.
+service_available(RD, Ctx0) ->
+    Ctx = riak_kv_wm_utils:ensure_bucket_type(RD, Ctx0, #ctx.bucket_type),
+    {ok, Client} = riak_kv_wm_utils:get_riak_client(
+                     local, riak_kv_wm_utils:get_client_id(RD)),
+    {true, RD,
+     Ctx#ctx{client=Client,
+             bucket=path_segment_to_bin(bucket, RD),
+             key=path_segment_to_bin(key, RD),
+             crdt_type=proplists:get_value(crdt, wrq:path_info(RD)),
+             method=wrq:method(RD)}}.
 
-get_op_context(undefined) ->
-    undefined;
-get_op_context(Ctx) ->
-    base64:decode(Ctx).
+allowed_methods(RD, Ctx) ->
+    {['GET', 'HEAD', 'POST'], RD, Ctx}.
 
 is_authorized(ReqData, Ctx) ->
     case riak_api_web_security:is_authorized(ReqData) of
@@ -172,85 +179,41 @@ is_authorized(ReqData, Ctx) ->
             %% XXX 301 may be more appropriate here, but since the http and
             %% https port are different and configurable, it is hard to figure
             %% out the redirect URL to serve.
-            {{halt, 426}, wrq:append_to_resp_body(<<"Security is enabled and "
-                    "Riak does not accept credentials over HTTP. Try HTTPS "
-                    "instead.">>, ReqData), Ctx}
+            halt_with_message(426,
+                              <<"Security is enabled and Riak does not accept "
+                                "credentials over HTTP. Try HTTPS instead.">>,
+                              ReqData, Ctx)
     end.
 
-forbidden(RD, Ctx = #ctx{security=undefined}) ->
-    {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx};
-forbidden(RD, Ctx=#ctx{security=Security}) ->
-    case riak_kv_wm_utils:is_forbidden(RD) of
-        true ->
-            {true, RD, Ctx};
-        false ->
-            Perm = case Ctx#ctx.method of
-                'POST' ->
-                    "riak_kv.put";
-                'GET' ->
-                    "riak_kv.get"
-            end,
-
-            Res = riak_core_security:check_permission({Perm,
-                                                           {<<"default">>,
-                                                            Ctx#ctx.bucket}},
-                                                           Security),
-            case Res of
-                {false, Error, _} ->
-                    RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
-                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD1), Ctx};
-                {true, _} ->
-                    {false, RD, Ctx}
-            end
-    end.
-
-allowed_methods(RD, Ctx) ->
-    {['GET', 'POST'], RD, Ctx}.
-
-malformed_request(RD, Ctx0) when Ctx0#ctx.method =:= 'POST' ->
-    case riak_kv_crdt:parse_operation(Ctx0#ctx.crdt_op, wrq:req_body(RD)) of
-        {error, Reason} ->
-            {true,
-             wrq:set_resp_body(
-               io_lib:format("Invalid operation: ~p~n", [Reason]),
-               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
-             Ctx0};
-        {ok, Op} ->
-            Ctx = Ctx0#ctx{crdt_op = Op},
-            case malformed_rw_params(RD, Ctx) of
-                Result={true, _, _} ->
-                    Result;
-                {false, RWRD, RWCtx} ->
-                    {false, RWRD, RWCtx}
-            end
-    end;
+malformed_request(RD, Ctx=#ctx{method='POST'}) ->
+    malformed_check_post_ctype(RD, Ctx);
 malformed_request(RD, Ctx) ->
-    case malformed_rw_params(RD, Ctx) of
-        Result = {true, _, _} ->
-            Result;
-        {false, ResRD, ResCtx} ->
-            DocCtx = ensure_doc(ResCtx),
-            case DocCtx#ctx.doc of
-                {error, Reason} ->
-                    handle_common_error(Reason, ResRD, DocCtx);
-                _ ->
-                    {false, ResRD, DocCtx}
-            end
+    malformed_rw_params(RD, Ctx).
+
+malformed_check_post_ctype(RD, Ctx) ->
+    CType = wrq:get_req_header(?HEAD_CTYPE, RD),
+    case mochiweb_util:parse_header(CType) of
+        {"application/json",_} ->
+            malformed_rw_params(RD, Ctx);
+        _Other ->
+            {{halt, 406}, RD, Ctx}
     end.
 
 malformed_rw_params(RD, Ctx) ->
-    Res =
-    lists:foldl(fun malformed_rw_param/2,
-                {false, RD, Ctx},
-                [{#ctx.r, "r", "default"},
-                 {#ctx.w, "w", "default"},
-                 {#ctx.dw, "dw", "default"},
-                 {#ctx.pw, "pw", "default"},
-                 {#ctx.pr, "pr", "default"}]),
-    lists:foldl(fun malformed_boolean_param/2,
-                Res,
-                [{#ctx.basic_quorum, "basic_quorum", "default"},
-                 {#ctx.notfound_ok, "notfound_ok", "default"}]).
+    Res = lists:foldl(fun malformed_rw_param/2,
+                      {false, RD, Ctx},
+                      [{#ctx.r,  "r",  "default"},
+                       {#ctx.w,  "w",  "default"},
+                       {#ctx.dw, "dw", "default"},
+                       {#ctx.pw, "pw", "default"},
+                       {#ctx.pr, "pr", "default"}]),
+    Res1 = lists:foldl(fun malformed_boolean_param/2,
+                       Res,
+                       [{#ctx.basic_quorum,    "basic_quorum",    "default"},
+                        {#ctx.notfound_ok,     "notfound_ok",     "default"},
+                        {#ctx.include_context, "include_context", "true"},
+                        {#ctx.returnbody,      "returnbody",      "false"}]),
+    malformed_timeout_param(Res1).
 
 malformed_rw_param({Idx, Name, Default}, {Result, RD, Ctx}) ->
     case catch normalize_rw_param(wrq:get_qs_value(Name, Default, RD)) of
@@ -258,11 +221,9 @@ malformed_rw_param({Idx, Name, Default}, {Result, RD, Ctx}) ->
             {Result, RD, setelement(Idx, Ctx, P)};
         _ ->
             {true,
-             wrq:append_to_resp_body(
-               io_lib:format("~s query parameter must be an integer or "
-                   "one of the following words: 'one', 'quorum' or 'all'~n",
-                             [Name]),
-               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             error_response("~s query parameter must be an integer or "
+                            "one of the following words: 'one', 'quorum' or 'all'~n",
+                            [Name], RD),
              Ctx}
     end.
 
@@ -276,174 +237,284 @@ malformed_boolean_param({Idx, Name, Default}, {Result, RD, Ctx}) ->
             {Result, RD, setelement(Idx, Ctx, default)};
         _ ->
             {true,
-            wrq:append_to_resp_body(
-              io_lib:format("~s query parameter must be true or false~n",
-                            [Name]),
-              wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             error_response("~s query parameter must be true or false~n",
+                            [Name], RD),
              Ctx}
     end.
 
-normalize_rw_param("default") -> default;
-normalize_rw_param("one") -> one;
-normalize_rw_param("quorum") -> quorum;
-normalize_rw_param("all") -> all;
-normalize_rw_param(V) -> list_to_integer(V).
+malformed_timeout_param({Result, RD, Ctx}) ->
+    case wrq:get_qs_value("timeout", undefined, RD) of
+        undefined ->
+            {Result, RD, Ctx};
+        TimeoutStr when is_list(TimeoutStr) ->
+            try
+                Timeout = list_to_integer(TimeoutStr),
+                {Result, RD, Ctx#ctx{timeout=Timeout}}
+            catch
+                error:badarg ->
+                    {true,
+                     error_response("timeout query parameter must be an "
+                                    "integer, ~s is invalid~n", [TimeoutStr], RD),
+                     Ctx}
+            end
+    end.
+
+forbidden(RD, Ctx) ->
+    case riak_kv_wm_utils:is_forbidden(RD) of
+        true ->
+            {true, RD, Ctx};
+        false ->
+            forbidden_check_security(RD, Ctx)
+    end.
+
+forbidden_check_security(RD, Ctx=#ctx{security=undefined}) ->
+    forbidden_check_bucket_type(RD, Ctx);
+forbidden_check_security(RD, Ctx=#ctx{bucket_type=BType, bucket=Bucket,
+                                      security=SecContext, method=Method}) ->
+    Perm = permission(Method),
+    case riak_core_security:check_permission({Perm, {BType, Bucket}},
+                                             SecContext) of
+        {false, Error, _} ->
+            {true, error_response(Error, RD), Ctx};
+        {true, _} ->
+            forbidden_check_bucket_type(RD, Ctx)
+    end.
+
+%% @doc Detects whether the requested object's bucket-type exists.
+forbidden_check_bucket_type(RD, Ctx) ->
+    case riak_kv_wm_utils:bucket_type_exists(Ctx#ctx.bucket_type) of
+        true ->
+            forbidden_check_crdt_type(RD, Ctx);
+        false ->
+            handle_common_error(bucket_type_unknown, RD, Ctx)
+    end.
+
+forbidden_check_crdt_type(RD, Ctx=#ctx{bucket_type = <<"default">>,
+                                       bucket=B0,
+                                       key=K0}) ->
+    B = mochiweb_util:quote_plus(B0),
+    K = mochiweb_util:quote_plus(K0),
+    CountersUrl = lists:flatten(
+                    io_lib:format("/buckets/~s/counters/~s",[B, K])),
+    halt_with_message(301,
+                      "Counters in the default bucket-type should use the "
+                      "legacy URL\n",
+                      wrq:set_resp_header("Location", CountersUrl, RD),
+                      Ctx);
+forbidden_check_crdt_type(RD, Ctx=#ctx{bucket_type=T, bucket=B}) ->
+    case riak_core_bucket:get_bucket({T, B}) of
+        BProps when is_list(BProps) ->
+            DataType = proplists:get_value(datatype, BProps),
+            AllowMult = proplists:get_value(allow_mult, BProps),
+            Mod = riak_kv_crdt:to_mod(DataType),
+            case {AllowMult, riak_kv_crdt:supported(Mod)} of
+                {false, _} ->
+                    {true, error_response("Bucket must be allow_mult=true~n",
+                                          [], RD), Ctx};
+                {_, false} ->
+                    {true, error_response("Bucket datatype '~s' is not a "
+                                          "supported type.~n", [DataType], RD), Ctx};
+                _ ->
+                    {false, RD, Ctx#ctx{module=Mod, crdt_type=DataType}}
+            end;
+        {error, no_type} ->
+            %% This should be handled by forbidden_check_bucket_type/2
+            handle_common_error(bucket_type_unknown, RD, Ctx)
+    end.
 
 content_types_provided(RD, Ctx) ->
-    {[{"text/plain", to_text}], RD, Ctx}.
+    {[{"application/json", produce_json}], RD, Ctx}.
 
-resource_exists(RD, Ctx0) when Ctx0#ctx.method =:= 'GET' ->
-    DocCtx = ensure_doc(Ctx0),
-    case DocCtx#ctx.doc of
-        {ok, _Doc} ->
-            {true, RD, DocCtx};
-        {error, _} ->
-            %% This should never actually be reached because all the error
-            %% conditions from ensure_doc are handled up in malformed_request.
-            {false, RD, DocCtx}
-    end;
-resource_exists(RD, Ctx) ->
-    {true, RD, Ctx}.
+encodings_provided(RD, Ctx) ->
+    {riak_kv_wm_utils:default_encodings(), RD, Ctx}.
 
-post_is_create(RD, Ctx) ->
-    {false, RD, Ctx}.
+resource_exists(RD, Ctx=#ctx{method='POST'}) ->
+    %% When submitting an operation, the resource always exists, even
+    %% if key is unspecified.
+    {true, RD, Ctx};
+resource_exists(RD, Ctx=#ctx{key=undefined}) ->
+    %% When fetching, if the key does not exist, we should give a not
+    %% found.
+    handle_common_error(notfound, RD, Ctx);
+resource_exists(RD, Ctx=#ctx{client=C, bucket_type=T, bucket=B, key=K}) ->
+    Options = make_options(Ctx),
+    case C:get({T,B}, K, Options) of
+        {ok, O} ->
+            {true, RD, Ctx#ctx{data=O}};
+        {error, Reason} ->
+            handle_common_error(Reason, RD, Ctx)
+    end.
 
-process_post(RD, Ctx) -> accept_doc_body(RD, Ctx).
-
-accept_doc_body(RD, Ctx=#ctx{bucket=B, key=K, client=C,
-                            crdt_op=Op}) ->
-    case allow_mult(B) of
-        true ->
-            Doc = riak_kv_crdt:new(B, K, Op?CRDT_OP.mod),
-            Options = [{crdt_op, Op}] ++ return_value(RD),
-            case C:put(Doc, [{w, Ctx#ctx.w}, {dw, Ctx#ctx.dw}, {pw, Ctx#ctx.pw}, {timeout, 60000} |
-                                   Options]) of
-                {error, Reason} ->
-                    handle_common_error(Reason, RD, Ctx);
+process_post(RD0, Ctx0=#ctx{client=C, bucket_type=T, bucket=B, module=Mod}) ->
+    case check_post_body(RD0, Ctx0) of
+        {error, RD} ->
+            {{halt, 400}, RD, Ctx0};
+        {ok, {_Type, Op, OpCtx}} ->
+            {RD, Ctx} = maybe_generate_key(RD0, Ctx0),
+            O = riak_kv_crdt:new({T, B}, Ctx#ctx.key, Mod),
+            Options0 = make_options(Ctx),
+            CrdtOp = make_operation(Mod, Op, OpCtx),
+            Options = [{crdt_op, CrdtOp},
+                       {retry_put_coordinator_failure,false}|Options0],
+            case C:put(O, Options) of
                 ok ->
-                    {true, RD, Ctx#ctx{doc={ok, Doc}}};
+                    {true, RD, Ctx};
                 {ok, RObj} ->
-                    ?CRDT_OP{mod=Type} = Ctx#ctx.crdt_op,
-                    Body = produce_doc_body(RObj, Type),
-                    {true, wrq:append_to_resp_body(Body, RD), Ctx#ctx{doc={ok, RObj}}}
-            end;
-        false ->
-            handle_common_error(allow_mult_false, RD, Ctx)
+                    {Body, RD1, Ctx1} = produce_json(RD, Ctx#ctx{data=RObj}),
+                    {true,
+                     wrq:set_resp_body(Body, wrq:set_resp_header(
+                                               ?HEAD_CTYPE, "application/json",
+                                               RD1)),
+                     Ctx1};
+                {error, Reason} ->
+                    handle_common_error(Reason, RD, Ctx)
+            end
     end.
 
-return_value(RD) ->
-    case wrq:get_qs_value(?Q_RETURNVALUE, RD) of
-        ?Q_TRUE ->
-            [returnbody];
-        _ ->
-            []
-end.
+produce_json(RD, Ctx=#ctx{module=Mod, data=RObj, include_context=I}) ->
+    Type = riak_kv_crdt:from_mod(Mod),
+    {RespCtx, Value} = riak_kv_crdt:value(RObj, Mod),
+    Body = riak_kv_crdt_json:fetch_response_to_json(
+                     Type, Value, get_context(RespCtx,I), ?MOD_MAP),
+    {mochijson2:encode(Body), RD, Ctx}.
 
-allow_mult(Bucket) ->
-    proplists:get_value(allow_mult, riak_core_bucket:get_bucket(Bucket)).
+%% Internal functions
 
-to_text(RD, Ctx=#ctx{doc={ok, Doc}}) ->
-    ?CRDT_OP{mod=Type} = Ctx#ctx.crdt_op,
-    {ClientContext, Body} = produce_doc_body(Doc, Type),
-    {Body, wrq:merge_resp_headers([{?HEAD_CRDT_CONTEXT, ClientContext}], RD), Ctx}.
+check_post_body(RD, #ctx{crdt_type=CRDTType}) ->
+    try
+        JSON = mochijson2:decode(wrq:req_body(RD)),
+        Data = {CRDTType, _Op, _Context} =
+            riak_kv_crdt_json:update_request_from_json(CRDTType, JSON,
+                                                       ?MOD_MAP),
+        {ok, Data}
+    catch
+        throw:{invalid_operation, {BadType, BadOp}} ->
+            {error,
+             error_response("Invalid operation on datatype '~s': ~s~n",
+                            [BadType, mochijson2:encode(BadOp)], RD)};
+        throw:{invalid_field_name, Field} ->
+            {error,
+             error_response("Invalid map field name '~s'~n", [Field], RD)};
+        throw:invalid_utf8 ->
+            {error,
+             error_response("Malformed JSON submitted, invalid UTF-8", RD)};
+        _Other:Reason ->
+            {error,
+             error_response("Couldn't decode JSON: ~p~n", [Reason], RD)}
+    end.
 
-produce_doc_body(Doc, Type) ->
-    {ClientContext, Body} = riak_kv_crdt:value(Doc, Type),
-    JSON = to_json(Type, Body),
-    {binary_to_list(base64:encode(ClientContext)), mochijson2:encode(JSON)}.
 
-to_json(?MAP_TYPE, Val) ->
-    map_to_json(Val, []);
-to_json(_, Val) ->
-    Val.
+%% @doc Converts a query string value into a quorum value.
+normalize_rw_param("default") -> default;
+normalize_rw_param("one")     -> one;
+normalize_rw_param("quorum")  -> quorum;
+normalize_rw_param("all")     -> all;
+normalize_rw_param(V)         -> list_to_integer(V).
 
-map_to_json([], Acc) ->
-    {struct, Acc};
-map_to_json([{{Name, Type}, Val} | Rest], Acc) ->
-    Elem = {make_name(Name, Type), to_json(Type, Val)},
-    map_to_json(Rest, [Elem | Acc]).
+%% @doc Returns the appropriate permission for a given request method.
+permission('POST') -> "riak_kv.put";
+permission('GET')  -> "riak_kv.get";
+permission('HEAD') -> "riak_kv.get".
 
-make_name(Name, Type) ->
-    lists:flatten(io_lib:format("~s_~s", [Name, riak_kv_crdt:from_mod(Type)])).
+%% @doc Halts the resource with the given formatted response message.
+halt_with_message(Status, Format, Args, RD, Ctx) ->
+    halt_with_message(Status, io_lib:format(Format, Args), RD, Ctx).
 
-ensure_doc(Ctx=#ctx{doc=undefined, key=undefined}) ->
-    Ctx#ctx{doc={error, notfound}};
-ensure_doc(Ctx=#ctx{doc=undefined, bucket=B, key=K, client=C, r=R,
-        pr=PR, basic_quorum=Quorum, notfound_ok=NotFoundOK}) ->
-    Ctx#ctx{doc=C:get(B, K, [{r, R}, {pr, PR},
-                {basic_quorum, Quorum}, {notfound_ok, NotFoundOK}])};
-ensure_doc(Ctx) -> Ctx.
+%% @doc Halts the resource with the given response message.
+halt_with_message(Status, Message, RD, Ctx) ->
+    {{halt, Status}, error_response(Message,RD), Ctx}.
 
+%% @doc Outputs a formatted error response with the text/plain content type.
+error_response(Fmt, Args, RD) ->
+    error_response(io_lib:format(Fmt, Args), RD).
+
+%% @doc Outputs an error response with the text/plain content type.
+error_response(Msg, RD) ->
+    wrq:set_resp_header(?HEAD_CTYPE, "text/plain",
+                        wrq:append_to_response_body(Msg, RD)).
+
+%% @doc Converts an error into the appropriate resource halt and message.
 handle_common_error(Reason, RD, Ctx) ->
-    case {error, Reason} of
-        {error, too_many_fails} ->
-            {{halt, 503}, wrq:append_to_response_body("Too Many write failures"
-                    " to satisfy W/DW\n", RD), Ctx};
-        {error, timeout} ->
-            {{halt, 503},
-                wrq:set_resp_header("Content-Type", "text/plain",
-                    wrq:append_to_response_body(
-                        io_lib:format("request timed out~n",[]),
-                        RD)),
-                Ctx};
-        {error, notfound} ->
-            {{halt, 404},
-                wrq:set_resp_header("Content-Type", "text/plain",
-                    wrq:append_to_response_body(
-                        io_lib:format("not found~n",[]),
-                        RD)),
-                Ctx};
-        {error, {deleted, _VClock}} ->
-            {{halt, 404},
-                wrq:set_resp_header("Content-Type", "text/plain",
-                    wrq:append_to_response_body(
-                        io_lib:format("not found~n",[]),
-                        RD)),
-                Ctx};
-        {error, {n_val_violation, N}} ->
-            Msg = io_lib:format("Specified w/dw/pw values invalid for bucket"
-                " n value of ~p~n", [N]),
-            {{halt, 400}, wrq:append_to_response_body(Msg, RD), Ctx};
-        {error, allow_mult_false} ->
-            Msg = "Counters require bucket property 'allow_mult=true'",
-            {{halt, 409}, wrq:append_to_response_body(Msg, RD), Ctx};
-        {error, {r_val_unsatisfied, Requested, Returned}} ->
-            {{halt, 503},
-                wrq:set_resp_header("Content-Type", "text/plain",
-                    wrq:append_to_response_body(
-                        io_lib:format("R-value unsatisfied: ~p/~p~n",
-                            [Returned, Requested]),
-                        RD)),
-                Ctx};
-        {error, {w_val_unsatisfied, NumW, NumDW, W, DW}} ->
-            {{halt, 503},
-                wrq:set_resp_header("Content-Type", "text/plain",
-                    wrq:append_to_response_body(
-                        io_lib:format("W/DW-value unsatisfied: w=~p/~p dw=~p/~p~n",
-                            [NumW, W, NumDW, DW]),
-                        RD)),
-                Ctx};
-        {error, {pr_val_unsatisfied, Requested, Returned}} ->
-            {{halt, 503},
-                wrq:set_resp_header("Content-Type", "text/plain",
-                    wrq:append_to_response_body(
-                        io_lib:format("PR-value unsatisfied: ~p/~p~n",
-                            [Returned, Requested]),
-                        RD)),
-                Ctx};
-        {error, {pw_val_unsatisfied, Requested, Returned}} ->
-            Msg = io_lib:format("PW-value unsatisfied: ~p/~p~n", [Returned,
-                    Requested]),
-            {{halt, 503}, wrq:append_to_response_body(Msg, RD), Ctx};
-        {error, Err} ->
-            {{halt, 500},
-                wrq:set_resp_header("Content-Type", "text/plain",
-                    wrq:append_to_response_body(
-                        io_lib:format("Error:~n~p~n",[Err]),
-                        RD)),
-                Ctx}
+    case Reason of
+        too_many_fails ->
+            halt_with_message(503, "Too many write failures to satisfy W/DW\n",
+                              RD, Ctx);
+        timeout ->
+            halt_with_message(503, "request timed out\n", RD, Ctx);
+        notfound ->
+            {{halt, 404}, notfound_body(RD, Ctx), Ctx};
+        bucket_type_unknown ->
+            halt_with_message(404, "Unknown bucket type: ~s~n",
+                              [Ctx#ctx.bucket_type], RD, Ctx);
+        {deleted, _VClock} ->
+            {{halt,404},
+             wrq:set_resp_header(?HEAD_DELETED, "true", notfound_body(RD, Ctx)),
+                              Ctx};
+        {n_val_violation, N} ->
+            halt_with_message(400,
+                              "Specified w/dw/pw values invalid for bucket n "
+                              "value of ~p~n",[N], RD, Ctx);
+        {r_val_unsatisfied, Requested, Returned} ->
+            halt_with_message(503, "R-value unsatisfied: ~p/~p~n",
+                              [Returned, Requested], RD, Ctx);
+        {dw_val_unsatisfied, DW, NumDW} ->
+            halt_with_message(503, "DW-value unsatisfied: ~p/~p~n", [NumDW, DW],
+                              RD, Ctx);
+        {pr_val_unsatisfied, Requested, Returned} ->
+            halt_with_message(503, "PR-value unsatisfied: ~p/~p~n",
+                              [Returned, Requested], RD, Ctx);
+        {pw_val_unsatisfied, Requested, Returned} ->
+            halt_with_message(503, "PW-value unsatisfied: ~p/~p~n",
+                              [Returned, Requested], RD, Ctx);
+        failed ->
+            halt_with_message(412, "", RD, Ctx);
+        Err ->
+            halt_with_message(500, "Error:~n~p~n", [Err], RD, Ctx)
     end.
 
-%% @dc Webmachine dispatch guard for crdt resource
-known_type(ReqData) ->
-    undefined /= riak_kv_crdt:to_mod(wrq:path_info(crdt, ReqData)).
+%% @doc Converts a path segment into a binary by key.
+path_segment_to_bin(Key, RD) ->
+    Segment = proplists:get_value(Key, wrq:path_info(RD)),
+    case Segment of
+        undefined -> undefined;
+        _ ->
+            list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, Segment))
+    end.
+
+%% @doc If the key is not submitted on POST, generate a key and set
+%% the appropriate redirect location.
+maybe_generate_key(RD, Ctx=#ctx{api_version=V, bucket_type=T, bucket=B,
+                                key=undefined}) ->
+    K = riak_core_util:unique_id_62(),
+    {wrq:set_resp_header("Location",
+                         riak_kv_wm_utils:format_uri(T, B, K, undefined, V), RD),
+     Ctx#ctx{key=list_to_binary(K)}};
+maybe_generate_key(RD, Ctx) ->
+    {RD, Ctx}.
+
+make_operation(Mod, Op, Ctx) ->
+    #crdt_op{mod=Mod, op=Op, ctx=Ctx}.
+
+get_context(_Ctx, false) ->
+    undefined;
+get_context(Ctx, true) ->
+    Ctx.
+
+make_options(Ctx) ->
+    OptList = [{r, Ctx#ctx.r},
+               {w, Ctx#ctx.w},
+               {dw, Ctx#ctx.dw},
+               {rw, Ctx#ctx.rw},
+               {pr, Ctx#ctx.pr},
+               {pw, Ctx#ctx.pw},
+               {basic_quorum, Ctx#ctx.basic_quorum},
+               {notfound_ok, Ctx#ctx.notfound_ok},
+               {timeout, Ctx#ctx.timeout},
+               {returnbody, Ctx#ctx.returnbody}],
+    [ {K,V} || {K,V} <- OptList, V /= default, V /= undefined ].
+
+notfound_body(RD, #ctx{module=Mod}) ->
+    JSON = {struct, [{<<"type">>, atom_to_binary(riak_kv_crdt:from_mod(Mod), utf8)},
+                     {<<"error">>, <<"notfound">>}]},
+    wrq:set_resp_header(?HEAD_CTYPE, "application/json",
+                        wrq:set_resp_body(mochijson2:encode(JSON), RD)).

--- a/src/riak_kv_wm_crdt.erl
+++ b/src/riak_kv_wm_crdt.erl
@@ -247,12 +247,15 @@ malformed_timeout_param({Result, RD, Ctx}) ->
             {Result, RD, Ctx};
         TimeoutStr when is_list(TimeoutStr) ->
             try list_to_integer(TimeoutStr) of
+                0 ->
+                    {Result, RD, Ctx#ctx{timeout=infinity}};
                 Timeout when is_integer(Timeout), Timeout > 0 ->
                     {Result, RD, Ctx#ctx{timeout=Timeout}};
                 _Other ->
                     {true,
                      error_response("timeout query parameter must be an "
-                                    "integer greater than 0, ~s is invalid~n",
+                                    "integer greater than 0 (or 0 for disabled), "
+                                    "~s is invalid~n",
                                     [TimeoutStr], RD),
                      Ctx}
             catch


### PR DESCRIPTION
This rewrites `riak_kv_wm_crdt` and ensures that the functionality it exposes is similar to PB. The JSON format of request/response payloads is described in detail at the top of the module, and implemented in `riak_kv_crdt_json`.
