### PR TITLE
Fix handling of bucket+type with MR keyfilters

### DIFF
--- a/src/riak_kv_mapred_term.erl
+++ b/src/riak_kv_mapred_term.erl
@@ -190,6 +190,11 @@ get_required_permissions(Inputs, _Query) ->
                                is_list(Filters) ->
             [{"riak_kv.list_keys", {<<"default">>, Bucket}},
              {"riak_kv.mapreduce", {<<"default">>, Bucket}}];
+        {{Type, Bucket}, Filters} when is_binary(Type),
+                                       is_binary(Bucket),
+                                       is_list(Filters) ->
+            [{"riak_kv.list_keys", {Type, Bucket}},
+             {"riak_kv.mapreduce", {Type, Bucket}}];
         Targets when is_list(Targets) ->
             %% MR over a list of bucket/key pairs, with
             %% optional keydata.

--- a/src/riak_kv_mapred_term.erl
+++ b/src/riak_kv_mapred_term.erl
@@ -102,6 +102,9 @@ parse_inputs(Inputs = {search, _Bucket, _Query, _Filter}) ->
     {ok, Inputs};
 parse_inputs(Inputs = {Bucket, Filters}) when is_binary(Bucket), is_list(Filters) ->
     {ok, Inputs};
+parse_inputs(Inputs = {{Type, Bucket}, Filters})
+  when is_binary(Type), is_binary(Bucket), is_list(Filters) ->
+    {ok, Inputs};
 parse_inputs(Invalid) ->
     {error, {"Inputs must be a binary bucket, a tuple of bucket and key-filters, a list of target tuples, or a search, index, or modfun tuple:", Invalid}}.
 


### PR DESCRIPTION
Roach found this while writing tests for the Java client. If using the
JS syntax for using bucket types and keyfilters together through the PB
interface, this was broken. In the http case without security, the path
is not touched so it didn't show before.

/cc @broach can you verify with the tests you are building?
