### PR TITLE
Fix vnode sending > max_results items for 2i query

### DIFF
--- a/include/riak_kv_index.hrl
+++ b/include/riak_kv_index.hrl
@@ -38,10 +38,11 @@
           start_term :: binary() | undefined, %% Note, in a $key query, start_key==start_term
           end_term :: binary() | undefined, %% Note, in an eq query, start==end
           return_terms=true :: boolean(), %% Note, should be false for an equals query
-          term_regex :: binary() | undefined,
           start_inclusive=true :: boolean(),
           end_inclusive=true :: boolean(),
-          return_body=false ::boolean() %% Note, only for riak cs bucket folds
+          return_body=false ::boolean(), %% Note, only for riak cs bucket folds
+          term_regex :: binary() | undefined,
+          max_results :: integer() | undefined
          }).
 
 -define(KV_INDEX_Q, #riak_kv_index_v3).

--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -252,7 +252,7 @@ parse_field_if_defined(Field, Val) ->
 to_index_query(?CURRENT_2I_VERSION, Args) ->
     Defaults = ?KV_INDEX_Q{},
     [Field1, Start, StartInc, End1, EndInc,
-     TermRegex, ReturnBody, Cont
+     TermRegex, ReturnBody, MaxResults, Cont
     ] =
         [proplists:get_value(F, Args, Default) ||
             {F, Default} <-
@@ -263,6 +263,7 @@ to_index_query(?CURRENT_2I_VERSION, Args) ->
              {end_inclusive, Defaults?KV_INDEX_Q.end_inclusive},
              {term_regex, Defaults?KV_INDEX_Q.term_regex},
              {return_body, Defaults?KV_INDEX_Q.return_body},
+             {max_results, Defaults?KV_INDEX_Q.max_results},
              {continuation, undefined}]],
     End = case End1 of undefined -> Start; _ -> End1 end,
     Field = normalize_index_field(Field1),
@@ -285,10 +286,12 @@ to_index_query(?CURRENT_2I_VERSION, Args) ->
                     start_term=NormStart,
                     end_term=NormEnd,
                     return_terms=ReturnTerms,
-                    term_regex=TermRegex,
                     start_inclusive=StartInc,
                     end_inclusive=EndInc,
-                    return_body=ReturnBody},
+                    return_body=ReturnBody,
+                    term_regex=TermRegex,
+                    max_results=MaxResults
+                     },
             case Cont of
                 undefined ->
                     {ok, Req1};

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -142,13 +142,16 @@ handle_query_results(ReturnTerms, MaxResults,  {ok, Results}, State) ->
     {reply, Resp, State}.
 
 query_params(#rpbindexreq{qtype=eq, index=Index, key=Value,
-                          term_regex=Re, continuation=Continuation}) ->
+                          term_regex=Re, max_results=MaxResults,
+                          continuation=Continuation}) ->
     [{field, Index}, {start_term, Value}, {term_regex, Re},
-     {continuation, Continuation}];
+     {max_results, MaxResults}, {continuation, Continuation}];
 query_params(#rpbindexreq{index=Index, range_min=Min, range_max=Max,
-                          term_regex=Re, continuation=Continuation}) ->
+                          term_regex=Re, max_results=MaxResults,
+                          continuation=Continuation}) ->
      [{field, Index}, {start_term, Min}, {end_term, Max},
-      {term_regex, Re}, {continuation, Continuation}].
+      {term_regex, Re}, {max_results, MaxResults},
+      {continuation, Continuation}].
 
 encode_results(true, Results0, Continuation) ->
     Results = [encode_result(Res) || Res <- Results0],

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -127,11 +127,15 @@ malformed_request(RD, Ctx) ->
         [S] -> {S, undefined};
         [S, E] -> {S, E}
     end,
-    QRes = riak_index:to_index_query([
+    MaxVal = validate_max(MaxResults0),
+    QRes = riak_index:to_index_query(
+             [
                 {field, IndexField}, {start_term, Start}, {end_term, End},
                 {return_terms, ReturnTerms}, {continuation, Continuation},
                 {term_regex, TermRegex}
-                ]),
+             ]
+             ++ [{max_results, MaxResults} || {true, MaxResults} <- [MaxVal]]
+            ),
     ValRe = case TermRegex of
         undefined ->
             ok;
@@ -142,7 +146,7 @@ malformed_request(RD, Ctx) ->
     case {PgSort,
           ReturnTerms,
           validate_timeout(Timeout0),
-          validate_max(MaxResults0),
+          MaxVal,
           QRes,
           ValRe} of
         {malformed, _, _, _, _, _} ->


### PR DESCRIPTION
This change sends the max_results value in the 2i query to the vnode,
which then may be used as the batch size if < than the default batch
size.  Before, a batch would be sent with possibly more items than the
index FSM would ever send back to the client.

/cc THE @russelldb 
