### PR TITLE
Ajs overload plumbing

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -461,9 +461,9 @@ list_keys(Bucket, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
 list_keys(Bucket, Filter, Timeout0, {?MODULE, [Node, _ClientId]}) ->
-    Timeout = 
+    Timeout =
         case Timeout0 of
-            T when is_integer(T) -> T; 
+            T when is_integer(T) -> T;
             _ -> ?DEFAULT_TIMEOUT*8
         end,
     Me = self(),
@@ -588,9 +588,9 @@ list_buckets(Filter, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
 list_buckets(Filter, Timeout, Type, {?MODULE, [Node, _ClientId]}) ->
     Me = self(),
     ReqId = mk_reqid(),
-    {ok, _Pid} = riak_kv_buckets_fsm_sup:start_buckets_fsm(Node, 
-                                                           [{raw, ReqId, Me}, 
-                                                            [Filter, Timeout, 
+    {ok, _Pid} = riak_kv_buckets_fsm_sup:start_buckets_fsm(Node,
+                                                           [{raw, ReqId, Me},
+                                                            [Filter, Timeout,
                                                              false, Type]]),
     wait_for_listbuckets(ReqId).
 
@@ -607,10 +607,10 @@ stream_list_buckets({?MODULE, [_Node, _ClientId]}=THIS) ->
 
 stream_list_buckets(undefined, {?MODULE, [_Node, _ClientId]}=THIS) ->
     stream_list_buckets(none, ?DEFAULT_TIMEOUT, THIS);
-stream_list_buckets(Timeout, {?MODULE, [_Node, _ClientId]}=THIS) 
+stream_list_buckets(Timeout, {?MODULE, [_Node, _ClientId]}=THIS)
   when is_integer(Timeout) ->
     stream_list_buckets(none, Timeout, THIS);
-stream_list_buckets(Filter, {?MODULE, [_Node, _ClientId]}=THIS) 
+stream_list_buckets(Filter, {?MODULE, [_Node, _ClientId]}=THIS)
   when is_function(Filter) ->
     stream_list_buckets(Filter, ?DEFAULT_TIMEOUT, THIS).
 
@@ -629,7 +629,7 @@ stream_list_buckets(Filter, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
 %%      out of date if called immediately after any operation that
 %%      either adds the first key or removes the last remaining key from
 %%      a bucket.
-stream_list_buckets(Filter, Timeout, Client, 
+stream_list_buckets(Filter, Timeout, Client,
                     {?MODULE, [_Node, _ClientId]}=THIS) when is_pid(Client) ->
     stream_list_buckets(Filter, Timeout, Client, <<"default">>, THIS);
 stream_list_buckets(Filter, Timeout, Type,
@@ -640,10 +640,10 @@ stream_list_buckets(Filter, Timeout, Type,
 stream_list_buckets(Filter, Timeout, Client, Type,
                     {?MODULE, [Node, _ClientId]}) ->
     ReqId = mk_reqid(),
-    {ok, _Pid} = riak_kv_buckets_fsm_sup:start_buckets_fsm(Node, 
-                                                           [{raw, ReqId, 
-                                                             Client}, 
-                                                            [Filter, Timeout, 
+    {ok, _Pid} = riak_kv_buckets_fsm_sup:start_buckets_fsm(Node,
+                                                           [{raw, ReqId,
+                                                             Client},
+                                                            [Filter, Timeout,
                                                              true, Type]]),
     {ok, ReqId}.
 
@@ -781,15 +781,16 @@ wait_for_listkeys(ReqId, Acc) ->
             riak_kv_keys_fsm:ack_keys(From),
             wait_for_listkeys(ReqId, [Res|Acc]);
         {ReqId,{keys,Res}} -> wait_for_listkeys(ReqId, [Res|Acc]);
-        {ReqId, {error, Error}} -> {error, Error}
+        {ReqId, {error, Error}} ->
+            {error, Error}
     end.
 
 %% @private
 wait_for_listbuckets(ReqId) ->
     receive
-        {ReqId,{buckets, Buckets}} -> 
+        {ReqId,{buckets, Buckets}} ->
             {ok, Buckets};
-        {ReqId, Error} -> 
+        {ReqId, {error, Error}} ->
             {error, Error}
     end.
 

--- a/src/riak_kv_keys_fsm.erl
+++ b/src/riak_kv_keys_fsm.erl
@@ -103,18 +103,18 @@ process_results({From, Bucket, Keys},
     process_keys(Bucket, Keys, ReqId, ClientPid),
     riak_kv_vnode:ack_keys(From), % tell that vnode we're ready for more
     {ok, StateData};
+process_results({error, Reason}, _State) ->
+    ?DTRACE(?C_KEYS_PROCESS_RESULTS, [-1], []),
+    {error, Reason};
 process_results({Bucket, Keys},
                 StateData=#state{from={raw, ReqId, ClientPid}}) ->
     ?DTRACE(?C_KEYS_PROCESS_RESULTS, [length(Keys)], []),
     process_keys(Bucket, Keys, ReqId, ClientPid),
     {ok, StateData};
 process_results(done, StateData) ->
-    {done, StateData};
-process_results({error, Reason}, _State) ->
-    ?DTRACE(?C_KEYS_PROCESS_RESULTS, [-1], []),
-    {error, Reason}.
+    {done, StateData}.
 
-finish({error, Error},
+finish({error, _}=Error,
        StateData=#state{from={raw, ReqId, ClientPid}}) ->
     ?DTRACE(?C_KEYS_FINISH, [-1], []),
     %% Notify the requesting client that an error

--- a/src/riak_kv_pb_bucket.erl
+++ b/src/riak_kv_pb_bucket.erl
@@ -138,6 +138,9 @@ process_stream({ReqId, From, {keys, Keys}}, ReqId,
 process_stream({ReqId, {keys, Keys}}, ReqId,
                State=#state{req=#rpblistkeysreq{}, req_ctx=ReqId}) ->
     {reply, #rpblistkeysresp{keys = Keys}, State};
+process_stream({ReqId, {error, Error}}, ReqId,
+               State=#state{ req=#rpblistkeysreq{}, req_ctx=ReqId}) ->
+    {error, {format, Error}, State#state{req = undefined, req_ctx = undefined}};
 process_stream({ReqId, Error}, ReqId,
                State=#state{ req=#rpblistkeysreq{}, req_ctx=ReqId}) ->
     {error, {format, Error}, State#state{req = undefined, req_ctx = undefined}};
@@ -151,6 +154,9 @@ process_stream({ReqId, {buckets_stream, []}}, ReqId,
 process_stream({ReqId, {buckets_stream, Buckets}}, ReqId,
                State=#state{req=#rpblistbucketsreq{}, req_ctx=ReqId}) ->
     {reply, #rpblistbucketsresp{buckets = Buckets}, State};
+process_stream({ReqId, {error, Error}}, ReqId,
+               State=#state{ req=#rpblistbucketsreq{}, req_ctx=ReqId}) ->
+    {error, {format, Error}, State#state{req = undefined, req_ctx = undefined}};
 process_stream({ReqId, Error}, ReqId,
                State=#state{ req=#rpblistbucketsreq{}, req_ctx=ReqId}) ->
     {error, {format, Error}, State#state{req = undefined, req_ctx = undefined}}.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -119,7 +119,7 @@
                 handoff_target :: node(),
                 forward :: node() | [{integer(), node()}],
                 hashtrees :: pid(),
-                md_cache :: ets:tab(), 
+                md_cache :: ets:tab(),
                 md_cache_size :: pos_integer() }).
 
 -type index_op() :: add | remove.
@@ -400,15 +400,15 @@ init([Index]) ->
     {ok, VId} = get_vnodeid(Index),
     DeleteMode = app_helper:get_env(riak_kv, delete_mode, 3000),
     AsyncFolding = app_helper:get_env(riak_kv, async_folds, true) == true,
-    MDCacheSize = app_helper:get_env(riak_kv, vnode_md_cache_size), 
-    MDCache = 
+    MDCacheSize = app_helper:get_env(riak_kv, vnode_md_cache_size),
+    MDCache =
         case MDCacheSize of
             N when is_integer(N),
                    N > 0 ->
-                lager:debug("Initializing metadata cache with size limit: ~p bytes", 
+                lager:debug("Initializing metadata cache with size limit: ~p bytes",
                            [MDCacheSize]),
                 new_md_cache(VId);
-            _ -> 
+            _ ->
                 lager:debug("No metadata cache size defined, not starting"),
                 undefined
         end,
@@ -456,9 +456,8 @@ handle_overload_command(?KV_GET_REQ{req_id=ReqID}, Sender, Idx) ->
     riak_core_vnode:reply(Sender, {r, {error, overload}, Idx, ReqID});
 handle_overload_command(?KV_VNODE_STATUS_REQ{}, Sender, Idx) ->
     riak_core_vnode:reply(Sender, {vnode_status, Idx, [{error, overload}]});
-handle_overload_command(_, _, _) ->
-    %% not handled yet
-    ok.
+handle_overload_command(_, Sender, _) ->
+    riak_core_vnode:reply(Sender, {error, mailbox_overload}).
 
 handle_command(?KV_PUT_REQ{bkey=BKey,
                            object=Object,
@@ -597,7 +596,7 @@ handle_command({refresh_index_data, BKey, OldIdxData}, Sender,
                     {false, undefined, []}
             end,
             IndexSpecs = riak_object:diff_index_data(OldIdxData, IdxData),
-            {Reply, UpModState} = 
+            {Reply, UpModState} =
             case Mod:put(Bucket, Key, IndexSpecs, undefined, ModState) of
                 {ok, ModState2} ->
                     riak_kv_stat:update(vnode_index_refresh),
@@ -941,7 +940,7 @@ handle_handoff_data(BinObj, State) ->
     try
         {BKey, Val} = decode_binary_object(BinObj),
         {B, K} = BKey,
-        case do_diffobj_put(BKey, riak_object:from_binary(B, K, Val), 
+        case do_diffobj_put(BKey, riak_object:from_binary(B, K, Val),
                             State) of
             {ok, UpdModState} ->
                 {reply, ok, State#state{modstate=UpdModState}};
@@ -1247,7 +1246,7 @@ prepare_put(#state{vnodeid=VId,
             IndexBackend) ->
     {CacheClock, CacheData} = maybe_check_md_cache(MDCache, BKey),
 
-    RequiresGet = 
+    RequiresGet =
         case CacheClock of
             undefined ->
                 true;
@@ -1260,7 +1259,7 @@ prepare_put(#state{vnodeid=VId,
                 end
         end,
     GetReply =
-        case RequiresGet of 
+        case RequiresGet of
             true ->
                 case do_get_object(Bucket, Key, Mod, ModState) of
                     {error, not_found, _UpdModState} ->
@@ -1503,7 +1502,7 @@ put_merge(true, false, LocalObj, PutObj, VId, StartTime) -> %% Coordinating=true
 do_get(_Sender, BKey, ReqID,
        State=#state{idx=Idx, mod=Mod, modstate=ModState}) ->
     StartTS = os:timestamp(),
-    Retval = do_get_term(BKey, Mod, ModState),                
+    Retval = do_get_term(BKey, Mod, ModState),
     case Retval of
         {ok, Obj} ->
             maybe_cache_object(BKey, Obj, State);
@@ -2199,9 +2198,9 @@ maybe_check_md_cache(Table, BKey) ->
             {undefined, undefined};
         _ ->
             case ets:lookup(Table, BKey) of
-                [{_TS, BKey, MD}] -> 
+                [{_TS, BKey, MD}] ->
                     MD;
-                [] -> 
+                [] ->
                     {undefined, undefined}
             end
     end.
@@ -2240,7 +2239,7 @@ insert_md_cache(Table, MaxSize, BKey, MD) ->
 
 trim_md_cache(Table, MaxSize) ->
     Oldest = ets:first(Table),
-    case Oldest of 
+    case Oldest of
         '$end_of_table' ->
             ok;
         BKey ->
@@ -2253,8 +2252,8 @@ trim_md_cache(Table, MaxSize) ->
                     ok
             end
     end.
-        
-new_md_cache(VId) ->                
+
+new_md_cache(VId) ->
     MDCacheName = list_to_atom(?MD_CACHE_BASE ++ integer_to_list(binary:decode_unsigned(VId))),
     %% ordered set to make sure that the first key is the oldest
     %% term format is {TimeStamp, Key, ValueTuple}


### PR DESCRIPTION
Process overload for coverage queries and other queries that were previously not handled. Return `{error, mailbox_overload}` when the riak_core_vnode_proxy tells us we are overloaded.

Part of a fix for #753 
Should be merged together with https://github.com/basho/riak_core/pull/513
