### PR TITLE
Make 2i pagination sort optional - 1.4 branch version

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -522,9 +522,10 @@ get_index(Bucket, Query) ->
 get_index(Bucket, Query, Opts) ->
     Timeout = proplists:get_value(timeout, Opts, ?DEFAULT_TIMEOUT),
     MaxResults = proplists:get_value(max_results, Opts, all),
+    PgSort = proplists:get_value(pagination_sort, Opts),
     Me = self(),
     ReqId = mk_reqid(),
-    riak_kv_index_fsm_sup:start_index_fsm(Node, [{raw, ReqId, Me}, [Bucket, none, Query, Timeout, MaxResults]]),
+    riak_kv_index_fsm_sup:start_index_fsm(Node, [{raw, ReqId, Me}, [Bucket, none, Query, Timeout, MaxResults, PgSort]]),
     wait_for_query_results(ReqId, Timeout).
 
 %% @doc Run the provided index query, return a stream handle.
@@ -540,13 +541,14 @@ stream_get_index(Bucket, Query) ->
 stream_get_index(Bucket, Query, Opts) ->
     Timeout = proplists:get_value(timeout, Opts, ?DEFAULT_TIMEOUT),
     MaxResults = proplists:get_value(max_results, Opts, all),
+    PgSort = proplists:get_value(pagination_sort, Opts),
     Me = self(),
     ReqId = mk_reqid(),
     case riak_kv_index_fsm_sup:start_index_fsm(Node,
                                                [{raw, ReqId, Me},
                                                 [Bucket, none,
                                                  Query, Timeout,
-                                                 MaxResults]]) of
+                                                 MaxResults, PgSort]]) of
         {ok, Pid} ->
             {ok, ReqId, Pid};
         {error, Reason} ->

--- a/src/riak_kv_index_fsm.erl
+++ b/src/riak_kv_index_fsm.erl
@@ -51,7 +51,8 @@
 -type req_id() :: non_neg_integer().
 
 -record(state, {from :: from(),
-                merge_sort_buffer :: sms:sms(),
+                pagination_sort :: boolean(),
+                merge_sort_buffer = undefined :: sms:sms() | undefined,
                 max_results :: all | pos_integer(),
                 results_per_vnode = dict:new() :: dict(),
                 results_sent = 0 :: non_neg_integer()}).
@@ -87,16 +88,29 @@ init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout]) ->
     %% atom() > number()
     init(From, [Bucket, ItemFilter, Query, Timeout, all]);
 init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout, MaxResults]) ->
+    init(From, [Bucket, ItemFilter, Query, Timeout, MaxResults, undefined]);
+init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout, MaxResults, PgSort0]) ->
     %% Get the bucket n_val for use in creating a coverage plan
     BucketProps = riak_core_bucket:get_bucket(Bucket),
     NVal = proplists:get_value(n_val, BucketProps),
