### PR TITLE
Add Yokozuna stats so they appear in console and http /stats

### DIFF
--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -155,7 +155,8 @@ produce_stats() ->
        ring_stats(),
        config_stats(),
        app_stats(),
-       memory_stats()
+       memory_stats(),
+       yz_stat:search_stats()
       ]).
 
 %% Stats in folsom are stored with tuples as keys, the

--- a/src/riak_kv_wm_stats.erl
+++ b/src/riak_kv_wm_stats.erl
@@ -86,4 +86,4 @@ pretty_print(RD1, C1=#ctx{}) ->
 get_stats() ->
     {value, {disk, Disk}, Stats} = lists:keytake(disk, 1, riak_kv_stat:get_stats()),
     DiskFlat = [{struct, [{id, list_to_binary(Id)}, {size, Size}, {used, Used}]} || {Id, Size, Used} <- Disk],
-    lists:append([Stats, [{disk, DiskFlat}], riak_core_stat:get_stats()]).
+    lists:append([Stats, [{disk, DiskFlat}], riak_core_stat:get_stats(), yz_stat:search_stats()]).


### PR DESCRIPTION
Yokozuna stats are current not appearing in 'riak-admin status' or http output. Add them to riak_kv_status and riak_kv_wm_stats so that they do.
