### PR TITLE
Fix list_to_binary invocations on permissions errors

### DIFF
--- a/src/riak_kv_wm_bucket_type.erl
+++ b/src/riak_kv_wm_bucket_type.erl
@@ -139,7 +139,7 @@ forbidden(RD, Ctx=#ctx{security=Security}) ->
             case Res of
                 {false, Error, _} ->
                     RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
-                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD1), Ctx};
+                    {true, wrq:append_to_resp_body(unicode:characters_to_binary(Error, utf8, utf8), RD1), Ctx};
                 {true, _} ->
                     forbidden_check_bucket_type(RD, Ctx)
             end

--- a/src/riak_kv_wm_buckets.erl
+++ b/src/riak_kv_wm_buckets.erl
@@ -131,7 +131,7 @@ forbidden(RD, Ctx) ->
             case Res of
                 {false, Error, _} ->
                     RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
-                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD1), Ctx};
+                    {true, wrq:append_to_resp_body(unicode:characters_to_binary(Error, utf8, utf8), RD1), Ctx};
                 {true, _} ->
                     {false, RD, Ctx}
             end

--- a/src/riak_kv_wm_counter.erl
+++ b/src/riak_kv_wm_counter.erl
@@ -190,7 +190,7 @@ forbidden(RD, Ctx=#ctx{security=Security}) ->
             case Res of
                 {false, Error, _} ->
                     RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
-                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD1), Ctx};
+                    {true, wrq:append_to_resp_body(unicode:characters_to_binary(Error, utf8, utf8), RD1), Ctx};
                 {true, _} ->
                     {false, RD, Ctx}
             end

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -139,7 +139,7 @@ forbidden(RD, Ctx) ->
             case Res of
                 {false, Error, _} ->
                     RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
-                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD1), Ctx};
+                    {true, wrq:append_to_resp_body(unicode:characters_to_binary(Error, utf8, utf8), RD1), Ctx};
                 {true, _} ->
                     {false, RD, Ctx}
             end

--- a/src/riak_kv_wm_keylist.erl
+++ b/src/riak_kv_wm_keylist.erl
@@ -141,7 +141,7 @@ forbidden(RD, Ctx) ->
             case Res of
                 {false, Error, _} ->
                     RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
-                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD1), Ctx};
+                    {true, wrq:append_to_resp_body(unicode:characters_to_binary(Error, utf8, utf8), RD1), Ctx};
                 {true, _} ->
                     {false, RD, Ctx}
             end

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -77,7 +77,7 @@ forbidden(RD, State) ->
                                 {false, Error, _} ->
                                     RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
                                     {true, wrq:append_to_resp_body(
-                                             list_to_binary(Error), RD1), State};
+                                             unicode:characters_to_binary(Error, utf8, utf8), RD1), State};
                                 {true, _} ->
                                     {false, RD, State}
                             end;

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -260,7 +260,9 @@ forbidden(RD, Ctx=#ctx{security=Security}) ->
             case Res of
                 {false, Error, _} ->
                     RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
-                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD1), Ctx};
+                    {true, wrq:append_to_resp_body(
+                             unicode:characters_to_binary(Error, utf8, utf8),
+                             RD1), Ctx};
                 {true, _} ->
                     case Perm of
                         "riak_kv.get" ->

--- a/src/riak_kv_wm_props.erl
+++ b/src/riak_kv_wm_props.erl
@@ -163,7 +163,7 @@ forbidden(RD, Ctx=#ctx{security=Security}) ->
             case Res of
                 {false, Error, _} ->
                     RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
-                    {true, wrq:append_to_resp_body(list_to_binary(Error), RD1), Ctx};
+                    {true, wrq:append_to_resp_body(unicode:characters_to_binary(Error, utf8, utf8), RD1), Ctx};
                 {true, _} ->
                     {false, RD, Ctx}
             end


### PR DESCRIPTION
Change to `unicode:characters_to_binary`. This is required if the forthcoming `riak_core` PR is accepted, but is recommended even if not.

/cc @Vagabond 