+    Paginating = is_integer(MaxResults) andalso MaxResults > 0, 
+    PgSort = case {Paginating, PgSort0} of
+        {true, _} ->
+            true;
+        {_, undefined} ->
+            app_helper:get_env(riak_kv, secondary_index_sort_default, false);
+        _ ->
+            PgSort0
+    end,
     %% Construct the key listing request
     Req = req(Bucket, ItemFilter, Query),
     {Req, all, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout,
-     #state{from=From, max_results=MaxResults}}.
+     #state{from=From, max_results=MaxResults, pagination_sort=PgSort}}.
 
-plan(CoverageVNodes, State) ->
-    {ok, State#state{merge_sort_buffer=sms:new(CoverageVNodes)}}.
+plan(CoverageVNodes, State = #state{pagination_sort=true}) ->
+    {ok, State#state{merge_sort_buffer=sms:new(CoverageVNodes)}};
+plan(_CoverageVNodes, State) ->
+    {ok, State}.
 
 process_results(_VNode, {error, Reason}, _State) ->
     {error, Reason};
@@ -105,7 +119,7 @@ process_results(_VNode, {From, _Bucket, _Results}, State=#state{max_results=X, r
     {done, State};
 process_results(VNode, {From, Bucket, Results}, State) ->
     case process_results(VNode, {Bucket, Results}, State) of
-        {ok, State2} ->
+        {ok, State2 = #state{pagination_sort=true}} ->
             #state{results_per_vnode=PerNode, max_results=MaxResults} = State2,
             VNodeCount = dict:fetch(VNode, PerNode),
             case VNodeCount < MaxResults of
@@ -116,11 +130,14 @@ process_results(VNode, {From, Bucket, Results}, State) ->
                     riak_kv_vnode:stop_fold(From),
                     {done, State2}
             end;
+        {ok, State2} ->
+            riak_kv_vnode:ack_keys(From),
+            {ok, State2};
         {done, State2} ->
             riak_kv_vnode:stop_fold(From),
             {done, State2}
     end;
-process_results(VNode, {_Bucket, Results}, State) ->
+process_results(VNode, {_Bucket, Results}, State = #state{pagination_sort=true}) ->
     #state{merge_sort_buffer=MergeSortBuffer, results_per_vnode=PerNode,
            from={raw, ReqId, ClientPid}, results_sent=ResultsSent, max_results=MaxResults} = State,
     %% add new results to buffer
@@ -133,11 +150,17 @@ process_results(VNode, {_Bucket, Results}, State) ->
     {Response, State#state{merge_sort_buffer=NewBuff,
                            results_per_vnode=NewPerNode,
                            results_sent=ResultsSent+ResultsLen}};
-process_results(VNode, done, State) ->
+process_results(VNode, done, State = #state{pagination_sort=true}) ->
     %% tell the sms buffer about the done vnode
     #state{merge_sort_buffer=MergeSortBuffer} = State,
     BufferWithNewResults = sms:add_results(VNode, done, MergeSortBuffer),
-    {done, State#state{merge_sort_buffer=BufferWithNewResults}}.
+    {done, State#state{merge_sort_buffer=BufferWithNewResults}};
+process_results(_VNode, {_Bucket, Results}, State) ->
+    #state{from={raw, ReqId, ClientPid}} = State,
+    send_results(ClientPid, ReqId, Results),
+    {ok, State};
+process_results(_VNode, done, State) ->
+    {done, State}.
 
 %% @private Update the buffer with results and process it
 update_buffer(VNode, Results, Buffer) ->

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -105,16 +105,21 @@ process(#rpbindexreq{} = Req, State) ->
 maybe_perform_query({error, Reason}, _Req, State) ->
     {error, {format, Reason}, State};
 maybe_perform_query({ok, Query}, Req=#rpbindexreq{stream=true}, State) ->
-    #rpbindexreq{bucket=Bucket, max_results=MaxResults, timeout=Timeout} = Req,
+    #rpbindexreq{bucket=Bucket, max_results=MaxResults, timeout=Timeout,
+                 pagination_sort=PgSort} = Req,
     #state{client=Client} = State,
-    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults}]),
+    Opts0 = [{max_results, MaxResults}] ++ [{pagination_sort, PgSort} || PgSort /= undefined],
+    Opts = riak_index:add_timeout_opt(Timeout, Opts0),
     {ok, ReqId, _FSMPid} = Client:stream_get_index(Bucket, Query, Opts),
     ReturnTerms = riak_index:return_terms(Req#rpbindexreq.return_terms, Query),
     {reply, {stream, ReqId}, State#state{req_id=ReqId, req=Req#rpbindexreq{return_terms=ReturnTerms}}};
 maybe_perform_query({ok, Query}, Req, State) ->
-    #rpbindexreq{bucket=Bucket, max_results=MaxResults, return_terms=ReturnTerms0, timeout=Timeout} = Req,
+    #rpbindexreq{bucket=Bucket, max_results=MaxResults,
+                 return_terms=ReturnTerms0, timeout=Timeout,
+                 pagination_sort=PgSort} = Req,
     #state{client=Client} = State,
-    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults}]),
+    Opts0 = [{max_results, MaxResults}] ++ [{pagination_sort, PgSort} || PgSort /= undefined],
+    Opts = riak_index:add_timeout_opt(Timeout, Opts0),
     ReturnTerms =  riak_index:return_terms(ReturnTerms0, Query),
     QueryResult = Client:get_index(Bucket, Query, Opts),
     handle_query_results(ReturnTerms, MaxResults, QueryResult , State).

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -26,6 +26,21 @@
 %%
 %% GET /buckets/bucket/indexes/index/op/arg1...
 %%   Run an index lookup, return the results as JSON.
+%%
+%% Supports the following query-string options:
+%%   * max_results=Integer
+%%         limits the number of results returned
+%%   * stream=true
+%%         streams the results back in multipart/mixed chunks
+%%   * continuation=C
+%%         the continuation returned from the last query, used to
+%%         fetch the next "page" of results.
+%%   * return_terms=true
+%%         when querying with a range, returns the value of the index
+%%         along with the key.
+%%   * pagination_sort=true|false
+%%         whether the results will be sorted. Ignored when max_results
+%%         is set, as pagination requires sorted results.
 
 -module(riak_kv_wm_index).
 
@@ -48,7 +63,8 @@
           index_query,   %% The query..
           max_results :: all | pos_integer(), %% maximum number of 2i results to return, the page size.
           return_terms = false :: boolean(), %% should the index values be returned
-          timeout :: non_neg_integer() | undefined | infinity
+          timeout :: non_neg_integer() | undefined | infinity,
+          pagination_sort :: boolean() | undefined
          }).
 
 -define(ALL_2I_RESULTS, all).
@@ -97,6 +113,11 @@ malformed_request(RD, Ctx) ->
     Args2 = [list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, X)) || X <- Args1],
     ReturnTerms0 = wrq:get_qs_value(?Q_2I_RETURNTERMS, "false", RD),
     ReturnTerms = normalize_boolean(string:to_lower(ReturnTerms0)),
