### PR TITLE
Fix broken return terms handling

### DIFF
--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -403,7 +403,9 @@ return_terms(false, _) ->
 return_terms(true, ?KV_INDEX_Q{return_terms=ReturnTerms}) ->
     ReturnTerms;
 return_terms(true, OldQ) ->
-    return_terms(true, upgrade_query(OldQ)).
+    return_terms(true, upgrade_query(OldQ));
+return_terms(_, _) ->
+    false.
 
 %% @doc Should the object body of an indexed key
 %% be returned with the result?


### PR DESCRIPTION
This problem was introduced in the previous hotfix for mixed cluster
queries.  Queries not specifying the return_terms parameter were
failing.
