### PR TITLE
Send reply in event of a premature exit (via throw) from fold.

### DIFF
--- a/src/riak_kv_worker.erl
+++ b/src/riak_kv_worker.erl
@@ -45,7 +45,8 @@ handle_work({fold, FoldFun, FinishFun}, _Sender, State) ->
     try
         FinishFun(FoldFun())
     catch
-        receiver_down -> ok;
-        stop_fold -> ok
+        throw:receiver_down -> ok;
+        throw:stop_fold     -> ok;
+        throw:PrematureAcc  -> FinishFun(PrematureAcc)
     end,
     {noreply, State}.


### PR DESCRIPTION
Allow a folder to throw its accumulator to send it to the fold client, e.g. hinted/repair/ownership handoff.
