### PR TITLE
Setting "object.format" should not be in the default config file. [JIRA: RIAK-3372]

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -297,7 +297,8 @@ end
 %% * 1: New format for more compact storage of small values.
 {mapping, "object.format", "riak_kv.object_format", [
   {default, 1},
-  {datatype, [{integer, 1}, {integer, 0}]}
+  {datatype, [{integer, 1}, {integer, 0}]},
+  {level, advanced}
 ]}.
 
 {translation, "riak_kv.object_format",


### PR DESCRIPTION
This setting is only for use in upgrades/downgrades from versions 1.3 and earlier.
- [x] CSE approval
- [x] PM approval
