### PR TITLE
Add yz_stat exception to xref analysis

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,8 @@
 
 {xref_checks, []}.
 %% XXX yz_kv is here becase Ryan has not yet made a generic hook interface for object modification
-{xref_queries, [{"(XC - UC) || (XU - X - B - \"(cluster_info|dtrace|yz_kv)\" : Mod)", []}]}.
+%% XXX yz_stat is here for similar reasons -- we do not yet support dynamic stat hooks
+{xref_queries, [{"(XC - UC) || (XU - X - B - \"(cluster_info|dtrace|yz_kv|yz_stat)\" : Mod)", []}]}.
 
 {erl_first_files, [
                    "src/riak_kv_backend.erl"


### PR DESCRIPTION
Running `xref` complains about undefined calls to `yz_stat` because Yokozuna is not a riak_kv dependency.

Since we already ignore `yz_kv` calls, this commit adds an exception for `yz_stat` calls as well.

In the future, we'll either make Yokozuna a proper sub-dependency of riak_kv, or add support to dynamically registered stat callbacks for stat aggregation (eg. for `/stats`).

For reference, the two calls into `yz_stat` are on [riak_kv_stat_bc.erl#L159](https://github.com/basho/riak_kv/blob/a5103ad56cafbbc3d8724f5ccc36eed4a1bb70fa/src/riak_kv_stat_bc.erl#L159) and [riak_kv_wm_stats.erl#L89](https://github.com/basho/riak_kv/blob/a5103ad56cafbbc3d8724f5ccc36eed4a1bb70fa/src/riak_kv_wm_stats.erl#L89).
