### PR TITLE
Make vnode_status overload safe

### DIFF
--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -429,13 +429,19 @@ leveldb_read_block_errors() ->
 
 vnode_status(Idx) ->
     PList = [{Idx, node()}],
-    [{Idx, [Status]}] = riak_kv_vnode:vnode_status(PList),
-    Status.
+    case riak_kv_vnode:vnode_status(PList) of
+        [{Idx, [Status]}] ->
+            Status;
+        Err ->
+            Err
+    end.
 
 leveldb_read_block_errors({backend_status, riak_kv_eleveldb_backend, Status}) ->
     rbe_val(proplists:get_value(read_block_error, Status));
 leveldb_read_block_errors({backend_status, riak_kv_multi_backend, Statuses}) ->
     multibackend_read_block_errors(Statuses, undefined);
+leveldb_read_block_errors({error, Reason}) ->
+    {error, Reason};
 leveldb_read_block_errors(_) ->
     undefined.
 

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -429,12 +429,8 @@ leveldb_read_block_errors() ->
 
 vnode_status(Idx) ->
     PList = [{Idx, node()}],
-    case riak_kv_vnode:vnode_status(PList) of
-        [{Idx, [Status]}] ->
-            Status;
-        Err ->
-            Err
-    end.
+    [{Idx, [Status]}] = riak_kv_vnode:vnode_status(PList),
+    Status.
 
 leveldb_read_block_errors({backend_status, riak_kv_eleveldb_backend, Status}) ->
     rbe_val(proplists:get_value(read_block_error, Status));

--- a/src/riak_kv_status.erl
+++ b/src/riak_kv_status.erl
@@ -48,7 +48,8 @@ transfers() ->
 vnode_status() ->
     %% Get the kv vnode indexes and the associated pids for the node.
     PrefLists = riak_core_vnode_manager:all_index_pid(riak_kv_vnode),
-    riak_kv_vnode:vnode_status(PrefLists).
+    %% Using the Pids for this request byepasses overload protection
+    riak_kv_vnode:vnode_status([{Idx, node()} || {Idx, _Pid} <- PrefLists]).
 
 %% @doc Get status of 2i reformat. If the backend requires reformatting, a boolean
 %%      value is returned indicating if all partitions on the node have completed

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -403,6 +403,8 @@ handle_overload_command(?KV_PUT_REQ{}, Sender, Idx) ->
     riak_core_vnode:reply(Sender, {fail, Idx, overload});
 handle_overload_command(?KV_GET_REQ{req_id=ReqID}, Sender, Idx) ->
     riak_core_vnode:reply(Sender, {r, {error, overload}, Idx, ReqID});
+handle_overload_command(?KV_VNODE_STATUS_REQ{}, Sender, _Idx) ->
+    riak_core_vnode:reply(Sender, {error, overload});
 handle_overload_command(_, _, _) ->
     %% not handled yet
     ok.
@@ -1777,6 +1779,8 @@ wait_for_vnode_status_results(PrefLists, ReqId, Acc) ->
             wait_for_vnode_status_results(UpdPrefLists,
                                           ReqId,
                                           [{Index, Status} | Acc]);
+        {ReqId, {error, overload}} ->
+            {error, overload};
          _ ->
             wait_for_vnode_status_results(PrefLists, ReqId, Acc)
     end.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -403,8 +403,8 @@ handle_overload_command(?KV_PUT_REQ{}, Sender, Idx) ->
     riak_core_vnode:reply(Sender, {fail, Idx, overload});
 handle_overload_command(?KV_GET_REQ{req_id=ReqID}, Sender, Idx) ->
     riak_core_vnode:reply(Sender, {r, {error, overload}, Idx, ReqID});
-handle_overload_command(?KV_VNODE_STATUS_REQ{}, Sender, _Idx) ->
-    riak_core_vnode:reply(Sender, {error, overload});
+handle_overload_command(?KV_VNODE_STATUS_REQ{}, Sender, Idx) ->
+    riak_core_vnode:reply(Sender, {vnode_status, Idx, [{error, overload}]});
 handle_overload_command(_, _, _) ->
     %% not handled yet
     ok.
@@ -1779,8 +1779,6 @@ wait_for_vnode_status_results(PrefLists, ReqId, Acc) ->
             wait_for_vnode_status_results(UpdPrefLists,
                                           ReqId,
                                           [{Index, Status} | Acc]);
-        {ReqId, {error, overload}} ->
-            {error, overload};
          _ ->
             wait_for_vnode_status_results(PrefLists, ReqId, Acc)
     end.


### PR DESCRIPTION
- add overload for vnode_status commands
- add handling for overload messages

This stems from the stats lockup issue.  While this will work on its own, it will occasionally break stats without the tagging stuff in https://github.com/basho/riak_core/pull/482, so these should likely be reviewed as a pair.

Testing notes:

I tested this two different ways: 
- using `meck:expect(riak_kv_vnode, vnode_status, fun(_) -> recieve ok -> ok end end).` which simulates the vnode command getting dropped silently by overload
- setting `{vnode_overload_threshold,`},` in riak_core's app.config section or advanced.config 

after 10 or so seconds you should see `riak-admin status | grep level` and `curl -s localhost:10018/stats | grep level` start returning `"stale: 0"` for the leveldb block read errors.
