### PR TITLE
Add 2i AAE command

### DIFF
--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -117,6 +117,7 @@
          local_compare/2,
          compare/2,
          compare/3,
+         compare/4,
          top_hash/1,
          get_bucket/3,
          key_hashes/2,
@@ -402,6 +403,9 @@ compare(Tree, Remote) ->
 -spec compare(hashtree(), remote_fun(), acc_fun(X)) -> X.
 compare(Tree, Remote, AccFun) ->
     compare(1, 0, Tree, Remote, AccFun, []).
+
+compare(Tree, Remote, AccFun, Acc) ->
+    compare(1, 0, Tree, Remote, AccFun, Acc).
 
 -spec levels(hashtree()) -> pos_integer().
 levels(#state{levels=L}) ->

--- a/src/riak_kv_2i_aae.erl
+++ b/src/riak_kv_2i_aae.erl
@@ -1,0 +1,673 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Code related to repairing 2i data.
+-module(riak_kv_2i_aae).
+-behaviour(gen_fsm).
+
+-include("riak_kv_wm_raw.hrl").
+
+-export([start/2, stop/1, get_status/0, to_report/1]).
+
+-export([next_partition/2, wait_for_aae_pid/2, wait_for_repair/3,
+         wait_for_repair/2]).
+
+%% gen_fsm callbacks
+-export([init/1,
+         handle_event/3,
+         handle_sync_event/4,
+         handle_info/3,
+         format_status/2,
+         terminate/3,
+         code_change/4]).
+
+-export_type([status/0, partition_result/0, worker_status/0]).
+
+%% How many items to scan before possibly pausing to obey speed throttle
+-define(DEFAULT_SCAN_BATCH, 1000).
+-define(MAX_DUTY_CYCLE, 100).
+-define(MIN_DUTY_CYCLE, 1).
+-define(LOCK_RETRIES, 10).
+-define(AAE_PID_TIMEOUT, 30000).
+-define(INDEX_SCAN_TIMEOUT, 300000). % 5 mins, in case fold dies timeout
+-define(INDEX_REFRESH_TIMEOUT, 60000).
+
+-type worker_status() :: starting | scanning_indexes | populating_hashtree |
+                         exchanging.
+
+-type partition_result() :: {Partition :: integer(),
+                             {ok,  term()} | {error, term()}}.
+
+-type status() :: [{speed, integer()} |
+                   {partitions, [integer()]} |
+                   {remaining, [integer()]} |
+                   {results, [partition_result()]}|
+                   {current_partition, integer()} |
+                   {current_partition_status, worker_status()} |
+                   {index_scan_count, integer()} |
+                   {hashtree_population_count, integer()} |
+                   {exchange_count, integer()}].
+
+-record(state,
+        {
+         speed :: integer(),
+         partitions :: [integer()],
+         remaining :: [integer()],
+         results = [],
+         caller :: pid(),
+         reply_to,
+         early_reply,
+         aae_pid_req_id :: pid() | undefined,
+         worker_monitor :: reference() | undefined,
+         worker_status :: worker_status(),
+         index_scan_count = 0 :: integer(),
+         hashtree_population_count = 0 :: integer(),
+         exchange_count = 0 :: integer(),
+         open_dbs = [] :: [reference()]
+        }).
+
+-record(partition_result, {
+          status :: ok | error,
+          error,
+          index_scan_count = 0 :: integer(),
+          hashtree_population_count = 0:: integer(),
+          exchange_count = 0 :: integer()
+         }).
+
+
+%% @doc Starts a process that will issue a repair for each partition in the
+%% list, sequentially.
+%% The Speed parameter controls how fast we go. 100 means full speed,
+%% 50 means to do a unit of work and pause for the duration of that unit
+%% to achieve a 50% duty cycle, etc.
+%% If a single partition is requested, this function will block until that
+%% partition has been blocked or that fails to notify the user immediately.
+-spec start([integer()], integer()) -> {ok, pid()} | {error, term()}.
+start(Partitions, Speed)
+  when Speed >= ?MIN_DUTY_CYCLE, Speed =< ?MAX_DUTY_CYCLE ->
+    Res = gen_fsm:start({local, ?MODULE}, ?MODULE,
+                        [Partitions, Speed, self()], []),
+    case {Res, length(Partitions)} of
+        {{ok, _Pid}, 1} ->
+            try
+                EarlyAck = gen_fsm:sync_send_all_state_event(?MODULE,
+                                                             early_ack,
+                                                             infinity),
+                case EarlyAck of
+                    lock_acquired ->
+                        Res;
+                    _ ->
+                        EarlyAck
+                end
+            catch
+                exit:_ ->
+                    {error, early_exit}
+            end;
+
+        _ ->
+            Res
+    end.
+
+%% @doc Will stop any worker process and try to close leveldb databases.
+stop(TimeOut) ->
+    gen_fsm:sync_send_all_state_event(?MODULE, stop, TimeOut).
+
+-spec get_status() -> [{Key :: atom(), Val :: term()}].
+get_status() ->
+    gen_fsm:sync_send_all_state_event(?MODULE, status, infinity).
+
+init([Partitions, Speed, Caller]) ->
+    process_flag(trap_exit, true),
+    lager:info("Starting 2i repair at speed ~p for partitions ~p",
+               [Speed, Partitions]),
+    {ok, next_partition, #state{partitions=Partitions, remaining=Partitions,
+                                speed=Speed, caller=Caller}, 0}.
+
+%% @doc Notifies caller for certain cases involving a single partition
+%% so the user sees an error condition from the command line.
+maybe_notify(State=#state{reply_to=undefined}, Reply) ->
+    State#state{early_reply=Reply};
+maybe_notify(State=#state{reply_to=From}, Reply) ->
+    gen_fsm:reply(From, Reply),
+    State#state{reply_to=undefined}.
+
+
+%% @doc Process next partition or finish if no more remaining.
+next_partition(timeout, State=#state{remaining=[]}) ->
+    %% We are done. Report results
+    Status = to_simple_state(State),
+    Report = to_report(Status),
+    lager:info("Finished 2i repair:\n~s", [Report]),
+    {stop, normal, State};
+next_partition(timeout, State=#state{remaining=[Partition|_]}) ->
+    ReqId = make_ref(),
+    riak_kv_vnode:request_hashtree_pid(Partition, {fsm, ReqId, self()}),
+    {next_state, wait_for_aae_pid, State#state{aae_pid_req_id=ReqId}, ?AAE_PID_TIMEOUT}.
+
+%% @doc Waiting for vnode to send back the Pid of the AAE tree process.
+wait_for_aae_pid(timeout, State) ->
+    State2 = maybe_notify(State, {error, no_aae_pid}),
+    {stop, no_aae_pid, State2};
+wait_for_aae_pid({ReqId, {error, Err}}, State=#state{aae_pid_req_id=ReqId}) ->
+    State2 = maybe_notify(State, {error, {no_aae_pid, Err}}),
+    {stop, no_aae_pid, State2};
+wait_for_aae_pid({ReqId, {ok, TreePid}},
+                 State=#state{aae_pid_req_id=ReqId, speed=Speed,
+                              remaining=[Partition|_]}) ->
+    WorkerFun =
+    fun() ->
+            Res =
+            repair_partition(Partition, Speed, ?MODULE, TreePid),
+            gen_fsm:sync_send_event(?MODULE, {repair_result, Res}, infinity)
+    end,
+    Mon = monitor(process, spawn_link(WorkerFun)),
+    {next_state, wait_for_repair, State#state{worker_monitor=Mon}}.
+
+%% @doc Waiting for a partition repair process to finish
+wait_for_repair({lock_acquired, Partition},
+                _From,
+                State=#state{remaining=[Partition|_]}) ->
+    State2 = maybe_notify(State, lock_acquired),
+    {reply, ok, wait_for_repair, State2};
+wait_for_repair({repair_result, Res},
+                _From,
+                State=#state{remaining=[Partition|Rem],
+                             results=Results,
+                             worker_monitor=Mon}) ->
+    State2 =
+    case Res of
+        {error, {lock_failed, LockErr}} ->
+            maybe_notify(State, {lock_failed, LockErr});
+        _ ->
+            State
+    end,
+    demonitor(Mon, [flush]),
+    {reply, ok, next_partition,
+     State2#state{remaining=Rem,
+                  results=[{Partition, Res}|Results],
+                  worker_monitor=undefined,
+                  worker_status=starting,
+                  index_scan_count=0,
+                  hashtree_population_count=0,
+                  exchange_count=0},
+     0}.
+
+%% @doc Process async worker status updates during a repair
+wait_for_repair({index_scan_update, Count}, State) ->
+    {next_state, wait_for_repair,
+     State#state{worker_status=scanning_indexes,
+                 index_scan_count=Count}};
+wait_for_repair({hashtree_population_update, Count}, State) ->
+    {next_state, wait_for_repair,
+     State#state{worker_status=populating_hashtree,
+                 hashtree_population_count=Count}};
+wait_for_repair({repair_count_update, Count}, State) ->
+    {next_state, wait_for_repair,
+     State#state{worker_status=exchanging,
+                 exchange_count=Count}};
+wait_for_repair({open_db, DBRef}, State = #state{open_dbs=DBs}) ->
+    {next_state, wait_for_repair,
+     State#state{open_dbs=[DBRef|DBs]}};
+wait_for_repair({close_db, DBRef}, State = #state{open_dbs=DBs}) ->
+    {next_state, wait_for_repair,
+     State#state{open_dbs=lists:delete(DBRef, DBs)}}.
+
+%% @doc Performs the actual repair work, called from a spawned process.
+-spec repair_partition(integer(), integer(), {pid(), any()}, pid()) ->
+    #partition_result{}.
+repair_partition(Partition, DutyCycle, From, TreePid) ->
+    case get_hashtree_lock(TreePid, ?LOCK_RETRIES) of
+        ok ->
+            lager:info("Acquired lock on partition ~p", [Partition]),
+            gen_fsm:sync_send_event(From, {lock_acquired, Partition}, infinity),
+            lager:info("Repairing indexes in partition ~p", [Partition]),
+            case create_index_data_db(Partition, DutyCycle) of
+                {ok, {DBDir, DBRef, IndexDBCount}} ->
+                    Res =
+                    case build_tmp_tree(Partition, DBRef, DutyCycle) of
+                        {ok, {TmpTree, TmpTreeCount}} ->
+                            Res0 = do_exchange(Partition, DBRef, TmpTree,
+                                               TreePid),
+                            remove_tmp_tree(Partition, TmpTree),
+                            case Res0 of
+                                {ok, CmpCount} ->
+                                    #partition_result{
+                                       status=ok,
+                                       index_scan_count=IndexDBCount,
+                                       hashtree_population_count=TmpTreeCount,
+                                       exchange_count=CmpCount};
+                                {error, TmpTreeErr} ->
+                                    #partition_result{
+                                       status=error,
+                                       error=TmpTreeErr,
+                                       index_scan_count=IndexDBCount,
+                                       hashtree_population_count=TmpTreeCount}
+                            end;
+                        {error, BuildTreeErr} ->
+                            #partition_result{status=error,
+                                              error=BuildTreeErr,
+                                              index_scan_count=IndexDBCount}
+                    end,
+                    destroy_index_data_db(DBDir, DBRef),
+                    lager:info("Finished repairing indexes in partition ~p",
+                               [Partition]),
+                    Res;
+                {error, CreateDBErr} ->
+                    #partition_result{status=error, error=CreateDBErr}
+            end;
+        LockErr ->
+            lager:error("Failed to acquire hashtree lock on partition ~p",
+                        [Partition]),
+            #partition_result{status=error, error=LockErr}
+    end.
+
+%% No wait for speed 100, wait equal to work time when speed is 50,
+%% wait equal to 99 times the work time when speed is 1.
+wait_factor(DutyCycle) ->
+    if
+        %% Avoid potential floating point funkiness for full speed.
+        DutyCycle >= ?MAX_DUTY_CYCLE -> 0;
+        true -> (100 - DutyCycle) / DutyCycle
+    end.
+
+scan_batch() ->
+    app_helper:get_env(riak_kv, aae_2i_batch_size, ?DEFAULT_SCAN_BATCH).
+
+%% @doc Create temporary DB holding 2i index data from disk.
+create_index_data_db(Partition, DutyCycle) ->
+    DBDir = filename:join(data_root(), "tmp_db"),
+    (catch eleveldb:destroy(DBDir, [])),
+    case filelib:ensure_dir(DBDir) of
+        ok ->
+            create_index_data_db(Partition, DutyCycle, DBDir);
+        _ ->
+            {error, io_lib:format("Could not create directory ~s", [DBDir])}
+    end.
+
+create_index_data_db(Partition, DutyCycle, DBDir) ->
+    lager:info("Creating temporary database of 2i data in ~s", [DBDir]),
+    DBOpts = leveldb_opts(),
+    case eleveldb:open(DBDir, DBOpts) of
+        {ok, DBRef} ->
+            create_index_data_db(Partition, DutyCycle, DBDir, DBRef);
+        {error, DBErr} ->
+            {error, DBErr}
+    end.
+
+create_index_data_db(Partition, DutyCycle, DBDir, DBRef) ->
+    Client = self(),
+    BatchRef = make_ref(),
+    WaitFactor = wait_factor(DutyCycle),
+    ScanBatch = scan_batch(),
+    Fun =
+    fun(Bucket, Key, Field, Term, Count) ->
+            BKey = term_to_binary({Bucket, Key}),
+            OldVal = fetch_index_data(BKey, DBRef),
+            Val = [{Field, Term}|OldVal],
+            ok = eleveldb:put(DBRef, BKey, term_to_binary(Val), []),
+            Count2 = Count + 1,
+            case Count2 rem ScanBatch of
+                0 when DutyCycle < ?MAX_DUTY_CYCLE ->
+                    Mon = monitor(process, Client),
+                    Client ! {BatchRef, self(), Count2},
+                    receive
+                        {BatchRef, continue} ->
+                            ok;
+                        {'DOWN', Mon, _, _, _} ->
+                            throw(fold_receiver_died)
+                    end,
+                    demonitor(Mon, [flush]);
+                _ ->
+                    ok
+            end,
+            Count2
+    end,
+    lager:info("Grabbing all index data for partition ~p", [Partition]),
+    Ref = make_ref(),
+    Sender = {raw, Ref, Client},
+    StartTime = now(),
+    riak_core_vnode_master:command({Partition, node()},
+                                   {fold_indexes, Fun, 0},
+                                   Sender,
+                                   riak_kv_vnode_master),
+    NumFound = wait_for_index_scan(Ref, BatchRef, StartTime, WaitFactor),
+    case NumFound of
+        {error, _} = Err ->
+            destroy_index_data_db(DBDir, DBRef),
+            Err;
+        _ ->
+            lager:info("Grabbed ~p index data entries from partition ~p",
+                       [NumFound, Partition]),
+            {ok, {DBDir, DBRef, NumFound}}
+    end.
+
+leveldb_opts() ->
+    ConfigOpts = app_helper:get_env(riak_kv,
+                                    anti_entropy_leveldb_opts,
+                                    [{write_buffer_size, 20 * 1024 * 1024},
+                                     {max_open_files, 20}]),
+    Config0 = orddict:from_list(ConfigOpts),
+    ForcedOpts = [{create_if_missing, true}, {error_if_exists, true}],
+    Config =
+    lists:foldl(fun({K,V}, Cfg) ->
+                        orddict:store(K, V, Cfg)
+                end, Config0, ForcedOpts),
+    Config.
+
+duty_cycle_pause(WaitFactor, StartTime) ->
+    case WaitFactor > 0 of
+        true ->
+            Now = now(),
+            ElapsedMicros = timer:now_diff(Now, StartTime),
+            WaitMicros = ElapsedMicros * WaitFactor,
+            WaitMillis = trunc(WaitMicros / 1000 + 0.5),
+            timer:sleep(WaitMillis);
+        false ->
+            ok
+    end.
+
+%% @doc Async notify this FSM of an update.
+-spec send_event(any()) -> ok.
+send_event(Event) ->
+    gen_fsm:send_event(?MODULE, Event).
+
+%% @doc Waiting for 2i data scanning updates and final result.
+wait_for_index_scan(Ref, BatchRef, StartTime, WaitFactor) ->
+    receive
+        {BatchRef, Pid, Count} ->
+            duty_cycle_pause(WaitFactor, StartTime),
+            Pid ! {BatchRef, continue},
+            send_event({index_scan_update, Count}),
+            wait_for_index_scan(Ref, BatchRef, now(), WaitFactor);
+        {Ref, Result} ->
+            Result
+    after
+        ?INDEX_SCAN_TIMEOUT ->
+            {error, index_scan_timeout}
+    end.
+
+-spec fetch_index_data(BK :: binary(), reference()) -> term().
+fetch_index_data(BK, DBRef) ->
+    % Let it crash on leveldb error
+    case eleveldb:get(DBRef, BK, []) of
+        {ok, BinVal} ->
+            binary_to_term(BinVal);
+        not_found ->
+            []
+    end.
+
+%% @doc Remove all traces of the temporary 2i index DB
+destroy_index_data_db(DBDir, DBRef) ->
+    catch eleveldb:close(DBRef),
+    eleveldb:destroy(DBDir, []).
+
+%% @doc Returns the base data directory to use inside the AAE directory.
+data_root() ->
+    BaseDir = riak_kv_index_hashtree:determine_data_root(),
+    filename:join(BaseDir, "2i").
+
+%% @doc Builds a temporary hashtree based on the 2i data fetched from the
+%% backend.
+build_tmp_tree(Index, DBRef, DutyCycle) ->
+    lager:info("Building tree for 2i data on disk for partition ~p", [Index]),
+    %% Build temporary hashtree with this index data.
+    TreeId = <<0:176/integer>>,
+    Path = filename:join(data_root(), integer_to_list(Index)),
+    catch eleveldb:destroy(Path, []),
+    case filelib:ensure_dir(Path) of
+        ok ->
+            Tree = hashtree:new({Index, TreeId}, [{segment_path, Path}]),
+            WaitFactor = wait_factor(DutyCycle),
+            BatchSize = scan_batch(),
+            FoldFun =
+            fun({K, V}, {Count, TreeAcc, StartTime}) ->
+                    Indexes = binary_to_term(V),
+                    Hash = riak_kv_index_hashtree:hash_index_data(Indexes),
+                    Tree2 = hashtree:insert(K, Hash, TreeAcc),
+                    Count2 = Count + 1,
+                    StartTime2 =
+                    case Count2 rem BatchSize of
+                        0 ->
+                            send_event({hashtree_population_update, Count2}),
+                            duty_cycle_pause(WaitFactor, StartTime),
+                            now();
+                        _ ->
+                            StartTime
+                    end,
+                    {Count2, Tree2, StartTime2}
+            end,
+            send_event({hashtree_population_update, 0}),
+            {Count, Tree2, _} = eleveldb:fold(DBRef, FoldFun,
+                                              {0, Tree, erlang:now()}, []),
+            lager:info("Done building temporary tree for 2i data "
+                       "with ~p entries",
+                       [Count]),
+            {ok, {Tree2, Count}};
+        _ ->
+            {error, io_lib:format("Could not create directory ~s", [Path])}
+    end.
+
+%% @doc Remove all traces of the temporary hashtree for 2i index data.
+remove_tmp_tree(Partition, Tree) ->
+    lager:debug("Removing temporary AAE 2i tree for partition ~p", [Partition]),
+    hashtree:close(Tree),
+    hashtree:destroy(Tree).
+
+%% @doc Run exchange between the temporary 2i tree and the vnode's 2i tree.
+-spec do_exchange(integer(), reference(), hashtree:hashtree(), pid()) ->
+    {ok, integer()} | {error, any()}.
+do_exchange(Partition, DBRef, TmpTree0, TreePid) ->
+    lager:info("Reconciling 2i data"),
+    IndexN2i = riak_kv_index_hashtree:index_2i_n(),
+    lager:debug("Updating the vnode tree"),
+    ok = riak_kv_index_hashtree:update(IndexN2i, TreePid),
+    lager:debug("Updating the temporary 2i AAE tree"),
+    TmpTree = hashtree:update_tree(TmpTree0),
+    Remote =
+    fun(get_bucket, {L, B}) ->
+            R1 = riak_kv_index_hashtree:exchange_bucket(IndexN2i, L, B,
+                                                        TreePid),
+            R1;
+       (key_hashes, Segment) ->
+            R2 = riak_kv_index_hashtree:exchange_segment(IndexN2i, Segment,
+                                                         TreePid),
+            R2;
+       (A, B) ->
+            throw({riak_kv_2i_aae_internal_error, A, B})
+    end,
+    AccFun =
+    fun(KeyDiff, Acc) ->
+            lists:foldl(
+              fun({_DiffReason, BKeyBin}, Count) ->
+                      BK = binary_to_term(BKeyBin),
+                      IdxData = fetch_index_data(BKeyBin, DBRef),
+                      % Sync refresh it. Not in a rush here.
+                      riak_kv_vnode:refresh_index_data(Partition, BK, IdxData,
+                                                      ?INDEX_REFRESH_TIMEOUT),
+                      Count2 = Count + 1,
+                      send_event({repair_count_update, Count2}),
+                      Count2
+              end,
+              Acc, KeyDiff)
+    end,
+    try
+        NumDiff = hashtree:compare(TmpTree, Remote, AccFun, 0),
+        lager:info("Found ~p differences", [NumDiff]),
+        {ok, NumDiff}
+    catch
+        CmpErrClass:CmpErr ->
+            lager:error("Hashtree exchange failed ~p, ~p", [CmpErrClass, CmpErr]),
+            case CmpErrClass of
+                error ->
+                    {error, CmpErr};
+                _ ->
+                    {error, {CmpErrClass, CmpErr}}
+            end
+    end.
+
+get_hashtree_lock(TreePid, Retries) ->
+    case riak_kv_index_hashtree:get_lock(TreePid, local_fsm) of
+        Reply = already_locked ->
+            case Retries > 0 of
+                true ->
+                    timer:sleep(1000),
+                    get_hashtree_lock(TreePid, Retries-1);
+                false ->
+                    Reply
+            end;
+        Reply ->
+            Reply
+    end.
+
+
+%%%===================================================================
+%%% gen_fsm callbacks
+%%%===================================================================
+
+to_simple_partition_result(#partition_result{
+                              status=Status,
+                              error=Err,
+                              index_scan_count=IdxCount,
+                              hashtree_population_count=TreePopCount,
+                              exchange_count=CmpCount}) ->
+    [{status, Status}] ++
+    [{error, Err} || Err /= undefined] ++
+    [{index_scan_count, IdxCount},
+     {hashtree_population_count, TreePopCount},
+     {exchange_count, CmpCount}].
+
+%% @doc Returns a proplist simplified version of the state.
+to_simple_state(State) ->
+    #state{
+         speed=Speed,
+         partitions=Partitions,
+         remaining=Rem,
+         worker_status=WStatus,
+         index_scan_count=IdxCount,
+         hashtree_population_count=PopCount,
+         results = Results0
+      } = State,
+    Results =
+    [{Partition, to_simple_partition_result(Res)}
+     || {Partition, Res} <- Results0],
+    {TotIdxCount, TotPopCount, TotXchgCount} =
+    lists:foldl(fun({_, #partition_result{
+                       index_scan_count=NI,
+                       hashtree_population_count=NP,
+                       exchange_count=NX}}, {I, P, X}) ->
+                        {I+NI, P+NP, X+NX}
+                end, {0,0,0}, Results0),
+    PartStatus =
+    case length(Rem) > 0 of
+        true ->
+            [{current_partition, hd(Rem)},
+             {current_partition_status, WStatus},
+             {current_index_scan_count, IdxCount},
+             {current_hashtree_population_count, PopCount}];
+        false ->
+            []
+    end,
+    [{speed, Speed},
+     {partitions, Partitions},
+     {remaining, Rem},
+     {index_scan_count, TotIdxCount},
+     {hashtree_population_count, TotPopCount},
+     {exchange_count, TotXchgCount},
+     {results, Results}]
+    ++ PartStatus.
+
+format_status(_Opt, [_PDict, State]) ->
+    [{detailed_status, to_simple_state(State)}].
+
+%% @doc Human readable status report.
+to_report(Status) ->
+    Speed = proplists:get_value(speed, Status),
+    IdxScanCount = proplists:get_value(index_scan_count, Status),
+    PopCount = proplists:get_value(hashtree_population_count, Status),
+    XchgCount = proplists:get_value(exchange_count, Status),
+    Partitions = proplists:get_value(partitions, Status),
+    Rem = proplists:get_value(remaining, Status),
+    NParts = length(Partitions),
+    NDone = NParts - length(Rem),
+    Report0 = io_lib:format("\tTotal partitions: ~p\n"
+                            "\tFinished partitions: ~p\n"
+                            "\tSpeed: ~p\n"
+                            "\tTotal 2i items scanned: ~p\n"
+                            "\tTotal tree objects: ~p\n"
+                            "\tTotal objects fixed: ~p\n",
+                            [NParts, NDone, Speed, IdxScanCount, PopCount,
+                             XchgCount]),
+    Results = proplists:get_value(results, Status),
+    Errors =
+    [{P, proplists:get_value(error, R)}
+     || {P, R} <- Results,
+        proplists:get_value(status, R) == error],
+    case Errors of
+        [] ->
+            Report0;
+        _ ->
+            lists:flatten(
+             [Report0, io_lib:format("With errors:\n", []) |
+              [io_lib:format("Partition: ~p\nError: ~p\n\n", [P, E])
+               || {P, E} <- Errors]])
+    end.
+
+%% @doc Handles repair worker death notification
+handle_info({'EXIT', _From, _Reason}, StateName, State) ->
+    %% We handle the monitor down message instead.
+    {next_state, StateName, State};
+handle_info({'DOWN', Mon, _, _, Reason}, _StateName,
+            State=#state{worker_monitor=Mon, remaining=[Partition|_]}) ->
+    lager:error("Index repair of partition ~p failed : ~p",
+                [Partition, Reason]),
+    {stop, {partition_failed, Reason}, State};
+handle_info({'DOWN', _Mon, _, _, _Reason}, StateName, State) ->
+    % Proces died after we got its result, so ignore.
+    {next_state, StateName, State}.
+
+handle_event(_Event, StateName, State) ->
+    {next_state, StateName, State}.
+
+%% @doc Handles early reply and status requests.
+%% A client may request an early acknowledgement, so early
+%% errors can be returned immediately to the user.
+handle_sync_event(early_ack, From, StateName,
+                  State=#state{early_reply=undefined}) ->
+    {next_state, StateName, State#state{reply_to=From}};
+handle_sync_event(early_ack, _From, StateName,
+                  State=#state{early_reply=Reply}) ->
+    {reply, Reply, StateName, State};
+handle_sync_event(status, _From, StateName, State) ->
+    {reply, to_simple_state(State), StateName, State};
+handle_sync_event(stop, From, _StateName, State=#state{open_dbs=DBs}) ->
+    [try
+         eleveldb:close(DB)
+     catch
+         _:_ ->
+             ok
+     end || DB <- DBs],
+    gen_fsm:reply(From, ok),
+    {stop, user_request, State}.
+
+terminate(_Reason, _StateName, _State) ->
+    ok.
+
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -35,6 +35,7 @@
          cluster_info/1,
          down/1,
          aae_status/1,
+         repair_2i/1,
          reformat_indexes/1,
          reformat_objects/1,
          reload_code/1]).
@@ -436,9 +437,154 @@ run_reformat(M, F, A) ->
                         [Err, Reason])
     end.
 
+repair_2i(["status"]) ->
+    try
+        Status = riak_kv_2i_aae:get_status(),
+        Report = riak_kv_2i_aae:to_report(Status),
+        io:format("2i repair status is running:\n~s", [Report]),
+        ok
+    catch
+        exit:{noproc, _NoProcErr} ->
+            io:format("2i repair is not running\n", []),
+            ok
+    end;
+repair_2i(["kill"]) ->
+    case whereis(riak_kv_2i_aae) of
+        Pid when is_pid(Pid) ->
+            try
+                riak_kv_2i_aae:stop(60000)
+            catch
+                _:_->
+                    lager:warning("Asking nicely did not work."
+                                  " Will try a hammer"),
+                    ok
+            end,
+            Mon = monitor(process, riak_kv_2i_aae),
+            exit(Pid, kill),
+            receive
+                {'DOWN', Mon, _, _, _} ->
+                    lager:info("2i repair process has been killed by user"
+                               " request"),
+                    io:format("The 2i repair process has ceased to be.\n"
+                              "Since it was killed forcibly, you may have to "
+                              "wait some time\n"
+                              "for all internal locks to be released before "
+                              "trying again\n", []),
+                    ok
+            end;
+        undefined ->
+            io:format("2i repair is not running\n"),
+            ok
+    end;
+repair_2i(Args) ->
+    case validate_repair_2i_args(Args) of
+        {ok, IdxList, DutyCycle} ->
+            case length(IdxList) < 5 of
+                true ->
+                    io:format("Will repair 2i on these partitions:\n", []),
+                    [io:format("\t~p\n", [Idx]) || Idx <- IdxList];
+                false ->
+                    io:format("Will repair 2i data on ~p partitions\n", [length(IdxList)])
+            end,
+            Ret = riak_kv_2i_aae:start(IdxList, DutyCycle),
+            case Ret of
+                {ok, _Pid} ->
+                    io:format("Watch the logs for 2i repair progress reports\n", []),
+                    ok;
+                {error, {lock_failed, not_built}} ->
+                    io:format("Error: The AAE tree for that partition has not been built yet\n", []),
+                    error;
+                {error, {lock_failed, LockErr}} ->
+                    io:format("Error: Could not get a lock on AAE tree for"
+                              " partition ~p : ~p\n", [hd(IdxList), LockErr]),
+                    error;
+                {error, already_running} ->
+                    io:format("Error: 2i repair is already running. Check the logs for progress\n", []),
+                    error;
+                {error, early_exit} ->
+                    io:format("Error: 2i repair finished immediately. Check the logs for details\n", []),
+                    error;
+                {error, Reason} ->
+                    io:format("Error running 2i repair : ~p\n", [Reason]),
+                    error
+            end;
+        {error, aae_disabled} ->
+            io:format("Error: AAE is currently not enabled\n", []),
+            error;
+        {error, Reason} ->
+            io:format("Error: ~p\n", [Reason]),
+            io:format("Usage: riak-admin repair-2i [--speed [1-100]] <Idx> ...\n", []),
+            io:format("Speed defaults to 100 (full speed)\n", []),
+            io:format("If no partitions are given, all partitions in the\n"
+                      "node are repaired\n", []),
+            error
+    end.
+
 %%%===================================================================
 %%% Private
 %%%===================================================================
+
+validate_repair_2i_args(Args) ->
+    case riak_kv_entropy_manager:enabled() of
+        true ->
+            parse_repair_2i_args(Args);
+        false ->
+            {error, aae_disabled}
+    end.
+
+parse_repair_2i_args(["--speed", DutyCycleStr | Partitions]) ->
+    DutyCycle = parse_int(DutyCycleStr),
+    case DutyCycle of
+        undefined ->
+            {error, io_lib:format("Invalid speed value (~s). It should be a " ++
+                                  "number between 1 and 100",
+                                  [DutyCycleStr])};
+        _ ->
+            parse_repair_2i_args(DutyCycle, Partitions)
+    end;
+parse_repair_2i_args(Partitions) ->
+    parse_repair_2i_args(100, Partitions).
+
+parse_repair_2i_args(DutyCycle, Partitions) ->
+    case get_2i_repair_indexes(Partitions) of
+        {ok, IdxList} ->
+            {ok, IdxList, DutyCycle};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+get_2i_repair_indexes([]) ->
+    AllVNodes = riak_core_vnode_manager:all_vnodes(riak_kv_vnode),
+    {ok, [Idx || {riak_kv_vnode, Idx, _} <- AllVNodes]};
+get_2i_repair_indexes(IntStrs) ->
+    {ok, NodeIdxList} = get_2i_repair_indexes([]),
+    F =
+    fun(_, {error, Reason}) ->
+            {error, Reason};
+       (IntStr, Acc) ->
+            case parse_int(IntStr) of
+                undefined ->
+                    {error, io_lib:format("~s is not an integer\n", [IntStr])};
+                Int ->
+                    case lists:member(Int, NodeIdxList) of
+                        true ->
+                            Acc ++ [Int];
+                        false ->
+                            {error,
+                             io_lib:format("Partition ~p does not belong"
+                                           ++ " to this node\n",
+                                           [Int])}
+                    end
+            end
+    end,
+    IdxList = lists:foldl(F, [], IntStrs),
+    case IdxList of
+        {error, Reason} ->
+            {error, Reason};
+        _ ->
+            {ok, IdxList}
+    end.
+
 format_stats([], Acc) ->
     lists:reverse(Acc);
 format_stats([{Stat, V}|T], Acc) ->

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -39,17 +39,20 @@
 -export([get_lock/2,
          compare/3,
          compare/4,
+         determine_data_root/0,
          exchange_bucket/4,
          exchange_segment/3,
+         hash_index_data/1,
+         hash_object/2,
          update/2,
          start_exchange_remote/4,
          delete/2,
-         insert/4,
-         insert/5,
-         insert_object/3,
-         async_insert_object/3,
+         async_delete/2,
+         insert/3,
+         async_insert/3,
          stop/1,
-         destroy/1]).
+         destroy/1,
+         index_2i_n/0]).
 
 -export([poke/1]).
 
