### PR TITLE
Change AAE to pass internal_db option to LevelDB

### DIFF
--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -497,8 +497,9 @@ new_segment_store(Opts, State) ->
     Config2 = orddict:store(write_buffer_size, WriteBufferSize, Config),
     Config3 = orddict:erase(write_buffer_size_min, Config2),
     Config4 = orddict:erase(write_buffer_size_max, Config3),
-    Config5 = orddict:store(use_bloomfilter, true, Config4),
-    Options = orddict:store(create_if_missing, true, Config5),
+    Config5 = orddict:store(is_internal_db, true, Config4),
+    Config6 = orddict:store(use_bloomfilter, true, Config5),
+    Options = orddict:store(create_if_missing, true, Config6),
 
     filelib:ensure_dir(DataDir),
     {ok, Ref} = eleveldb:open(DataDir, Options),


### PR DESCRIPTION
This pull-request changes AAE to use the `internal_db` option for it's LevelDB instances that enables different write throttling treatment. This feature was backported from develop/2.0 and relies upon basho/leveldb#116 and basho/eleveldb#91

On Riak 1.4, a fresh Riak node/cluster takes several hours to build initial AAE trees. Testing the impact of this write throttle during builds is important, but so is testing the impact after builds have finished and AAE is running in normal realtime/exchange phase.

To more quickly test the post-build phase on an empty node, do the following:
1. Start up Riak as normal.
2. Attach to Riak using `riak attach`.
3. From the console, run the following to allow AAE to build trees quickly:

``` erlang
application:set_env(riak_kv, anti_entropy_build_limit, {100, 1000}).
application:set_env(riak_kv, anti_entropy_concurrency, 100).
application:set_env(riak_kv, anti_entropy_tick, 1000).
```
1. Wait until all AAE trees are built. This should only take a few seconds. Use `riak-admin aae_status` to verify.
2. Restart the node to restore default AAE settings.
3. Perform normal benchmarking/testing as usual.
