### PR TITLE
Provide a minimal type for query_def.

### DIFF
--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -68,10 +68,13 @@
 %% @type query_element()   :: {eq,    index_field(), [index_value()]},
 %%                         :: {range, index_field(), [index_value(), index_value()}
 
+-type query_def() :: {ok, term()} | {error, term()} | {term(), {error, term()}}.
+-export_type([query_def/0]).
+
 -type last_result() :: {value(), key()} | key().
 -type value() :: binary() | integer().
 -type key() :: binary().
--opaque continuation() :: binary(). %% encoded last_result().
+-opaque continuation() :: binary() | undefined. %% encoded last_result().
 -export_type([continuation/0]).
 
 -type query_version() :: v1 | v2 | v3.


### PR DESCRIPTION
query_def is specified across kv and repl, but the type no longer
exists, provided a minimal type to use for the meantime.  We can't use
typer to derive the type, because riak_index is so incorrectly
specified, typer believes all of the functions return no value.

cc: @Vagabond 
