### PR TITLE
A fix and optimization for the HTTP interface to riak_kv

### DIFF
--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -17,7 +17,6 @@
 %% Names of riak_object metadata fields
 -define(MD_CTYPE,    <<"content-type">>).
 -define(MD_CHARSET,  <<"charset">>).
--define(MD_ENCODING, <<"content-encoding">>).
 -define(MD_VTAG,     <<"X-Riak-VTag">>).
 -define(MD_LINKS,    <<"Links">>).
 -define(MD_LASTMOD,  <<"X-Riak-Last-Modified">>).
@@ -29,7 +28,6 @@
 -define(HEAD_CTYPE,           "Content-Type").
 -define(HEAD_VCLOCK,          "X-Riak-Vclock").
 -define(HEAD_LINK,            "Link").
--define(HEAD_ENCODING,        "Content-Encoding").
 -define(HEAD_CLIENT,          "X-Riak-ClientId").
 -define(HEAD_USERMETA_PREFIX, "x-riak-meta-").
 -define(HEAD_INDEX_PREFIX,    "x-riak-index-").

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -33,6 +33,7 @@
 -define(HEAD_INDEX_PREFIX,    "x-riak-index-").
 -define(HEAD_DELETED,         "X-Riak-Deleted").
 -define(HEAD_TIMEOUT,         "X-Riak-Timeout").
+-define(HEAD_CONDITION_PREFIX,"if-").
 
 %% Names of JSON fields in bucket properties
 -define(JSON_PROPS,   <<"props">>).

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -106,10 +106,6 @@ multipart_encode_body(Prefix, Bucket, {MD, V}, APIVersion) ->
          error -> []
      end,
      "\r\n",
-     case dict:find(?MD_ENCODING, MD) of
-         {ok, Enc} -> [?HEAD_ENCODING,": ",Enc,"\r\n"];
-         error -> []
-     end,
      ?HEAD_LINK,": ",Links4,"\r\n",
      "Etag: ",dict:fetch(?MD_VTAG, MD),"\r\n",
      "Last-Modified: ",


### PR DESCRIPTION
The fix is just dropping the ability to have the user set "content-encoding" and subsequently stop storing it on the riak_object.  It seems to have possibly be previously conflated as another sort of "content-type" metadata, but the HTTP RFC disagrees with us.

The optimization is to avoid the current code path on PUT that does a full client replica GET request at the coordinator before performing the actual PUT operation.  Testing done by @deanproctor showed that on a 100% PUT load we could cut CPU, network, and disk utilization almost in half.
