### PR TITLE
Pass crdt_op to vnode on read-repair.

### DIFF
--- a/src/riak_kv_pb_crdt.erl
+++ b/src/riak_kv_pb_crdt.erl
@@ -122,7 +122,7 @@ maybe_fetch(true, Req, State) ->
     #dtfetchreq{bucket=B, key=K, type=BType, include_context=InclCtx} = Req,
     #state{client=C} = State,
     Options = make_options(Req),
-    Resp = C:get({BType, B}, K, Options),
+    Resp = C:get({BType, B}, K, [{crdt_op, true}|Options]),
     process_fetch_response(Resp, State#state{return_ctx=InclCtx});
 maybe_fetch(false, _Req, State) ->
     #state{type=Type} = State,

--- a/src/riak_kv_wm_crdt.erl
+++ b/src/riak_kv_wm_crdt.erl
@@ -351,7 +351,7 @@ resource_exists(RD, Ctx=#ctx{key=undefined}) ->
     handle_common_error(notfound, RD, Ctx);
 resource_exists(RD, Ctx=#ctx{client=C, bucket_type=T, bucket=B, key=K}) ->
     Options = make_options(Ctx),
-    case C:get({T,B}, K, Options) of
+    case C:get({T,B}, K, [{crdt_op, true}|Options]) of
         {ok, O} ->
             {true, RD, Ctx#ctx{data=O}};
         {error, Reason} ->


### PR DESCRIPTION
This allows another opportunity for CRDTs to merge, instead of simply
creating more siblings on read-repair.

/cc @russelldb 
