### PR TITLE
Cuttlefish schema for background manager subsystem (aae and handoff) kill/enable switch

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -577,24 +577,24 @@ end
     is_boolean(Value) orelse (is_integer(Value) andalso Value =< 9 andalso Value >= 0)
  end}.
 
-%% @doc Enable or skip using the background manager during KV handoff.
-%% This will help to prevent system response degradation under times of
-%% heavy load from multiple background tasks that contend for the same
-%% vnode. To disable background coordination, set this parameter to false.
-%% Riak 2.0+.
-{mapping, "handoff.use_bg_manager", "riak_kv.handoff_use_background_manager", [
-    {datatype, {enum, [true, false]}},
+%% @doc Whether to use the background manager to limit KV handoff.
+%% This will help to prevent system response degradation under times
+%% of heavy load from multiple background tasks that contend for the
+%% same resources.
+%% @see background_manager
+{mapping, "handoff.use_background_manager", "riak_kv.handoff_use_background_manager", [
+    {datatype, flag},    
     {level, advanced},
-    {default, true}
+    {default, on}
 ]}.
 
-%% @doc Enable or skip using the background manager during AAE tree rebuilds.
-%% This will help to prevent system response degradation under times of
-%% heavy load from multiple background tasks that contend for the same
-%% vnode. To disable background coordination, set this parameter to false.
-%% Riak 2.0+.
-{mapping, "anti_entropy.use_bg_manager", "riak_kv.aae_use_background_manager", [
-    {datatype, {enum, [true, false]}},
+%% @doc Whether to use the background manager to limit AAE tree
+%% rebuilds. This will help to prevent system response degradation
+%% under times of heavy load from multiple background tasks that
+%% contend for the same resources.
+%% @see background_manager
+{mapping, "anti_entropy.use_background_manager", "riak_kv.aae_use_background_manager", [
+    {datatype, flag},
     {level, advanced},
-    {default, true}
+    {default, on}
 ]}.

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -583,9 +583,9 @@ end
 %% same resources.
 %% @see background_manager
 {mapping, "handoff.use_background_manager", "riak_kv.handoff_use_background_manager", [
-    {datatype, flag},    
-    {level, advanced},
-    {default, on}
+    {datatype, flag},
+    {default, on},
+    hidden
 ]}.
 
 %% @doc Whether to use the background manager to limit AAE tree
@@ -595,6 +595,6 @@ end
 %% @see background_manager
 {mapping, "anti_entropy.use_background_manager", "riak_kv.aae_use_background_manager", [
     {datatype, flag},
-    {level, advanced},
-    {default, on}
+    {default, on},
+    hidden
 ]}.

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -576,3 +576,25 @@ end
  fun(Value)->
     is_boolean(Value) orelse (is_integer(Value) andalso Value =< 9 andalso Value >= 0)
  end}.
+
+%% @doc Enable or skip using the background manager during KV handoff.
+%% This will help to prevent system response degradation under times of
+%% heavy load from multiple background tasks that contend for the same
+%% vnode. To disable background coordination, set this parameter to false.
+%% Riak 2.0+.
+{mapping, "handoff.use_bg_manager", "riak_kv.handoff_use_background_manager", [
+    {datatype, {enum, [true, false]}},
+    {level, advanced},
+    {default, true}
+]}.
+
+%% @doc Enable or skip using the background manager during AAE tree rebuilds.
+%% This will help to prevent system response degradation under times of
+%% heavy load from multiple background tasks that contend for the same
+%% vnode. To disable background coordination, set this parameter to false.
+%% Riak 2.0+.
+{mapping, "anti_entropy.use_bg_manager", "riak_kv.aae_use_background_manager", [
+    {datatype, {enum, [true, false]}},
+    {level, advanced},
+    {default, true}
+]}.

--- a/test/riak_kv_schema_tests.erl
+++ b/test/riak_kv_schema_tests.erl
@@ -61,6 +61,8 @@ basic_schema_test() ->
     cuttlefish_unit:assert_not_configured(Config, "riak_core.default_bucket_props.precommit"),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.default_bucket_props.postcommit"),
     cuttlefish_unit:assert_config(Config, "riak_dt.binary_compression", 1),
+    cuttlefish_unit:assert_config(Config, "riak_kv.handoff_use_background_manager", true),
+    cuttlefish_unit:assert_config(Config, "riak_kv.aae_use_background_manager", true),
     ok.
 
 override_non_multi_backend_schema_test() ->
@@ -114,7 +116,9 @@ override_non_multi_backend_schema_test() ->
         {["buckets", "default", "last_write_wins"], true},
         {["buckets", "default", "precommit"], "module:function javascriptFunction"},
         {["buckets", "default", "postcommit"], "module2:function2"},
-        {["datatypes", "compression_level"], "off"}
+        {["datatypes", "compression_level"], "off"},
+        {["handoff", "use_background_manager"], off},
+        {["anti_entropy", "use_background_manager"], off}
     ],
 
     Config = cuttlefish_unit:generate_templated_config(
@@ -181,6 +185,9 @@ override_non_multi_backend_schema_test() ->
                ]}
     ]),
     cuttlefish_unit:assert_config(Config, "riak_dt.binary_compression", false),
+    cuttlefish_unit:assert_config(Config, "riak_kv.handoff_use_background_manager", false),
+    cuttlefish_unit:assert_config(Config, "riak_kv.aae_use_background_manager", false),
+
     ok.
 
 multi_backend_test() ->


### PR DESCRIPTION
Add cuttlefish schema for the KV's background manager "use/kill/enable" switch. When set to "false", KV won't use the background manager for the specified subsystems, namely AAE tree rebuilding and Handoff.
- On by default
- Advanced mode setting means it doesn't get generated into the config file "riak.config"
- Look for it in "dev/devN/data/generated.configs" where N=1..6 after `make devrel`

I examined the `generated.configs` file to confirm it was present and had the correct default value… you should see this:

```
...
 {riak_kv,
     [{aae_use_background_manager,true},
      {handoff_use_background_manager,true},
      {max_siblings,100},
     …
```
