### PR TITLE
Add timer:sleep()-based throttle to riak_kv_exchange_fsm:read_repair_keydiff()

### DIFF
--- a/src/riak_kv_cinfo.erl
+++ b/src/riak_kv_cinfo.erl
@@ -48,12 +48,13 @@ cluster_info_generator_funs() ->
 aae_throttle(CPid) ->
     {Throttle, ThrottleLimits} = get_aae_throttle(),
     cluster_info:format(CPid, "Current throttle: ~p msec\n", [Throttle]),
-    cluster_info:format(CPid, "Limit AAT throttle parameters: ~p\n",
+    cluster_info:format(CPid, "Limit AAE throttle parameters: ~p\n",
                         [ThrottleLimits]).
 
 get_aae_throttle() ->
-    {riak_kv_entropy_manager:get_aae_throttle(),
-     riak_kv_entropy_manager:get_aae_throttle_limits()}.
+    [{throttle_kill, riak_kv_entropy_manager:get_aae_throttle_kill()},
+     {current_throttle, riak_kv_entropy_manager:get_aae_throttle()},
+     {limits, riak_kv_entropy_manager:get_aae_throttle_limits()}].
 
 status(CPid) -> % CPid is the data collector's pid.
     cluster_info:format(CPid, "~p\n", [riak_kv_status:statistics()]).

--- a/src/riak_kv_cinfo.erl
+++ b/src/riak_kv_cinfo.erl
@@ -22,6 +22,7 @@
 
 -module(riak_kv_cinfo).
 -export([cluster_info_init/0, cluster_info_generator_funs/0]).
+-export([get_aae_throttle/0]).
 
 %% @spec () -> term()
 %% @doc Required callback function for cluster_info: initialization.
@@ -40,8 +41,19 @@ cluster_info_generator_funs() ->
     [
      {"Riak KV status", fun status/1},
      {"Riak KV ringready", fun ringready/1},
-     {"Riak KV transfers", fun transfers/1}
+     {"Riak KV transfers", fun transfers/1},
+     {"Riak KV anti-entropy throttle", fun aae_throttle/1}
     ].
+
+aae_throttle(CPid) ->
+    {Throttle, ThrottleLimits} = get_aae_throttle(),
+    cluster_info:format(CPid, "Current throttle: ~p msec\n", [Throttle]),
+    cluster_info:format(CPid, "Limit AAT throttle parameters: ~p\n",
+                        [ThrottleLimits]).
+
+get_aae_throttle() ->
+    {riak_kv_entropy_manager:get_aae_throttle(),
+     riak_kv_entropy_manager:get_aae_throttle_limits()}.
 
 status(CPid) -> % CPid is the data collector's pid.
     cluster_info:format(CPid, "~p\n", [riak_kv_status:statistics()]).

--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -42,13 +42,13 @@
          get_aae_throttle_limits/0,
          set_aae_throttle_limits/1,
          get_max_local_vnodeq/0]).
+-export([multicall/5]).                         % for meck twiddle-testing
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
 -ifdef(TEST).
--export([multicall/5]).                         % for meck twiddle-testing
 -export([query_and_set_aae_throttle/1]).        % for eunit twiddle-testing
 -export([make_state/0, get_last_throttle/1]).   % for eunit twiddle-testing
 -include_lib("eunit/include/eunit.hrl").

--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -37,10 +37,22 @@
          start_exchange_remote/3,
          exchange_status/4]).
 -export([all_pairwise_exchanges/2]).
+-export([get_aae_throttle/0,
+         set_aae_throttle/1,
+         get_aae_throttle_limits/0,
+         set_aae_throttle_limits/1,
+         get_max_local_vnodeq/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
+
+-ifdef(TEST).
+-export([multicall/5]).                         % for meck twiddle-testing
+-export([query_and_set_aae_throttle/1]).        % for eunit twiddle-testing
+-export([make_state/0, get_last_throttle/1]).   % for eunit twiddle-testing
+-include_lib("eunit/include/eunit.hrl").
+-endif.
 
 -type index() :: non_neg_integer().
 -type index_n() :: {index(), pos_integer()}.
@@ -54,13 +66,15 @@
                 locks          = []        :: [{pid(), reference()}],
                 build_tokens   = 0         :: non_neg_integer(),
                 exchange_queue = []        :: [exchange()],
-                exchanges      = []        :: [{index(), reference(), pid()}]
+                exchanges      = []        :: [{index(), reference(), pid()}],
+                last_throttle  = undefined :: 'undefined' | non_neg_integer()
                }).
 
 -type state() :: #state{}.
 
 -define(DEFAULT_CONCURRENCY, 2).
 -define(DEFAULT_BUILD_LIMIT, {1, 3600000}). %% Once per hour
