### PR TITLE
Add Yokozuna stats so they appear in console and http /stats 

### DIFF
--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -156,7 +156,7 @@ produce_stats() ->
        config_stats(),
        app_stats(),
        memory_stats(),
-       yz_stats()
+       yz_stat:search_stats()
       ]).
 
 %% Stats in folsom are stored with tuples as keys, the
@@ -552,15 +552,6 @@ config_stats() ->
 %% with those stats already in the blob
 pipe_stats() ->
     lists:flatten([bc_stat(Name, Val) || {Name, Val} <- riak_pipe_stat:get_stats()]).
-
-%% @doc add the yz stats to the blob in a style consistent
-%% with those stats already in the blob
-yz_stats() ->
-    {Legacy, _Calculated} = lists:foldl(fun({Old, New, Type}, {Acc, Cache}) ->
-                                                bc_stat({Old, New, Type}, Acc, Cache) end,
-                                        {[], []},
-                                        yz_stat:stats_map()),
-    lists:reverse(Legacy).
 
 %% old style blob stats don't have the app name
 %% and they have underscores, not commas

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -155,7 +155,8 @@ produce_stats() ->
        ring_stats(),
        config_stats(),
        app_stats(),
-       memory_stats()
+       memory_stats(),
+       yz_stats()
       ]).
 
 %% Stats in folsom are stored with tuples as keys, the
@@ -551,6 +552,15 @@ config_stats() ->
 %% with those stats already in the blob
 pipe_stats() ->
     lists:flatten([bc_stat(Name, Val) || {Name, Val} <- riak_pipe_stat:get_stats()]).
+
+%% @doc add the yz stats to the blob in a style consistent
+%% with those stats already in the blob
+yz_stats() ->
+    {Legacy, _Calculated} = lists:foldl(fun({Old, New, Type}, {Acc, Cache}) ->
+                                                bc_stat({Old, New, Type}, Acc, Cache) end,
+                                        {[], []},
+                                        yz_stat:stats_map()),
+    lists:reverse(Legacy).
 
 %% old style blob stats don't have the app name
 %% and they have underscores, not commas

--- a/src/riak_kv_status.erl
+++ b/src/riak_kv_status.erl
@@ -36,7 +36,6 @@
 -spec(statistics() -> [any()]).
 statistics() ->
     riak_kv_stat:get_stats().
-%%    riak_kv_stat:get_stats() ++ yz_stat:get_formatted_stats().
 
 ringready() ->
     riak_core_status:ringready().

--- a/src/riak_kv_status.erl
+++ b/src/riak_kv_status.erl
@@ -35,7 +35,8 @@
 
 -spec(statistics() -> [any()]).
 statistics() ->
-    riak_kv_stat:get_stats() ++ yz_stat:get_formatted_stats().
+    riak_kv_stat:get_stats().
+%%    riak_kv_stat:get_stats() ++ yz_stat:get_formatted_stats().
 
 ringready() ->
     riak_core_status:ringready().

--- a/src/riak_kv_status.erl
+++ b/src/riak_kv_status.erl
@@ -35,7 +35,7 @@
 
 -spec(statistics() -> [any()]).
 statistics() ->
-    riak_kv_stat:get_stats().
+    riak_kv_stat:get_stats() ++ yz_stat:get_formatted_stats().
 
 ringready() ->
     riak_core_status:ringready().

--- a/src/riak_kv_wm_stats.erl
+++ b/src/riak_kv_wm_stats.erl
@@ -86,4 +86,4 @@ pretty_print(RD1, C1=#ctx{}) ->
 get_stats() ->
     {value, {disk, Disk}, Stats} = lists:keytake(disk, 1, riak_kv_stat:get_stats()),
     DiskFlat = [{struct, [{id, list_to_binary(Id)}, {size, Size}, {used, Used}]} || {Id, Size, Used} <- Disk],
-    lists:append([Stats, [{disk, DiskFlat}], riak_core_stat:get_stats(), yz_stat:get_stats()]).
+    lists:append([Stats, [{disk, DiskFlat}], riak_core_stat:get_stats(), yz_stat:search_stats()]).

--- a/src/riak_kv_wm_stats.erl
+++ b/src/riak_kv_wm_stats.erl
@@ -86,4 +86,4 @@ pretty_print(RD1, C1=#ctx{}) ->
 get_stats() ->
     {value, {disk, Disk}, Stats} = lists:keytake(disk, 1, riak_kv_stat:get_stats()),
     DiskFlat = [{struct, [{id, list_to_binary(Id)}, {size, Size}, {used, Used}]} || {Id, Size, Used} <- Disk],
-    lists:append([Stats, [{disk, DiskFlat}], riak_core_stat:get_stats()]).
+    lists:append([Stats, [{disk, DiskFlat}], riak_core_stat:get_stats(), yz_stat:get_formatted_stats()]).

--- a/src/riak_kv_wm_stats.erl
+++ b/src/riak_kv_wm_stats.erl
@@ -86,4 +86,4 @@ pretty_print(RD1, C1=#ctx{}) ->
 get_stats() ->
     {value, {disk, Disk}, Stats} = lists:keytake(disk, 1, riak_kv_stat:get_stats()),
     DiskFlat = [{struct, [{id, list_to_binary(Id)}, {size, Size}, {used, Used}]} || {Id, Size, Used} <- Disk],
-    lists:append([Stats, [{disk, DiskFlat}], riak_core_stat:get_stats(), yz_stat:get_formatted_stats()]).
+    lists:append([Stats, [{disk, DiskFlat}], riak_core_stat:get_stats(), yz_stat:get_stats()]).


### PR DESCRIPTION
Yokozuna stats are current not appearing in 'riak-admin status' or http output. Add them to riak_kv_status and riak_kv_wm_stats so that they do.

In support of this YZ PR:

https://github.com/basho/yokozuna/pull/304