@@ -72,6 +75,8 @@
 
 %% Time from build to expiration of tree, in millseconds
 -define(DEFAULT_EXPIRE, 604800000). %% 1 week
+%% Magic Tree id for 2i data.
+-define(INDEX_2I_N, {0, 0}).
 
 %%%===================================================================
 %%% API
@@ -91,45 +96,32 @@ start(Index, IndexNs=[_|_], VNPid) ->
 start_link(Index, IndexNs=[_|_], VNPid) ->
     gen_server:start_link(?MODULE, [Index, IndexNs, VNPid], []).
 
-%% @doc Add a key/hash pair to the tree identified by the given tree id
-%%      that is managed by the provided index_hashtree pid.
--spec insert(index_n(), binary(), binary(), pid()) -> ok.
-insert(Id, Key, Hash, Tree) ->
-    insert(Id, Key, Hash, Tree, []).
-
-%% @doc A variant of {@link insert/4} that accepts a list of options.
 %%      Valid options:
 %%       ``if_missing'' :: Only insert the key/hash pair if the key does not
 %%                         already exist in the hashtree.
--spec insert(index_n(), binary(), binary(), pid(), proplist()) -> ok.
-insert(_Id, _Key, _Hash, undefined, _Options) ->
+insert(Items, _Opts, Tree) when Tree =:= undefined; Items =:= [] ->
     ok;