+-define(AAE_THROTTLE_ENV_KEY, aae_throttle_sleep_time).
 
 %%%===================================================================
 %%% API
@@ -183,7 +197,12 @@ cancel_exchanges() ->
 
 -spec init([]) -> {'ok',state()}.
 init([]) ->
+    %% Side-effects section
+    set_aae_throttle(0),
+    set_aae_throttle_limits(
+      [{-1, 0}, {200, 10}, {500, 50}, {750, 250}, {900, 1000}, {1100, 5000}]),
     schedule_tick(),
+
     {_, Opts} = settings(),
     Mode = case proplists:is_defined(manual, Opts) of
                true ->
@@ -264,7 +283,8 @@ handle_cast(_Msg, State) ->
     {noreply, State}.
 
 handle_info(tick, State) ->
-    State2 = maybe_tick(State),
+    State1 = query_and_set_aae_throttle(State),
+    State2 = maybe_tick(State1),
     {noreply, State2};
 handle_info(reset_build_tokens, State) ->
     State2 = reset_build_tokens(State),
@@ -685,3 +705,86 @@ requeue_exchange(LocalIdx, RemoteIdx, IndexN, State) ->
             Exchanges = State#state.exchange_queue ++ [Exchange],
             State#state{exchange_queue=Exchanges}
     end.
