### PR TITLE
Add mounts_points to stats

### DIFF
--- a/src/riak_kv_env.erl
+++ b/src/riak_kv_env.erl
@@ -22,7 +22,8 @@
 
 -module(riak_kv_env).
 
--export([doc_env/0]).
+-export([doc_env/0,
+         get_mount_point/1]).
 
 -define(LINUX_PARAMS, [
                        {"vm.swappiness",                        0, gte}, 
@@ -36,6 +37,18 @@
                        {"net.ipv4.tcp_fin_timeout",            15, gte},
                        {"net.ipv4.tcp_tw_reuse",                1, eq}
                       ]).
+
+%% @doc Return a filesystem mount point for a given directory,
+%%      via a call to the unix 'df' command
+-spec get_mount_point(string()) -> string() | undefined.
+get_mount_point(Dir) ->
+  case Dir of
+    undefined -> undefined;
+    _ -> 
+      DiskFreeResult = os:cmd("df -P " ++ Dir),
+      [_ColumnLabels|[ColumnValues|_]] = string:tokens(DiskFreeResult, "\n"),
+      lists:last(string:tokens(ColumnValues, " "))
+  end.
 
 
 doc_env() ->

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -121,6 +121,9 @@
 %%</dd><dt> disk
 %%</dt><dd> Value returned by {@link disksup:get_disk_data/0}.
 %%
+%%</dd><dt> mount_points
+%%</dt><dd> List of file system mount points relevant to Riak (specifically, location of platform_data_dir)
+%%
 %%</dd><dt> pbc_connects_total
 %%</dt><dd> Total number of pb socket connections since start
 %%
@@ -151,6 +154,7 @@ produce_stats() ->
        cpu_stats(),
        mem_stats(),
        disk_stats(),
+       mount_point_stats(),
        system_stats(),
        ring_stats(),
        config_stats(),
@@ -352,6 +356,19 @@ mem_stats() ->
 %%      of the os_mon application.
 disk_stats() ->
     [{disk, disksup:get_disk_data()}].
+
+%% @doc Get a list of filesystem mount points relevant to Riak.
+%%      Currently includes the mount point for the riak data directory (platform_data_dir).
+%%      For use with disk_stats() to determine Riak disk space usage.
+-spec mount_point_stats() -> proplist().
+mount_point_stats() ->
+    RiakDataDir = case application:get_env(riak_core, platform_data_dir) of
+        {ok, PlatformRoot} -> PlatformRoot;
+        _ -> undefined
+    end,
+    DataDirMountPoint = riak_kv_env:get_mount_point(RiakDataDir),
+    MountPoints = [{platform_data_dir, DataDirMountPoint}],
+    [{mount_points, MountPoints}].
 
 system_stats() ->
     [{nodename, node()},

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -360,13 +360,13 @@ disk_stats() ->
 %% @doc Get a list of filesystem mount points relevant to Riak.
 %%      Currently includes the mount point for the riak data directory (platform_data_dir).
 %%      For use with disk_stats() to determine Riak disk space usage.
--spec mount_point_stats() -> proplist().
+-spec mount_point_stats() -> proplist:proplist().
 mount_point_stats() ->
     RiakDataDir = case application:get_env(riak_core, platform_data_dir) of
         {ok, PlatformRoot} -> PlatformRoot;
         _ -> undefined
     end,
-    DataDirMountPoint = riak_kv_env:get_mount_point(RiakDataDir),
+    DataDirMountPoint = list_to_binary(riak_kv_env:get_mount_point(RiakDataDir)),
     MountPoints = [{platform_data_dir, DataDirMountPoint}],
     [{mount_points, MountPoints}].
 


### PR DESCRIPTION
Add a `{mount_points, [...]}` section to the stats. This is a list of file system mount points relevant to Riak (specifically, location of `platform_data_dir`), for use with disk_stats() to determine Riak disk space usage.

Currently, the `{disk, [...]}` section of stats lists all of the mount points on the system and their usage. However, there is no way to programmatically tell which of those Riak (the back-ends, specifically) is mounted on.
This PR adds that missing component, to enable the disk usage calculation needed by https://github.com/basho/riak_cs/issues/612