-insert(Id, Key, Hash, Tree, Options) ->
-    catch gen_server:call(Tree, {insert, Id, Key, Hash, Options}, infinity).
+insert(Items=[_|_], Opts, Tree) ->
+    catch gen_server:call(Tree, {insert, Items, Opts}, infinity).
 
-%% @doc Add an encoded (binary) riak_object associated with a given
-%%      bucket/key to the appropriate hashtree managed by the provided
-%%      index_hashtree pid. The hash value is generated using
-%%      {@link hash_object/2}. Any encoding version is supported. The encoding
-%%      will be changed to the appropriate version before hashing the object.
--spec insert_object({binary(), binary()}, riak_object_t2b(), pid()) -> ok.
-insert_object(_BKey, _RObj, undefined) ->
+async_insert(Items, _Opts, Tree) when Tree =:= undefined; Items =:= [] ->
     ok;
-insert_object(BKey, RObj, Tree) ->
-    catch gen_server:call(Tree, {insert_object, BKey, RObj}, infinity).
+async_insert(Items=[_|_], Opts, Tree) ->
+    gen_server:cast(Tree, {insert, Items, Opts}).
 
-%% @doc Asynchronous version of {@link insert_object/3}.
-async_insert_object(BKey, RObj, Tree) ->
-    gen_server:cast(Tree, {insert_object, BKey, RObj}).
-
-%% @doc Remove the key/hash pair associated with a given bucket/key from the
-%%      appropriate hashtree managed by the provided index_hashtree pid.
--spec delete({binary(), binary()}, pid()) -> ok.
-delete(_BKey, undefined) ->
+-spec delete([{binary(), binary()}], pid()) -> ok.
+delete(Items, Tree) when Tree =:= undefined; Items =:= [] ->
     ok;
