### PR TITLE
Fix use of fsm timeouts in 2i AAE

### DIFF
--- a/src/riak_kv_2i_aae.erl
+++ b/src/riak_kv_2i_aae.erl
@@ -170,6 +170,7 @@ next_partition(State=#state{remaining=[Partition|_]}) ->
 wait_for_aae_pid(aae_pid_timeout, State) ->
     State2 = maybe_notify(State, {error, no_aae_pid}),
     State3 = add_result(#partition_result{status=error, error=no_aae_pid}, State2),
+    lager:error("AAE pid request timed out"),
     next_partition(State3#state{aae_pid_timer=undefined});
 % This is apparently a weird condition seen in the wild, change to error.
 wait_for_aae_pid({ReqId, {ok, undefined}},
@@ -181,6 +182,7 @@ wait_for_aae_pid({ReqId, {error, Err}}, State=#state{aae_pid_req_id=ReqId,
     State2 = State#state{aae_pid_timer=undefined},
     State3 = add_result(#partition_result{status=error, error={no_aae_pid, Err}}, State2),
     State4 = maybe_notify(State3, {error, {no_aae_pid, Err}}),
+    lager:error("AAE pid request failed"),
     next_partition(State4);
 wait_for_aae_pid({ReqId, {ok, TreePid}},
                  State=#state{aae_pid_req_id=ReqId, speed=Speed,

--- a/src/riak_kv_2i_aae.erl
+++ b/src/riak_kv_2i_aae.erl
@@ -26,7 +26,7 @@
 
 -export([start/2, stop/1, get_status/0, to_report/1]).
 
--export([next_partition/2, wait_for_aae_pid/2, wait_for_repair/3,
+-export([first_partition/2, wait_for_aae_pid/2, wait_for_repair/3,
          wait_for_repair/2]).
 
 %% gen_fsm callbacks
@@ -75,6 +75,7 @@
          reply_to,
          early_reply,
          aae_pid_req_id :: pid() | undefined,
+         aae_pid_timer :: reference() | undefined,
          worker_monitor :: reference() | undefined,
          worker_status :: worker_status(),
          index_scan_count = 0 :: integer(),
@@ -137,8 +138,8 @@ init([Partitions, Speed, Caller]) ->
     process_flag(trap_exit, true),
     lager:info("Starting 2i repair at speed ~p for partitions ~p",
                [Speed, Partitions]),
-    {ok, next_partition, #state{partitions=Partitions, remaining=Partitions,
-                                speed=Speed, caller=Caller}, 0}.
+    {ok, first_partition, #state{partitions=Partitions, remaining=Partitions,
+                                 speed=Speed, caller=Caller}, 0}.
 
 %% @doc Notifies caller for certain cases involving a single partition
 %% so the user sees an error condition from the command line.
@@ -148,29 +149,45 @@ maybe_notify(State=#state{reply_to=From}, Reply) ->
     gen_fsm:reply(From, Reply),
     State#state{reply_to=undefined}.
 
+first_partition(timeout, State) ->
+    next_partition(State).
 
 %% @doc Process next partition or finish if no more remaining.
-next_partition(timeout, State=#state{remaining=[]}) ->
+next_partition(State=#state{remaining=[]}) ->
     %% We are done. Report results
     Status = to_simple_state(State),
     Report = to_report(Status),
     lager:info("Finished 2i repair:\n~s", [Report]),
     {stop, normal, State};
-next_partition(timeout, State=#state{remaining=[Partition|_]}) ->
+next_partition(State=#state{remaining=[Partition|_]}) ->
     ReqId = make_ref(),
     riak_kv_vnode:request_hashtree_pid(Partition, {fsm, ReqId, self()}),
-    {next_state, wait_for_aae_pid, State#state{aae_pid_req_id=ReqId}, ?AAE_PID_TIMEOUT}.
+    Timer = gen_fsm:send_event_after(?AAE_PID_TIMEOUT, aae_pid_timeout),
+    {next_state, wait_for_aae_pid, State#state{aae_pid_req_id=ReqId,
+                                               aae_pid_timer=Timer}}.
 
 %% @doc Waiting for vnode to send back the Pid of the AAE tree process.
-wait_for_aae_pid(timeout, State) ->
-    State2 = maybe_notify(State, {error, no_aae_pid}),
-    {stop, no_aae_pid, State2};
-wait_for_aae_pid({ReqId, {error, Err}}, State=#state{aae_pid_req_id=ReqId}) ->
-    State2 = maybe_notify(State, {error, {no_aae_pid, Err}}),
-    {stop, no_aae_pid, State2};
+wait_for_aae_pid(aae_pid_timeout, State) ->
+    Err = {error, no_aae_pid},
+    State2 = maybe_notify(State, Err),
+    State3 = add_result(Err, State2),
+    next_partition(State3#state{aae_pid_timer=undefined});
+% This is apparently a weird condition seen in the wild, change to error.
+wait_for_aae_pid({ReqId, {ok, undefined}},
+                 State=#state{aae_pid_req_id=ReqId}) ->
+    wait_for_aae_pid({ReqId, {error, undefined_aae_pid}}, State);
+wait_for_aae_pid({ReqId, {error, Err}}, State=#state{aae_pid_req_id=ReqId,
+                                                     aae_pid_timer=Timer}) ->
+    gen_fsm:cancel_timer(Timer),
+    State2 = State#state{aae_pid_timer=undefined},
+    Err = {error, {no_aae_pid, Err}},
+    State3 = maybe_notify(State2, Err),
+    next_partition(State3);
 wait_for_aae_pid({ReqId, {ok, TreePid}},
                  State=#state{aae_pid_req_id=ReqId, speed=Speed,
+                              aae_pid_timer=Timer,
                               remaining=[Partition|_]}) ->
+    gen_fsm:cancel_timer(Timer),
     WorkerFun =
     fun() ->
             Res =
@@ -178,7 +195,12 @@ wait_for_aae_pid({ReqId, {ok, TreePid}},
             gen_fsm:sync_send_event(?MODULE, {repair_result, Res}, infinity)
     end,
     Mon = monitor(process, spawn_link(WorkerFun)),
-    {next_state, wait_for_repair, State#state{worker_monitor=Mon}}.
+    {next_state, wait_for_repair, State#state{worker_monitor=Mon,
+                                             aae_pid_timer=undefined}}.
+
+add_result(Result, State=#state{remaining=[Partition|Rem],
+                                results=Results}) ->
+    State#state{remaining=Rem, results=[{Partition, Result}|Results]}.
 
 %% @doc Waiting for a partition repair process to finish
 wait_for_repair({lock_acquired, Partition},
@@ -187,10 +209,8 @@ wait_for_repair({lock_acquired, Partition},
     State2 = maybe_notify(State, lock_acquired),
     {reply, ok, wait_for_repair, State2};
 wait_for_repair({repair_result, Res},
-                _From,
-                State=#state{remaining=[Partition|Rem],
-                             results=Results,
-                             worker_monitor=Mon}) ->
+                From,
+                State=#state{worker_monitor=Mon}) ->
     State2 =
     case Res of
         {error, {lock_failed, LockErr}} ->
@@ -199,15 +219,13 @@ wait_for_repair({repair_result, Res},
             State
     end,
     demonitor(Mon, [flush]),
-    {reply, ok, next_partition,
-     State2#state{remaining=Rem,
-                  results=[{Partition, Res}|Results],
-                  worker_monitor=undefined,
-                  worker_status=starting,
-                  index_scan_count=0,
-                  hashtree_population_count=0,
-                  exchange_count=0},
-     0}.
+    gen_fsm:reply(From, ok),
+    State3 = add_result(Res, State2),
+    next_partition(State3#state{worker_monitor=undefined,
+                                worker_status=starting,
+                                index_scan_count=0,
+                                hashtree_population_count=0,
+                                exchange_count=0}).
 
 %% @doc Process async worker status updates during a repair
 wait_for_repair({index_scan_update, Count}, State) ->


### PR DESCRIPTION
Joe pointed out some problems with FSM time outs in this code. It is
possible to set a timeout for the next FSM state, then receive a message
passed to handle_info and lose that timeout if not set again. Basically,
they are useless.
Refactored code to use gen_fsm:send_event_after() instead and managed
timer for the AAE pid request manually.
Also, a zero timeout transition was avoided by refactoring the code
around the next_partition state, which is now a simple function
directly executed from other states.
Also, if a request for an AAE pid every failed, the whole process would
have died silently. Instead, that is handled now like any other
partition error. So 2i AAE can happily go finishing the other
partitions.
