### PR TITLE
Export riak_kv_vnode:get/4

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -30,6 +30,7 @@
 -export([start_vnode/1,
          start_vnodes/1,
          get/3,
+         get/4,
          del/3,
          put/6,
          local_get/2,


### PR DESCRIPTION
The new AAE test needs to get values directly from vnodes to be able to
verify the state of all replicas of an object. The function that
performs the get with an arbitrary caller (not an FSM) was unfortunately
not exported.