-delete(BKey, Tree) ->
-    catch gen_server:call(Tree, {delete, BKey}, infinity).
+delete(Items=[{_Id, _Key}|_], Tree) ->
+    catch gen_server:call(Tree, {delete, Items}, infinity).
 
+-spec async_delete({binary(), binary()}|[{binary(), binary()}], pid()) -> ok.
+async_delete(Items, Tree) when Tree =:= undefined; Items =:= [] ->
+    ok;
+async_delete(Items=[{_Id, _Key}|_], Tree) ->
+    catch gen_server:cast(Tree, {delete, Items}).
+
+%
 %% @doc Called by the entropy manager to finish the process used to acquire
 %%      remote vnode locks when starting an exchange. For more details,
 %%      see {@link riak_kv_entropy_manager:start_exchange_remote/3}
@@ -235,16 +227,12 @@ handle_call({get_lock, Type, Pid}, _From, State) ->
     {Reply, State2} = do_get_lock(Type, Pid, State),
     {reply, Reply, State2};
 
-handle_call({insert, Id, Key, Hash, Options}, _From, State) ->
-    State2 = do_insert(Id, Key, Hash, Options, State),
+handle_call({insert, Items, Options}, _From, State) ->
+    State2 = do_insert(Items, Options, State),
     {reply, ok, State2};
