### PR TITLE
Clean up two security holes: link walking and arbitrary erlang MR

### DIFF
--- a/src/riak_kv_pb_mapred.erl
+++ b/src/riak_kv_pb_mapred.erl
@@ -88,7 +88,19 @@ process(#rpbmapredreq{request=MrReq, content_type=ContentType}=Req,
         {error, Reason} ->
             {error, {format, Reason}, State};
         {ok, Inputs, Query, Timeout} ->
-            pipe_mapreduce(Req, State, Inputs, Query, Timeout)
+            %% check for link walk queries when security is enabled,
+            %% we don't allow them.
+            case {riak_core_security:is_enabled(),
+                  lists:keyfind(link, 1, Query)} of
+                {true, Links} when Links /= false ->
+                    %% we don't support link walking when security is
+                    %% enabled, return an error of some kind
+                    {error, {format, "Link walking is"
+                             " deprecated in Riak 2.0 and is"
+                             " not compatible with security."}, State};
+                _ ->
+                    pipe_mapreduce(Req, State, Inputs, Query, Timeout)
+            end
     end.
 
 process_stream(#kv_mrc_sink{ref=ReqId,


### PR DESCRIPTION
Link walking is deprecated in 2.0, so we won't make it work with
security. Also, Erlang mapreduce phases and inputs must now use modules
that reside in an add_paths directory in the config file. This is to
prevent arbitrary use of the Erlang standard library to do malicious
things.
