### PR TITLE
2i improvements added in 1.4.4-1.4.6

### DIFF
--- a/include/riak_kv_index.hrl
+++ b/include/riak_kv_index.hrl
@@ -32,4 +32,17 @@
           return_body=false ::boolean() %% Note, only for riak cs bucket folds
          }).
 
--define(KV_INDEX_Q, #riak_kv_index_v2).
+-record(riak_kv_index_v3, {
+          start_key= <<>> :: binary(),
+          filter_field :: binary() | undefined,
+          start_term :: binary() | undefined, %% Note, in a $key query, start_key==start_term
+          end_term :: binary() | undefined, %% Note, in an eq query, start==end
+          return_terms=true :: boolean(), %% Note, should be false for an equals query
+          start_inclusive=true :: boolean(),
+          end_inclusive=true :: boolean(),
+          return_body=false ::boolean(), %% Note, only for riak cs bucket folds
+          term_regex :: binary() | undefined,
+          max_results :: integer() | undefined
+         }).
+
+-define(KV_INDEX_Q, #riak_kv_index_v3).

--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
         {erlang_js, ".*", {git, "git://github.com/basho/erlang_js.git", {branch, "develop"}}},
         {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {branch, "develop"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", {branch, "develop"}}},
-        {sext, ".*", {git, "git://github.com/uwiger/sext.git", {tag, "1.1-3-g3af5478"}}},
+        {sext, ".*", {git, "git://github.com/basho/sext.git", {tag, "1.1p1"}}},
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {branch, "develop"}}},
         {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {branch, "develop"}}},
         {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {branch, "develop"}}}

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -670,9 +670,10 @@ get_index(Bucket, Query, {?MODULE, [_Node, _ClientId]}=THIS) ->
 get_index(Bucket, Query, Opts, {?MODULE, [Node, _ClientId]}) ->
     Timeout = proplists:get_value(timeout, Opts, ?DEFAULT_TIMEOUT),
     MaxResults = proplists:get_value(max_results, Opts, all),
+    PgSort = proplists:get_value(pagination_sort, Opts),
     Me = self(),
     ReqId = mk_reqid(),
-    riak_kv_index_fsm_sup:start_index_fsm(Node, [{raw, ReqId, Me}, [Bucket, none, Query, Timeout, MaxResults]]),
+    riak_kv_index_fsm_sup:start_index_fsm(Node, [{raw, ReqId, Me}, [Bucket, none, Query, Timeout, MaxResults, PgSort]]),
     wait_for_query_results(ReqId, Timeout).
 
 %% @doc Run the provided index query, return a stream handle.
@@ -689,13 +690,14 @@ stream_get_index(Bucket, Query, {?MODULE, [_Node, _ClientId]}=THIS) ->
 stream_get_index(Bucket, Query, Opts, {?MODULE, [Node, _ClientId]}) ->
     Timeout = proplists:get_value(timeout, Opts, ?DEFAULT_TIMEOUT),
     MaxResults = proplists:get_value(max_results, Opts, all),
+    PgSort = proplists:get_value(pagination_sort, Opts),
     Me = self(),
     ReqId = mk_reqid(),
     case riak_kv_index_fsm_sup:start_index_fsm(Node,
                                                [{raw, ReqId, Me},
                                                 [Bucket, none,
                                                  Query, Timeout,
-                                                 MaxResults]]) of
+                                                 MaxResults, PgSort]]) of
         {ok, Pid} ->
             {ok, ReqId, Pid};
         {error, Reason} ->