-handle_call({insert_object, BKey, RObj}, _From, State) ->
-    IndexN = riak_kv_util:get_index_n(BKey),
-    State2 = do_insert(IndexN, term_to_binary(BKey), hash_object(BKey, RObj), [], State),
-    {reply, ok, State2};
-handle_call({delete, BKey}, _From, State) ->
-    IndexN = riak_kv_util:get_index_n(BKey),
-    State2 = do_delete(IndexN, term_to_binary(BKey), State),
+
+handle_call({delete, Items}, _From, State) ->
+    State2 = do_delete(Items, State),
     {reply, ok, State2};
 
 handle_call({update_tree, Id}, From, State) ->
@@ -296,9 +284,12 @@ handle_cast(stop, State) ->
     close_trees(State),
     {stop, normal, State};
 
-handle_cast({insert_object, BKey, RObj}, State) ->
-    IndexN = riak_kv_util:get_index_n(BKey),
-    State2 = do_insert(IndexN, term_to_binary(BKey), hash_object(BKey, RObj), [], State),
+handle_cast({insert, Items, Options}, State) ->
+    State2 = do_insert(Items, Options, State),
+    {noreply, State2};
+
+handle_cast({delete, Items}, State) ->
+    State2 = do_delete(Items, State),
     {noreply, State2};
 
 handle_cast(build_failed, State) ->
@@ -378,18 +369,25 @@ load_built(#state{trees=Trees}) ->
             false
     end.
 
-%% Generate a hash value for a binary-encoded `riak_object'
--spec hash_object({riak_object:bucket(), riak_object:key()}, riak_object_t2b()) -> binary().
-hash_object({Bucket, Key}, RObjBin) ->
-    %% Normalize the `riak_object' vector clock before hashing
+%% Generate a hash value for a `riak_object'
+-spec hash_object({riak_object:bucket(), riak_object:key()},
+                  riak_object_t2b() | riak_object:riak_object()) -> binary().
+hash_object({Bucket, Key}, RObj0) ->
     try
-        RObj = riak_object:from_binary(Bucket, Key, RObjBin),
+        RObj = case riak_object:is_robject(RObj0) of
+            true -> RObj0;
+            false -> riak_object:from_binary(Bucket, Key, RObj0)
+        end,
         Hash = riak_object:hash(RObj),
         term_to_binary(Hash)
     catch _:_ ->
             Null = erlang:phash2(<<>>),
             term_to_binary(Null)
     end.
+
+hash_index_data(IndexData) when is_list(IndexData) ->
+    Bin = term_to_binary(lists:usort(IndexData)),
+    crypto:sha(Bin).
 
 %% Fold over a given vnode's data, inserting each object into the appropriate
 %% hashtree. Use the `if_missing' option to only insert the key/hash pair if
@@ -398,19 +396,59 @@ hash_object({Bucket, Key}, RObjBin) ->
 %% incoming write triggers a real-time insert of a key/hash pair for an object
 %% before the fold reaches the now out-of-date version of the object, the old
 %% key/hash pair will be ignored.
--spec fold_keys(index(), pid()) -> ok.
-fold_keys(Partition, Tree) ->
-    Req = ?FOLD_REQ{foldfun=fun(BKey={Bucket,Key}, RObj, _) ->
-                                    IndexN = riak_kv_util:get_index_n({Bucket, Key}),
-                                    insert(IndexN, term_to_binary(BKey), hash_object(BKey, RObj),
-                                           Tree, [if_missing]),
-                                    ok
-                            end,
-                    acc0=ok},
+%% If `HasIndexTree` is true, also update the index spec tree.
+-spec fold_keys(index(), pid(), boolean()) -> ok.
+fold_keys(Partition, Tree, HasIndexTree) ->
+    FoldFun = fold_fun(Tree, HasIndexTree),
+    Req = ?FOLD_REQ{foldfun=FoldFun, acc0=ok},
     riak_core_vnode_master:sync_command({Partition, node()},
                                         Req,
                                         riak_kv_vnode_master, infinity),
     ok.
+
+%% @doc Generate the folding function
+%% for a riak fold_req
+-spec fold_fun(pid(), boolean()) -> fun().
+fold_fun(Tree, _HasIndexTree = false) ->
+    ObjectFoldFun = object_fold_fun(Tree),
+    fun(BKey, RObj, _) ->
+            BinBKey = term_to_binary(BKey),
+            ObjectFoldFun(BKey, RObj, BinBKey),
+            ok
+    end;
+fold_fun(Tree, _HasIndexTree = true) ->
+    %% Index AAE backend, so hash the indexes
+    ObjectFoldFun = object_fold_fun(Tree),
+    IndexFoldFun = index_fold_fun(Tree),
+    fun(BKey = {Bucket, Key}, BinObj, _) ->
+            RObj = riak_object:from_binary(Bucket, Key, BinObj),
+            BinBKey = term_to_binary(BKey),
+            ObjectFoldFun(BKey, RObj, BinBKey),
+            IndexFoldFun(RObj, BinBKey),
+            ok
+    end.
+
+-spec object_fold_fun(pid()) -> fun().
+object_fold_fun(Tree) ->
+    fun(BKey={Bucket,Key}, RObj, BinBKey) ->
+            IndexN = riak_kv_util:get_index_n({Bucket, Key}),
+            insert([{IndexN, BinBKey, hash_object(BKey, RObj)}],
+                   [if_missing],
+                   Tree)
+    end.
+
+-spec index_fold_fun(pid()) -> fun().
+index_fold_fun(Tree) ->
+    fun(RObj, BinBKey) ->
+            IndexData = riak_object:index_data(RObj),
+            [insert([{?INDEX_2I_N, BinBKey, hash_index_data(IndexDatum)}],
+                    [if_missing], Tree) || IndexDatum <- IndexData]
+    end.
+
+%% @Doc the 2i index hashtree as a Magic index_n of {0, 0}
+-spec index_2i_n() -> index_n().
+index_2i_n() ->
+    ?INDEX_2I_N.
 
 %% Generate a new {@link hashtree} for the specified `index_n'. If this is
 %% the first hashtree created by this index_hashtree, then open/create a new
@@ -510,36 +548,88 @@ valid_time({X,Y,Z}) when is_integer(X) and is_integer(Y) and is_integer(Z) ->
 valid_time(_) ->
     false.
 
--spec do_insert(index_n(), binary(), binary(), proplist(), state()) -> state().
-do_insert(Id, Key, Hash, Opts, State=#state{trees=Trees}) ->
+do_insert(Items, Opts, State=#state{trees=Trees}) ->
+    HasIndex = has_index_tree(Trees),
+    do_insert_expanded(expand_items(HasIndex, Items), Opts, State).
+
+expand_items(HasIndex, Items) ->
+    lists:foldl(fun(I, Acc) ->
+                        expand_item(HasIndex, I, Acc)
+                end, [], Items).
+
+expand_item(Has2ITree, {object, BKey, RObj}, Others) ->
+    IndexN = riak_kv_util:get_index_n(BKey),
+    BinBKey = term_to_binary(BKey),
+    ObjHash = hash_object(BKey, RObj),
+    Item0 = {IndexN, BinBKey, ObjHash},
+    case Has2ITree of
+        false ->
+            [Item0 | Others];
+        true ->
+            IndexData = riak_object:index_data(RObj),
+            Hash2i =  hash_index_data(IndexData),
+            [Item0, {?INDEX_2I_N, BinBKey, Hash2i} | Others]
+    end;
+expand_item(_, Item, Others) ->
+    [Item | Others].
+
+-spec do_insert_expanded([{index_n(), binary(), binary()}], proplist(),
+                         state()) -> state().
+do_insert_expanded([], _Opts, State) ->
+    State;
+do_insert_expanded([{Id, Key, Hash}|Rest], Opts, State=#state{trees=Trees}) ->
+    State2 = 
     case orddict:find(Id, Trees) of
         {ok, Tree} ->
             Tree2 = hashtree:insert(Key, Hash, Tree, Opts),
             Trees2 = orddict:store(Id, Tree2, Trees),
             State#state{trees=Trees2};
         _ ->
-            State2 = handle_unexpected_key(Id, Key, State),
-            State2
+            handle_unexpected_key(Id, Key, State)
+    end,
+    do_insert_expanded(Rest, Opts, State2).
+
+do_delete(Items, State=#state{trees=Trees}) ->
+    HasIndex = has_index_tree(Trees),
+    do_delete_expanded(expand_delete_items(HasIndex, Items), State).
+
+expand_delete_items(HasIndex, Items) ->
+    lists:foldl(fun(I, Acc) ->
+                        expand_delete_item(HasIndex, I, Acc)
+                end, [], Items).
+
+expand_delete_item(Has2ITree, {object, BKey}, Others) ->
+    IndexN = riak_kv_util:get_index_n(BKey),
+    BinKey = term_to_binary(BKey),
+    Item0 = {IndexN, BinKey},
+    case Has2ITree of
+        false ->
+            [Item0 | Others];
+        true ->
+            [Item0, {?INDEX_2I_N, BinKey} | Others]
     end.
 
--spec do_delete(index_n(), binary(), state()) -> state().
-do_delete(Id, Key, State=#state{trees=Trees}) ->
+-spec do_delete_expanded(list(), state()) -> state().
+do_delete_expanded([], State) ->
+    State;
+do_delete_expanded([{Id, Key}|Rest], State=#state{trees=Trees}) ->
+    State2 =
     case orddict:find(Id, Trees) of
         {ok, Tree} ->
             Tree2 = hashtree:delete(Key, Tree),
             Trees2 = orddict:store(Id, Tree2, Trees),
             State#state{trees=Trees2};
         _ ->
-            State2 = handle_unexpected_key(Id, Key, State),
-            State2
-    end.
+            handle_unexpected_key(Id, Key, State)
+    end,
+    do_delete_expanded(Rest, State2).
 
 -spec handle_unexpected_key(index_n(), binary(), state()) -> state().
 handle_unexpected_key(Id, Key, State=#state{index=Partition}) ->
     RP = riak_kv_util:responsible_preflists(Partition),
     case lists:member(Id, RP) of
         false ->
-            %% The encountered object does not belong to any preflists thata
+            %% The encountered object does not belong to any preflists that
             %% this partition is associated with. Under normal Riak operation,
             %% this should only happen when the `n_val' for an object is
             %% reduced. For example, write an object with N=3, then change N to
@@ -678,8 +768,8 @@ build_or_rehash(Self, State=#state{index=Index, trees=Trees}) ->
     case {Lock, Type} of
         {ok, build} ->
             lager:debug("Starting build: ~p", [Index]),
-            fold_keys(Index, Self),
-            lager:debug("Finished build (a): ~p", [Index]), 
+            fold_keys(Index, Self, has_index_tree(Trees)),
+            lager:debug("Finished build (a): ~p", [Index]),
             gen_server:cast(Self, build_finished);
         {ok, rehash} ->
             lager:debug("Starting rehash: ~p", [Index]),
@@ -689,6 +779,11 @@ build_or_rehash(Self, State=#state{index=Index, trees=Trees}) ->
         {_Error, _} ->
             gen_server:cast(Self, build_failed)
     end.
+
+%% Check if the trees contain the magic index tree
+-spec has_index_tree(orddict()) -> boolean().
+has_index_tree(Trees) ->
+    orddict:is_key(?INDEX_2I_N, Trees).
 
 close_trees(State=#state{trees=Trees}) ->
     Trees2 = [{IdxN, hashtree:close(Tree)} || {IdxN, Tree} <- Trees],

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -52,6 +52,7 @@
          fold_buckets/4,
          fold_keys/4,
          fold_objects/4,
+         fold_indexes/4,
          is_empty/1,
          status/1,
          callback/3]).
@@ -202,16 +203,20 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, State=#state{data_ref=DataRef,
                                                       ttl=TTL,
                                                       used_memory=UsedMemory}) ->
     Now = os:timestamp(),