+    PgSort0 = wrq:get_qs_value(?Q_2I_PAGINATION_SORT, RD),
+    PgSort = case PgSort0 of
+        undefined -> undefined;
+        _ -> normalize_boolean(string:to_lower(PgSort0))
+    end,
     MaxResults0 = wrq:get_qs_value(?Q_2I_MAX_RESULTS, ?ALL_2I_RESULTS, RD),
     Continuation = wrq:get_qs_value(?Q_2I_CONTINUATION, undefined, RD),
     TermRegex = wrq:get_qs_value(?Q_2I_TERM_REGEX, undefined, RD),
@@ -118,29 +139,39 @@ malformed_request(RD, Ctx) ->
             re:compile(TermRegex)
     end,
 
-    case {ReturnTerms, validate_timeout(Timeout0), validate_max(MaxResults0),
-          QRes, ValRe} of
-        {malformed, _, _, _, _} ->
+    case {PgSort,
+          ReturnTerms,
+          validate_timeout(Timeout0),
+          validate_max(MaxResults0),
+          QRes,
+          ValRe} of
+        {malformed, _, _, _, _, _} ->
+             {true,
+             wrq:set_resp_body(io_lib:format("Invalid ~p. ~p is not a boolean",
+                                             [?Q_2I_PAGINATION_SORT, PgSort0]),
+                               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx};
+        {_, malformed, _, _, _, _} ->
              {true,
              wrq:set_resp_body(io_lib:format("Invalid ~p. ~p is not a boolean",
                                              [?Q_2I_RETURNTERMS, ReturnTerms0]),
                                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx};
-        {_, _, _, {ok, ?KV_INDEX_Q{start_term=NormStart}}, {ok, _CompiledRe}}
+        {_, _, _, _, {ok, ?KV_INDEX_Q{start_term=NormStart}}, {ok, _CompiledRe}}
          when is_integer(NormStart) ->
             {true,
              wrq:set_resp_body("Can not use term regular expressions"
                                " on integer queries",
                                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx};
-        {_, _, _, _, {error, ReError}} ->
+        {_, _, _, _, _, {error, ReError}} ->
             {true,
              wrq:set_resp_body(
                     io_lib:format("Invalid term regular expression ~p : ~p",
                                   [TermRegex, ReError]),
                     wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx};
-        {_, {true, Timeout}, {true, MaxResults}, {ok, Query}, _} ->
+        {_, _, {true, Timeout}, {true, MaxResults}, {ok, Query}, _} ->
             %% Request is valid.
             ReturnTerms1 = riak_index:return_terms(ReturnTerms, Query),
             NewCtx = Ctx#ctx{
@@ -148,22 +179,23 @@ malformed_request(RD, Ctx) ->
                        index_query = Query,
                        max_results = MaxResults,
                        return_terms = ReturnTerms1,
-                       timeout=Timeout
+                       timeout=Timeout,
+                       pagination_sort = PgSort
                       },
             {false, RD, NewCtx};
-        {_, _, _, {error, Reason}, _} ->
+        {_, _, _, _, {error, Reason}, _} ->
             {true,
              wrq:set_resp_body(
                io_lib:format("Invalid query: ~p~n", [Reason]),
                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx};
-        {_, _, {false, BadVal}, _, _} ->
+        {_, _, _, {false, BadVal}, _, _} ->
             {true,
              wrq:set_resp_body(io_lib:format("Invalid ~p. ~p is not a positive integer",
                                              [?Q_2I_MAX_RESULTS, BadVal]),
                                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx};
-        {_, {error, Input}, _, _, _} ->
+        {_, _, {error, Input}, _, _, _} ->
             {true, wrq:append_to_resp_body(io_lib:format("Bad timeout "
                                                            "value ~p. Must be a non-negative integer~n",
                                                            [Input]),
@@ -238,6 +270,7 @@ handle_streaming_index_query(RD, Ctx) ->
     MaxResults = Ctx#ctx.max_results,
     ReturnTerms = Ctx#ctx.return_terms,
     Timeout = Ctx#ctx.timeout,
+    PgSort = Ctx#ctx.pagination_sort,
 
     %% Create a new multipart/mixed boundary
     Boundary = riak_core_util:unique_id_62(),
@@ -246,7 +279,8 @@ handle_streaming_index_query(RD, Ctx) ->
                 "multipart/mixed;boundary="++Boundary,
                 RD),
 
-    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults}]),
+    Opts0 = [{max_results, MaxResults}] ++ [{pagination_sort, PgSort} || PgSort /= undefined],
+    Opts = riak_index:add_timeout_opt(Timeout, Opts0), 
 
     {ok, ReqID, FSMPid} =  Client:stream_get_index(Bucket, Query, Opts),
     StreamFun = index_stream_helper(ReqID, FSMPid, Boundary, ReturnTerms, MaxResults, proplists:get_value(timeout, Opts), undefined, 0),
@@ -330,9 +364,11 @@ handle_all_in_memory_index_query(RD, Ctx) ->
     Query = Ctx#ctx.index_query,
     MaxResults = Ctx#ctx.max_results,
     ReturnTerms = Ctx#ctx.return_terms,
+    PgSort = Ctx#ctx.pagination_sort,
     Timeout = Ctx#ctx.timeout,
 
-    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults}]),
+    Opts0 = [{max_results, MaxResults}] ++ [{pagination_sort, PgSort} || PgSort /= undefined],
+    Opts = riak_index:add_timeout_opt(Timeout, Opts0), 
 
     %% Do the index lookup...
     case Client:get_index(Bucket, Query, Opts) of

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -66,5 +66,6 @@
 -define(Q_2I_MAX_RESULTS, "max_results").
 -define(Q_2I_TERM_REGEX, "term_regex").
 -define(Q_2I_CONTINUATION, "continuation").
+-define(Q_2I_PAGINATION_SORT, "pagination_sort").
 -define(Q_RESULTS,  "results").
 -define(Q_RETURNVALUE, "returnvalue").


### PR DESCRIPTION
This addresses the performance penalty from the new default of sorting
2i results since pagination was added. When paginating, (max_results
set) sorting is always enabled. But when not, it will only be used if
configured in app.config or specified in the client request.

This is a backport to 1.4 of https://github.com/basho/riak_kv/pull/671 with two main differences:
- The parameter name has been changed from 'sort' to 'pagination_sort' to help avoid confusion with its meaning since we don't use a "natural" sort based on keys, but rather (term, key) as is required by pagination.
- The call to app_helper:get_env to get the default for the global switch has an in-code default of false. This is necessary so that it defaults to false without any config. The 2.0 version was relying on cuttlefish, but even there it's necessary for deployments with legacy configuration files.
