### PR TITLE
Integrate Background Manager with Handoff And AAE Tree Rebuilds

### DIFF
--- a/include/riak_kv_vnode.hrl
+++ b/include/riak_kv_vnode.hrl
@@ -68,4 +68,4 @@
 %% @doc vnode_lock(PartitionIndex) is a kv per-vnode lock, used possibly,
 %% by AAE tree rebuilds, fullsync, and handoff.
 %% See @link riak_core_background_mgr:get_lock/1
--define(VNODE_LOCK(Idx), {vnode_lock, Idx}).
+-define(KV_VNODE_LOCK(Idx), {vnode_lock, Idx}).

--- a/include/riak_kv_vnode.hrl
+++ b/include/riak_kv_vnode.hrl
@@ -64,3 +64,8 @@
 -define(KV_DELETE_REQ, #riak_kv_delete_req_v1).
 -define(KV_MAP_REQ, #riak_kv_map_req_v1).
 -define(KV_VCLOCK_REQ, #riak_kv_vclock_req_v1).
+
+%% @doc vnode_lock(PartitionIndex) is a kv per-vnode lock, used possibly,
+%% by AAE tree rebuilds, fullsync, and handoff.
+%% See @link riak_core_background_mgr:get_lock/1
+-define(VNODE_LOCK(Idx), {vnode_lock, Idx}).

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -28,6 +28,7 @@
 -behaviour(gen_server).
 
 -include_lib("riak_kv_vnode.hrl").
+-include_lib("riak_core/include/riak_core_locks.hrl").
 
 %% API
 -export([start/3, start_link/3]).
@@ -680,22 +681,60 @@ build_or_rehash(Self, State=#state{index=Index, trees=Trees}) ->
                false -> build;
                true  -> rehash
            end,
-    Lock = riak_kv_entropy_manager:get_lock(Type),
-    case {Lock, Type} of
-        {ok, build} ->
-            lager:debug("Starting build: ~p", [Index]),
-            fold_keys(Index, Self),
-            lager:debug("Finished build (a): ~p", [Index]), 
-            gen_server:cast(Self, build_finished);
-        {ok, rehash} ->
-            lager:debug("Starting rehash: ~p", [Index]),
-            [hashtree:rehash_tree(T) || {_,T} <- Trees],
-            lager:debug("Finished rehash (a): ~p", [Index]),
-            gen_server:cast(Self, build_finished);
-        {_Error, _} ->
+    case maybe_get_vnode_lock(Index) of
+        ok ->
+            Lock = riak_kv_entropy_manager:get_lock(Type),
+            case {Lock, Type} of
+                {ok, build} ->
+                    lager:debug("Starting build: ~p", [Index]),
+                    fold_keys(Index, Self),
+                    lager:debug("Finished build (a): ~p", [Index]), 
+                    gen_server:cast(Self, build_finished);
+                {ok, rehash} ->
+                    lager:debug("Starting rehash: ~p", [Index]),
+                    [hashtree:rehash_tree(T) || {_,T} <- Trees],
+                    lager:debug("Finished rehash (a): ~p", [Index]),
+                    gen_server:cast(Self, build_finished);
+                {_Error, _} ->
+                    gen_server:cast(Self, build_failed)
+            end;
+        max_concurrency ->
+            %% Something else is already doing a fold on this vnode.
             gen_server:cast(Self, build_failed)
     end.
 
 close_trees(State=#state{trees=Trees}) ->
     Trees2 = [{IdxN, hashtree:close(Tree)} || {IdxN, Tree} <- Trees],
     State#state{trees=Trees2}.
+
+%% @private
+%% @doc Return true iff neither of the "skip background manager" configuration
+%%      settings are defined as anything other than false. 'skip_background_manager'
+%%      turns off all use of bg-mgr. 'aae_skip_background_manager' only stops
+%%      AAE tree rebuilds from using bg-mgr.
+-spec use_bg_mgr() -> boolean().
+use_bg_mgr() ->
+    %% note we're tolerant here of any non-boolean value as well. Iff it's 'false', we don't skip.
+    GlobalSkip = app_helper:get_env(riak_core, skip_background_manager, false) =/= false,
+    AAESkip = not app_helper:get_env(riak_core, aae_skip_background_manager, false) =/= false,
+    not (GlobalSkip orelse AAESkip).
+
+%% @private
+%% @doc Unless skipping the background manager, try to acquire the per-vnode lock.
+%%      Sets our task meta-data in the lock as 'aae_rebuild', which is useful for
+%%      seeing what's holding the lock via @link riak_core_background_mgr:ps/0.
+-spec maybe_get_vnode_lock(SrcPartition::integer()) -> ok | max_concurrency.
+maybe_get_vnode_lock(SrcPartition) ->
+    Lock = ?VNODE_LOCK(SrcPartition),
+    case use_bg_mgr() of
+        true  ->
+            case riak_core_bg_manager:get_lock(Lock, self(), [{task, aae_rebuild}]) of
+                {ok, _Ref} -> ok;
+                max_concurrency -> max_concurrency
+            end;
+        false ->
+            lager:debug("Handoff is skipping the background manager vnode lock: ~p", [Lock]),
+            ok
+    end.
+
+    

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -714,7 +714,7 @@ close_trees(State=#state{trees=Trees}) ->
 maybe_get_vnode_lock(SrcPartition) ->
     case riak_core_bg_manager:use_bg_mgr(riak_kv, aae_use_background_manager) of
         true  ->
-            Lock = ?VNODE_LOCK(SrcPartition),
+            Lock = ?KV_VNODE_LOCK(SrcPartition),
             case riak_core_bg_manager:get_lock(Lock, self(), [{task, aae_rebuild}]) of
                 {ok, _Ref} -> ok;
                 max_concurrency -> max_concurrency


### PR DESCRIPTION
NOTE: DO NOT MERGE YET (this PR requires code from #475 or https://github.com/basho/riak_core/pull/484)

The riak_core handoff portion is here: https://github.com/basho/riak_core/pull/484 (includes #475)
The riak_core background manager PR is here: basho/riak_core#475
The riak_repl PR is here: basho/riak_repl#488

The background manager allows subsystems to coordinate with locks (and tokens) in a non-blocking API when desired. In our case, we've seen several customer support issues related to a production cluster being overloaded by the combined weight of MDC fullsync replication in combination with either handoff, or AAE tree rebuilds (or all three!).

Each of these subsystems is being taught, for 2.0, to "take" a lock on the kv vnode/partition before it does a fold over that partition. Locks are returned when the process dies or exists normally. Each subsystem (at this point in time) is coded to keep working on other partitions if one partition is denied a lock via the return value of max_concurrency, which means progress is made even when one partition is busy.

Use of this feature can be bypassed in production. Besides a global skill switch on the background manager itself, the riak_core configuration supports two new parameters: aae_skip_bg_manager and handoff_skip_bg_manager, which defaults to false. Setting it to true will not call the background manager and proceed like it used to.

I chose not to separate the AAE and Handoff into two separate PRs because we already have too many, but if we determine that we want to exclude the handoff portion, I'll spit them up.
