### PR TITLE
revert allow_mult default only for untyped (default type) buckets

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -488,11 +488,11 @@ end
  hidden
 ]}.
 
-%% @doc Whether or not siblings are allowed.  Note: See Vector Clocks
-%% for a discussion of sibling resolution.
+%% @doc Whether or not siblings are allowed, by default, for untyped buckets.
+%% Note: See Vector Clocks for a discussion of sibling resolution.
 {mapping, "buckets.default.allow_mult", "riak_core.default_bucket_props.allow_mult", [
   {datatype, {enum, [true, false]}},
-  {default, true},
+  {default, false},
   hidden
 ]}.
 

--- a/test/riak_kv_schema_tests.erl
+++ b/test/riak_kv_schema_tests.erl
@@ -56,7 +56,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.rw", quorum),
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.notfound_ok", true),
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.basic_quorum", false),
-    cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.allow_mult", true),
+    cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.allow_mult", false),
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.last_write_wins", false),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.default_bucket_props.precommit"),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.default_bucket_props.postcommit"),
@@ -109,7 +109,7 @@ override_non_multi_backend_schema_test() ->
         {["buckets", "default", "rw"], 1},
         {["buckets", "default", "notfound_ok"], false},
         {["buckets", "default", "basic_quorum"], true},
-        {["buckets", "default", "allow_mult"], false},
+        {["buckets", "default", "allow_mult"], true},
         {["buckets", "default", "last_write_wins"], true},
         {["buckets", "default", "precommit"], "module:function javascriptFunction"},
         {["buckets", "default", "postcommit"], "module2:function2"}
@@ -162,7 +162,7 @@ override_non_multi_backend_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.rw", 1),
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.notfound_ok", false),
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.basic_quorum", true),
-    cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.allow_mult", false),
+    cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.allow_mult", true),
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.last_write_wins", true),
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.precommit", [
       {struct, [
@@ -235,7 +235,7 @@ multi_backend_test() ->
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.rw", quorum),
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.notfound_ok", true),
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.basic_quorum", false),
-    cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.allow_mult", true),
+    cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.allow_mult", false),
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.last_write_wins", false),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.default_bucket_props.precommit"),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.default_bucket_props.postcommit"),


### PR DESCRIPTION
as discussed.

confbal -- I attempted to update the description for `allow_mult` but am realizing now that this is probably insufficient given all default bucket properties in `riak.conf` only affect untyped buckets and we have yet to decide if "untyped buckets" is in fact what we want to call them.

Before Merge:
- [x] verify test changes are correct and pass
- [ ] CSE +1
- [x] PM +1
- [ ] Have a plan re: testing (specifically `riak_test`) as discussed -- ideally testing both setting values, or at a minimum preserve `allow_mult=true` in tests that have been updated to account for it
