### PR TITLE
Use a DVV like approach to stop sibling explosion

### DIFF
--- a/include/riak_object.hrl
+++ b/include/riak_object.hrl
@@ -1,0 +1,3 @@
+-define(DOT, <<"dot">>). %% The event at which a value was written, stored in metadata
+
+

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -347,7 +347,8 @@
 
 {mapping, "dvv", "riak_kv.dvv_enabled", [
   {default, on},
-  {datatype, {enum, [on, off]}}
+  {datatype, {enum, [on, off]}},
+  {level, advanced}
 ]}.
 
 { translation,

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -337,3 +337,26 @@
   {datatype, integer},
   {default, 100}
 ]}.
+
+%% @doc dvv is an enhancement to riak's logical clocks that prevents
+%% sibling explosion by storing an event in a value's metadata on
+%% creation. Riak later later uses that event information on merging
+%% conflicting writes to ensure that only genuinely concurrent values
+%% remain. DVV is enabled by default. As it is a new feature, you can
+%% switch it off.
+
+{mapping, "dvv", "riak_kv.dvv_enabled", [
+  {default, on},
+  {datatype, {enum, [on, off]}}
+]}.
+
+{ translation,
+  "riak_kv.dvv_enabled",
+  fun(Conf) ->
+    Setting = cuttlefish_util:conf_get_value("dvv", Conf),
+    case Setting of
+      on -> true;
+      off -> false;
+      _Default -> true
+    end
+  end}.

--- a/src/riak_kv.app.src
+++ b/src/riak_kv.app.src
@@ -42,6 +42,9 @@
          %% Disable active anti-entropy by default
          {anti_entropy, {off, []}},
 
+         %% Enable DVV by default
+         {dvv_enabled, true},
+
          %% Allow Erlang MapReduce functions to be specified as
          %% strings.
          %%

--- a/src/riak_kv_crdt.erl
+++ b/src/riak_kv_crdt.erl
@@ -25,6 +25,7 @@
 -export([update/3, merge/1, value/2, new/3,
          supported/1, to_mod/1, from_mod/1]).
 -export([to_binary/2, to_binary/1, from_binary/1]).
+-export([log_merge_errors/4, meta/2, merge_value/2]).
 
 -include("riak_kv_wm_raw.hrl").
 -include_lib("riak_kv_types.hrl").
@@ -103,6 +104,12 @@ merge_object(RObj) ->
     maybe_log_sibling_crdts(Bucket, Key, CRDTs),
     {CRDTs, NonCRDTSiblings}.
 
+%% @doc log any accumulated merge errors
+-spec log_merge_errors(riak_object:bucket(), riak_object:key(), crdts(), list()) -> ok.
+log_merge_errors(Bucket, Key, CRDTs, Errors) ->
+    log_errors(Bucket, Key, Errors),
+    maybe_log_sibling_crdts(Bucket, Key, CRDTs).
+
 log_errors(_, _, []) ->
     ok;
 log_errors(Bucket, Key, Errors) ->
@@ -124,9 +131,8 @@ merge_contents(Contents) ->
                 {orddict:new(), [], []},
                Contents).
 
