### PR TITLE
make riak_kv_test_util app startup less brittle

### DIFF
--- a/src/riak_kv_test_util.erl
+++ b/src/riak_kv_test_util.erl
@@ -162,12 +162,12 @@ setup(TestName, SetupFun) ->
     net_kernel:start([TestNode, longnames]),
 
     %% Start dependent applications
-    do_dep_apps(start, Deps),
+    AllApps = do_dep_apps(start, Deps),
 
     %% Wait for KV to be ready
     riak_core:wait_for_application(riak_kv),
     riak_core:wait_for_service(riak_kv),
-    ok.
+    AllApps.
 
 %% @doc Performs generic, riak_kv-specific and test-specific cleanup
 %% when used within a test fixture. This includes stopping dependent
@@ -180,12 +180,15 @@ setup(TestName, SetupFun) ->
 cleanup(Test, CleanupFun, setup) ->
     %% Remove existing ring files so we have a fresh ring
     os:cmd("rm -rf " ++ Test ++ "/ring"),
-    cleanup(Test, CleanupFun, ok);
-cleanup(Test, CleanupFun, _) ->
+    cleanup(Test, CleanupFun, []);
+cleanup(Test, CleanupFun, StartedApps) ->
     Deps = lists:reverse(dep_apps(Test, CleanupFun)),
+    Apps = Deps ++ lists:filtermap(fun(A) ->
+                                           not lists:member(A, Deps)
+                                   end, lists:reverse(StartedApps)),
 
-    %% Stop the applications in reverse order
-    do_dep_apps(stop, Deps),
+    %% Stop the applications in reverse order.
+    do_dep_apps(stop, Apps),
 
     %% Cleanup potentially runaway processes
     catch exit(whereis(riak_kv_vnode_master), kill),
@@ -244,23 +247,39 @@ dep_apps(Test, Extra) ->
            (_) -> ok
         end,
 
-    [sasl, Silencer, crypto, asn1, public_key, ssl, riak_sysmon, os_mon, pbkdf2,
-     runtime_tools, erlang_js, inets, mochiweb, webmachine, sidejob, poolboy,
-     basho_stats, bitcask, compiler, syntax_tools, lager, folsom, protobuffs,
-     eleveldb, riak_core, riak_pipe, riak_api, riak_dt, riak_pb, riak_kv, DefaultSetupFun, Extra].
+    [sasl, Silencer, runtime_tools, erlang_js, mochiweb, webmachine,
+     sidejob, poolboy, basho_stats, bitcask, lager, folsom, protobuffs,
+     eleveldb, riak_core, riak_pipe, riak_api, riak_dt, riak_pb, riak_kv,
+     DefaultSetupFun, Extra].
 
 
 %% @doc Runs the application-lifecycle phase across all of the given
 %% applications and functions.
 %% @see dep_apps/2
 -spec do_dep_apps(load | start | stop, [ atom() | fun() ]) -> [ any() ].
-do_dep_apps(StartStop, Apps) ->
+do_dep_apps(start, Apps) ->
+    lists:foldl(fun(A, Acc) when is_atom(A) ->
+                        case include_app_phase(start, A) of
+                            true ->
+                                {ok, Started} = start_app_and_deps(A, Acc),
+                                Started;
+                            _ ->
+                                Acc
+                        end;
+                    (F, Acc) ->
+                       F(start),
+                       Acc
+               end, [], Apps);
+do_dep_apps(LoadStop, Apps) ->
     lists:map(fun(A) when is_atom(A) ->
-                      case include_app_phase(StartStop, A) of
-                          true -> application:StartStop(A);
-                          _ -> ok
+                      case include_app_phase(LoadStop, A) of
+                          true ->
+                              application:LoadStop(A);
+                          _ ->
+                              ok
                       end;
-                 (F)                 -> F(StartStop)
+                 (F) ->
+                      F(LoadStop)
               end, Apps).
 
 %% @doc Determines whether a given application should be modified in
@@ -270,6 +289,32 @@ do_dep_apps(StartStop, Apps) ->
 include_app_phase(stop, crypto) -> false;
 include_app_phase(start, folsom) -> false;
 include_app_phase(_Phase, _App) -> true.
+
+%% Make sure an application and all of its dependent applications are started.
+%% Similar to application:ensure_all_started/1 available in R16B02.
+-spec start_app_and_deps(Application::atom(), [atom()]) -> {ok, [atom()]} | {error, term()}.
+start_app_and_deps(Application, Started) ->
+    case lists:member(Application, Started) of
+        true ->
+            {ok, Started};
+        false ->
+            case application:start(Application) of
+                ok ->
+                    {ok, [Application|Started]};
+                {error, {already_started, Application}} ->
+                    {ok, Started};
+                {error, {not_started, Dep}} ->
+                    case start_app_and_deps(Dep, Started) of
+                        {ok, NStarted} ->
+                            start_app_and_deps(Application, NStarted);
+                        Error ->
+                            Error
+                    end;
+                {error, Reason} ->
+                    [application:stop(App) || App <- Started],
+                    {error, Reason}
+            end
+    end.
 
 
 -endif. % TEST


### PR DESCRIPTION
In commit c3ebdc9 I added some missing apps to the list of apps in
riak_kv_test_util that need to be started for some riak_kv
testing. Unfortunately trying to list out the entire app dependency tree in
that module is very brittle and is to easy to forget to update if a new app
dependency is added in the future. Modify that list to eliminate the lower
level apps and instead just list the obvious higher-level apps, and add a
new function that starts each application's dependencies before starting
the app itself. Also change the riak_kv_test_util setup function to return
the list of all apps started, and change the cleanup function to take that
list of apps and stop them all.
