### PR TITLE
Backwards compat for users running map reduce jobs that use riak_kv_counter

### DIFF
--- a/src/riak_kv_counter.erl
+++ b/src/riak_kv_counter.erl
@@ -1,0 +1,43 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_counter: Backwards compatibile access to counters for
+%% customer MR
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Backwads compatibility with 1.4 counters `value' function as
+%% used in the CRDT cookbook.
+%%
+%% @see riak_kv_crdt.erl
+%% @end
+
+-module(riak_kv_counter).
+
+-export([value/1]).
+
+-include("riak_kv_wm_raw.hrl").
+-include_lib("riak_kv_types.hrl").
+
+%% @doc Get the value of V1 (1.4) Counter from an Object. Backwards
+%% compatability with 1.4 for MapReduce.
+-spec value(riak_object:riak_object()) ->
+                   integer().
+value(RObj) ->
+    {{_Ctx, Count}, _Stats} = riak_kv_crdt:value(RObj, ?V1_COUNTER_TYPE),
+    Count.

--- a/src/riak_kv_counter.erl
+++ b/src/riak_kv_counter.erl
@@ -21,7 +21,7 @@
 %%
 %% -------------------------------------------------------------------
 
-%% @doc Backwads compatibility with 1.4 counters `value' function as
+%% @doc Backwards compatibility with 1.4 counters `value' function as
 %% used in the CRDT cookbook.
 %%
 %% @see riak_kv_crdt.erl

--- a/src/riak_kv_crdt.erl
+++ b/src/riak_kv_crdt.erl
@@ -111,21 +111,21 @@ value(RObj) ->
 %% get a 2.0+ counter type value, or zero if no counter is present.
 -spec counter_value(riak_object:riak_object()) -> integer().
 counter_value(RObj) ->
-    {{_Ctx, Count}, _Stats}  = crdt_value(RObj, ?COUNTER_TYPE),
+    {{_Ctx, Count}, _Stats}  = value(RObj, ?COUNTER_TYPE),
     Count.
 
 %% @doc convenience for (e.g.) MapReduce functions. Pass an object,
 %% get a 2.0+ Set type value, or `[]' if no Set is present.
 -spec set_value(riak_object:riak_object()) -> list().
 set_value(RObj) ->
-    {{_Ctx, Set}, _Stats}  = crdt_value(RObj, ?SET_TYPE),
+    {{_Ctx, Set}, _Stats}  = value(RObj, ?SET_TYPE),
     Set.
 
 %% @doc convenience for (e.g.) MapReduce functions. Pass an object,
 %% get a 2.0+ Map type value, or `[]' if no Map is present.
 -spec map_value(riak_object:riak_object()) -> proplist:proplist().
 map_value(RObj) ->
-    {{_Ctx, Map}, _Stats}  = crdt_value(RObj, ?MAP_TYPE),
+    {{_Ctx, Map}, _Stats}  = value(RObj, ?MAP_TYPE),
     Map.
 
 %% @TODO in riak_dt change value to query allow query to take an


### PR DESCRIPTION
Also add similar convenience functions for 2.0+ data types to riak_kv_crdt.
