### PR TITLE
Merge CRDTs inside riak_object merge

### DIFF
--- a/src/riak_kv_crdt.erl
+++ b/src/riak_kv_crdt.erl
@@ -25,6 +25,7 @@
 -export([update/3, merge/1, value/2, new/3,
          supported/1, to_mod/1, from_mod/1]).
 -export([to_binary/2, to_binary/1, from_binary/1]).
+-export([log_merge_errors/4, meta/2, merge_value/2]).
 
 -include("riak_kv_wm_raw.hrl").
 -include_lib("riak_kv_types.hrl").
@@ -103,6 +104,12 @@ merge_object(RObj) ->
     maybe_log_sibling_crdts(Bucket, Key, CRDTs),
     {CRDTs, NonCRDTSiblings}.
 
+%% @doc log any accumulated merge errors
+-spec log_merge_errors(riak_object:bucket(), riak_object:key(), crdts(), list()) -> ok.
+log_merge_errors(Bucket, Key, CRDTs, Errors) ->
+    log_errors(Bucket, Key, Errors),
+    maybe_log_sibling_crdts(Bucket, Key, CRDTs).
+
 log_errors(_, _, []) ->
     ok;
 log_errors(Bucket, Key, Errors) ->
@@ -124,9 +131,8 @@ merge_contents(Contents) ->
                 {orddict:new(), [], []},
                Contents).
 
-%% @private worker for `merge_contents/1' if the content is a CRDT,
-%% de-binary it, merge it and store the most merged value in the
-%% accumulator dictionary.
+%% @doc if the content is a CRDT, de-binary it, merge it and store the
+%% most merged value in the accumulator dictionary.
 -spec merge_value(ro_content(), {crdts(), ro_contents()}) ->
                          {crdts(), ro_contents()}.
 merge_value({MD, <<?TAG:8/integer, Version:8/integer, CRDTBin/binary>>=Content},
@@ -293,7 +299,12 @@ merge_meta(CType, Meta1, Meta2) ->
            end,
     %% Make sure the content type is
     %% up-to-date
-    dict:store(?MD_CTYPE, CType, Meta).
+    drop_the_dot(dict:store(?MD_CTYPE, CType, Meta)).
+
+%% @private Never keep a dot for CRDTs, we want all values to survive
+%% a riak_obect:merge/2
+drop_the_dot(Dict) ->
+    dict:erase(riak_object:dot_key(), Dict).
 
 lastmod(Meta) ->
     dict:fetch(?MD_LASTMOD, Meta).

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1186,9 +1186,7 @@ handle_crdt(_, undefined, _VId, RObj) ->
 handle_crdt(true, CRDTOp, VId, RObj) ->
     riak_kv_crdt:update(RObj, VId, CRDTOp);
 handle_crdt(false, _CRDTOp, _Vid, RObj) ->
-    %% non co-ord put that was a CRDT operation? Merge the values if
-    %% there are siblings 'cos that is the point of CRDTs: no siblings
-    riak_kv_crdt:merge(RObj).
+    RObj.
 
 perform_put({fail, _, _}=Reply, State, _PutArgs) ->
     {Reply, State};


### PR DESCRIPTION
Why? Well it means no CRDT siblings on disk. Previously CRDTs
were merged only when a CRDT Operation was performed from the CRDT
API endpoints. This means read repair, AAE, and repl, could all cause
siblings on disk.

With the addition of DVV style causality, we need to make a choice
about CRDTs. We don't have DVVSets and the anonymous list. So CRDTs
either have to merge Dots into a mini-version-vector, or not have dots.

If CRDTs don't have dots, so their values always survive a merge,
then they are subject to repl induced sibling-explosion (possibly)

Merging in riak_object:merge solves that issue.
As an added benefit it also means that Yokozuna indexing of CRDTs
will just work.

I'd really appreciate a performance comparision between this and
the plain DVV branch, and the pre-DVV stuff for 2.0.
