### PR TITLE
Fix timeout handling for key and bucket listing via HTTP

### DIFF
--- a/src/riak_kv_wm_buckets.erl
+++ b/src/riak_kv_wm_buckets.erl
@@ -222,5 +222,5 @@ stream_buckets(ReqId) ->
         {ReqId, {buckets_stream, Buckets}} ->
             {mochijson2:encode({struct, [{<<"buckets">>, Buckets}]}),
              fun() -> stream_buckets(ReqId) end};
-        {ReqId, timeout} -> {mochijson2:encode({struct, [{error, timeout}]}), done}
+        {ReqId, {error, timeout}} -> {mochijson2:encode({struct, [{error, timeout}]}), done}
     end.

--- a/src/riak_kv_wm_keylist.erl
+++ b/src/riak_kv_wm_keylist.erl
@@ -261,5 +261,5 @@ stream_keys(ReqId) ->
         {ReqId, {keys, Keys}} ->
             {mochijson2:encode({struct, [{<<"keys">>, Keys}]}), fun() -> stream_keys(ReqId) end};
         {ReqId, done} -> {mochijson2:encode({struct, [{<<"keys">>, []}]}), done};
-        {ReqId, timeout} -> {mochijson2:encode({struct, [{error, timeout}]}), done}
+        {ReqId, {error, timeout}} -> {mochijson2:encode({struct, [{error, timeout}]}), done}
     end.


### PR DESCRIPTION
Commit 32060f0230b00d3b6ecd6ac7fe4a6b4f71744d82 changed error handling in
riak_kv_keys_fsm and riak_kv_buckets_fsm to return error tuples instead of
just the error reason term. This broke the error message expectations for
timeout messages in riak_kv_wm_keylist and riak_kv_wm_buckets. This change
updates the error handling in those modules to be consistent with the current
form sent by the fsm modules.

This can be tested using the verify_api_timeouts riak_test
module. Without this change the test and the associated keylisting
request hangs attempting to verify the timeout for keylisting request
works correctly. With this change the test works as expected and
passes.