-    case TTL of
-        undefined ->
-            Val1 = Val;
+    NoValChange = (TTL =:= undefined) orelse (Val =:= undefined),
+    Val1 =
+    case NoValChange of
+        true ->
+            Val;
         _ ->
-            Val1 = {{ts, Now}, Val}
+            {{ts, Now}, Val}
     end,
     {ok, Size} = do_put(Bucket, PrimaryKey, Val1, IndexSpecs, DataRef, IndexRef),
-    case MaxMemory of
-        undefined ->
-            UsedMemory1 = UsedMemory;
+    NoMemChange = (MaxMemory =:= undefined) orelse (Val =:= undefined),
+    UsedMemory1 =
+    case NoMemChange of
+        true ->
+            UsedMemory;
         _ ->
             time_entry(Bucket, PrimaryKey, Now, TimeRef),
             Freed = trim_data_table(MaxMemory,
@@ -220,7 +225,7 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, State=#state{data_ref=DataRef,
                                     TimeRef,
                                     IndexRef,
                                     0),
-            UsedMemory1 = UsedMemory + Size - Freed
+            UsedMemory + Size - Freed
     end,
     {ok, State#state{used_memory=UsedMemory1}}.
 
@@ -320,6 +325,26 @@ fold(FoldTypeFun, FoldFun0, Acc, Opts, #state{data_ref=DataRef, index_ref=IndexR
         false ->
             {ok, Folder()}
     end.
+
+fold_indexes(FoldIndexFun, Acc0, _Opts, #state{index_ref=IndexRef}) ->
+    Bucket = undefined, FF = undefined, StartKey = undefined,
+    Min = undefined, Max = undefined, Incl = true,
+    %% Adapt input fold function to our internal one that keys the entire
+    %% field from the ETS table
+    AdaptedFoldFun =
+    fun({{FoldBucket, FoldField, FoldVal, FoldKey}, _}, Acc) ->
+            FoldIndexFun(FoldBucket, FoldKey, FoldField, FoldVal, Acc)
+    end,
+
+    Folder =
+    fun() ->
+            index_range_folder(AdaptedFoldFun, Acc0, IndexRef,
+                               {Bucket, FF, Min, StartKey},
+                               {Bucket, FF, Min, Max, StartKey, Incl})
+    end,
+    {async, Folder}.
+
+
 %% @doc Delete all objects from this memory backend
 -spec drop(state()) -> {ok, state()}.
 drop(State=#state{data_ref=DataRef,
@@ -523,7 +548,11 @@ key_range_folder(_Folder, Acc, _DataRef, _DataKey, _Query) ->
 
 %% Iterates over a range of index postings
 index_range_folder(Folder, Acc0, IndexRef, {B, I, V, _K}=IndexKey,
-                   {B, I, Min, Max, StartKey, Incl}=Query) when V >= Min, V =< Max ->
+                   {QueryB, QueryI, Min, Max, StartKey, Incl}=Query) 
+  when ((QueryB =:= undefined) orelse (QueryB =:= B)),
+       ((QueryI =:= undefined) orelse (QueryI =:= I)),
+       ((Min =:= undefined) orelse (V >= Min)),
+       ((Max =:= undefined) orelse (V =< Max)) ->
     case {Incl, ets:lookup(IndexRef, IndexKey)} of
         {_, []} ->
             %% This will happen on the first iteration, where the key
@@ -546,10 +575,17 @@ index_range_folder(_Folder, Acc, _IndexRef, _IndexKey, _Query) ->
 
 %% @private
 do_put(Bucket, Key, Val, IndexSpecs, DataRef, IndexRef) ->
-    Object = {{Bucket, Key}, Val},
-    true = ets:insert(DataRef, Object),
+    ObjSize =
+    case Val of
+        undefined ->
+            undefined;
+        _ ->
+            Object = {{Bucket, Key}, Val},
+            true = ets:insert(DataRef, Object),
+            object_size(Object)
+    end,
     update_indexes(Bucket, Key, IndexSpecs, IndexRef),
-    {ok, object_size(Object)}.
+    {ok, ObjSize}.
 
 %% Check if this timestamp is past the ttl setting.
 exceeds_ttl(Timestamp, TTL) ->

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -36,6 +36,7 @@
          fold_buckets/4,
          fold_keys/4,
          fold_objects/4,
+         fold_indexes/4,
          is_empty/1,
          data_size/1,
          status/1,
@@ -51,6 +52,7 @@
 
 -define(API_VERSION, 1).
 -define(CAPABILITIES, [async_fold, index_reformat]).
+-define(ANY_CAPABILITIES, [indexes]).
 
 -record (state, {backends :: [{atom(), atom(), term()}],
                  default_backend :: atom()}).
@@ -111,7 +113,10 @@ capabilities(State) ->
     Caps1 = ordsets:intersection(AllCaps),
     Caps2 = ordsets:to_list(Caps1),
 
-    Capabilities = lists:usort(?CAPABILITIES ++ Caps2),
+    % Some caps we choose if ANY backend has them
+    AnyCaps = ordsets:intersection(ordsets:union(AllCaps),
+                                    ordsets:from_list(?ANY_CAPABILITIES)),
+    Capabilities = lists:usort(?CAPABILITIES ++ Caps2 ++ AnyCaps),
     {ok, Capabilities}.
 
 %% @doc Return the capabilities of the backend.
@@ -257,7 +262,13 @@ delete(Bucket, Key, IndexSpecs, State) ->
                    [{atom(), term()}],
                    state()) -> {ok, any()} | {async, fun()} | {error, term()}.
 fold_buckets(FoldBucketsFun, Acc, Opts, State) ->
-    fold_all(fold_buckets, FoldBucketsFun, Acc, Opts, State).
+    fold_all(fold_buckets, FoldBucketsFun, Acc, Opts, State,
+             fun default_backend_filter/4).
+
+%% @doc Fold only over index data in the backend, for all buckets.
+fold_indexes(FoldIndexFun, Acc, Opts, State) ->
+    fold_all(fold_indexes, FoldIndexFun, Acc, Opts, State,
+            fun indexes_filter/4).
 
 %% @doc Fold over all the keys for one or all buckets.
 -spec fold_keys(riak_kv_backend:fold_keys_fun(),
@@ -267,7 +278,8 @@ fold_buckets(FoldBucketsFun, Acc, Opts, State) ->
 fold_keys(FoldKeysFun, Acc, Opts, State) ->
     case proplists:get_value(bucket, Opts) of
         undefined ->
-            fold_all(fold_keys, FoldKeysFun, Acc, Opts, State);
+            fold_all(fold_keys, FoldKeysFun, Acc, Opts, State,
+                    fun default_backend_filter/4);
         Bucket ->
             fold_in_bucket(Bucket, fold_keys, FoldKeysFun, Acc, Opts, State)
     end.
@@ -280,7 +292,8 @@ fold_keys(FoldKeysFun, Acc, Opts, State) ->
 fold_objects(FoldObjectsFun, Acc, Opts, State) ->
     case proplists:get_value(bucket, Opts) of
         undefined ->
-            fold_all(fold_objects, FoldObjectsFun, Acc, Opts, State);
+            fold_all(fold_objects, FoldObjectsFun, Acc, Opts, State,
+                    fun default_backend_filter/4);
         Bucket ->
             fold_in_bucket(Bucket, fold_objects, FoldObjectsFun, Acc, Opts, State)
     end.
@@ -457,7 +470,7 @@ update_backend_state(Backend,
 
 %% @private
 %% @doc Shared code used by all the backend fold functions.
-fold_all(ModFun, FoldFun, Acc, Opts, State) ->
+fold_all(ModFun, FoldFun, Acc, Opts, State, BackendFilter) ->
     Backends = State#state.backends,
     try
         AsyncFold = lists:member(async_fold, Opts),
@@ -465,7 +478,8 @@ fold_all(ModFun, FoldFun, Acc, Opts, State) ->
             lists:foldl(backend_fold_fun(ModFun,
                                          FoldFun,
                                          Opts,
-                                         AsyncFold),
+                                         AsyncFold,
+                                         BackendFilter),
                         {Acc, []},
                         Backends),
 
@@ -496,22 +510,33 @@ fold_in_bucket(Bucket, ModFun, FoldFun, Acc, Opts, State) ->
                   Opts,
                   SubState).
 
+%% @doc Skips folding if index reformat operation on
+%% non-index reformat capable backend.
+default_backend_filter(Opts, _Module, _SubState, ModCaps) ->
+    Indexes = lists:keyfind(index, 1, Opts),
+    CanReformatIndex = lists:member(index_reformat, ModCaps),
+    case {Indexes, CanReformatIndex} of
+        {{index, incorrect_format, _ForUpgrade}, false} ->
+            false;
+        _ ->
+            true
+    end.
+
+%% @doc Skips folding on backends that do not support indexes.
+indexes_filter(_Opts, _Module, _SubState, ModCaps) ->
+    lists:member(indexes, ModCaps).
+
 %% @private
-backend_fold_fun(ModFun, FoldFun, Opts, AsyncFold) ->
+backend_fold_fun(ModFun, FoldFun, Opts, AsyncFold, BackendFilter) ->
     fun({_, Module, SubState}, {Acc, WorkList}) ->
             %% Get the backend capabilities to determine
             %% if it supports asynchronous folding.
             {ok, ModCaps} = Module:capabilities(SubState),
             DoAsync = AsyncFold andalso lists:member(async_fold, ModCaps),
-            Indexes = lists:keyfind(index, 1, Opts),
-            case Indexes of
-                {index, incorrect_format, _ForUpgrade} ->
-                    case lists:member(index_reformat, ModCaps) of
-                        true -> backend_fold_fun(Module, ModFun, SubState, FoldFun,
-                                                 Opts, {Acc, WorkList}, DoAsync);
-                        false -> {Acc, WorkList}
-                    end;
-                _ ->
+            case BackendFilter(Opts, Module, SubState, ModCaps) of
+                false ->
+                    {Acc, WorkList};
+                true ->
                     backend_fold_fun(Module,
                                      ModFun,
                                      SubState,

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -175,6 +175,8 @@ do_update({vnode_put, Idx, USecs}) ->
     folsom_metrics:notify_existing_metric({?APP, vnode, puts}, 1, spiral),
     create_or_update({?APP, vnode, puts, time}, USecs, histogram),
     do_per_index(puts, Idx, USecs);
+do_update(vnode_index_refresh) ->
+    folsom_metrics:notify_existing_metric({?APP, vnode, index, refreshes}, 1, spiral);
 do_update(vnode_index_read) ->
     folsom_metrics:notify_existing_metric({?APP, vnode, index, reads}, 1, spiral);
 do_update({vnode_index_write, PostingsAdded, PostingsRemoved}) ->
@@ -344,6 +346,7 @@ stats() ->
      {[vnode, gets, time], histogram},
      {[vnode, puts], spiral},
      {[vnode, puts, time], histogram},
+     {[vnode, index, refreshes], spiral},
      {[vnode, index, reads], spiral},
      {[vnode, index ,writes], spiral},
      {[vnode, index, writes, postings], spiral},
@@ -502,6 +505,8 @@ stats_from_update_arg({vnode_get, _, _}) ->
     riak_core_stat_q:names_and_types([?APP, vnode, gets]);
 stats_from_update_arg({vnode_put, _, _}) ->
     riak_core_stat_q:names_and_types([?APP, vnode, puts]);
+stats_from_update_arg(vnode_index_refresh) ->
+    riak_core_stat_q:names_and_types([?APP, vnode, index, refreshes]);
 stats_from_update_arg(vnode_index_read) ->
     riak_core_stat_q:names_and_types([?APP, vnode, index, reads]);
 stats_from_update_arg({vnode_index_write, _, _}) ->

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -219,6 +219,8 @@ legacy_stat_map() ->
      {vnode_gets_total, {{riak_kv, vnode, gets}, count}, spiral},
      {vnode_puts, {{riak_kv, vnode, puts}, one}, spiral},
      {vnode_puts_total, {{riak_kv, vnode, puts}, count}, spiral},
+     {vnode_index_refreshes, {{riak_kv, vnode, index, refreshes}, one}, spiral},
+     {vnode_index_refreshes_total, {{riak_kv, vnode, index, refreshes}, count}, spiral},
      {vnode_index_reads, {{riak_kv, vnode, index, reads}, one}, spiral},
      {vnode_index_reads_total, {{riak_kv, vnode, index, reads}, count}, spiral},
      {vnode_index_writes, {{riak_kv, vnode, index, writes}, one}, spiral},

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -47,7 +47,9 @@
          repair_filter/1,
          hashtree_pid/1,
          rehash/3,
+         refresh_index_data/4,
          request_hashtree_pid/1,
+         request_hashtree_pid/2,
          reformat_object/2,
          stop_fold/1]).
 
@@ -128,13 +130,16 @@ maybe_create_hashtrees(State) ->
 -spec maybe_create_hashtrees(boolean(), state()) -> state().
 maybe_create_hashtrees(false, State) ->
     State;
-maybe_create_hashtrees(true, State=#state{idx=Index}) ->
+maybe_create_hashtrees(true, State=#state{idx=Index,
+                                          mod=Mod, modstate=ModState}) ->
     %% Only maintain a hashtree if a primary vnode
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     case riak_core_ring:vnode_type(Ring, Index) of
         primary ->
             RP = riak_kv_util:responsible_preflists(Index),
-            case riak_kv_index_hashtree:start(Index, RP, self()) of
+            {ok, ModCaps} = Mod:capabilities(ModState),
+            RP2 = add_2i_index_rp(RP, ModCaps),
+            case riak_kv_index_hashtree:start(Index, RP2, self()) of
                 {ok, Trees} ->
                     monitor(process, Trees),
                     State#state{hashtrees=Trees};
@@ -146,6 +151,16 @@ maybe_create_hashtrees(true, State=#state{idx=Index}) ->
             end;
         _ ->
             State
+    end.
+
+%% Use special magic index_n for
+%% 2i index specs hashtree ID.
+add_2i_index_rp(RP, Capabilities) ->
+    case lists:member(indexes, Capabilities) of
+        true ->
+            [riak_kv_index_hashtree:index_2i_n() | RP];
+        false ->
+            RP
     end.
 
 %% API
@@ -220,6 +235,12 @@ local_get(Index, BKey) ->
         {Ref, Reply} ->
             {error, Reply}
     end.
+
+refresh_index_data(Partition, BKey, IdxData, TimeOut) ->
+    riak_core_vnode_master:sync_command({Partition, node()},
+                                        {refresh_index_data, BKey, IdxData},
+                                        riak_kv_vnode_master,
+                                        TimeOut).
 
 %% Issue a put for the object to the preflist, expecting a reply
 %% to an FSM.
@@ -312,9 +333,14 @@ hashtree_pid(Partition) ->
 -spec request_hashtree_pid(index()) -> ok.
 request_hashtree_pid(Partition) ->
     ReqId = {hashtree_pid, Partition},
+    request_hashtree_pid(Partition, {raw, ReqId, self()}).
+
+%% Version of {@link request_hashtree_pid/1} that takes a sender argument,
+%% which could be a raw process, fsm, gen_server, etc.
+request_hashtree_pid(Partition, Sender) ->
     riak_core_vnode_master:command({Partition, node()},
                                    {hashtree_pid, node()},
-                                   {raw, ReqId, self()},
+                                   Sender,
                                    riak_kv_vnode_master).
 
 %% Used by {@link riak_kv_exchange_fsm} to force a vnode to update the hashtree
@@ -501,9 +527,57 @@ handle_command({rehash, Bucket, Key}, _, State=#state{mod=Mod, modstate=ModState
             update_hashtree(Bucket, Key, Bin, State);
         _ ->
             %% Make sure hashtree isn't tracking deleted data
-            riak_kv_index_hashtree:delete({Bucket, Key}, State#state.hashtrees)
+            delete_from_hashtree(Bucket, Key, State)
     end,
     {noreply, State};
+
+handle_command({refresh_index_data, BKey, OldIdxData}, Sender,
+               State=#state{mod=Mod, modstate=ModState}) ->
+    {Bucket, Key} = BKey,
+    {ok, Caps} = Mod:capabilities(Bucket, ModState),
+    IndexCap = lists:member(indexes, Caps),
+    case IndexCap of
+        true ->
+            {Exists, RObj, IdxData} =
+            case do_get_term(BKey, Mod, ModState) of
+                {ok, ExistingObj} ->
+                    {true, ExistingObj, riak_object:index_data(ExistingObj)};
+                _ ->
+                    {false, undefined, []}
+            end,
+            IndexSpecs = riak_object:diff_index_data(OldIdxData, IdxData),
+            {Reply, UpModState} = 
+            case Mod:put(Bucket, Key, IndexSpecs, undefined, ModState) of
+                {ok, ModState2} ->
+                    riak_kv_stat:update(vnode_index_refresh),
+                    {ok, ModState2};
+                {error, Reason, ModState2} ->
+                    {{error, Reason}, ModState2}
+            end,
+            case Exists of
+                true ->
+                    update_hashtree(Bucket, Key, RObj, State);
+                false ->
+                    delete_from_hashtree(Bucket, Key, State)
+            end,
+            riak_core_vnode:reply(Sender, Reply),
+            {noreply, State#state{modstate=UpModState}};
+        false ->
+            {reply, {error, {indexes_not_supported, Mod}}, State}
+    end;
+
+handle_command({fold_indexes, FoldIndexFun, Acc}, Sender, State=#state{mod=Mod, modstate=ModState}) ->
+    {ok, Caps} = Mod:capabilities(ModState),
+    case lists:member(indexes, Caps) of
+        true ->
+            {async, AsyncWork} = Mod:fold_indexes(FoldIndexFun, Acc, [async_fold], ModState),
+            FinishFun = fun(FinalAcc) ->
+                                riak_core_vnode:reply(Sender, FinalAcc)
+                        end,
+            {async, {fold, AsyncWork, FinishFun}, Sender, State};
+        false ->
+            {reply, {error, {indexes_not_supported, Mod}}, State}
+    end;
 
 %% Commands originating from inside this vnode
 handle_command({backend_callback, Ref, Msg}, _Sender,
@@ -940,7 +1014,7 @@ do_backend_delete(BKey, RObj, State = #state{mod = Mod, modstate = ModState}) ->
     {Bucket, Key} = BKey,
     case Mod:delete(Bucket, Key, IndexSpecs, ModState) of
         {ok, UpdModState} ->
-            riak_kv_index_hashtree:delete(BKey, State#state.hashtrees),
+            delete_from_hashtree(Bucket, Key, State),
             update_index_delete_stats(IndexSpecs),
             State#state{modstate = UpdModState};
         {error, _Reason, UpdModState} ->
@@ -1077,8 +1151,8 @@ perform_put({true, Obj},
                      reqid=ReqID,
                      index_specs=IndexSpecs}) ->
     case encode_and_put(Obj, Mod, Bucket, Key, IndexSpecs, ModState) of
-        {{ok, UpdModState}, EncodedVal} ->
-            update_hashtree(Bucket, Key, EncodedVal, State),
+        {{ok, UpdModState}, _EncodedVal} ->
+            update_hashtree(Bucket, Key, Obj, State),
             case RB of
                 true ->
                     Reply = {dw, Idx, Obj, ReqID};
@@ -1407,8 +1481,8 @@ do_diffobj_put({Bucket, Key}, DiffObj,
             end,
             case encode_and_put(DiffObj, Mod, Bucket, Key,
                                 IndexSpecs, ModState) of
-                {{ok, _UpdModState} = InnerRes, EncodedVal} ->
-                    update_hashtree(Bucket, Key, EncodedVal, StateData),
+                {{ok, _UpdModState} = InnerRes, _EncodedVal} ->
+                    update_hashtree(Bucket, Key, DiffObj, StateData),
                     update_index_write_stats(IndexBackend, IndexSpecs),
                     update_vnode_stats(vnode_put, Idx, StartTS),
                     InnerRes;
@@ -1432,8 +1506,8 @@ do_diffobj_put({Bucket, Key}, DiffObj,
                     end,
                     case encode_and_put(AMObj, Mod, Bucket, Key,
                                         IndexSpecs, ModState) of
-                        {{ok, _UpdModState} = InnerRes, EncodedVal} ->
-                            update_hashtree(Bucket, Key, EncodedVal, StateData),
+                        {{ok, _UpdModState} = InnerRes, _EncodedVal} ->
+                            update_hashtree(Bucket, Key, AMObj, StateData),
                             update_index_write_stats(IndexBackend, IndexSpecs),
                             update_vnode_stats(vnode_put, Idx, StartTS),
                             InnerRes;
@@ -1444,13 +1518,29 @@ do_diffobj_put({Bucket, Key}, DiffObj,
     end.
 
 -spec update_hashtree(binary(), binary(), binary(), state()) -> ok.
-update_hashtree(Bucket, Key, Val, #state{hashtrees=Trees}) ->
+update_hashtree(Bucket, Key, BinObj, State) when is_binary(BinObj) ->
+    RObj = riak_object:from_binary(Bucket, Key, BinObj),
+    update_hashtree(Bucket, Key, RObj, State);
+update_hashtree(Bucket, Key, RObj, #state{hashtrees=Trees}) ->
+    Items = [{object, {Bucket, Key}, RObj}],
     case get_hashtree_token() of
         true ->
-            riak_kv_index_hashtree:async_insert_object({Bucket, Key}, Val, Trees),
+            riak_kv_index_hashtree:async_insert(Items, [], Trees),
             ok;
         false ->
-            riak_kv_index_hashtree:insert_object({Bucket, Key}, Val, Trees),
+            riak_kv_index_hashtree:insert(Items, [], Trees),
+            put(hashtree_tokens, max_hashtree_tokens()),
+            ok
+    end.
+
+delete_from_hashtree(Bucket, Key, #state{hashtrees=Trees})->
+    Items = [{object, {Bucket, Key}}],
+    case get_hashtree_token() of
+        true ->
+            riak_kv_index_hashtree:async_delete(Items, Trees),
+            ok;
+        false ->
+            riak_kv_index_hashtree:delete(Items, Trees),
             put(hashtree_tokens, max_hashtree_tokens()),
             ok
     end.

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -73,6 +73,7 @@
 -export([get_update_metadata/1, get_update_value/1, get_contents/1]).
 -export([merge/2, apply_updates/1, syntactic_merge/2]).
 -export([to_json/1, from_json/1]).
+-export([index_data/1, diff_index_data/2]).
 -export([index_specs/1, diff_index_specs/2]).
 -export([to_binary/2, from_binary/3, to_binary_version/4, binary_version/1]).
 -export([set_contents/2, set_vclock/2]). %% INTERNAL, only for riak_*
@@ -368,8 +369,14 @@ index_specs(Obj) ->
                               [{index_op(), binary(), index_value()}].
 diff_index_specs(Obj, OldObj) ->
     OldIndexes = index_data(OldObj),
-    OldIndexSet = ordsets:from_list(OldIndexes),
     AllIndexes = index_data(Obj),
+    diff_index_data(OldIndexes, AllIndexes).
+
+-spec diff_index_data([{binary(), index_value()}],
+                      [{binary(), index_value()}]) ->
+    [{index_op(), binary(), index_value()}].
+diff_index_data(OldIndexes, AllIndexes) ->
+    OldIndexSet = ordsets:from_list(OldIndexes),
     AllIndexSet = ordsets:from_list(AllIndexes),
     NewIndexSet = ordsets:subtract(AllIndexSet, OldIndexSet),
     RemoveIndexSet =


### PR DESCRIPTION
This change adds support for a manual command to repair secondary index
data that is out of sync with the KV objects. The command will
repair a given partition or all partitions in a given node, with an
optional speed throttle parameter. The speed throttle is a duty cycle
number such that if 50 is given, it will try to do some work, then wait
for the time that work took before the next unit of work and so on.

Each vnode will now have a special AAE tree where it will store hashes
for the 2i data of each object in the backend.
When the command runs, for each partition to be repaired it fetches all
secondary index data from the backend and builds a temporary hashtree.
It then runs an exchange between this temporary hashtree and the vnode's
2i AAE tree. Differences found will trigger an index refresh command
that will rewrite 2i data based on an object's current index terms.

A fold_indexes command has been added to index supporting backends to
fold only over 2i data, as well as a refresh index put that will only
rewrite index data that is inconsistent. This was all added to the
memory backend too, which is kind of overkill as it should never have
any 2i inconsistencies, but it makes other layers agnostic, so...
The multi backend was also updated.

Data for this operation will be stored in the anti_entropy directory in
a new '2i' folder. It should be cleaned up after each operation under
normal conditions. LevelDB is used to create the temporary 2i database.
Some tuning might be needed in the future. It would be nice to have a
mostly in-memory database that only used disk if the 2i data was too big
to fit into some amount of data specified by the operator.
