### PR TITLE
Fix lost 2i AAE tree on rebuild

### DIFF
--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -731,10 +731,12 @@ maybe_clear(State) ->
     State.
 
 -spec clear_tree(state()) -> state().
-clear_tree(State=#state{index=Index}) ->
+clear_tree(State=#state{index=Index, trees=Trees}) ->
     lager:debug("Clearing tree ~p", [State#state.index]),
     State2 = destroy_trees(State),
-    IndexNs = riak_kv_util:responsible_preflists(Index),
+    IndexNs = riak_kv_util:responsible_preflists(Index) ++
+    %% If initialized with 2i tree, re-create it
+    [?INDEX_2I_N || has_index_tree(Trees)],
     State3 = init_trees(IndexNs, State2#state{trees=orddict:new()}),
     State3#state{built=false}.
 

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -137,10 +137,9 @@ maybe_create_hashtrees(true, State=#state{idx=Index,
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     case riak_core_ring:vnode_type(Ring, Index) of
         primary ->
-            RP = riak_kv_util:responsible_preflists(Index),
             {ok, ModCaps} = Mod:capabilities(ModState),
-            RP2 = add_2i_index_rp(RP, ModCaps),
-            case riak_kv_index_hashtree:start(Index, RP2, self()) of
+            Opts = [use_2i || lists:member(indexes, ModCaps)],
+            case riak_kv_index_hashtree:start(Index, self(), Opts) of
                 {ok, Trees} ->
                     monitor(process, Trees),
                     State#state{hashtrees=Trees};
@@ -152,16 +151,6 @@ maybe_create_hashtrees(true, State=#state{idx=Index,
             end;
         _ ->
             State
-    end.
-
-%% Use special magic index_n for
-%% 2i index specs hashtree ID.
-add_2i_index_rp(RP, Capabilities) ->
-    case lists:member(indexes, Capabilities) of
-        true ->
-            [riak_kv_index_hashtree:index_2i_n() | RP];
-        false ->
-            RP
     end.
 
 %% API


### PR DESCRIPTION
This is a fix to avoid 2i AAE trees to be dropped on a rebuild.

/cc @jtuple @jonmeredith 
