### PR TITLE
Fix CS buckets 2i query

### DIFF
--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -141,11 +141,17 @@ handle_query_results(ReturnTerms, MaxResults,  {ok, Results}, State) ->
     Resp = encode_results(ReturnTerms, Results, Cont),
     {reply, Resp, State}.
 
+query_params(#rpbindexreq{index=Index= <<"$bucket">>,
+                          term_regex=Re, max_results=MaxResults,
+                          continuation=Continuation}) ->
+    [{field, Index},
+     {return_terms, false}, {term_regex, Re},
+     {max_results, MaxResults}, {continuation, Continuation}];
 query_params(#rpbindexreq{qtype=eq, index=Index, key=Value,
                           term_regex=Re, max_results=MaxResults,
                           continuation=Continuation}) ->
-    [{field, Index}, {start_term, Value}, {term_regex, Re},
-     {max_results, MaxResults}, {continuation, Continuation}];
+    [{field, Index}, {start_term, Value}, {end_term, Value}, {term_regex, Re},
+     {max_results, MaxResults}, {return_terms, false}, {continuation, Continuation}];
 query_params(#rpbindexreq{index=Index, range_min=Min, range_max=Max,
                           term_regex=Re, max_results=MaxResults,
                           continuation=Continuation}) ->


### PR DESCRIPTION
This change makes sure that those always use pagination sort and fixes a
problem with start/end parameters after the refactor for the 1.4.4 2i
changes.  This uncovered some inconsistencies with the internal 2i query
parameters. This makes sure that bucket queries don't set start/end terms
and quality always have start=end and return_terms=false, among other
things. All 2i riak tests pass with this.

@russelldb my man, if you could please review this, it would be spectacular.