+
+get_aae_throttle() ->
+    app_helper:get_env(riak_kv, ?AAE_THROTTLE_ENV_KEY, 0).
+
+set_aae_throttle(Milliseconds) when is_integer(Milliseconds), Milliseconds >= 0 ->
+    application:set_env(riak_kv, ?AAE_THROTTLE_ENV_KEY, Milliseconds).
+
+get_max_local_vnodeq() ->
+    try
+        {element(2,lists:keyfind(riak_kv_vnodeq_max, 1, riak_core_stat:get_stats())), node()}
+    catch _X:_Y ->
+            %% This can fail locally if riak_core & riak_kv haven't finished their setup.
+            {0, node()}
+    end.
+
+get_aae_throttle_limits() ->
+    %% init() should have already set a sane default, so the default below should never be used.
+    app_helper:get_env(riak_kv, aae_throttle_limits, [{-1, 0}]).
+
+%% @doc Set AAE throttle limits list
+%%
+%% Limit list = [{max_vnode_q_len, per-repair-delay}]
+%% A tuple with max_vnode_q_len=-1 must be present.
+%% List sorting is not required: the throttle is robust with any ordering.
+
+set_aae_throttle_limits(Limits) ->
+    case {lists:keyfind(-1, 1, Limits),
+          catch lists:all(fun({Min, Lim}) ->
+                                  is_integer(Min) andalso is_integer(Lim) andalso
+                                      Lim >= 0
+                          end, Limits)} of
+        {{-1, _}, true} ->
+            lager:info("Setting AAE throttle limits: ~p\n", [Limits]),
+            application:set_env(riak_kv, aae_throttle_limits, Limits),
+            ok;
+        Else ->
+            {error, Else}
+    end.
+
+query_and_set_aae_throttle(#state{last_throttle=LastThrottle} = State) ->
+    Limits = lists:sort(get_aae_throttle_limits()),
+    {MaxNds, BadNds} = ?MODULE:multicall([node()|nodes()], ?MODULE, get_max_local_vnodeq, [], 10*1000),
+    %% If a node is really hosed, then this RPC call is going to fail for that node.
+    %% We might also delay the 'tick' processing by several seconds.  But the tick
+    %% processing is OK if it's delayed while we wait for slow nodes here.
+    {WorstVMax, WorstNode} =
+        case {BadNds, lists:reverse(lists:sort(MaxNds))} of
+            {[], [{VMax, Node}|_]} ->
+                {VMax, Node};
+            {BadNodes, _} ->
+                %% If anyone couldn't respond, let's assume the worst.  If that node
+                %% is actually down, then the net_kernel will mark it down for us
+                %% soon, and then we'll calculate a real value after that.
+                %% Note that a tuple as WorstVMax will always be bigger than an integer,
+                %% so we can avoid using false information like WorstVMax=99999999999999
+                %% and also give something meaningful in the user's info msg.
+                {{unknown_mailbox_sizes, node_list, BadNds}, BadNodes}
+        end,
+    {Sat, _NonSat} = lists:partition(fun({X, _Limit}) -> X < WorstVMax end, Limits),
+    [{_, NewThrottle}|_] = lists:reverse(lists:sort(Sat)),
+    if NewThrottle /= LastThrottle ->
+            _ = lager:info("Changing AAE throttle from ~p -> ~p msec/key, "
+                           "based on maximum vnode mailbox size ~p from ~p",
+                           [LastThrottle, NewThrottle, WorstVMax, WorstNode]),
+            set_aae_throttle(NewThrottle),
+            State#state{last_throttle=NewThrottle};
+       true ->
+            State
+    end.
+
+%% Wrapper for meck interception for testing.
+multicall(A, B, C, D, E) ->
+    rpc:multicall(A, B, C, D, E).
+
+-ifdef(TEST).
+
+make_state() ->
+    #state{}.
+
+get_last_throttle(#state{last_throttle=Last}) ->
+    Last.
+
+-endif.

--- a/src/riak_kv_exchange_fsm.erl
+++ b/src/riak_kv_exchange_fsm.erl
@@ -232,6 +232,7 @@ read_repair_keydiff(RC, LocalVN, RemoteVN, {_, KeyBin}) ->
     RC:get(Bucket, Key),
     %% Force vnodes to update AAE tree in case read repair wasn't triggered
     riak_kv_vnode:rehash([LocalVN, RemoteVN], Bucket, Key),
+    timer:sleep(riak_kv_entropy_manager:get_aae_throttle()),
     ok.
 
 %% @private

--- a/test/riak_kv_entropy_manager_test.erl
+++ b/test/riak_kv_entropy_manager_test.erl
@@ -52,12 +52,15 @@ set_aae_throttle_limits_test() ->
 
 side_effects_test_() ->
     BigWait = 100,
+    LittleWait = 10,
     {setup,
      fun() ->
              meck:new(?TM, [passthrough]),
-             ?TM:set_aae_throttle_limits([{-1, 0}, {5, BigWait}])
+             ?TM:set_aae_throttle_limits([{-1, 0},
+                                          {30, LittleWait}, {50, BigWait}])
      end,
      fun(_) ->
+             ?TM:set_aae_throttle_kill(false),
              meck:unload(?TM),
              ?TM:set_aae_throttle(0)
      end,
@@ -77,9 +80,24 @@ side_effects_test_() ->
              State3 = ?TM:query_and_set_aae_throttle(State2),
              BigWait = ?TM:get_last_throttle(State3),
 
-             meck:expect(?TM, multicall, fun(_,_,_,_,_) -> {[{2,nd}], []} end),
+             BadRPC_result = {badrpc,{'EXIT',{undef,[{riak_kv_entropy_manager,multicall,[x,x,x],[y,y,y]},{rpc,'-handle_call_call/6-fun-0-',5,[stack,trace,here]}]}}},
+             meck:expect(?TM, multicall, fun(_,_,_,_,_) -> { [BadRPC_result], []} end),
              State4 = ?TM:query_and_set_aae_throttle(State3),
-             0 = ?TM:get_last_throttle(State4)
+             BigWait = ?TM:get_last_throttle(State4),
+
+             ?TM:set_aae_throttle_kill(true),
+             meck:expect(?TM, multicall, fun(_,_,_,_,_) -> { [BadRPC_result], []} end),
+             State4b = ?TM:query_and_set_aae_throttle(State4),
+             0 = ?TM:get_last_throttle(State4b),
+             ?TM:set_aae_throttle_kill(false),
+
+             meck:expect(?TM, multicall, fun(_,_,_,_,_) -> {[{31,nd}], []} end),
+             State5 = ?TM:query_and_set_aae_throttle(State4b),
+             LittleWait = ?TM:get_last_throttle(State5),
+
+             meck:expect(?TM, multicall, fun(_,_,_,_,_) -> {[{2,nd}], []} end),
+             State6 = ?TM:query_and_set_aae_throttle(State5),
+             0 = ?TM:get_last_throttle(State6)
          end)
       ]
     }.

