### PR TITLE
multi_backend.schema doesn't handle error cases of cuttlefish_generator:map/2

### DIFF
--- a/priv/multi_backend.schema
+++ b/priv/multi_backend.schema
@@ -22,8 +22,6 @@
 {translation,
  "riak_kv.multi_backend",
  fun(Conf, Schema) ->
-
-
   GenerateSubConfig = fun(Name, Prefix, ProplistKey, ModuleName) ->
       BackendConfigName = ["multi_backend", Name],
       BackendConfigPrefix = BackendConfigName ++ [Prefix],
@@ -33,15 +31,15 @@
 
       case cuttlefish_generator:map(Schema, SubConf) of
         {error, _Phase, _Errors} ->
-            cuttlefish:invalid("Error running recursive call to cuttlefish_generator:map/2");
+            cuttlefish:invalid(
+              lists:flatten(io_lib:format(
+                "Error processing multi_backend configuration for backend ~s", [Name])));
         BackendProplist ->
           Proplist = lists:foldl(
           fun(K, Acc) ->
-            NewAcc = proplists:get_value(K, Acc, []),
-            NewAcc
+            proplists:get_value(K, Acc, [])
           end,
           BackendProplist, ProplistKey),
-
           {ModuleName, Proplist}
       end
   end,

--- a/priv/multi_backend.schema
+++ b/priv/multi_backend.schema
@@ -28,7 +28,7 @@
       BackendConfigName = ["multi_backend", Name],
       BackendConfigPrefix = BackendConfigName ++ [Prefix],
       SubConf = [ begin
-          {Key -- BackendConfigName, Value}
+          {lists:nthtail(2, Key), Value}
       end || {Key, Value} <- cuttlefish_variable:filter_by_prefix(BackendConfigPrefix, Conf)],
 
       case cuttlefish_generator:map(Schema, SubConf) of

--- a/priv/multi_backend.schema
+++ b/priv/multi_backend.schema
@@ -22,6 +22,29 @@
 {translation,
  "riak_kv.multi_backend",
  fun(Conf, Schema) ->
+
+
+  GenerateSubConfig = fun(Name, Prefix, ProplistKey, ModuleName) ->
+      BackendConfigName = ["multi_backend", Name],
+      BackendConfigPrefix = BackendConfigName ++ [Prefix],
+      SubConf = [ begin
+          {Key -- BackendConfigName, Value}
+      end || {Key, Value} <- cuttlefish_variable:filter_by_prefix(BackendConfigPrefix, Conf)],
+
+      case cuttlefish_generator:map(Schema, SubConf) of
+        {error, _Phase, _Errors} ->
+            cuttlefish:invalid("Error running recursive call to cuttlefish_generator:map/2");
+        BackendProplist ->
+          Proplist = lists:foldl(
+          fun(K, Acc) ->
+            NewAcc = proplists:get_value(K, Acc, []),
+            NewAcc
+          end,
+          BackendProplist, ProplistKey),
+
+          {ModuleName, Proplist}
+      end
+  end,
   %% group by $name into list, also cut the "multi_backend.$name" off every key
   BackendNames = cuttlefish_variable:fuzzy_matches(["multi_backend","$name","storage_backend"], Conf),
   %% for each in list, case statement on backend type
@@ -29,31 +52,12 @@
     BackendConfigName = ["multi_backend", Name],
     {BackendModule, BackendConfig} = case cuttlefish:conf_get(BackendConfigName ++ ["storage_backend"], Conf) of
       bitcask ->
-        BackendConfigPrefix = BackendConfigName ++ ["bitcask"],
-        SubConf = [ begin
-          {Key -- BackendConfigName, Value}
-        end || {Key, Value} <- cuttlefish_variable:filter_by_prefix(BackendConfigPrefix, Conf)],
-
-        BackendProplist = cuttlefish_generator:map(Schema, SubConf),
-
-        {riak_kv_bitcask_backend, proplists:get_value(bitcask, BackendProplist)};
+        GenerateSubConfig(Name, "bitcask", [bitcask], riak_kv_bitcask_backend);
       leveldb ->
-        BackendConfigPrefix = BackendConfigName ++ ["leveldb"],
-        SubConf = [ begin
-          {Key -- BackendConfigName, Value}
-        end || {Key, Value} <- cuttlefish_variable:filter_by_prefix(BackendConfigPrefix, Conf)],
-
-        BackendProplist = cuttlefish_generator:map(Schema, SubConf),
-
-        {riak_kv_eleveldb_backend, proplists:get_value(eleveldb, BackendProplist)};
+        GenerateSubConfig(Name, "leveldb", [eleveldb], riak_kv_eleveldb_backend);
       memory ->
-        BackendConfigPrefix = BackendConfigName ++ ["memory_backend"],
-        SubConf = [ begin
-          {Key -- BackendConfigName, Value}
-        end || {Key, Value} <- cuttlefish_variable:filter_by_prefix(BackendConfigPrefix, Conf)],
-        BackendProplist = cuttlefish_generator:map(Schema, SubConf),
-        {riak_kv_memory_backend, proplists:get_value(memory_backend, proplists:get_value(riak_kv, BackendProplist), [])}
-    end,
+        GenerateSubConfig(Name, "memory_backend", [riak_kv, memory_backend], riak_kv_memory_backend)
+      end,
     {list_to_binary(Name),  BackendModule, BackendConfig}
   end || {"$name", Name} <- BackendNames],
   case Backends of

--- a/test/bad_bitcask_multi.schema
+++ b/test/bad_bitcask_multi.schema
@@ -1,0 +1,6 @@
+%% @see bitcask.merge.thresholds.small_file
+{mapping, "multi_backend.$name.bitcask.thresholds.small_file", "riak_kv.multi_backend", [
+  {datatype, bytesize},
+  hidden,
+  {default, "10MB"}
+]}.

--- a/test/riak_kv_schema_tests.erl
+++ b/test/riak_kv_schema_tests.erl
@@ -274,7 +274,7 @@ datatype_compression_validator_test() ->
     cuttlefish_unit:assert_error_in_phase(Config, validation),
     ok.
 
-correct_error_handingling_by_multibackend_test() ->
+correct_error_handling_by_multibackend_test() ->
     Conf = [
         {["multi_backend", "default", "storage_backend"], bitcask},
         {["multi_backend", "default", "bitcask", "data_root"], "/data/default_bitcask"}


### PR DESCRIPTION
Cuttlefish is pretty awesome. One of the awesome things it does is phased error handling. If there's an error in any phase, it returns the 3-tuple `{error, phase_name, [{error, "Message"}]}`

multi_backend is the only translation that recurses back in to recycle the translations and validators from individual backend configurations. If something in there caused a problem, it throws back that awesome error tuple, but doesn't handle it, generating an `[error, function_clause]` instead. this can be fixed by checking for the 3-tuple and passing the error back upstream.
