### PR TITLE
Make get_put_monitor_eqc pass during `make test`

### DIFF
--- a/test/get_put_monitor_eqc.erl
+++ b/test/get_put_monitor_eqc.erl
@@ -25,14 +25,13 @@
         eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).
 
 eqc_test_() ->
-    error_logger:tty(false),
-    catch code:purge(riak_kv_stat_sj),
-    catch code:delete(riak_kv_stat_sj),
-    net_kernel:stop(),
-    net_kernel:start(['test-master@127.0.0.1', 'longnames']),
-    erlang:set_cookie(node(), ayo),
-    {node, 'tester@127.0.0.1', "-setcookie ayo", 
-     [
+    {setup, 
+        fun() -> 
+            error_logger:tty(false),
+            catch code:purge(riak_kv_stat_sj),
+            catch code:delete(riak_kv_stat_sj)
+        end, 
+        [
          {timeout, 120, [?_assertEqual(true, quickcheck(eqc:testing_time(90,
                            ?QC_OUT(prop()))))]}
        ]}.


### PR DESCRIPTION
Calling code:purge/1 and code:delete/1 were needed to make the test
pass. They effectively skirt using a sidejob worker to update folsom
stats, and do it directly instead. Since riak_kv is not running casts to
update folsom were being dropped on the floor that were needed by the
test. This only occurred in `make test` and not when running
get_put_monitor_eqc standalone because riak_kv was started and shutdown
before this test ran during `make test`.

Additionally, I added timeouts for the polling in case of a regression,
made the precondition more specific and ran this test in a slave node.
While these changes aren't strictly necessary they provide for cleaner
code and a better example for future tests.

I also removed some dead code.