--- a/src/riak_kv_2i_aae.erl
+++ b/src/riak_kv_2i_aae.erl
@@ -1,0 +1,673 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Code related to repairing 2i data.
+-module(riak_kv_2i_aae).
+-behaviour(gen_fsm).
+
+-include("riak_kv_wm_raw.hrl").
+
+-export([start/2, stop/1, get_status/0, to_report/1]).
+
+-export([next_partition/2, wait_for_aae_pid/2, wait_for_repair/3,
+         wait_for_repair/2]).
+
+%% gen_fsm callbacks
+-export([init/1,
+         handle_event/3,
+         handle_sync_event/4,
+         handle_info/3,
+         format_status/2,
+         terminate/3,
+         code_change/4]).
+
+-export_type([status/0, partition_result/0, worker_status/0]).
+
+%% How many items to scan before possibly pausing to obey speed throttle
+-define(DEFAULT_SCAN_BATCH, 1000).
+-define(MAX_DUTY_CYCLE, 100).
+-define(MIN_DUTY_CYCLE, 1).
+-define(LOCK_RETRIES, 10).
+-define(AAE_PID_TIMEOUT, 30000).
+-define(INDEX_SCAN_TIMEOUT, 300000). % 5 mins, in case fold dies timeout
+-define(INDEX_REFRESH_TIMEOUT, 60000).
+
+-type worker_status() :: starting | scanning_indexes | populating_hashtree |
+                         exchanging.
+
+-type partition_result() :: {Partition :: integer(),
+                             {ok,  term()} | {error, term()}}.
+
+-type status() :: [{speed, integer()} |
+                   {partitions, [integer()]} |
+                   {remaining, [integer()]} |
+                   {results, [partition_result()]}|
+                   {current_partition, integer()} |
+                   {current_partition_status, worker_status()} |
+                   {index_scan_count, integer()} |
+                   {hashtree_population_count, integer()} |
+                   {exchange_count, integer()}].
+
+-record(state,
+        {
+         speed :: integer(),
+         partitions :: [integer()],
+         remaining :: [integer()],
+         results = [],
+         caller :: pid(),
+         reply_to,
+         early_reply,
+         aae_pid_req_id :: pid() | undefined,
+         worker_monitor :: reference() | undefined,
+         worker_status :: worker_status(),
+         index_scan_count = 0 :: integer(),
+         hashtree_population_count = 0 :: integer(),
+         exchange_count = 0 :: integer(),
+         open_dbs = [] :: [reference()]
+        }).
+
+-record(partition_result, {
+          status :: ok | error,
+          error,
+          index_scan_count = 0 :: integer(),
+          hashtree_population_count = 0:: integer(),
+          exchange_count = 0 :: integer()
+         }).
+
+
+%% @doc Starts a process that will issue a repair for each partition in the
+%% list, sequentially.
+%% The Speed parameter controls how fast we go. 100 means full speed,
+%% 50 means to do a unit of work and pause for the duration of that unit
+%% to achieve a 50% duty cycle, etc.
+%% If a single partition is requested, this function will block until that
+%% partition has been blocked or that fails to notify the user immediately.
+-spec start([integer()], integer()) -> {ok, pid()} | {error, term()}.
+start(Partitions, Speed)
+  when Speed >= ?MIN_DUTY_CYCLE, Speed =< ?MAX_DUTY_CYCLE ->
+    Res = gen_fsm:start({local, ?MODULE}, ?MODULE,
+                        [Partitions, Speed, self()], []),
+    case {Res, length(Partitions)} of
+        {{ok, _Pid}, 1} ->
+            try
+                EarlyAck = gen_fsm:sync_send_all_state_event(?MODULE,
+                                                             early_ack,
+                                                             infinity),
+                case EarlyAck of
+                    lock_acquired ->
+                        Res;
+                    _ ->
+                        EarlyAck
+                end
+            catch
+                exit:_ ->
+                    {error, early_exit}
+            end;
+
+        _ ->
+            Res
+    end.
+
+%% @doc Will stop any worker process and try to close leveldb databases.
+stop(TimeOut) ->
+    gen_fsm:sync_send_all_state_event(?MODULE, stop, TimeOut).
+
+-spec get_status() -> [{Key :: atom(), Val :: term()}].
+get_status() ->
+    gen_fsm:sync_send_all_state_event(?MODULE, status, infinity).
+
+init([Partitions, Speed, Caller]) ->
+    process_flag(trap_exit, true),
+    lager:info("Starting 2i repair at speed ~p for partitions ~p",
+               [Speed, Partitions]),
+    {ok, next_partition, #state{partitions=Partitions, remaining=Partitions,
+                                speed=Speed, caller=Caller}, 0}.
+
+%% @doc Notifies caller for certain cases involving a single partition
+%% so the user sees an error condition from the command line.
+maybe_notify(State=#state{reply_to=undefined}, Reply) ->
+    State#state{early_reply=Reply};
+maybe_notify(State=#state{reply_to=From}, Reply) ->
+    gen_fsm:reply(From, Reply),
+    State#state{reply_to=undefined}.
+
+
+%% @doc Process next partition or finish if no more remaining.
+next_partition(timeout, State=#state{remaining=[]}) ->
+    %% We are done. Report results
+    Status = to_simple_state(State),
+    Report = to_report(Status),
+    lager:info("Finished 2i repair:\n~s", [Report]),
+    {stop, normal, State};
+next_partition(timeout, State=#state{remaining=[Partition|_]}) ->
+    ReqId = make_ref(),
+    riak_kv_vnode:request_hashtree_pid(Partition, {fsm, ReqId, self()}),
+    {next_state, wait_for_aae_pid, State#state{aae_pid_req_id=ReqId}, ?AAE_PID_TIMEOUT}.
+
+%% @doc Waiting for vnode to send back the Pid of the AAE tree process.
+wait_for_aae_pid(timeout, State) ->
+    State2 = maybe_notify(State, {error, no_aae_pid}),
+    {stop, no_aae_pid, State2};
+wait_for_aae_pid({ReqId, {error, Err}}, State=#state{aae_pid_req_id=ReqId}) ->
+    State2 = maybe_notify(State, {error, {no_aae_pid, Err}}),
+    {stop, no_aae_pid, State2};
+wait_for_aae_pid({ReqId, {ok, TreePid}},
+                 State=#state{aae_pid_req_id=ReqId, speed=Speed,
+                              remaining=[Partition|_]}) ->
+    WorkerFun =
+    fun() ->
+            Res =
+            repair_partition(Partition, Speed, ?MODULE, TreePid),
+            gen_fsm:sync_send_event(?MODULE, {repair_result, Res}, infinity)
+    end,
+    Mon = monitor(process, spawn_link(WorkerFun)),
+    {next_state, wait_for_repair, State#state{worker_monitor=Mon}}.
+
+%% @doc Waiting for a partition repair process to finish
+wait_for_repair({lock_acquired, Partition},
+                _From,
+                State=#state{remaining=[Partition|_]}) ->
+    State2 = maybe_notify(State, lock_acquired),
+    {reply, ok, wait_for_repair, State2};
+wait_for_repair({repair_result, Res},
+                _From,
+                State=#state{remaining=[Partition|Rem],
+                             results=Results,
+                             worker_monitor=Mon}) ->
+    State2 =
+    case Res of
+        {error, {lock_failed, LockErr}} ->
+            maybe_notify(State, {lock_failed, LockErr});
+        _ ->
+            State
+    end,
+    demonitor(Mon, [flush]),
+    {reply, ok, next_partition,
+     State2#state{remaining=Rem,
+                  results=[{Partition, Res}|Results],
+                  worker_monitor=undefined,
+                  worker_status=starting,
+                  index_scan_count=0,
+                  hashtree_population_count=0,
+                  exchange_count=0},
+     0}.
+
+%% @doc Process async worker status updates during a repair
+wait_for_repair({index_scan_update, Count}, State) ->
+    {next_state, wait_for_repair,
+     State#state{worker_status=scanning_indexes,
+                 index_scan_count=Count}};
+wait_for_repair({hashtree_population_update, Count}, State) ->
+    {next_state, wait_for_repair,
+     State#state{worker_status=populating_hashtree,
+                 hashtree_population_count=Count}};
+wait_for_repair({repair_count_update, Count}, State) ->
+    {next_state, wait_for_repair,
+     State#state{worker_status=exchanging,
+                 exchange_count=Count}};
+wait_for_repair({open_db, DBRef}, State = #state{open_dbs=DBs}) ->
+    {next_state, wait_for_repair,
+     State#state{open_dbs=[DBRef|DBs]}};
+wait_for_repair({close_db, DBRef}, State = #state{open_dbs=DBs}) ->
+    {next_state, wait_for_repair,
+     State#state{open_dbs=lists:delete(DBRef, DBs)}}.
+
+%% @doc Performs the actual repair work, called from a spawned process.
+-spec repair_partition(integer(), integer(), {pid(), any()}, pid()) ->
+    #partition_result{}.
+repair_partition(Partition, DutyCycle, From, TreePid) ->
+    case get_hashtree_lock(TreePid, ?LOCK_RETRIES) of
+        ok ->
+            lager:info("Acquired lock on partition ~p", [Partition]),
+            gen_fsm:sync_send_event(From, {lock_acquired, Partition}, infinity),
+            lager:info("Repairing indexes in partition ~p", [Partition]),
+            case create_index_data_db(Partition, DutyCycle) of
+                {ok, {DBDir, DBRef, IndexDBCount}} ->
+                    Res =
+                    case build_tmp_tree(Partition, DBRef, DutyCycle) of
+                        {ok, {TmpTree, TmpTreeCount}} ->
+                            Res0 = do_exchange(Partition, DBRef, TmpTree,
+                                               TreePid),
+                            remove_tmp_tree(Partition, TmpTree),
+                            case Res0 of
+                                {ok, CmpCount} ->
+                                    #partition_result{
+                                       status=ok,
+                                       index_scan_count=IndexDBCount,
+                                       hashtree_population_count=TmpTreeCount,
+                                       exchange_count=CmpCount};
+                                {error, TmpTreeErr} ->
+                                    #partition_result{
+                                       status=error,
+                                       error=TmpTreeErr,
+                                       index_scan_count=IndexDBCount,
+                                       hashtree_population_count=TmpTreeCount}
+                            end;
+                        {error, BuildTreeErr} ->
+                            #partition_result{status=error,
+                                              error=BuildTreeErr,
+                                              index_scan_count=IndexDBCount}
+                    end,
+                    destroy_index_data_db(DBDir, DBRef),
+                    lager:info("Finished repairing indexes in partition ~p",
+                               [Partition]),
+                    Res;
+                {error, CreateDBErr} ->
+                    #partition_result{status=error, error=CreateDBErr}
+            end;
+        LockErr ->
+            lager:error("Failed to acquire hashtree lock on partition ~p",
+                        [Partition]),
+            #partition_result{status=error, error=LockErr}
+    end.
+
+%% No wait for speed 100, wait equal to work time when speed is 50,
+%% wait equal to 99 times the work time when speed is 1.
+wait_factor(DutyCycle) ->
+    if
+        %% Avoid potential floating point funkiness for full speed.
+        DutyCycle >= ?MAX_DUTY_CYCLE -> 0;
+        true -> (100 - DutyCycle) / DutyCycle
+    end.
+
+scan_batch() ->
+    app_helper:get_env(riak_kv, aae_2i_batch_size, ?DEFAULT_SCAN_BATCH).
+
+%% @doc Create temporary DB holding 2i index data from disk.
+create_index_data_db(Partition, DutyCycle) ->
+    DBDir = filename:join(data_root(), "tmp_db"),
+    (catch eleveldb:destroy(DBDir, [])),
+    case filelib:ensure_dir(DBDir) of
+        ok ->
+            create_index_data_db(Partition, DutyCycle, DBDir);
+        _ ->
+            {error, io_lib:format("Could not create directory ~s", [DBDir])}
+    end.
+
+create_index_data_db(Partition, DutyCycle, DBDir) ->
+    lager:info("Creating temporary database of 2i data in ~s", [DBDir]),
+    DBOpts = leveldb_opts(),
+    case eleveldb:open(DBDir, DBOpts) of
+        {ok, DBRef} ->
+            create_index_data_db(Partition, DutyCycle, DBDir, DBRef);
+        {error, DBErr} ->
+            {error, DBErr}
+    end.
+
+create_index_data_db(Partition, DutyCycle, DBDir, DBRef) ->
+    Client = self(),
+    BatchRef = make_ref(),
+    WaitFactor = wait_factor(DutyCycle),
+    ScanBatch = scan_batch(),
+    Fun =
+    fun(Bucket, Key, Field, Term, Count) ->
+            BKey = term_to_binary({Bucket, Key}),
+            OldVal = fetch_index_data(BKey, DBRef),
+            Val = [{Field, Term}|OldVal],
+            ok = eleveldb:put(DBRef, BKey, term_to_binary(Val), []),
+            Count2 = Count + 1,
+            case Count2 rem ScanBatch of
+                0 when DutyCycle < ?MAX_DUTY_CYCLE ->
+                    Mon = monitor(process, Client),
+                    Client ! {BatchRef, self(), Count2},
+                    receive
+                        {BatchRef, continue} ->
+                            ok;
+                        {'DOWN', Mon, _, _, _} ->
+                            throw(fold_receiver_died)
+                    end,
+                    demonitor(Mon, [flush]);
+                _ ->
+                    ok
+            end,
+            Count2
+    end,
+    lager:info("Grabbing all index data for partition ~p", [Partition]),
+    Ref = make_ref(),
+    Sender = {raw, Ref, Client},
+    StartTime = now(),
+    riak_core_vnode_master:command({Partition, node()},
+                                   {fold_indexes, Fun, 0},
+                                   Sender,
+                                   riak_kv_vnode_master),
+    NumFound = wait_for_index_scan(Ref, BatchRef, StartTime, WaitFactor),
+    case NumFound of
+        {error, _} = Err ->
+            destroy_index_data_db(DBDir, DBRef),
+            Err;
+        _ ->
+            lager:info("Grabbed ~p index data entries from partition ~p",
+                       [NumFound, Partition]),
+            {ok, {DBDir, DBRef, NumFound}}
+    end.
+
+leveldb_opts() ->
+    ConfigOpts = app_helper:get_env(riak_kv,
+                                    anti_entropy_leveldb_opts,
+                                    [{write_buffer_size, 20 * 1024 * 1024},
+                                     {max_open_files, 20}]),
+    Config0 = orddict:from_list(ConfigOpts),
+    ForcedOpts = [{create_if_missing, true}, {error_if_exists, true}],
+    Config =
+    lists:foldl(fun({K,V}, Cfg) ->
+                        orddict:store(K, V, Cfg)
+                end, Config0, ForcedOpts),
+    Config.
+
+duty_cycle_pause(WaitFactor, StartTime) ->
+    case WaitFactor > 0 of
+        true ->
+            Now = now(),
+            ElapsedMicros = timer:now_diff(Now, StartTime),
+            WaitMicros = ElapsedMicros * WaitFactor,
+            WaitMillis = trunc(WaitMicros / 1000 + 0.5),
+            timer:sleep(WaitMillis);
+        false ->
+            ok
+    end.
+
+%% @doc Async notify this FSM of an update.
+-spec send_event(any()) -> ok.
+send_event(Event) ->
+    gen_fsm:send_event(?MODULE, Event).
+
+%% @doc Waiting for 2i data scanning updates and final result.
+wait_for_index_scan(Ref, BatchRef, StartTime, WaitFactor) ->
+    receive
+        {BatchRef, Pid, Count} ->
+            duty_cycle_pause(WaitFactor, StartTime),
+            Pid ! {BatchRef, continue},
+            send_event({index_scan_update, Count}),
+            wait_for_index_scan(Ref, BatchRef, now(), WaitFactor);
+        {Ref, Result} ->
+            Result
+    after
+        ?INDEX_SCAN_TIMEOUT ->
+            {error, index_scan_timeout}
+    end.
+
+-spec fetch_index_data(BK :: binary(), reference()) -> term().
+fetch_index_data(BK, DBRef) ->
+    % Let it crash on leveldb error
+    case eleveldb:get(DBRef, BK, []) of
+        {ok, BinVal} ->
+            binary_to_term(BinVal);
+        not_found ->
+            []
+    end.
+
+%% @doc Remove all traces of the temporary 2i index DB
+destroy_index_data_db(DBDir, DBRef) ->
+    catch eleveldb:close(DBRef),
+    eleveldb:destroy(DBDir, []).
+
+%% @doc Returns the base data directory to use inside the AAE directory.
+data_root() ->
+    BaseDir = riak_kv_index_hashtree:determine_data_root(),
+    filename:join(BaseDir, "2i").
+
+%% @doc Builds a temporary hashtree based on the 2i data fetched from the
+%% backend.
+build_tmp_tree(Index, DBRef, DutyCycle) ->
+    lager:info("Building tree for 2i data on disk for partition ~p", [Index]),
+    %% Build temporary hashtree with this index data.
+    TreeId = <<0:176/integer>>,
+    Path = filename:join(data_root(), integer_to_list(Index)),
+    catch eleveldb:destroy(Path, []),
+    case filelib:ensure_dir(Path) of
+        ok ->
+            Tree = hashtree:new({Index, TreeId}, [{segment_path, Path}]),
+            WaitFactor = wait_factor(DutyCycle),
+            BatchSize = scan_batch(),
+            FoldFun =
+            fun({K, V}, {Count, TreeAcc, StartTime}) ->
+                    Indexes = binary_to_term(V),
+                    Hash = riak_kv_index_hashtree:hash_index_data(Indexes),
+                    Tree2 = hashtree:insert(K, Hash, TreeAcc),
+                    Count2 = Count + 1,
+                    StartTime2 =
+                    case Count2 rem BatchSize of
+                        0 ->
+                            send_event({hashtree_population_update, Count2}),
+                            duty_cycle_pause(WaitFactor, StartTime),
+                            now();
+                        _ ->
+                            StartTime
+                    end,
+                    {Count2, Tree2, StartTime2}
+            end,
+            send_event({hashtree_population_update, 0}),
+            {Count, Tree2, _} = eleveldb:fold(DBRef, FoldFun,
+                                              {0, Tree, erlang:now()}, []),
+            lager:info("Done building temporary tree for 2i data "
+                       "with ~p entries",
+                       [Count]),
+            {ok, {Tree2, Count}};
+        _ ->
+            {error, io_lib:format("Could not create directory ~s", [Path])}
+    end.
+
+%% @doc Remove all traces of the temporary hashtree for 2i index data.
+remove_tmp_tree(Partition, Tree) ->
+    lager:debug("Removing temporary AAE 2i tree for partition ~p", [Partition]),
+    hashtree:close(Tree),
+    hashtree:destroy(Tree).
+
+%% @doc Run exchange between the temporary 2i tree and the vnode's 2i tree.
+-spec do_exchange(integer(), reference(), hashtree:hashtree(), pid()) ->
+    {ok, integer()} | {error, any()}.
+do_exchange(Partition, DBRef, TmpTree0, TreePid) ->
+    lager:info("Reconciling 2i data"),
+    IndexN2i = riak_kv_index_hashtree:index_2i_n(),
+    lager:debug("Updating the vnode tree"),
+    ok = riak_kv_index_hashtree:update(IndexN2i, TreePid),
+    lager:debug("Updating the temporary 2i AAE tree"),
+    TmpTree = hashtree:update_tree(TmpTree0),
+    Remote =
+    fun(get_bucket, {L, B}) ->
+            R1 = riak_kv_index_hashtree:exchange_bucket(IndexN2i, L, B,
+                                                        TreePid),
+            R1;
+       (key_hashes, Segment) ->
+            R2 = riak_kv_index_hashtree:exchange_segment(IndexN2i, Segment,
+                                                         TreePid),
+            R2;
+       (A, B) ->
+            throw({riak_kv_2i_aae_internal_error, A, B})
+    end,
+    AccFun =
+    fun(KeyDiff, Acc) ->
+            lists:foldl(
+              fun({_DiffReason, BKeyBin}, Count) ->
+                      BK = binary_to_term(BKeyBin),
+                      IdxData = fetch_index_data(BKeyBin, DBRef),
+                      % Sync refresh it. Not in a rush here.
+                      riak_kv_vnode:refresh_index_data(Partition, BK, IdxData,
+                                                      ?INDEX_REFRESH_TIMEOUT),
+                      Count2 = Count + 1,
+                      send_event({repair_count_update, Count2}),
+                      Count2
+              end,
+              Acc, KeyDiff)
+    end,
+    try
+        NumDiff = hashtree:compare(TmpTree, Remote, AccFun, 0),
+        lager:info("Found ~p differences", [NumDiff]),
+        {ok, NumDiff}
+    catch
+        CmpErrClass:CmpErr ->
+            lager:error("Hashtree exchange failed ~p, ~p", [CmpErrClass, CmpErr]),
+            case CmpErrClass of
+                error ->
+                    {error, CmpErr};
+                _ ->
+                    {error, {CmpErrClass, CmpErr}}
+            end
+    end.
+
+get_hashtree_lock(TreePid, Retries) ->
+    case riak_kv_index_hashtree:get_lock(TreePid, local_fsm) of
+        Reply = already_locked ->
+            case Retries > 0 of
+                true ->
+                    timer:sleep(1000),
+                    get_hashtree_lock(TreePid, Retries-1);
+                false ->
+                    Reply
+            end;
+        Reply ->
+            Reply
+    end.
+
+
+%%%===================================================================
+%%% gen_fsm callbacks
+%%%===================================================================
+
+to_simple_partition_result(#partition_result{
+                              status=Status,
+                              error=Err,
+                              index_scan_count=IdxCount,
+                              hashtree_population_count=TreePopCount,
+                              exchange_count=CmpCount}) ->
+    [{status, Status}] ++
+    [{error, Err} || Err /= undefined] ++
+    [{index_scan_count, IdxCount},
+     {hashtree_population_count, TreePopCount},
+     {exchange_count, CmpCount}].
+
+%% @doc Returns a proplist simplified version of the state.
+to_simple_state(State) ->
+    #state{
+         speed=Speed,
+         partitions=Partitions,
+         remaining=Rem,
+         worker_status=WStatus,
+         index_scan_count=IdxCount,
+         hashtree_population_count=PopCount,
+         results = Results0
+      } = State,
+    Results =
+    [{Partition, to_simple_partition_result(Res)}
+     || {Partition, Res} <- Results0],
+    {TotIdxCount, TotPopCount, TotXchgCount} =
+    lists:foldl(fun({_, #partition_result{
+                       index_scan_count=NI,
+                       hashtree_population_count=NP,
+                       exchange_count=NX}}, {I, P, X}) ->
+                        {I+NI, P+NP, X+NX}
+                end, {0,0,0}, Results0),
+    PartStatus =
+    case length(Rem) > 0 of
+        true ->
+            [{current_partition, hd(Rem)},
+             {current_partition_status, WStatus},
+             {current_index_scan_count, IdxCount},
+             {current_hashtree_population_count, PopCount}];
+        false ->
+            []
+    end,
+    [{speed, Speed},
+     {partitions, Partitions},
+     {remaining, Rem},
+     {index_scan_count, TotIdxCount},
+     {hashtree_population_count, TotPopCount},
+     {exchange_count, TotXchgCount},
+     {results, Results}]
+    ++ PartStatus.
+
+format_status(_Opt, [_PDict, State]) ->
+    [{detailed_status, to_simple_state(State)}].
+
+%% @doc Human readable status report.
+to_report(Status) ->
+    Speed = proplists:get_value(speed, Status),
+    IdxScanCount = proplists:get_value(index_scan_count, Status),
+    PopCount = proplists:get_value(hashtree_population_count, Status),
+    XchgCount = proplists:get_value(exchange_count, Status),
+    Partitions = proplists:get_value(partitions, Status),
+    Rem = proplists:get_value(remaining, Status),
+    NParts = length(Partitions),
+    NDone = NParts - length(Rem),
+    Report0 = io_lib:format("\tTotal partitions: ~p\n"
+                            "\tFinished partitions: ~p\n"
+                            "\tSpeed: ~p\n"
+                            "\tTotal 2i items scanned: ~p\n"
+                            "\tTotal tree objects: ~p\n"
+                            "\tTotal objects fixed: ~p\n",
+                            [NParts, NDone, Speed, IdxScanCount, PopCount,
+                             XchgCount]),
+    Results = proplists:get_value(results, Status),
+    Errors =
+    [{P, proplists:get_value(error, R)}
+     || {P, R} <- Results,
+        proplists:get_value(status, R) == error],
+    case Errors of
+        [] ->
+            Report0;
+        _ ->
+            lists:flatten(
+             [Report0, io_lib:format("With errors:\n", []) |
+              [io_lib:format("Partition: ~p\nError: ~p\n\n", [P, E])
+               || {P, E} <- Errors]])
+    end.
+
+%% @doc Handles repair worker death notification
+handle_info({'EXIT', _From, _Reason}, StateName, State) ->
+    %% We handle the monitor down message instead.
+    {next_state, StateName, State};
+handle_info({'DOWN', Mon, _, _, Reason}, _StateName,
+            State=#state{worker_monitor=Mon, remaining=[Partition|_]}) ->
+    lager:error("Index repair of partition ~p failed : ~p",
+                [Partition, Reason]),
+    {stop, {partition_failed, Reason}, State};
+handle_info({'DOWN', _Mon, _, _, _Reason}, StateName, State) ->
+    % Proces died after we got its result, so ignore.
+    {next_state, StateName, State}.
+
+handle_event(_Event, StateName, State) ->
+    {next_state, StateName, State}.
+
+%% @doc Handles early reply and status requests.
+%% A client may request an early acknowledgement, so early
+%% errors can be returned immediately to the user.
+handle_sync_event(early_ack, From, StateName,
+                  State=#state{early_reply=undefined}) ->
+    {next_state, StateName, State#state{reply_to=From}};
+handle_sync_event(early_ack, _From, StateName,
+                  State=#state{early_reply=Reply}) ->
+    {reply, Reply, StateName, State};
+handle_sync_event(status, _From, StateName, State) ->
+    {reply, to_simple_state(State), StateName, State};
+handle_sync_event(stop, From, _StateName, State=#state{open_dbs=DBs}) ->
+    [try
+         eleveldb:close(DB)
+     catch
+         _:_ ->
+             ok
+     end || DB <- DBs],
+    gen_fsm:reply(From, ok),
+    {stop, user_request, State}.
+
+terminate(_Reason, _StateName, _State) ->
+    ok.
+
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -172,7 +172,7 @@ start(_Type, _StartArgs) ->
                                           v0),
 
             riak_core_capability:register({riak_kv, secondary_index_version},
-                                          [v2, v1],
+                                          [v3, v2, v1],
                                           v1),
 
             riak_core_capability:register({riak_kv, vclock_data_encoding},

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -40,6 +40,7 @@
          fold_buckets/4,
          fold_keys/4,
          fold_objects/4,
+         fold_indexes/4,
          is_empty/1,
          status/1,
          callback/3]).
@@ -178,7 +179,7 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, #state{ref=Ref,
                                                 fixed_indexes=FixedIndexes}=State) ->
     %% Create the KV update...
     StorageKey = to_object_key(Bucket, PrimaryKey),
-    Updates1 = [{put, StorageKey, Val}],
+    Updates1 = [{put, StorageKey, Val} || Val /= undefined],
 
     %% Convert IndexSpecs to index updates...
     F = fun({add, Field, Value}) ->
@@ -399,6 +400,33 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{fold_opts=FoldOpts,
             {async, KeyFolder};
         false ->
             {ok, KeyFolder()}
+    end.
+
+fold_indexes(FoldIndexFun, Acc, _Opts, #state{fold_opts=FoldOpts,
+                                              ref=Ref}) ->
+    FirstKey = to_index_key(<<>>, <<>>, <<>>, <<>>),
+    FoldOpts1 = [{first_key, FirstKey} | FoldOpts],
+    FoldFun = fold_indexes_fun(FoldIndexFun),
+    KeyFolder =
+        fun() ->
+                %% Do the fold. ELevelDB uses throw/1 to break out of a fold...
+                try
+                    eleveldb:fold_keys(Ref, FoldFun, Acc, FoldOpts1)
+                catch
+                    {break, BrkResult} ->
+                        BrkResult
+                end
+        end,
+    {async, KeyFolder}.
+
+fold_indexes_fun(FoldIndexFun) ->
+    fun(StorageKey, Acc) ->
+            case from_index_key(StorageKey) of
+                {Bucket, Key, Field, Term} ->
+                    FoldIndexFun(Bucket, Key, Field, Term, Acc);
+                _ ->
+                    throw({break, Acc})
+            end
     end.
 
 legacy_key_fold(Ref, FoldFun, Acc, FoldOpts0, Query={index, _, _}) ->
@@ -659,32 +687,65 @@ fold_keys_fun(FoldKeysFun, {bucket, FilterBucket}) ->
             end
     end;
 %% 2i queries
-fold_keys_fun(FoldKeysFun, {index, FilterBucket, Q=?KV_INDEX_Q{filter_field=FilterField}})
+fold_keys_fun(FoldKeysFun, {index, FilterBucket,
+                            Q=?KV_INDEX_Q{filter_field=FilterField,
+                                         term_regex=TermRe}})
   when FilterField =:= <<"$bucket">>;
        FilterField =:= <<"$key">> ->
+    AccFun = case FilterField =:= <<"$key">> andalso TermRe =/= undefined of
+        true ->
+            fun(Bucket, Key, Acc) ->
+                    case re:run(Key, TermRe) of
+                        nomatch -> Acc;
+                        _ -> stoppable_fold(FoldKeysFun, Bucket, Key, Acc)
+                    end
+            end;
+        false ->
+            fun(Bucket, Key, Acc) ->
+                    stoppable_fold(FoldKeysFun, Bucket, Key, Acc)
+            end
+    end,
+
     %% Inbuilt indexes
     fun(StorageKey, Acc) ->
             ObjectKey = from_object_key(StorageKey),
             case riak_index:object_key_in_range(ObjectKey, FilterBucket, Q) of
                 {true, {Bucket, Key}} ->
-                    stoppable_fold(FoldKeysFun, Bucket, Key, Acc);
+                    AccFun(Bucket, Key, Acc);
                 {skip, _BK} ->
                     Acc;
                 _ ->
                     throw({break, Acc})
             end
     end;
-fold_keys_fun(FoldKeysFun, {index, FilterBucket, Q=?KV_INDEX_Q{return_terms=Terms}}) ->
+fold_keys_fun(FoldKeysFun, {index, FilterBucket, Q=?KV_INDEX_Q{return_terms=Terms,
+                                                              term_regex=TermRe}}) ->
+    AccFun = case TermRe =:= undefined of
+        true ->
+            fun(Bucket, _Term, Val, Acc) ->
+                    stoppable_fold(FoldKeysFun, Bucket, Val, Acc)
+            end;
+        false ->
+            fun(Bucket, Term, Val, Acc) ->
+                    case re:run(Term, TermRe) of
+                        nomatch ->
+                            Acc;
+                        _ ->
+                            stoppable_fold(FoldKeysFun, Bucket, Val, Acc)
+                    end
+            end
+    end,
+
     %% User indexes
     fun(StorageKey, Acc) ->
             IndexKey = from_index_key(StorageKey),
             case riak_index:index_key_in_range(IndexKey, FilterBucket, Q) of
                 {true, {Bucket, Key, _Field, Term}} ->
                     Val = if
-                              Terms -> {Term, Key};
-                              true -> Key
-                          end,
-                    stoppable_fold(FoldKeysFun, Bucket, Val, Acc);
+                        Terms -> {Term, Key};
+                        true -> Key
+                    end,
+                    AccFun(Bucket, Term, Val, Acc);
                 {skip, _IK} ->
                     Acc;
                 _ ->

--- a/src/riak_kv_index_fsm.erl
+++ b/src/riak_kv_index_fsm.erl
@@ -51,7 +51,8 @@
 -type req_id() :: non_neg_integer().
 
 -record(state, {from :: from(),
-                merge_sort_buffer :: sms:sms(),
+                pagination_sort :: boolean(),
+                merge_sort_buffer = undefined :: sms:sms() | undefined,
                 max_results :: all | pos_integer(),
                 results_per_vnode = dict:new() :: dict(),
                 results_sent = 0 :: non_neg_integer()}).
@@ -87,16 +88,29 @@ init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout]) ->
     %% atom() > number()
     init(From, [Bucket, ItemFilter, Query, Timeout, all]);
 init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout, MaxResults]) ->
