### PR TITLE
Enable bloom filters for AAE LevelDB instances

### DIFF
--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -497,7 +497,8 @@ new_segment_store(Opts, State) ->
     Config2 = orddict:store(write_buffer_size, WriteBufferSize, Config),
     Config3 = orddict:erase(write_buffer_size_min, Config2),
     Config4 = orddict:erase(write_buffer_size_max, Config3),
-    Options = orddict:store(create_if_missing, true, Config4),
+    Config5 = orddict:store(use_bloomfilter, true, Config4),
+    Options = orddict:store(create_if_missing, true, Config5),
 
     filelib:ensure_dir(DataDir),
     {ok, Ref} = eleveldb:open(DataDir, Options),


### PR DESCRIPTION
This pull-request ensures that the LevelDB instances used by AAE take advantage of bloom filters. AAE was designed assuming bloom filters were enabled, and not enabling them was an oversight. This should help AAE tree rebuild times in certain scenarios.

Sibling PR: Added harness for AAE rebuild benchmarking in basho/riak_test#488

For 100k keys, single node, N=3 running benchmark against Riak w/ and w/o this PR shows:

```
Average build time: 19721090 us (w/o bloom filter)
Average build time: 19020692 us (w/ bloom filter)
```

Granted, those results are likely in the noise. But, at least shows that things aren't worse. Currently running some larger benchmark, and will add results to this pull request before merging.
