### PR TITLE
Numerous AAE improvements

### DIFF
--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -202,8 +202,15 @@ init([]) ->
     schedule_reset_build_tokens(),
     {ok, State2}.
 
-handle_call({set_mode, Mode}, _From, State) ->
-    {reply, ok, State#state{mode=Mode}};
+handle_call({set_mode, Mode}, _From, State=#state{mode=CurrentMode}) ->
+    State2 = case {CurrentMode, Mode} of
+                 {auto, manual} ->
+                     %% Clear exchange queue when switching to manual mode
+                     State#state{exchange_queue=[]};
+                 _ ->
+                     State
+             end,
+    {reply, ok, State2#state{mode=Mode}};
 handle_call({manual_exchange, Exchange}, _From, State) ->
     State2 = enqueue_exchange(Exchange, State),
     {reply, ok, State2};

--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -204,7 +204,7 @@ init([]) ->
 
 handle_call({set_mode, Mode}, _From, State=#state{mode=CurrentMode}) ->
     State2 = case {CurrentMode, Mode} of
-                 {auto, manual} ->
+                 {automatic, manual} ->
                      %% Clear exchange queue when switching to manual mode
                      State#state{exchange_queue=[]};
                  _ ->

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -444,22 +444,13 @@ hash_object({Bucket, Key}, RObjBin) ->
 %% key/hash pair will be ignored.
 -spec fold_keys(index(), pid()) -> ok.
 fold_keys(Partition, Tree) ->
-    {Limit, Wait} = app_helper:get_env(riak_kv,
-                                       anti_entropy_build_throttle,
-                                       ?DEFAULT_BUILD_THROTTLE),
+    {Limit, Wait} = get_build_throttle(),
     Req = riak_core_util:make_fold_req(
             fun(BKey={Bucket,Key}, RObjBin, Acc) ->
-                    ObjSize = byte_size(RObjBin),
-                    if (Limit =/= 0) andalso ((Acc + ObjSize) > Limit) ->
-                            lager:debug("Throttling AAE rebuild for ~b ms", [Wait]),
-                            Acc2 = 0,
-                            timer:sleep(Wait);
-                       true ->
-                            Acc2 = Acc + ObjSize
-                    end,
                     IndexN = riak_kv_util:get_index_n({Bucket, Key}),
                     insert(IndexN, term_to_binary(BKey), hash_object(BKey, RObjBin),
                            Tree, [if_missing]),
+                    Acc2 = maybe_throttle_build(RObjBin, Limit, Wait, Acc),
                     Acc2
             end,
             0, false, [aae_reconstruction]),
@@ -467,6 +458,22 @@ fold_keys(Partition, Tree) ->
                                         Req,
                                         riak_kv_vnode_master, infinity),
     ok.
+
+get_build_throttle() ->
+    app_helper:get_env(riak_kv,
+                       anti_entropy_build_throttle,
+                       ?DEFAULT_BUILD_THROTTLE).
+
+maybe_throttle_build(RObjBin, Limit, Wait, Acc) ->
+    ObjSize = byte_size(RObjBin),
+    Acc2 = Acc + ObjSize,
+    if (Limit =/= 0) andalso (Acc2 > Limit) ->
+            lager:debug("Throttling AAE build for ~b ms", [Wait]),
+            timer:sleep(Wait),
+            0;
+       true ->
+            Acc2
+    end.
 
 %% Generate a new {@link hashtree} for the specified `index_n'. If this is
 %% the first hashtree created by this index_hashtree, then open/create a new

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -151,7 +151,10 @@ maybe_create_hashtrees(true, State=#state{idx=Index}) ->
     case riak_core_ring:vnode_type(Ring, Index) of
         primary ->
             RP = riak_kv_util:responsible_preflists(Index),
-            Empty = element(1, is_empty(State)),
+            Empty = case is_empty(State) of
+                        {true, _}     -> true;
+                        {false, _, _} -> false
+                    end,
             case riak_kv_index_hashtree:start(Index, RP, self(), Empty) of
                 {ok, Trees} ->
                     monitor(process, Trees),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -151,7 +151,8 @@ maybe_create_hashtrees(true, State=#state{idx=Index}) ->
     case riak_core_ring:vnode_type(Ring, Index) of
         primary ->
             RP = riak_kv_util:responsible_preflists(Index),
-            case riak_kv_index_hashtree:start(Index, RP, self()) of
+            Empty = element(1, is_empty(State)),
+            case riak_kv_index_hashtree:start(Index, RP, self(), Empty) of
                 {ok, Trees} ->
                     monitor(process, Trees),
                     State#state{hashtrees=Trees};


### PR DESCRIPTION
This pull request adds multiple improves to the AAE subsystem. Each improvement is a separate isolated commit. Reviewing this PR commit by commit would be the easiest approach.

The changes includes the following:
1. A new throttle that can be used to throttle AAE rebuilds to prevent rebuilds from monopolizing I/O.
2. A change that causes AAE trees for empty vnodes to be build instantly, rather than waiting for being scheduled in the future and performing an empty fold. With this change, newly provisioned clusters come up with AAE trees already built.
3. The ability to disable AAE expiration by setting the expiration time to `never`.
4. A bug fix that ensures in-memory AAE buffers are flushed to LevelDB before closing the AAE trees. Also, cleanly close AAE trees in `riak_kv_index_hashtree:terminate/2`.
5. When switching from automatic to manual exchange mode, the existing queue of exchanges (filled by the automatic mode) is now cleared.
6. AAE trees are no longer deleted immediately when expired. Instead, trees are marked as expired, but not deleted until right before they are going to be rebuilt (ie. after being scheduled and acquiring all necessary locks). The previous behavior was to throw all trees away, even though most would not be re-built until hours/days later.

For more information, more detailed commit message exist for most of these changes.

Sibling pull request: basho/riak_core#483, basho/riak_test#481
