### PR TITLE
Fixed 2i queries in mixed clusters

### DIFF
--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -327,7 +327,7 @@ make_query({range, ?KEYFIELD, Start, End}, Q) ->
                 end_term=End, return_terms=false}};
 make_query({range, Field, Start, End}, Q) ->
     {ok, Q?KV_INDEX_Q{filter_field=Field, start_term=Start,
-                 end_term=End}};
+                 end_term=End, return_terms=false}};
 make_query(V1Q, _) ->
     {error, {invalid_v1_query, V1Q}}.
 
@@ -398,10 +398,12 @@ downgrade_query(V, Q) ->
 %% @doc Should index terms be returned in a result
 %% to the client. Requires both that they are wanted (arg1)
 %% and available (arg2)
-return_terms(true, ?KV_INDEX_Q{return_terms=true}) ->
-    true;
-return_terms(_, _) ->
-    false.
+return_terms(false, _) ->
+    false;
+return_terms(true, ?KV_INDEX_Q{return_terms=ReturnTerms}) ->
+    ReturnTerms;
+return_terms(true, OldQ) ->
+    return_terms(true, upgrade_query(OldQ)).
 
 %% @doc Should the object body of an indexed key
 %% be returned with the result?


### PR DESCRIPTION
- In a mixed 1.4.2 - 1.4.4+ cluster, terms are not passed back to a
  query originating in a 1.4.2 node.
- In a mixed 1.3.2 - 1.4.X cluster, terms are passed back to the 1.3.2
  if the query originated there.

A riak test will be made soon. In the meantime this is easy to verify from the command line.  Make a mixed cluster with two nodes (dev1=1.4.2, dev2=1.4.4). Create a range of items:

``` bash
for n in {a..z}; do 
curl -X POST -H "x-riak-index-b_bin: $n" -d"$n" http://localhost:10018/buckets/b/keys/k$n 
done
```

And query either node requesting terms to be returned from both nodes with and without the fix:

``` bash
curl -v http://localhost:10018/buckets/b/index/b_bin/a/f?return_terms=true
curl -v http://localhost:10028/buckets/b/index/b_bin/a/f?return_terms=true
```

Now a different cluster (dev1=1.3.2, dev2=1.4.4), populate the same way:

``` bash
for n in {a..z}; do 
curl -X POST -H "x-riak-index-b_bin: $n" -d"$n" http://localhost:10018/buckets/b/keys/k$n 
done
```

And do a range query on both nodes(return terms is not understood by the 1.3 node, so don't try that):

``` bash
curl -v http://localhost:10018/buckets/b/index/b_bin/a/f
curl -v http://localhost:10028/buckets/b/index/b_bin/a/f
```
