### PR TITLE
Handle all return values of merge.

### DIFF
--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -725,12 +725,13 @@ syntactic_merge(CurrentObject, NewObject) ->
                   end,
 
     case ancestors([UpdatedCurr, UpdatedNew]) of
-        [] -> merge(UpdatedCurr, UpdatedNew);
         [Ancestor] ->
             case equal(Ancestor, UpdatedCurr) of
                 true  -> UpdatedNew;
                 false -> UpdatedCurr
-            end
+            end;
+        _ ->
+            merge(UpdatedCurr, UpdatedNew)
     end.
 
 %% @doc Get an approximation of object size by adding together the bucket, key,


### PR DESCRIPTION
In the event that two objects, which are strict ancestors of themselves
are compared, handle that as if there are no strict ancestors available.
This prevents a crash of the kv_vnode during a put request.