-%% @private worker for `merge_contents/1' if the content is a CRDT,
-%% de-binary it, merge it and store the most merged value in the
-%% accumulator dictionary.
+%% @doc if the content is a CRDT, de-binary it, merge it and store the
+%% most merged value in the accumulator dictionary.
 -spec merge_value(ro_content(), {crdts(), ro_contents()}) ->
                          {crdts(), ro_contents()}.
 merge_value({MD, <<?TAG:8/integer, Version:8/integer, CRDTBin/binary>>=Content},
@@ -293,7 +299,12 @@ merge_meta(CType, Meta1, Meta2) ->
            end,
     %% Make sure the content type is
     %% up-to-date
-    dict:store(?MD_CTYPE, CType, Meta).
+    drop_the_dot(dict:store(?MD_CTYPE, CType, Meta)).
+
+%% @private Never keep a dot for CRDTs, we want all values to survive
+%% a riak_obect:merge/2
+drop_the_dot(Dict) ->
+    dict:erase(riak_object:dot_key(), Dict).
 
 lastmod(Meta) ->
     dict:fetch(?MD_LASTMOD, Meta).

--- a/src/riak_kv_crdt.erl
+++ b/src/riak_kv_crdt.erl
@@ -31,7 +31,6 @@
 -include("riak_object.hrl").
 -include_lib("riak_kv_types.hrl").
 
-
 -ifdef(TEST).
 -ifdef(EQC).
 -export([test_split/0, test_split/1]).

--- a/src/riak_kv_crdt.erl
+++ b/src/riak_kv_crdt.erl
@@ -28,7 +28,9 @@
 -export([log_merge_errors/4, meta/2, merge_value/2]).
 
 -include("riak_kv_wm_raw.hrl").
+-include("riak_object.hrl").
 -include_lib("riak_kv_types.hrl").
+
 
 -ifdef(TEST).
 -ifdef(EQC).
@@ -304,7 +306,7 @@ merge_meta(CType, Meta1, Meta2) ->
 %% @private Never keep a dot for CRDTs, we want all values to survive
 %% a riak_obect:merge/2
 drop_the_dot(Dict) ->
-    dict:erase(riak_object:dot_key(), Dict).
+    dict:erase(?DOT, Dict).
 
 lastmod(Meta) ->
     dict:fetch(?MD_LASTMOD, Meta).

--- a/src/riak_kv_get_core.erl
+++ b/src/riak_kv_get_core.erl
@@ -200,7 +200,7 @@ final_action(GetCore = #getcore{n = N, merged = Merged0, results = Results,
                           [];
                       _ -> % ok or tombstone
                           [{Idx, outofdate} || {Idx, {ok, RObj}} <- Results,
-                                  strict_descendant(MObj, RObj)] ++
+                                  riak_object:strict_descendant(MObj, RObj)] ++
                               [{Idx, notfound} || {Idx, {error, notfound}} <- Results]
                   end,
     Action = case ReadRepairs of
@@ -242,11 +242,6 @@ info(#getcore{num_ok = NumOks, num_fail = NumFail, results = Results}) ->
 %% ====================================================================
 %% Internal functions
 %% ====================================================================
-
-strict_descendant(O1, O2) ->
-    vclock:descends(riak_object:vclock(O1),riak_object:vclock(O2)) andalso
-    not vclock:descends(riak_object:vclock(O2),riak_object:vclock(O1)).
-
 merge(Replies, AllowMult) ->
     RObjs = [RObj || {_I, {ok, RObj}} <- Replies],
     case RObjs of

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1186,9 +1186,7 @@ handle_crdt(_, undefined, _VId, RObj) ->
 handle_crdt(true, CRDTOp, VId, RObj) ->
     riak_kv_crdt:update(RObj, VId, CRDTOp);
 handle_crdt(false, _CRDTOp, _Vid, RObj) ->
-    %% non co-ord put that was a CRDT operation? Merge the values if
-    %% there are siblings 'cos that is the point of CRDTs: no siblings
-    riak_kv_crdt:merge(RObj).
+    RObj.
 
 perform_put({fail, _, _}=Reply, State, _PutArgs) ->
     {Reply, State};

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1321,7 +1321,7 @@ put_merge(true, false, LocalObj, PutObj, VId, StartTime) -> %% Coordinating=true
             %% so merge the PUT object and the local object.
             MergedClock = vclock:merge([PutVC, LocalVC]),
             FrontierClock = vclock:increment(VId, StartTime, MergedClock),
-            Dot = vclock:get_entry(VId, FrontierClock),
+            {ok, Dot} = vclock:get_entry(VId, FrontierClock),
             %% Asign an event to the put value
             DottedPutObject = riak_object:assign_dot(PutObj, Dot),
             MergedObject = riak_object:merge(DottedPutObject, LocalObj),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1292,6 +1292,9 @@ select_newest_content(Mult) ->
 put_merge(false, true, _CurObj, UpdObj, _VId, _StartTime) -> % coord=false, LWW=true
     {newobj, UpdObj};
 put_merge(false, false, CurObj, UpdObj, _VId, _StartTime) -> % coord=false, LWW=false
+    %% a downstream merge, or replication of a coordinated PUT
+    %% Merge the value received with local replica value
+    %% and store the value IIF it is different to what we already have
     ResObj = riak_object:syntactic_merge(CurObj, UpdObj),
     case riak_object:equal(ResObj, CurObj) of
         true ->
@@ -1301,21 +1304,28 @@ put_merge(false, false, CurObj, UpdObj, _VId, _StartTime) -> % coord=false, LWW=
     end;
 put_merge(true, true, _CurObj, UpdObj, VId, StartTime) -> % coord=true, LWW=true
     {newobj, riak_object:increment_vclock(UpdObj, VId, StartTime)};
-put_merge(true, false, CurObj, UpdObj, VId, StartTime) ->
-    UpdObj1 = riak_object:increment_vclock(UpdObj, VId, StartTime),
-    UpdVC = riak_object:vclock(UpdObj1),
-    CurVC = riak_object:vclock(CurObj),
+put_merge(true, false, LocalObj, PutObj, VId, StartTime) -> %% Coordinating=true, LWW=false, local replica has value for key
+    %% Get the vclock we have the object stored on disk at this replica
+    LocalVC = riak_object:vclock(LocalObj),
+    %% get the vclock from the put
+    PutVC = riak_object:vclock(PutObj),
 
-    %% Check the coord put will replace the existing object
-    case vclock:get_counter(VId, UpdVC) > vclock:get_counter(VId, CurVC) andalso
-        vclock:descends(CurVC, UpdVC) == false andalso
-        vclock:descends(UpdVC, CurVC) == true of
+    %% Optimisation: if the put object's vclock descends from the
+    %% local object's vclock, then don't merge with local value, just
+    %% increment the clock and overwrite.
+    case vclock:descends(PutVC, LocalVC) of
         true ->
-            {newobj, UpdObj1};
+            {newobj, riak_object:increment_vclock(PutObj, VId, StartTime)};
         false ->
-            %% If not, make sure it does
-            {newobj, riak_object:increment_vclock(
-                       riak_object:merge(CurObj, UpdObj1), VId, StartTime)}
+            %% The PUT object is concurrent with some other PUT,
+            %% so merge the PUT object and the local object.
+            MergedClock = vclock:merge([PutVC, LocalVC]),
+            FrontierClock = vclock:increment(VId, StartTime, MergedClock),
+            Dot = vclock:get_entry(VId, FrontierClock),
+            %% Asign an event to the put value
+            DottedPutObject = riak_object:assign_dot(PutObj, Dot),
+            MergedObject = riak_object:merge(DottedPutObject, LocalObj),
+            {newobj, riak_object:set_vclock(MergedObject, FrontierClock)}
     end.
 
 %% @private

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1292,7 +1292,7 @@ put_merge(false, true, _CurObj, UpdObj, _VId, _StartTime) -> % coord=false, LWW=
 put_merge(false, false, CurObj, UpdObj, _VId, _StartTime) -> % coord=false, LWW=false
     %% a downstream merge, or replication of a coordinated PUT
     %% Merge the value received with local replica value
-    %% and store the value IIF it is different to what we already have
+    %% and store the value IFF it is different to what we already have
     ResObj = riak_object:syntactic_merge(CurObj, UpdObj),
     case riak_object:equal(ResObj, CurObj) of
         true ->
@@ -1320,7 +1320,7 @@ put_merge(true, false, LocalObj, PutObj, VId, StartTime) -> %% Coordinating=true
             MergedClock = vclock:merge([PutVC, LocalVC]),
             FrontierClock = vclock:increment(VId, StartTime, MergedClock),
             {ok, Dot} = vclock:get_entry(VId, FrontierClock),
-            %% Asign an event to the put value
+            %% Assign an event to the put value
             DottedPutObject = riak_object:assign_dot(PutObj, Dot),
             MergedObject = riak_object:merge(DottedPutObject, LocalObj),
             {newobj, riak_object:set_vclock(MergedObject, FrontierClock)}

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -1027,6 +1027,14 @@ is_updated_test() ->
     OVu = riak_object:update_value(O, testupdate),
     ?assert(is_updated(OVu)).
 
+remove_duplicates_test() ->
+    O0 = riak_object:new(<<"test">>, <<"test">>, zero),
+    O1 = riak_object:new(<<"test">>, <<"test">>, one),
+    ND = remove_duplicate_objects([O0, O0, O1, O1, O0, O1]),
+    ?assertEqual(2, length(ND)),
+    ?assert(lists:member(O0, ND)),
+    ?assert(lists:member(O1, ND)).
+
 new_with_ctype_test() ->
     O = riak_object:new(<<"b">>, <<"k">>, <<"{\"a\":1}">>, "application/json"),
     ?assertEqual("application/json", dict:fetch(?MD_CTYPE, riak_object:get_metadata(O))).

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -1013,14 +1013,6 @@ is_updated_test() ->
     OVu = riak_object:update_value(O, testupdate),
     ?assert(is_updated(OVu)).
 
-remove_duplicates_test() ->
-    O0 = riak_object:new(<<"test">>, <<"test">>, zero),
-    O1 = riak_object:new(<<"test">>, <<"test">>, one),
-    ND = remove_duplicate_objects([O0, O0, O1, O1, O0, O1]),
-    ?assertEqual(2, length(ND)),
-    ?assert(lists:member(O0, ND)),
-    ?assert(lists:member(O1, ND)).
-
 new_with_ctype_test() ->
     O = riak_object:new(<<"b">>, <<"k">>, <<"{\"a\":1}">>, "application/json"),
     ?assertEqual("application/json", dict:fetch(?MD_CTYPE, riak_object:get_metadata(O))).

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -181,9 +181,7 @@ equal_contents([C1|R1],[C2|R2]) ->
 ancestors(pure_baloney_to_fool_dialyzer) ->
     [#r_object{vclock = vclock:fresh()}];
 ancestors(Objects) ->
-    ToRemove = [[O2 || O2 <- Objects, strict_descendant(O1, O2)]
-                || O1 <- Objects],
-    lists:flatten(ToRemove).
+    [ O2 || O1 <- Objects, O2 <- Objects, strict_descendant(O1, O2) ].
 
 %% @doc returns true if the `riak_object()' at `O1' is a strict
 %% descendant of that at `O2'. This means that the first object

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -368,7 +368,7 @@ fold_contents({r_content, Dict, Value}=C0, MergeAcc, Clock) ->
             %% Riak, not by the client. A CRDT PUT _NEVER_ overwrites
             %% existing values in Riak, it is always merged with
             %% them. The resulting value then does not have a single
-            %% event origin. Instead it is a merge of may events. In
+            %% event origin. Instead it is a merge of many events. In
             %% DVVSets (referenced above) there is an `anonymous list'
             %% for values that have no single event. In Riak we
             %% already have that, by having an `undefined' dot. We

--- a/test/ec_eqc.erl
+++ b/test/ec_eqc.erl
@@ -802,8 +802,7 @@ kv_vnode(#msg{from = From, c = {coord_put, ReqId, NewObj, Timestamp}},
     [Pri1, Pri2] = lists:sort([next_pri(), next_pri()]),
     WMsg = new_msg(Name, From, {w, Idx, ReqId}, Pri1),
     NodeId = {vc, Start, Node},
-    NewObj1 = NewObj,%%riak_object:increment_vclock(NewObj, NodeId, ReqId),
-    UpdObj = coord_put_merge(CurObj, NewObj1, NodeId, Timestamp),
+    UpdObj = coord_put_merge(CurObj, NewObj, NodeId, Timestamp),
     DWMsg = new_msg(Name, From, {dw, Idx, ReqId, UpdObj}, Pri2), % ignore returnbody for now
     [{msgs, [WMsg, DWMsg]},
      {updp, P#proc{procst = PS#kvvnodest{start = Start, object = UpdObj}}}];

--- a/test/ec_eqc.erl
+++ b/test/ec_eqc.erl
@@ -912,7 +912,7 @@ coord_put_merge(LocalObj, PutObj, NodeId, Timestamp) ->
             %% so merge the PUT object and the local object.
             MergedClock = vclock:merge([PutVC, LocalVC]),
             FrontierClock = vclock:increment(NodeId, Timestamp, MergedClock),
-            Dot = vclock:get_entry(NodeId, FrontierClock),
+            {ok, Dot} = vclock:get_entry(NodeId, FrontierClock),
             %% Asign an event to the put value
             DottedPutObject = riak_object:assign_dot(PutObj, Dot),
             MergedObject = riak_object:merge(DottedPutObject, LocalObj),

--- a/test/ec_eqc.erl
+++ b/test/ec_eqc.erl
@@ -791,7 +791,7 @@ kv_vnode(#msg{from = From, c = {coord_put, ReqId, NewObj, Timestamp}},
     [Pri1, Pri2] = lists:sort([next_pri(), next_pri()]),
     WMsg = new_msg(Name, From, {w, Idx, ReqId}, Pri1),
     NodeId = {vc, Start, Node},
-    NewObj1 = riak_object:increment_vclock(NewObj, NodeId, ReqId),
+    NewObj1 = NewObj,%%riak_object:increment_vclock(NewObj, NodeId, ReqId),
     UpdObj = coord_put_merge(CurObj, NewObj1, NodeId, Timestamp),
     DWMsg = new_msg(Name, From, {dw, Idx, ReqId, UpdObj}, Pri2), % ignore returnbody for now
     [{msgs, [WMsg, DWMsg]},
@@ -882,21 +882,30 @@ syntactic_put_merge(CurObj, UpdObj) ->
     end.
 
 
-coord_put_merge(undefined, UpdObj, _NodeId, _Timestamp) ->
-    UpdObj;
-coord_put_merge(CurObj, UpdObj, NodeId, Timestamp) ->
-    %% Make sure UpdObj descends from CurObj and that NodeId is greater
-    CurVC = riak_object:vclock(CurObj),
-    UpdVC = riak_object:vclock(UpdObj),
+coord_put_merge(undefined, UpdObj, NodeId, Timestamp) ->
+    riak_object:increment_vclock(UpdObj, NodeId, Timestamp);
+coord_put_merge(LocalObj, PutObj, NodeId, Timestamp) ->
+  %% Get the vclock we have the object stored on disk at this replica
+    LocalVC = riak_object:vclock(LocalObj),
+    %% get the vclock from the put
+    PutVC = riak_object:vclock(PutObj),
 
-    %% Valid coord put replacing current object
-    case get_counter(NodeId, UpdVC) > get_counter(NodeId, CurVC) andalso
-        vclock:descends(CurVC, UpdVC) == false andalso 
-        vclock:descends(UpdVC, CurVC) == true of
+    %% Optimisation: if the put object's vclock descends from the
+    %% local object's vclock, then don't merge with local value, just
+    %% increment the clock and overwrite.
+    case vclock:descends(PutVC, LocalVC) of
         true ->
-            UpdObj;
+            riak_object:increment_vclock(PutObj, NodeId, Timestamp);
         false ->
-            riak_object:increment_vclock(riak_object:merge(CurObj, UpdObj),NodeId, Timestamp)
+            %% The PUT object is concurrent with some other PUT,
+            %% so merge the PUT object and the local object.
+            MergedClock = vclock:merge([PutVC, LocalVC]),
+            FrontierClock = vclock:increment(NodeId, Timestamp, MergedClock),
+            Dot = vclock:get_entry(NodeId, FrontierClock),
+            %% Asign an event to the put value
+            DottedPutObject = riak_object:assign_dot(PutObj, Dot),
+            MergedObject = riak_object:merge(DottedPutObject, LocalObj),
+            riak_object:set_vclock(MergedObject, FrontierClock)
     end.
 
 


### PR DESCRIPTION
As has been witnessed by our customers, and demonstrated by Baquero et al, sibling explosion occurs when we keep values as concurrent when they're not really.

Our vnode vclocks are not fine grained enough to describe which of a set of siblings should be overwritten by a PUT, so we keep all siblings. It is trivially easy to create a scenario where interleaving writes create an explosion of sibling values, even without failure, or concurrency (see basho/riak_test#383.)

This PR introduces a more fine grained approach to causality tracking, without going all the way and using DVV or DVVSets.

The general mechanism is to store the event (`{actor, {count, ts}}`) that a value is created at as metadata with the value. When a PUT is received, any siblings whose events are dominated by the PUT vclock are removed. Only siblings that the writer has not seen are genuinely concurrent.

In order not to drop ALL the values during other merge types, when any two merging objects both have the same event, that sibling stays.

Nothing is for free, so there is some extra complexity around `riak_object:merge`.

This PR requires the basho/riak_core#463 and can be tested with basho/riak_test#480.