+    init(From, [Bucket, ItemFilter, Query, Timeout, MaxResults, undefined]);
+init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout, MaxResults, PgSort0]) ->
     %% Get the bucket n_val for use in creating a coverage plan
     BucketProps = riak_core_bucket:get_bucket(Bucket),
     NVal = proplists:get_value(n_val, BucketProps),
+    Paginating = is_integer(MaxResults) andalso MaxResults > 0, 
+    PgSort = case {Paginating, PgSort0} of
+        {true, _} ->
+            true;
+        {_, undefined} ->
+            app_helper:get_env(riak_kv, secondary_index_sort_default, false);
+        _ ->
+            PgSort0
+    end,
     %% Construct the key listing request
     Req = req(Bucket, ItemFilter, Query),
     {Req, all, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout,
-     #state{from=From, max_results=MaxResults}}.
+     #state{from=From, max_results=MaxResults, pagination_sort=PgSort}}.
 
-plan(CoverageVNodes, State) ->
-    {ok, State#state{merge_sort_buffer=sms:new(CoverageVNodes)}}.
+plan(CoverageVNodes, State = #state{pagination_sort=true}) ->
+    {ok, State#state{merge_sort_buffer=sms:new(CoverageVNodes)}};
+plan(_CoverageVNodes, State) ->
+    {ok, State}.
 
 process_results(_VNode, {error, Reason}, _State) ->
     {error, Reason};
@@ -105,7 +119,7 @@ process_results(_VNode, {From, _Bucket, _Results}, State=#state{max_results=X, r
     {done, State};
 process_results(VNode, {From, Bucket, Results}, State) ->
     case process_results(VNode, {Bucket, Results}, State) of
-        {ok, State2} ->
+        {ok, State2 = #state{pagination_sort=true}} ->
             #state{results_per_vnode=PerNode, max_results=MaxResults} = State2,
             VNodeCount = dict:fetch(VNode, PerNode),
             case VNodeCount < MaxResults of
@@ -116,11 +130,14 @@ process_results(VNode, {From, Bucket, Results}, State) ->
                     riak_kv_vnode:stop_fold(From),
                     {done, State2}
             end;
+        {ok, State2} ->
+            riak_kv_vnode:ack_keys(From),
+            {ok, State2};
         {done, State2} ->
             riak_kv_vnode:stop_fold(From),
             {done, State2}
     end;
-process_results(VNode, {_Bucket, Results}, State) ->
+process_results(VNode, {_Bucket, Results}, State = #state{pagination_sort=true}) ->
     #state{merge_sort_buffer=MergeSortBuffer, results_per_vnode=PerNode,
            from={raw, ReqId, ClientPid}, results_sent=ResultsSent, max_results=MaxResults} = State,
     %% add new results to buffer
@@ -133,11 +150,17 @@ process_results(VNode, {_Bucket, Results}, State) ->
     {Response, State#state{merge_sort_buffer=NewBuff,
                            results_per_vnode=NewPerNode,
                            results_sent=ResultsSent+ResultsLen}};
-process_results(VNode, done, State) ->
+process_results(VNode, done, State = #state{pagination_sort=true}) ->
     %% tell the sms buffer about the done vnode
     #state{merge_sort_buffer=MergeSortBuffer} = State,
     BufferWithNewResults = sms:add_results(VNode, done, MergeSortBuffer),
-    {done, State#state{merge_sort_buffer=BufferWithNewResults}}.
+    {done, State#state{merge_sort_buffer=BufferWithNewResults}};
+process_results(_VNode, {_Bucket, Results}, State) ->
+    #state{from={raw, ReqId, ClientPid}} = State,
+    send_results(ClientPid, ReqId, Results),
+    {ok, State};
+process_results(_VNode, done, State) ->
+    {done, State}.
 
 %% @private Update the buffer with results and process it
 update_buffer(VNode, Results, Buffer) ->

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -52,6 +52,7 @@
          fold_buckets/4,
          fold_keys/4,
          fold_objects/4,
+         fold_indexes/4,
          is_empty/1,
          status/1,
          callback/3]).
@@ -208,16 +209,20 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, State=#state{data_ref=DataRef,
                                                       ttl=TTL,
                                                       used_memory=UsedMemory}) ->
     Now = os:timestamp(),
-    case TTL of
-        undefined ->
-            Val1 = Val;
+    NoValChange = (TTL =:= undefined) orelse (Val =:= undefined),
+    Val1 =
+    case NoValChange of
+        true ->
+            Val;
         _ ->
-            Val1 = {{ts, Now}, Val}
+            {{ts, Now}, Val}
     end,
     {ok, Size} = do_put(Bucket, PrimaryKey, Val1, IndexSpecs, DataRef, IndexRef),
-    case MaxMemory of
-        undefined ->
-            UsedMemory1 = UsedMemory;
+    NoMemChange = (MaxMemory =:= undefined) orelse (Val =:= undefined),
+    UsedMemory1 =
+    case NoMemChange of
+        true ->
+            UsedMemory;
         _ ->
             time_entry(Bucket, PrimaryKey, Now, TimeRef),
             Freed = trim_data_table(MaxMemory,
@@ -226,7 +231,7 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, State=#state{data_ref=DataRef,
                                     TimeRef,
                                     IndexRef,
                                     0),
-            UsedMemory1 = UsedMemory + Size - Freed
+            UsedMemory + Size - Freed
     end,
     {ok, State#state{used_memory=UsedMemory1}}.
 
@@ -326,6 +331,26 @@ fold(FoldTypeFun, FoldFun0, Acc, Opts, #state{data_ref=DataRef, index_ref=IndexR
         false ->
             {ok, Folder()}
     end.
+
+fold_indexes(FoldIndexFun, Acc0, _Opts, #state{index_ref=IndexRef}) ->
+    Bucket = undefined, FF = undefined, StartKey = undefined,
+    Min = undefined, Max = undefined, Incl = true,
+    %% Adapt input fold function to our internal one that keys the entire
+    %% field from the ETS table
+    AdaptedFoldFun =
+    fun({{FoldBucket, FoldField, FoldVal, FoldKey}, _}, Acc) ->
+            FoldIndexFun(FoldBucket, FoldKey, FoldField, FoldVal, Acc)
+    end,
+
+    Folder =
+    fun() ->
+            index_range_folder(AdaptedFoldFun, Acc0, IndexRef,
+                               {Bucket, FF, Min, StartKey},
+                               {Bucket, FF, Min, Max, StartKey, Incl})
+    end,
+    {async, Folder}.
+
+
 %% @doc Delete all objects from this memory backend
 -spec drop(state()) -> {ok, state()}.
 drop(State=#state{data_ref=DataRef,
@@ -440,9 +465,31 @@ fold_keys_fun(FoldKeysFun, {bucket, FilterBucket}) ->
 fold_keys_fun(FoldKeysFun, {index, FilterBucket, ?KV_INDEX_Q{filter_field=FF}}) when
       FF == <<"$bucket">>; FF == <<"$key">> ->
     fold_keys_fun(FoldKeysFun, {bucket, FilterBucket});
-fold_keys_fun(FoldKeysFun, {index, _FilterBucket, ?KV_INDEX_Q{}}) ->
+fold_keys_fun(FoldKeysFun, {index, _FilterBucket,
+                            ?KV_INDEX_Q{term_regex=Re, return_terms=Terms}})
+    when Re /= undefined ->
     fun({{Bucket, _FilterField, FilterTerm, Key}, _}, Acc) ->
-            FoldKeysFun(Bucket, {FilterTerm, Key}, Acc);
+            case re:run(FilterTerm, Re) of
+                nomatch ->
+                    Acc;
+                {match, _} ->
+                    Val = if
+                        Terms -> {FilterTerm, Key};
+                        true -> Key
+                    end,
+                    FoldKeysFun(Bucket, Val, Acc)
+            end;
+       (_, Acc) ->
+            Acc
+    end;
+fold_keys_fun(FoldKeysFun, {index, _FilterBucket,
+                            ?KV_INDEX_Q{return_terms=Terms}}) ->
+    fun({{Bucket, _FilterField, FilterTerm, Key}, _}, Acc) ->
+                    Val = if
+                        Terms -> {FilterTerm, Key};
+                        true -> Key
+                    end,
+            FoldKeysFun(Bucket, Val, Acc);
        (_, Acc) ->
             Acc
     end;
@@ -486,7 +533,6 @@ get_folder(FoldFun, Acc, DataRef) ->
     end.
 
 %% @private
-%% V2 2i
 get_index_folder(Folder, Acc0, {index, Bucket, Q=?KV_INDEX_Q{filter_field=FF, start_key=StartKey}}, DataRef, _)
   when FF == <<"$bucket">>; FF == <<"$key">> ->
     fun() ->
@@ -536,7 +582,11 @@ key_range_folder(_Folder, Acc, _DataRef, _DataKey, _Query) ->
 
 %% Iterates over a range of index postings
 index_range_folder(Folder, Acc0, IndexRef, {B, I, V, _K}=IndexKey,
-                   {B, I, Min, Max, StartKey, Incl}=Query) when V >= Min, V =< Max ->
+                   {QueryB, QueryI, Min, Max, StartKey, Incl}=Query) 
+  when ((QueryB =:= undefined) orelse (QueryB =:= B)),
+       ((QueryI =:= undefined) orelse (QueryI =:= I)),
+       ((Min =:= undefined) orelse (V >= Min)),
+       ((Max =:= undefined) orelse (V =< Max)) ->
     case {Incl, ets:lookup(IndexRef, IndexKey)} of
         {_, []} ->
             %% This will happen on the first iteration, where the key
@@ -559,10 +609,17 @@ index_range_folder(_Folder, Acc, _IndexRef, _IndexKey, _Query) ->
 
 %% @private
 do_put(Bucket, Key, Val, IndexSpecs, DataRef, IndexRef) ->
-    Object = {{Bucket, Key}, Val},
-    true = ets:insert(DataRef, Object),
+    ObjSize =
+    case Val of
+        undefined ->
+            undefined;
+        _ ->
+            Object = {{Bucket, Key}, Val},
+            true = ets:insert(DataRef, Object),
+            object_size(Object)
+    end,
     update_indexes(Bucket, Key, IndexSpecs, IndexRef),
-    {ok, object_size(Object)}.
+    {ok, ObjSize}.
 
 %% Check if this timestamp is past the ttl setting.
 exceeds_ttl(Timestamp, TTL) ->

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -36,6 +36,7 @@
          fold_buckets/4,
          fold_keys/4,
          fold_objects/4,
+         fold_indexes/4,
          is_empty/1,
          data_size/1,
          status/1,
@@ -51,6 +52,7 @@
 
 -define(API_VERSION, 1).
 -define(CAPABILITIES, [async_fold, index_reformat]).
+-define(ANY_CAPABILITIES, [indexes]).
 
 -record (state, {backends :: [{atom(), atom(), term()}],
                  default_backend :: atom()}).
@@ -111,7 +113,10 @@ capabilities(State) ->
     Caps1 = ordsets:intersection(AllCaps),
     Caps2 = ordsets:to_list(Caps1),
 
-    Capabilities = lists:usort(?CAPABILITIES ++ Caps2),
+    % Some caps we choose if ANY backend has them
+    AnyCaps = ordsets:intersection(ordsets:union(AllCaps),
+                                    ordsets:from_list(?ANY_CAPABILITIES)),
+    Capabilities = lists:usort(?CAPABILITIES ++ Caps2 ++ AnyCaps),
     {ok, Capabilities}.
 
 %% @doc Return the capabilities of the backend.
@@ -257,7 +262,13 @@ delete(Bucket, Key, IndexSpecs, State) ->
                    [{atom(), term()}],
                    state()) -> {ok, any()} | {async, fun()} | {error, term()}.
 fold_buckets(FoldBucketsFun, Acc, Opts, State) ->
-    fold_all(fold_buckets, FoldBucketsFun, Acc, Opts, State).
+    fold_all(fold_buckets, FoldBucketsFun, Acc, Opts, State,
+             fun default_backend_filter/4).
+
+%% @doc Fold only over index data in the backend, for all buckets.
+fold_indexes(FoldIndexFun, Acc, Opts, State) ->
+    fold_all(fold_indexes, FoldIndexFun, Acc, Opts, State,
+            fun indexes_filter/4).
 
 %% @doc Fold over all the keys for one or all buckets.
 -spec fold_keys(riak_kv_backend:fold_keys_fun(),
@@ -267,7 +278,8 @@ fold_buckets(FoldBucketsFun, Acc, Opts, State) ->
 fold_keys(FoldKeysFun, Acc, Opts, State) ->
     case proplists:get_value(bucket, Opts) of
         undefined ->
-            fold_all(fold_keys, FoldKeysFun, Acc, Opts, State);
+            fold_all(fold_keys, FoldKeysFun, Acc, Opts, State,
+                    fun default_backend_filter/4);
         Bucket ->
             fold_in_bucket(Bucket, fold_keys, FoldKeysFun, Acc, Opts, State)
     end.
@@ -280,7 +292,8 @@ fold_keys(FoldKeysFun, Acc, Opts, State) ->
 fold_objects(FoldObjectsFun, Acc, Opts, State) ->
     case proplists:get_value(bucket, Opts) of
         undefined ->
-            fold_all(fold_objects, FoldObjectsFun, Acc, Opts, State);
+            fold_all(fold_objects, FoldObjectsFun, Acc, Opts, State,
+                    fun default_backend_filter/4);
         Bucket ->
             fold_in_bucket(Bucket, fold_objects, FoldObjectsFun, Acc, Opts, State)
     end.
@@ -457,7 +470,7 @@ update_backend_state(Backend,
 
 %% @private
 %% @doc Shared code used by all the backend fold functions.
-fold_all(ModFun, FoldFun, Acc, Opts, State) ->
+fold_all(ModFun, FoldFun, Acc, Opts, State, BackendFilter) ->
     Backends = State#state.backends,
     try
         AsyncFold = lists:member(async_fold, Opts),
@@ -465,7 +478,8 @@ fold_all(ModFun, FoldFun, Acc, Opts, State) ->
             lists:foldl(backend_fold_fun(ModFun,
                                          FoldFun,
                                          Opts,
-                                         AsyncFold),
+                                         AsyncFold,
+                                         BackendFilter),
                         {Acc, []},
                         Backends),
 
@@ -496,22 +510,33 @@ fold_in_bucket(Bucket, ModFun, FoldFun, Acc, Opts, State) ->
                   Opts,
                   SubState).
 
+%% @doc Skips folding if index reformat operation on
+%% non-index reformat capable backend.
+default_backend_filter(Opts, _Module, _SubState, ModCaps) ->
+    Indexes = lists:keyfind(index, 1, Opts),
+    CanReformatIndex = lists:member(index_reformat, ModCaps),
+    case {Indexes, CanReformatIndex} of
+        {{index, incorrect_format, _ForUpgrade}, false} ->
+            false;
+        _ ->
+            true
+    end.
+
+%% @doc Skips folding on backends that do not support indexes.
+indexes_filter(_Opts, _Module, _SubState, ModCaps) ->
+    lists:member(indexes, ModCaps).
+
 %% @private
-backend_fold_fun(ModFun, FoldFun, Opts, AsyncFold) ->
+backend_fold_fun(ModFun, FoldFun, Opts, AsyncFold, BackendFilter) ->
     fun({_, Module, SubState}, {Acc, WorkList}) ->
             %% Get the backend capabilities to determine
             %% if it supports asynchronous folding.
             {ok, ModCaps} = Module:capabilities(SubState),
             DoAsync = AsyncFold andalso lists:member(async_fold, ModCaps),
-            Indexes = lists:keyfind(index, 1, Opts),
-            case Indexes of
-                {index, incorrect_format, _ForUpgrade} ->
-                    case lists:member(index_reformat, ModCaps) of
-                        true -> backend_fold_fun(Module, ModFun, SubState, FoldFun,
-                                                 Opts, {Acc, WorkList}, DoAsync);
-                        false -> {Acc, WorkList}
-                    end;
-                _ ->
+            case BackendFilter(Opts, Module, SubState, ModCaps) of
+                false ->
+                    {Acc, WorkList};
+                true ->
                     backend_fold_fun(Module,
                                      ModFun,
                                      SubState,

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -37,6 +37,7 @@
 -module(riak_kv_pb_index).
 
 -include_lib("riak_pb/include/riak_kv_pb.hrl").
+-include("riak_kv_index.hrl").
 
 -behaviour(riak_api_pb_service).
 
@@ -68,33 +69,73 @@ decode(Code, Bin) ->
 encode(Message) ->
     {ok, riak_pb_codec:encode(Message)}.
 
+validate_request(#rpbindexreq{qtype=QType, key=SKey,
+                              range_min=Min, range_max=Max,
+                              term_regex=TermRe} = Req) ->
+    {ValRe, ValErr} = case TermRe of
+        undefined ->
+            {undefined, undefined};
+        _ ->
+            re:compile(TermRe)
+    end,
+
+    if
+        QType == eq andalso not is_binary(SKey) ->
+            {error, {format, "Invalid equality query ~p", [SKey]}};
+        QType == range andalso not(is_binary(Min) andalso is_binary(Max)) ->
+            {error, {format, "Invalid range query: ~p -> ~p", [Min, Max]}};
+        ValRe =:= error ->
+            {error, {format, "Invalid term regular expression ~p : ~p",
+                     [TermRe, ValErr]}};
+        true ->
+            Query = riak_index:to_index_query(query_params(Req)),
+            case Query of
+                {ok, ?KV_INDEX_Q{start_term=Start, term_regex=Re}} when is_integer(Start)
+                       andalso Re =/= undefined ->
+                    {error, "Can not use term regular expression in integer query"};
+                _ ->
+                    Query
+            end
+    end.
+
 %% @doc process/2 callback. Handles an incoming request message.
-process(#rpbindexreq{qtype=eq, key=SKey}, State)
-  when not is_binary(SKey) ->
-    {error, {format, "Invalid equality query ~p", [SKey]}, State};
-process(#rpbindexreq{qtype=range, range_min=Min, range_max=Max}, State)
-  when not (is_binary(Min) andalso is_binary(Max)) ->
-    {error, {format, "Invalid range query: ~p -> ~p", [Min, Max]}, State};
-process(Req=#rpbindexreq{}, State) ->
-    {Index, Args, Continuation} = query_params(Req),
-    Query = riak_index:to_index_query(Index, Args, Continuation),
-    maybe_perform_query(Query, Req, State).
+process(#rpbindexreq{} = Req, State) ->
+    case validate_request(Req) of
+        {error, Err} ->
+            {error, Err, State};
+        QueryVal ->
+            maybe_perform_query(QueryVal, Req, State)
+    end.
 
 maybe_perform_query({error, Reason}, _Req, State) ->
     {error, {format, Reason}, State};
 maybe_perform_query({ok, Query}, Req=#rpbindexreq{stream=true}, State) ->
-    #rpbindexreq{type = T, bucket=B, max_results=MaxResults, timeout=Timeout} = Req,
+    #rpbindexreq{type=T, bucket=B, max_results=MaxResults, timeout=Timeout,
+                 pagination_sort=PgSort0, continuation=Continuation} = Req,
     #state{client=Client} = State,
     Bucket = maybe_bucket_type(T, B),
-    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults}]),
+    %% Special case: a continuation implies pagination even if no max_results
+    PgSort = case Continuation of
+                 undefined -> PgSort0;
+                 _ -> true
+             end,
+    Opts0 = [{max_results, MaxResults}] ++ [{pagination_sort, PgSort} || PgSort /= undefined],
+    Opts = riak_index:add_timeout_opt(Timeout, Opts0),
     {ok, ReqId, _FSMPid} = Client:stream_get_index(Bucket, Query, Opts),
     ReturnTerms = riak_index:return_terms(Req#rpbindexreq.return_terms, Query),
     {reply, {stream, ReqId}, State#state{req_id=ReqId, req=Req#rpbindexreq{return_terms=ReturnTerms}}};
 maybe_perform_query({ok, Query}, Req, State) ->
-    #rpbindexreq{type = T, bucket=B, max_results=MaxResults, return_terms=ReturnTerms0, timeout=Timeout} = Req,
+    #rpbindexreq{type=T, bucket=B, max_results=MaxResults,
+                 return_terms=ReturnTerms0, timeout=Timeout,
+                 pagination_sort=PgSort0, continuation=Continuation} = Req,
     #state{client=Client} = State,
     Bucket = maybe_bucket_type(T, B),
-    Opts = riak_index:add_timeout_opt(Timeout, [{max_results, MaxResults}]),
+    PgSort = case Continuation of
+                 undefined -> PgSort0;
+                 _ -> true
+             end,
+    Opts0 = [{max_results, MaxResults}] ++ [{pagination_sort, PgSort} || PgSort /= undefined],
+    Opts = riak_index:add_timeout_opt(Timeout, Opts0),
     ReturnTerms =  riak_index:return_terms(ReturnTerms0, Query),
     QueryResult = Client:get_index(Bucket, Query, Opts),
     handle_query_results(ReturnTerms, MaxResults, QueryResult , State).
@@ -107,10 +148,23 @@ handle_query_results(ReturnTerms, MaxResults,  {ok, Results}, State) ->
     Resp = encode_results(ReturnTerms, Results, Cont),
     {reply, Resp, State}.
 
-query_params(#rpbindexreq{qtype=eq, index=Index, key=Value, continuation=Continuation}) ->
-    {Index, [Value], Continuation};
-query_params(#rpbindexreq{index=Index, range_min=Min, range_max=Max, continuation=Continuation}) ->
-    {Index, [Min, Max], Continuation}.
+query_params(#rpbindexreq{index=Index= <<"$bucket">>,
+                          term_regex=Re, max_results=MaxResults,
+                          continuation=Continuation}) ->
+    [{field, Index},
+     {return_terms, false}, {term_regex, Re},
+     {max_results, MaxResults}, {continuation, Continuation}];
+query_params(#rpbindexreq{qtype=eq, index=Index, key=Value,
+                          term_regex=Re, max_results=MaxResults,
+                          continuation=Continuation}) ->
+    [{field, Index}, {start_term, Value}, {end_term, Value}, {term_regex, Re},
+     {max_results, MaxResults}, {return_terms, false}, {continuation, Continuation}];
+query_params(#rpbindexreq{index=Index, range_min=Min, range_max=Max,
+                          term_regex=Re, max_results=MaxResults,
+                          continuation=Continuation}) ->
+     [{field, Index}, {start_term, Min}, {end_term, Max},
+      {term_regex, Re}, {max_results, MaxResults},
+      {continuation, Continuation}].
 
 encode_results(true, Results0, Continuation) ->
     Results = [encode_result(Res) || Res <- Results0],

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -175,6 +175,8 @@ do_update({vnode_put, Idx, USecs}) ->
     folsom_metrics:notify_existing_metric({?APP, vnode, puts}, 1, spiral),
     create_or_update({?APP, vnode, puts, time}, USecs, histogram),
     do_per_index(puts, Idx, USecs);
+do_update(vnode_index_refresh) ->
+    folsom_metrics:notify_existing_metric({?APP, vnode, index, refreshes}, 1, spiral);
 do_update(vnode_index_read) ->
     folsom_metrics:notify_existing_metric({?APP, vnode, index, reads}, 1, spiral);
 do_update({vnode_index_write, PostingsAdded, PostingsRemoved}) ->
@@ -344,6 +346,7 @@ stats() ->
      {[vnode, gets, time], histogram},
      {[vnode, puts], spiral},
      {[vnode, puts, time], histogram},
+     {[vnode, index, refreshes], spiral},
      {[vnode, index, reads], spiral},
      {[vnode, index ,writes], spiral},
      {[vnode, index, writes, postings], spiral},
@@ -502,6 +505,8 @@ stats_from_update_arg({vnode_get, _, _}) ->
     riak_core_stat_q:names_and_types([?APP, vnode, gets]);
 stats_from_update_arg({vnode_put, _, _}) ->
     riak_core_stat_q:names_and_types([?APP, vnode, puts]);
+stats_from_update_arg(vnode_index_refresh) ->
+    riak_core_stat_q:names_and_types([?APP, vnode, index, refreshes]);
 stats_from_update_arg(vnode_index_read) ->
     riak_core_stat_q:names_and_types([?APP, vnode, index, reads]);
 stats_from_update_arg({vnode_index_write, _, _}) ->

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -219,6 +219,8 @@ legacy_stat_map() ->
      {vnode_gets_total, {{riak_kv, vnode, gets}, count}, spiral},
      {vnode_puts, {{riak_kv, vnode, puts}, one}, spiral},
      {vnode_puts_total, {{riak_kv, vnode, puts}, count}, spiral},
+     {vnode_index_refreshes, {{riak_kv, vnode, index, refreshes}, one}, spiral},
+     {vnode_index_refreshes_total, {{riak_kv, vnode, index, refreshes}, count}, spiral},
      {vnode_index_reads, {{riak_kv, vnode, index, reads}, one}, spiral},
      {vnode_index_reads_total, {{riak_kv, vnode, index, reads}, count}, spiral},
      {vnode_index_writes, {{riak_kv, vnode, index, writes}, one}, spiral},

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -44,7 +44,9 @@
          repair_filter/1,
          hashtree_pid/1,
          rehash/3,
+         refresh_index_data/4,
          request_hashtree_pid/1,
+         request_hashtree_pid/2,
          reformat_object/2,
          stop_fold/1]).
 
@@ -73,6 +75,7 @@
 -export([set_vnode_forwarding/2]).
 
 -include_lib("riak_kv_vnode.hrl").
+-include_lib("riak_kv_index.hrl").
 -include_lib("riak_kv_map_phase.hrl").
 -include_lib("riak_core_pb.hrl").
 
@@ -144,13 +147,16 @@ maybe_create_hashtrees(State) ->
 -spec maybe_create_hashtrees(boolean(), state()) -> state().
 maybe_create_hashtrees(false, State) ->
     State;
-maybe_create_hashtrees(true, State=#state{idx=Index}) ->
+maybe_create_hashtrees(true, State=#state{idx=Index,
+                                          mod=Mod, modstate=ModState}) ->
     %% Only maintain a hashtree if a primary vnode
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     case riak_core_ring:vnode_type(Ring, Index) of
         primary ->
             RP = riak_kv_util:responsible_preflists(Index),
-            case riak_kv_index_hashtree:start(Index, RP, self()) of
+            {ok, ModCaps} = Mod:capabilities(ModState),
+            RP2 = add_2i_index_rp(RP, ModCaps),
+            case riak_kv_index_hashtree:start(Index, RP2, self()) of
                 {ok, Trees} ->
                     monitor(process, Trees),
                     State#state{hashtrees=Trees};
@@ -162,6 +168,16 @@ maybe_create_hashtrees(true, State=#state{idx=Index}) ->
             end;
         _ ->
             State
+    end.
+
+%% Use special magic index_n for
+%% 2i index specs hashtree ID.
+add_2i_index_rp(RP, Capabilities) ->
+    case lists:member(indexes, Capabilities) of
+        true ->
+            [riak_kv_index_hashtree:index_2i_n() | RP];
+        false ->
+            RP
     end.
 
 %% API
@@ -236,6 +252,12 @@ local_get(Index, BKey) ->
         {Ref, Reply} ->
             {error, Reply}
     end.
+
+refresh_index_data(Partition, BKey, IdxData, TimeOut) ->
+    riak_core_vnode_master:sync_command({Partition, node()},
+                                        {refresh_index_data, BKey, IdxData},
+                                        riak_kv_vnode_master,
+                                        TimeOut).
 
 %% Issue a put for the object to the preflist, expecting a reply
 %% to an FSM.
@@ -327,9 +349,14 @@ hashtree_pid(Partition) ->
 -spec request_hashtree_pid(index()) -> ok.
 request_hashtree_pid(Partition) ->
     ReqId = {hashtree_pid, Partition},
+    request_hashtree_pid(Partition, {raw, ReqId, self()}).
+
+%% Version of {@link request_hashtree_pid/1} that takes a sender argument,
+%% which could be a raw process, fsm, gen_server, etc.
+request_hashtree_pid(Partition, Sender) ->
     riak_core_vnode_master:command({Partition, node()},
                                    {hashtree_pid, node()},
-                                   {raw, ReqId, self()},
+                                   Sender,
                                    riak_kv_vnode_master).
 
 %% Used by {@link riak_kv_exchange_fsm} to force a vnode to update the hashtree
@@ -527,9 +554,57 @@ handle_command({rehash, Bucket, Key}, _, State=#state{mod=Mod, modstate=ModState
             update_hashtree(Bucket, Key, Bin, State);
         _ ->
             %% Make sure hashtree isn't tracking deleted data
-            riak_kv_index_hashtree:delete({Bucket, Key}, State#state.hashtrees)
+            delete_from_hashtree(Bucket, Key, State)
     end,
     {noreply, State};
+
+handle_command({refresh_index_data, BKey, OldIdxData}, Sender,
+               State=#state{mod=Mod, modstate=ModState}) ->
+    {Bucket, Key} = BKey,
+    {ok, Caps} = Mod:capabilities(Bucket, ModState),
+    IndexCap = lists:member(indexes, Caps),
+    case IndexCap of
+        true ->
+            {Exists, RObj, IdxData} =
+            case do_get_term(BKey, Mod, ModState) of
+                {ok, ExistingObj} ->
+                    {true, ExistingObj, riak_object:index_data(ExistingObj)};
+                _ ->
+                    {false, undefined, []}
+            end,
+            IndexSpecs = riak_object:diff_index_data(OldIdxData, IdxData),
+            {Reply, UpModState} = 
+            case Mod:put(Bucket, Key, IndexSpecs, undefined, ModState) of
+                {ok, ModState2} ->
+                    riak_kv_stat:update(vnode_index_refresh),
+                    {ok, ModState2};
+                {error, Reason, ModState2} ->
+                    {{error, Reason}, ModState2}
+            end,
+            case Exists of
+                true ->
+                    update_hashtree(Bucket, Key, RObj, State);
+                false ->
+                    delete_from_hashtree(Bucket, Key, State)
+            end,
+            riak_core_vnode:reply(Sender, Reply),
+            {noreply, State#state{modstate=UpModState}};
+        false ->
+            {reply, {error, {indexes_not_supported, Mod}}, State}
+    end;
+
+handle_command({fold_indexes, FoldIndexFun, Acc}, Sender, State=#state{mod=Mod, modstate=ModState}) ->
+    {ok, Caps} = Mod:capabilities(ModState),
+    case lists:member(indexes, Caps) of
+        true ->
+            {async, AsyncWork} = Mod:fold_indexes(FoldIndexFun, Acc, [async_fold], ModState),
+            FinishFun = fun(FinalAcc) ->
+                                riak_core_vnode:reply(Sender, FinalAcc)
+                        end,
+            {async, {fold, AsyncWork, FinishFun}, Sender, State};
+        false ->
+            {reply, {error, {indexes_not_supported, Mod}}, State}
+    end;
 
 %% Commands originating from inside this vnode
 handle_command({backend_callback, Ref, Msg}, _Sender,
@@ -705,9 +780,26 @@ handle_coverage(?KV_INDEX_REQ{bucket=Bucket,
     handle_coverage_index(Bucket, ItemFilter, Query,
                           FilterVNodes, Sender, State, fun result_fun_ack/2).
 
+prepare_index_query(#riak_kv_index_v3{term_regex=RE} = Q) when
+        RE =/= undefined ->
+    {ok, CompiledRE} = re:compile(RE),
+    Q#riak_kv_index_v3{term_regex=CompiledRE};
+prepare_index_query(Q) ->
+    Q.
+
+%% @doc Batch size for results is set to 2i max_results if that is less
+%% than the default size. Without this the vnode may send back to the FSM
+%% more items than could ever be sent back to the client.
+buffer_size_for_index_query(#riak_kv_index_v3{max_results=N}, DefaultSize)
+  when is_integer(N), N < DefaultSize ->
+    N;
+buffer_size_for_index_query(_Q, DefaultSize) ->
+    DefaultSize.
+
 handle_coverage_index(Bucket, ItemFilter, Query,
                       FilterVNodes, Sender,
                       State=#state{mod=Mod,
+                                   key_buf_size=DefaultBufSz,
                                    modstate=ModState},
                       ResultFunFun) ->
     {ok, Capabilities} = Mod:capabilities(Bucket, ModState),
@@ -718,8 +810,9 @@ handle_coverage_index(Bucket, ItemFilter, Query,
             riak_kv_stat:update(vnode_index_read),
 
             ResultFun = ResultFunFun(Bucket, Sender),
-            Opts = [{index, Bucket, Query},
-                    {bucket, Bucket}],
+            BufSize = buffer_size_for_index_query(Query, DefaultBufSz),
+            Opts = [{index, Bucket, prepare_index_query(Query)},
+                    {bucket, Bucket}, {buffer_size, BufSize}],
             %% @HACK
             %% Really this should be decided in the backend
             %% if there was a index_query fun.
@@ -747,13 +840,14 @@ handle_coverage_fold(FoldType, Bucket, ItemFilter, ResultFun,
                         FilterVNodes, Sender, Opts0,
                         State=#state{async_folding=AsyncFolding,
                                      idx=Index,
-                                     key_buf_size=BufferSize,
+                                     key_buf_size=DefaultBufSz,
                                      mod=Mod,
                                      modstate=ModState}) ->
     %% Construct the filter function
     FilterVNode = proplists:get_value(Index, FilterVNodes),
     Filter = riak_kv_coverage_filter:build_filter(Bucket, ItemFilter, FilterVNode),
     BufferMod = riak_kv_fold_buffer,
+    BufferSize = proplists:get_value(buffer_size, Opts0, DefaultBufSz),
     Buffer = BufferMod:new(BufferSize, ResultFun),
     Extras = fold_extras(keys, Index, Bucket),
     FoldFun = fold_fun(keys, BufferMod, Filter, Extras),
@@ -1074,7 +1168,7 @@ do_backend_delete(BKey, RObj, State = #state{idx = Idx,
     case Mod:delete(Bucket, Key, IndexSpecs, ModState) of
         {ok, UpdModState} ->
             ?INDEX(RObj, delete, Idx),
-            riak_kv_index_hashtree:delete(BKey, State#state.hashtrees),
+            delete_from_hashtree(Bucket, Key, State),
             update_index_delete_stats(IndexSpecs),
             State#state{modstate = UpdModState};
         {error, _Reason, UpdModState} ->
@@ -1237,8 +1331,8 @@ actual_put({Bucket, Key}, Obj, MaybeFake, IndexSpecs, RB, ReqID, State=#state{id
                                                                               mod=Mod,
                                                                               modstate=ModState}) ->
     case encode_and_put(Obj, Mod, Bucket, Key, IndexSpecs, ModState) of
-        {{ok, UpdModState}, EncodedVal} ->
-            update_hashtree(Bucket, Key, EncodedVal, State),
+        {{ok, UpdModState}, _EncodedVal} ->
+            update_hashtree(Bucket, Key, Obj, State),
             ?INDEX(Obj, put, Idx),
             case RB of
                 true ->
@@ -1635,8 +1729,8 @@ do_diffobj_put({Bucket, Key}, DiffObj,
             end,
             case encode_and_put(DiffObj, Mod, Bucket, Key,
                                 IndexSpecs, ModState) of
-                {{ok, _UpdModState} = InnerRes, EncodedVal} ->
-                    update_hashtree(Bucket, Key, EncodedVal, StateData),
+                {{ok, _UpdModState} = InnerRes, _EncodedVal} ->
+                    update_hashtree(Bucket, Key, DiffObj, StateData),
                     update_index_write_stats(IndexBackend, IndexSpecs),
                     update_vnode_stats(vnode_put, Idx, StartTS),
                     ?INDEX(DiffObj, handoff, Idx),
@@ -1661,8 +1755,8 @@ do_diffobj_put({Bucket, Key}, DiffObj,
                     end,
                     case encode_and_put(AMObj, Mod, Bucket, Key,
                                         IndexSpecs, ModState) of
-                        {{ok, _UpdModState} = InnerRes, EncodedVal} ->
-                            update_hashtree(Bucket, Key, EncodedVal, StateData),
+                        {{ok, _UpdModState} = InnerRes, _EncodedVal} ->
+                            update_hashtree(Bucket, Key, AMObj, StateData),
                             update_index_write_stats(IndexBackend, IndexSpecs),
                             update_vnode_stats(vnode_put, Idx, StartTS),
                             ?INDEX(AMObj, handoff, Idx),
@@ -1674,13 +1768,29 @@ do_diffobj_put({Bucket, Key}, DiffObj,
     end.
 
 -spec update_hashtree(binary(), binary(), binary(), state()) -> ok.
-update_hashtree(Bucket, Key, Val, #state{hashtrees=Trees}) ->
+update_hashtree(Bucket, Key, BinObj, State) when is_binary(BinObj) ->
+    RObj = riak_object:from_binary(Bucket, Key, BinObj),
+    update_hashtree(Bucket, Key, RObj, State);
+update_hashtree(Bucket, Key, RObj, #state{hashtrees=Trees}) ->
+    Items = [{object, {Bucket, Key}, RObj}],
     case get_hashtree_token() of
         true ->
-            riak_kv_index_hashtree:async_insert_object({Bucket, Key}, Val, Trees),
+            riak_kv_index_hashtree:async_insert(Items, [], Trees),
             ok;
         false ->
-            riak_kv_index_hashtree:insert_object({Bucket, Key}, Val, Trees),
+            riak_kv_index_hashtree:insert(Items, [], Trees),
+            put(hashtree_tokens, max_hashtree_tokens()),
+            ok
+    end.
+
+delete_from_hashtree(Bucket, Key, #state{hashtrees=Trees})->
+    Items = [{object, {Bucket, Key}}],
+    case get_hashtree_token() of
+        true ->
+            riak_kv_index_hashtree:async_delete(Items, Trees),
+            ok;
+        false ->
+            riak_kv_index_hashtree:delete(Items, Trees),
             put(hashtree_tokens, max_hashtree_tokens()),
             ok
     end.

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -66,6 +66,8 @@
 -define(Q_RETURNBODY, "returnbody").
 -define(Q_2I_RETURNTERMS, "return_terms").
 -define(Q_2I_MAX_RESULTS, "max_results").
+-define(Q_2I_TERM_REGEX, "term_regex").
 -define(Q_2I_CONTINUATION, "continuation").
+-define(Q_2I_PAGINATION_SORT, "pagination_sort").
 -define(Q_RESULTS,  "results").
 -define(Q_RETURNVALUE, "returnvalue").

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -84,7 +84,7 @@
 -export([get_update_metadata/1, get_update_value/1, get_contents/1]).
 -export([merge/2, apply_updates/1, syntactic_merge/2]).
 -export([to_json/1, from_json/1]).
--export([index_data/1]).
+-export([index_data/1, diff_index_data/2]).
 -export([index_specs/1, diff_index_specs/2]).
 -export([to_binary/2, from_binary/3, to_binary_version/4, binary_version/1]).
 -export([set_contents/2, set_vclock/2]). %% INTERNAL, only for riak_*
@@ -624,8 +624,14 @@ index_specs(Obj) ->
                               [{index_op(), binary(), index_value()}].
 diff_index_specs(Obj, OldObj) ->
     OldIndexes = index_data(OldObj),
-    OldIndexSet = ordsets:from_list(OldIndexes),
     AllIndexes = index_data(Obj),
+    diff_index_data(OldIndexes, AllIndexes).
+
+-spec diff_index_data([{binary(), index_value()}],
+                      [{binary(), index_value()}]) ->
+    [{index_op(), binary(), index_value()}].
+diff_index_data(OldIndexes, AllIndexes) ->
+    OldIndexSet = ordsets:from_list(OldIndexes),
     AllIndexSet = ordsets:from_list(AllIndexes),
     NewIndexSet = ordsets:subtract(AllIndexSet, OldIndexSet),
     RemoveIndexSet =


### PR DESCRIPTION
- Add 2i term regex filter
- Make 2i pagination sort optional
- Use sext NIF (C implementation)
- Fix vnode sending > max_results items for 2i query
- Add 2i AAE command
- Fix some mixed cluster queries (1.3.x and 1.4.2)
- Make memory backend obey 2i return terms properly

/cc @jtuple @russelldb This is a port of all the 2i changes for 1.4.4 err 1.4.5 no wait 1.4.6.
They passed all the updated 2i tests in develop except for verify_2i_mixed_cluster, as mixed clusters are broken in develop currently. I will link the riak_test PR soon.
