### PR TITLE
Backport object size/sibling limits to 1.4

### DIFF
--- a/src/riak_kv.app.src
+++ b/src/riak_kv.app.src
@@ -47,6 +47,12 @@
          %% This will allow arbitrary Erlang code to be submitted
          %% through the REST and Protocol Buffers interfaces. This
          %% should only be used for development purposes.
-         {allow_strfun, false}
+         {allow_strfun, false},
+
+         %% Log a warning if object bigger than this
+         {warn_object_size, 5000000},
+         %% Log a warning if # of siblings bigger than this
+         {warn_siblings, 25}
+
         ]}
  ]}.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1291,6 +1291,16 @@ do_get_object(Bucket, Key, Mod, ModState) ->
         false ->
             case do_get_binary(Bucket, Key, Mod, ModState) of
                 {ok, ObjBin, _UpdModState} ->
+                    ObjSize = size(ObjBin),
+                    WarnObjSize = app_helper:get_env(riak_kv, warn_object_size),
+                    case ObjSize > WarnObjSize of
+                        true ->
+                            lager:warning("Reading large object of size ~p from ~p/~p",
+                                          [ObjSize, Bucket, Key]);
+                        false ->
+                            ok
+                    end,
+
                     try
                         case riak_object:from_binary(Bucket, Key, ObjBin) of
                             {error, Reason} ->
@@ -1768,13 +1778,53 @@ return_encoded_binary_object(Method, EncodedObject) ->
            {{error, Reason::term(), UpdModState::term()}, EncodedObj::binary()}.
 
 encode_and_put(Obj, Mod, Bucket, Key, IndexSpecs, ModState) ->
+    NumSiblings = riak_object:value_count(Obj),
+    case NumSiblings > app_helper:get_env(riak_kv, max_siblings) of
+        true ->
+            lager:error("Too many siblings for object ~p/~p (~p)",
+                        [Bucket, Key, NumSiblings]),
+            {{error, {too_many_siblings, NumSiblings}, ModState},
+             undefined};
+        false ->
+            case NumSiblings > app_helper:get_env(riak_kv, warn_siblings) of
+                true ->
+                    lager:warning("Too many siblings for object ~p/~p (~p)",
+                                  [Bucket, Key, NumSiblings]);
+                false ->
+                    ok
+            end,
+            encode_and_put_no_sib_check(Obj, Mod, Bucket, Key, IndexSpecs, ModState)
+    end.
+
+encode_and_put_no_sib_check(Obj, Mod, Bucket, Key, IndexSpecs, ModState) ->
     case uses_r_object(Mod, ModState, Bucket) of
         true ->
             Mod:put_object(Bucket, Key, IndexSpecs, Obj, ModState);
         false ->
             ObjFmt = riak_core_capability:get({riak_kv, object_format}, v0),
             EncodedVal = riak_object:to_binary(ObjFmt, Obj),
-            {Mod:put(Bucket, Key, IndexSpecs, EncodedVal, ModState), EncodedVal}
+            BinSize = size(EncodedVal),
+            %% Report or fail on large objects
+            case BinSize > app_helper:get_env(riak_kv, max_object_size) of
+                true ->
+                    lager:error("Object too large to write: ~p/~p ~p bytes",
+                                [Bucket, Key, BinSize]),
+                    {{error, {too_large, BinSize}, ModState},
+                     EncodedVal};
+                false ->
+                    WarnSize = app_helper:get_env(riak_kv, warn_object_size),
+                    case BinSize > WarnSize of
+                       true ->
+                            lager:warning("Writing very large object " ++
+                                          "(~p bytes) to ~p/~p",
+                                          [BinSize, Bucket, Key]);
+                        false ->
+                            ok
+                    end,
+                    PutRet = Mod:put(Bucket, Key, IndexSpecs, EncodedVal,
+                                     ModState),
+                    {PutRet, EncodedVal}
+            end
     end.
 
 uses_r_object(Mod, ModState, Bucket) ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1169,8 +1169,8 @@ perform_put({true, Obj},
                 false ->
                     Reply = {dw, Idx, ReqID}
             end;
-        {{error, _Reason, UpdModState}, _EncodedVal} ->
-            Reply = {fail, Idx, ReqID}
+        {{error, Reason, UpdModState}, _EncodedVal} ->
+            Reply = {fail, Idx, Reason}
     end,
     {Reply, State#state{modstate=UpdModState}}.
 

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1781,7 +1781,7 @@ encode_and_put(Obj, Mod, Bucket, Key, IndexSpecs, ModState) ->
     NumSiblings = riak_object:value_count(Obj),
     case NumSiblings > app_helper:get_env(riak_kv, max_siblings) of
         true ->
-            lager:error("Too many siblings for object ~p/~p (~p)",
+            lager:error("Put failure: too many siblings for object ~p/~p (~p)",
                         [Bucket, Key, NumSiblings]),
             {{error, {too_many_siblings, NumSiblings}, ModState},
              undefined};
@@ -1807,7 +1807,7 @@ encode_and_put_no_sib_check(Obj, Mod, Bucket, Key, IndexSpecs, ModState) ->
             %% Report or fail on large objects
             case BinSize > app_helper:get_env(riak_kv, max_object_size) of
                 true ->
-                    lager:error("Object too large to write: ~p/~p ~p bytes",
+                    lager:error("Put failure: object too large to write ~p/~p ~p bytes",
                                 [Bucket, Key, BinSize]),
                     {{error, {too_large, BinSize}, ModState},
                      EncodedVal};


### PR DESCRIPTION
- Objects larger than warn_object_size will log a warning on read or
  write. The default is 5MiB
- Objects larger than max_object_size will fail to be written, logging
  an error message. By default no limit.
- Objects with a sibling count larger than warn_siblings will log a
  warning on write. By default 25.
- Objects with a sibling count larger than max_siblings will fail to
  write, logging an error message. By default no limit.

Note: in 2.0, there will be default values for max size and siblings, but I didn't want to risk failing operations for users in a point release.