--- a/test/riak_kv_entropy_manager_test.erl
+++ b/test/riak_kv_entropy_manager_test.erl
@@ -1,0 +1,87 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_kv_entropy_manager_test).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TM, riak_kv_entropy_manager).
+
+set_aae_throttle_test() ->
+    try
+        _ = ?TM:set_aae_throttle(-4),
+        error(u)
+    catch error:function_clause ->
+            ok;
+          error:u ->
+            error(unexpected_success);
+          _X:_Y ->
+            error(wrong_exception)
+    end,
+    [begin ?TM:set_aae_throttle(V), V = ?TM:get_aae_throttle() end ||
+        V <- [5,6]].
+
+set_aae_throttle_limits_test() ->
+    {error, _} = ?TM:set_aae_throttle_limits([]),
+    {error, _} = ?TM:set_aae_throttle_limits([{5,7}]),
+    {error, _} = ?TM:set_aae_throttle_limits([{-1,x}]),
+    {error, _} = ?TM:set_aae_throttle_limits([{-1,0}, {x,7}]),
+    ok = ?TM:set_aae_throttle_limits([{-1,0}, {100, 500}, {100, 500},
+                                      {100, 500}, {100, 500}, {100, 500}]).
+
+%% Drat, EUnit + Meck won't work if this test is inside the
+%% riak_kv_entropy_manager.erl module.
+
+side_effects_test_() ->
+    BigWait = 100,
+    {setup,
+     fun() ->
+             meck:new(?TM, [passthrough]),
+             ?TM:set_aae_throttle_limits([{-1, 0}, {5, BigWait}])
+     end,
+     fun(_) ->
+             meck:unload(?TM),
+             ?TM:set_aae_throttle(0)
+     end,
+     [
+      ?_test(
+         begin
+             State0 = ?TM:make_state(),
+             meck:expect(?TM, multicall, fun(_,_,_,_,_) -> {[], [nd]} end),
+             State1 = ?TM:query_and_set_aae_throttle(State0),
+             BigWait = ?TM:get_last_throttle(State1),
+
+             meck:expect(?TM, multicall, fun(_,_,_,_,_) -> {[{0,nd}], [nd]} end),
+             State2 = ?TM:query_and_set_aae_throttle(State1),
+             BigWait = ?TM:get_last_throttle(State2),
+
+             meck:expect(?TM, multicall, fun(_,_,_,_,_) -> {[{666,nd}], []} end),
+             State3 = ?TM:query_and_set_aae_throttle(State2),
+             BigWait = ?TM:get_last_throttle(State3),
+
+             meck:expect(?TM, multicall, fun(_,_,_,_,_) -> {[{2,nd}], []} end),
+             State4 = ?TM:query_and_set_aae_throttle(State3),
+             0 = ?TM:get_last_throttle(State4)
+         end)
+      ]
+    }.
+
+-endif.


### PR DESCRIPTION
Note: this PR is against the `1.4` branch.

The throttle part is easy: a 1-liner.  The rest is the infrastructure
to poll each node for its maximum vnode mailbox queue length, pick the
worst one, calculate a sleep time based on a list of {Q_length, SleepMSec},
and communicate via time-honored application env vars.

The only hot code path that reads the ETS table for app env vars is
riak_kv_exchange_fsm:read_repair_keydiff() itself, and since it is
doing a full KV get FSM plus other stuff, the extra heat on the hot
path is insignificant.

@joedevivo I'd appreciate some cuttlefish advice on how to go about
crafting the value of the {riak_kv, aae_throttle_limits} in a cuttlefish
config: `list({integer(), non_neg_integer()})`.  Once I have that figured out,
then I can create an expanded PR for `develop`.
