### PR TITLE
Object limit changes done in 1.4.8

### DIFF
--- a/src/riak_kv.app.src
+++ b/src/riak_kv.app.src
@@ -54,6 +54,17 @@
          %% should only be used for development purposes.
          {allow_strfun, false},
 
+         %% Log a warning if object bigger than 5MB
+         {warn_object_size, 5242880},
+         % Writing an object bigger than 50MB will send a failure to the client
+         {max_object_size, 52428800},
+         %% Log a warning if # of siblings bigger than this
+         {warn_siblings, 25},
+         % Writing an object with more than this number of siblings will
+         % generate a warning in the logs
+         {max_siblings, 100},
+
+
          %% @doc http_url_encoding determines how Riak treats URL encoded
          %% buckets, keys, and links over the REST API. When set to 'on' Riak
          %% always decodes encoded values sent as URLs and Headers.  Otherwise,


### PR DESCRIPTION
Jon wanted object limits to not apply during handoff, and Jon gets what he wants.
Messages for errors and messages are now different for clarity.
This also adds non-cuttlefish defaults for the size/sibling limits, since the app may run with a legacy configuration file.
