### PR TITLE
Use tools.mk in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test.*-temp-data
 ebin
 /.eqc-info
 /current_counterexample.eqc
+.local_dialyzer_plt

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ clean:
 distclean: clean
 	./rebar delete-deps
 
+DIALYZER_APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
+	xmerl webtool snmp public_key mnesia eunit syntax_tools compiler
+
+include tools.mk
+
 test-compile:
 ifeq (${has_eqc}, true)
 	cd deps/riak_dt; ./rebar -DEQC -DTEST clean compile
@@ -24,37 +29,4 @@ else
 	@echo "EQC not present, skipping recompile of riak_dt"
 endif
 
-test: all test-compile
-	./rebar skip_deps=true eunit
-
-docs:
-	./rebar skip_deps=true doc
-
-APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
-	xmerl webtool snmp public_key mnesia eunit syntax_tools compiler \
-	deps/**/ebin
-PLT ?= $(HOME)/.riak_kv_dialyzer_plt
-
-check_plt: compile
-	dialyzer --check_plt --plt $(PLT) --apps $(APPS) ebin
-
-build_plt: compile
-	dialyzer --build_plt --output_plt $(PLT) --apps $(APPS) ebin
-
-dialyzer: compile
-	@echo
-	@echo Use "'make check_plt'" to check PLT prior to using this target.
-	@echo Use "'make build_plt'" to build PLT prior to using this target.
-	@echo
-	@sleep 1
-	dialyzer -Wunmatched_returns -Werror_handling -Wrace_conditions \
-		-Wunderspecs --plt $(PLT) ebin
-
-cleanplt:
-	@echo
-	@echo "Are you sure?  It takes about 1/2 hour to re-build."
-	@echo Deleting $(PLT) in 5 seconds.
-	@ech
-	sleep 5
-	rm $(PLT)
-
+test: test-compile

--- a/tools.mk
+++ b/tools.mk
@@ -1,0 +1,45 @@
+test: compile
+	./rebar eunit skip_deps=true
+
+docs:
+	./rebar doc skip_deps=true
+
+PLT ?= $(HOME)/.riak_combo_dialyzer_plt
+LOCAL_PLT = .local_dialyzer_plt
+DIALYZER_FLAGS ?= -Wunmatched_returns
+
+${PLT}: compile
+ifneq (,$(wildcard $(PLT)))
+	dialyzer --check_plt --plt $(PLT) --apps $(DIALYZER_APPS) && \
+		dialyzer --add_to_plt --plt $(PLT) --output_plt $(PLT) --apps $(DIALYZER_APPS) ; test $$? -ne 1
+else
+	dialyzer --build_plt --output_plt $(PLT) --apps $(DIALYZER_APPS); test $$? -ne 1
+endif
+
+${LOCAL_PLT}: compile
+ifneq (,$(wildcard deps/*))
+ifneq (,$(wildcard $(LOCAL_PLT)))
+	dialyzer --check_plt --plt $(LOCAL_PLT) deps/*/ebin  && \
+		dialyzer --add_to_plt --plt $(LOCAL_PLT) --output_plt $(LOCAL_PLT) deps/*/ebin ; test $$? -ne 1
+else
+	dialyzer --build_plt --output_plt $(LOCAL_PLT) deps/*/ebin ; test $$? -ne 1
+endif
+endif
+
+dialyzer: ${PLT} ${LOCAL_PLT}
+	@echo "==> $(shell basename $(shell pwd)) (dialyzer)"
+	@if [ -f $(LOCAL_PLT) ]; then \
+		dialyzer $(DIALYZER_FLAGS) --plts $(PLT) $(LOCAL_PLT) -c ebin; \
+	else \
+		dialyzer $(DIALYZER_FLAGS) --plts $(PLT) -c ebin; \
+	fi
+
+cleanplt:
+	@echo 
+	@echo "Are you sure?  It takes several minutes to re-build."
+	@echo Deleting $(PLT) and $(LOCAL_PLT) in 5 seconds.
+	@echo 
+	sleep 5
+	rm $(PLT)
+	rm $(LOCAL_PLT)
+


### PR DESCRIPTION
We intentionally let the Makefile override the 'test' target from
tools.mk, because it does weird stuff.
