### PR TITLE
Use iterator_refresh backend option for some folds

### DIFF
--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -59,7 +59,8 @@
 -endif.
 
 -define(API_VERSION, 1).
--define(CAPABILITIES, [async_fold, indexes, index_reformat, size]).
+-define(CAPABILITIES, [async_fold, indexes, index_reformat, size,
+        iterator_refresh]).
 -define(FIXED_INDEXES_KEY, fixed_indexes).
 
 -record(state, {ref :: reference(),
@@ -466,9 +467,15 @@ fold_objects(FoldObjectsFun, Acc, Opts, #state{fold_opts=FoldOpts,
            true            -> undefined
         end,
 
+    IteratorRefresh =
+        case lists:keyfind(iterator_refresh, 1, Opts) of
+            false -> [];
+            Tuple -> [Tuple]
+        end,
+
     %% Set up the fold...
     FirstKey = to_first_key(Limiter),
-    FoldOpts1 = [{first_key, FirstKey} | FoldOpts],
+    FoldOpts1 = IteratorRefresh ++ [{first_key, FirstKey} | FoldOpts],
     FoldFun = fold_objects_fun(FoldObjectsFun, Limiter),
 
     ObjectFolder =

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -444,8 +444,11 @@ hash_index_data(IndexData) when is_list(IndexData) ->
 -spec fold_keys(index(), pid(), boolean()) -> ok.
 fold_keys(Partition, Tree, HasIndexTree) ->
     FoldFun = fold_fun(Tree, HasIndexTree),
+    Refresh = app_helper:get_env(riak_kv, iterator_refresh, true),
     Req = riak_core_util:make_fold_req(FoldFun,
-                                       0, false, [aae_reconstruction]),
+                                       0, false, 
+                                       [aae_reconstruction,
+                                        {iterator_refresh, Refresh}]),
     riak_core_vnode_master:sync_command({Partition, node()},
                                         Req,
                                         riak_kv_vnode_master, infinity),

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -52,7 +52,7 @@
 
 -define(API_VERSION, 1).
 -define(CAPABILITIES, [async_fold, index_reformat]).
--define(ANY_CAPABILITIES, [indexes]).
+-define(ANY_CAPABILITIES, [indexes, iterator_refresh]).
 
 -record (state, {backends :: [{atom(), atom(), term()}],
                  default_backend :: atom()}).


### PR DESCRIPTION
- Add iterator_refresh capability to riak_kv_elveldb_backend and
  riak_kv_multi_backend
- Handle iterator_refresh option/capability for ?FOLD_REQs in
  riak_kv_vnode
- support iterator_refresh option for AAE (riak_kv_index_hashtree)
- add riak_kv_vnode:fold/4
- return handoff fold options from handoff_started
  - handoff_started has been modified to require this
- Get value of iterator_refresh from env. Default to true.
