### PR TITLE
fix put fsm's use of random:uniform_s when choosing forwarding node

### DIFF
--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -334,8 +334,8 @@ prepare(timeout, StateData0 = #state{from = From, robj = RObj,
                 {_, true} ->
                     %% This node is not in the preference list
                     %% forward on to a random node
-                    ListPos = random:uniform_s(length(Preflist2)+1, os:timestamp()),
-                    {{_Idx, CoordNode},_Type} = lists:nth(ListPos, Preflist2), 
+                    {ListPos, _} = random:uniform_s(length(Preflist2), os:timestamp()),
+                    {{_Idx, CoordNode},_Type} = lists:nth(ListPos, Preflist2),
                     ?DTRACE(Trace, ?C_PUT_FSM_PREPARE, [1],
                             ["prepare", atom2list(CoordNode)]),
                     try


### PR DESCRIPTION
- uniform_s/2 returns a 2-tuple instead of just the randomly generated integer
- uniform_s/2 replaced crypto:rand_uniform/2. However, while the former is inclusive
  of the upper bound the latter is not.

http://www.erlang.org/doc/man/random.html#uniform_s-2
http://www.erlang.org/doc/man/crypto.html#rand_uniform-2

Failure found via `http_bucket_types`, reproduced locally. I've verified this fixes the test for me....

http://giddyup.basho.com/#/projects/riak_ee/scorecards/66/66-1537-http_bucket_types-centos-6-64-eleveldb/30414/artifacts/423757
