### PR TITLE
Make `dvv_enabled` a bucket property

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -414,12 +414,12 @@ end
 %% @doc The strategy used when merging objects that potentially have
 %% conflicts.
 %%
-%% * 2: Riak 2.0 default - reduces sibling creation through additional
+%% * 2: Riak 2.0 typed bucket default - reduces sibling creation through additional
 %%      metadata on each sibling (also known as dotted version vectors)
-%% * 1: Riak 1.4 and earlier default - may duplicate siblings that
-%%      originated in the same write
-{mapping, "object.merge_strategy", "riak_kv.dvv_enabled", [
-  {default, '2'},
+%% * 1: Riak 1.4, default buckets, and earlier default - may duplicate siblings
+%%      from interleaved writes (sibling explosion.)
+{mapping, "buckets.default.merge_strategy", "riak_core.default_bucket_props.dvv_enabled", [
+  {default, '1'},
   {datatype, {flag, '2', '1'}},
   hidden
 ]}.

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -263,7 +263,8 @@ compare_content_dates(C1,C2) ->
 -spec merge(riak_object(), riak_object()) -> riak_object().
 merge(OldObject, NewObject) ->
     NewObj1 = apply_updates(NewObject),
-    DVV = dvv_enabled(),
+    Bucket = bucket(OldObject),
+    DVV = dvv_enabled(Bucket),
     {Time,  {CRDT, Contents}} = timer:tc(fun merge_contents/3, [NewObject, OldObject, DVV]),
     riak_kv_stat:update({riak_object_merge, CRDT, Time}),
     OldObject#r_object{contents=Contents,
@@ -622,20 +623,20 @@ set_vclock(Object=#r_object{}, VClock) -> Object#r_object{vclock=VClock}.
 %% @doc  Increment the entry for ClientId in O's vclock.
 -spec increment_vclock(riak_object(), vclock:vclock_node()) -> riak_object().
 %% @spec increment_vclock(riak_object(), vclock:vclock_node()) -> riak_object()
-increment_vclock(Object=#r_object{}, ClientId) ->
+increment_vclock(Object=#r_object{bucket=B}, ClientId) ->
     NewClock = vclock:increment(ClientId, Object#r_object.vclock),
     {ok, Dot} = vclock:get_entry(ClientId, NewClock),
-    assign_dot(Object#r_object{vclock=NewClock}, Dot, dvv_enabled()).
+    assign_dot(Object#r_object{vclock=NewClock}, Dot, dvv_enabled(B)).
 
 %% @doc  Increment the entry for ClientId in O's vclock.
 -spec increment_vclock(riak_object(), vclock:vclock_node(), vclock:timestamp()) -> riak_object().
-increment_vclock(Object=#r_object{}, ClientId, Timestamp) ->
+increment_vclock(Object=#r_object{bucket=B}, ClientId, Timestamp) ->
     NewClock = vclock:increment(ClientId, Timestamp, Object#r_object.vclock),
     {ok, Dot} = vclock:get_entry(ClientId, NewClock),
     %% If it is true that we only ever increment the vclock to create
     %% a frontier object, then there must only ever be a single value
     %% when we increment, so add the dot here.
-    assign_dot(Object#r_object{vclock=NewClock}, Dot, dvv_enabled()).
+    assign_dot(Object#r_object{vclock=NewClock}, Dot, dvv_enabled(B)).
 
 %% @private assign the dot to the value only if DVV is enabled. Only
 %% call with a valid dot. Only assign dot when there is a single value
@@ -648,9 +649,13 @@ assign_dot(Object, _Dot, _DVVEnabled) ->
     Object.
 
 %% @private is dvv enabled on this node?
--spec dvv_enabled() -> boolean().
-dvv_enabled() ->
-    app_helper:get_env(riak_kv, dvv_enabled, true).
+-spec dvv_enabled(bucket()) -> boolean().
+dvv_enabled(Bucket) ->
+    BProps = riak_core_bucket:get_bucket(Bucket),
+    %% default to `true`, since legacy buckets should have `false` by
+    %% default, and typed should have `true` and `undefined` is not a
+    %% valid return.
+    proplists:get_value(dvv_enabled, BProps, true).
 
 %% @doc Prepare a list of index specifications
 %% to pass to the backend. This function is for
@@ -782,7 +787,8 @@ update(false, OldObject, NewObject, Actor, Timestamp) ->
             FrontierClock = vclock:increment(Actor, Timestamp, MergedClock),
             {ok, Dot} = vclock:get_entry(Actor, FrontierClock),
             %% Assign an event to the new value
-            DottedPutObject = assign_dot(NewObject, Dot, dvv_enabled()),
+            Bucket = bucket(OldObject),
+            DottedPutObject = assign_dot(NewObject, Dot, dvv_enabled(Bucket)),
             MergedObject = merge(DottedPutObject, OldObject),
             set_vclock(MergedObject, FrontierClock)
     end.
@@ -1090,7 +1096,36 @@ update_test() ->
     V2 = riak_object:get_value(O2),
     {O,O2}.
 
-ancestor_test() ->
+bucket_prop_needers_test_() ->
+    {setup,
+     fun() ->
+             meck:new(riak_core_bucket),
+             meck:expect(riak_core_bucket, get_bucket,
+                         fun(_) ->
+                                 []
+                         end)
+     end,
+     fun(_) ->
+             meck:unload(riak_core_bucket)
+     end,
+     [{"Ancestor", fun ancestor/0},
+      {"Ancestor Weird Clocks", fun ancestor_weird_clocks/0},
+      {"Reconcile", fun reconcile/0},
+      {"Merge 1", fun merge1/0},
+      {"Merge 2", fun merge2/0},
+      {"Merge 3", fun merge3/0},
+      {"Merge 4", fun merge4/0},
+      {"Merge 5", fun merge5/0},
+      {"Inequality", fun inequality1/0},
+      {"Inequality Vclock", fun inequality_vclock/0},
+      {"Date Reconcile", fun date_reconcile/0},
+      {"Dotted values reconcile", fun dotted_values_reconcile/0},
+      {"Weird Clocks, Weird Dots", fun weird_clocks_weird_dots/0},
+      {"Mixed Merge", fun mixed_merge/0},
+      {"Mixed Merge 2", fun mixed_merge2/0}]
+    }.
+
+ancestor() ->
     Actor = self(),
     {O,O2} = update_test(),
     O3 = riak_object:increment_vclock(O2, Actor),
@@ -1099,7 +1134,7 @@ ancestor_test() ->
     ?assertMatch({Actor, {1, _}}, dict:fetch(?DOT, MD)),
     {O,O3}.
 
-ancestor_weird_clocks_test() ->
+ancestor_weird_clocks() ->
     %% make objects with dots / clocks that are causally the same but
     %% with different timestamps (backup - restore, riak_kv#679)
     {B, K} = {<<"b">>, <<"k">>},
@@ -1110,18 +1145,18 @@ ancestor_weird_clocks_test() ->
     Ancestors = ancestors([A, AWat]),
     ?assertEqual(0, length(Ancestors)).
 
-reconcile_test() ->
-    {O,O3} = ancestor_test(),
+reconcile() ->
+    {O,O3} = ancestor(),
     O3 = riak_object:reconcile([O,O3],true),
     O3 = riak_object:reconcile([O,O3],false),
     {O,O3}.
 
-merge1_test() ->
-    {O,O3} = reconcile_test(),
+merge1() ->
+    {O,O3} = reconcile(),
     O3 = riak_object:syntactic_merge(O,O3),
     {O,O3}.
 
-merge2_test() ->
+merge2() ->
     B = <<"buckets_are_binaries">>,
     K = <<"keys are binaries">>,
     V = <<"testvalue2">>,
@@ -1131,12 +1166,12 @@ merge2_test() ->
     [node1, node2] = [N || {N,_} <- riak_object:vclock(O3)],
     2 = riak_object:value_count(O3).
 
-merge3_test() ->
+merge3() ->
     O0 = riak_object:new(<<"test">>, <<"test">>, hi),
     O1 = riak_object:increment_vclock(O0, x),
     ?assertEqual(O1, riak_object:syntactic_merge(O1, O1)).
 
-merge4_test() ->
+merge4() ->
     O0 = riak_object:new(<<"test">>, <<"test">>, hi),
     O1 = riak_object:increment_vclock(
            riak_object:update_value(O0, bye), x),
@@ -1148,7 +1183,7 @@ merge4_test() ->
     ?assertEqual(OM, OMp), %% merge should be symmetric here
     {O0, O1}.
 
-merge5_test() ->
+merge5() ->
     B = <<"buckets_are_binaries">>,
     K = <<"keys are binaries">>,
     V = <<"testvalue2">>,
@@ -1157,7 +1192,7 @@ merge5_test() ->
     ?assertEqual(riak_object:syntactic_merge(O1, O2),
                  riak_object:syntactic_merge(O2, O1)).
 
-equality1_test() ->
+inequality1() ->
     MD0 = dict:new(),
     MD = dict:store("X-Riak-Test", "value", MD0),
     O1 = riak_object:new(<<"test">>, <<"a">>, "value"),
@@ -1194,7 +1229,7 @@ inequality_key_test() ->
     O2 = riak_object:new(<<"test">>, <<"b">>, "value"),
     false = riak_object:equal(O1, O2).
 
-inequality_vclock_test() ->
+inequality_vclock() ->
     O1 = riak_object:new(<<"test">>, <<"a">>, "value"),
     false = riak_object:equal(O1, riak_object:increment_vclock(O1, foo)).
 
@@ -1222,8 +1257,8 @@ largekey_test() ->
             ok
     end.
 
-date_reconcile_test() ->
-    {O,O3} = reconcile_test(),
+date_reconcile() ->
+    {O,O3} = reconcile(),
     D = calendar:datetime_to_gregorian_seconds(
           httpd_util:convert_request_date(
             httpd_util:rfc1123_date())),
@@ -1342,7 +1377,7 @@ vclock_codec_test() ->
     [ ?assertEqual({Method, VC}, {Method, decode_vclock(encode_vclock(Method, VC))})
      || VC <- VCs, Method <- [encode_raw, encode_zlib]].
 
-dotted_values_reconcile_test() ->
+dotted_values_reconcile() ->
     {B, K} = {<<"b">>, <<"k">>},
     A = riak_object:increment_vclock(riak_object:new(B, K, <<"a">>), a),
     C = riak_object:increment_vclock(riak_object:new(B, K, <<"c">>), c),
@@ -1360,7 +1395,7 @@ dotted_values_reconcile_test() ->
     ?assertEqual(2, vclock:get_counter(z, Vclock)),
     ?assertEqual(3, length(Vclock)).
 
-weird_clocks_weird_dots_test() ->
+weird_clocks_weird_dots() ->
     %% make objects with dots / clocks that are causally the same but
     %% with different timestamps (backup - restore, riak_kv#679)
     {B, K} = {<<"b">>, <<"k">>},
@@ -1371,7 +1406,7 @@ weird_clocks_weird_dots_test() ->
 
 %% Test the case where an object with undotted values is merged with
 %% an object with dotted values.
-mixed_merge_test() ->
+mixed_merge() ->
     {B, K} = {<<"b">>, <<"k">>},
     A_VC = vclock:fresh(a, 3),
     Z_VC = vclock:fresh(b, 2),
@@ -1381,7 +1416,7 @@ mixed_merge_test() ->
     ACZ = riak_object:reconcile([A, C, Z], true),
     ?assertEqual(3, riak_object:value_count(ACZ)).
 
-mixed_merge2_test() ->
+mixed_merge2() ->
     {B, K} = {<<"b">>, <<"k">>},
     A = riak_object:new(B, K, <<"a">>),
     A1 = riak_object:increment_vclock(A, a),
@@ -1392,8 +1427,8 @@ mixed_merge2_test() ->
     ?assertEqual(2, riak_object:value_count(AZ2)),
     AZ3 = riak_object:set_contents(AZ2, [{dict:new(), <<"undotted">>} | riak_object:get_contents(AZ2)]),
     AZ4 = riak_object:syntactic_merge(AZ3, AZ2),
-    ?assertEqual(AZ3, AZ4),
-    ?assertEqual(3, riak_object:value_count(AZ4)).
+    ?assertEqual(3, riak_object:value_count(AZ4)),
+    ?assert(equal(AZ3, AZ4)).
 
 verify_contents([], []) ->
     ?assert(true);

--- a/test/ec_eqc.erl
+++ b/test/ec_eqc.erl
@@ -11,15 +11,21 @@
         eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).
 
 %%====================================================================
-%% eunit test 
+%% eunit test
 %%====================================================================
 
 eqc_test_() ->
     {setup,
-     fun() -> ok end,
+     fun() ->
+             meck:new(riak_core_bucket),
+             meck:expect(riak_core_bucket, get_bucket,
+                         fun(_Bucket) ->
+                                 [dvv_enabled]
+                         end)
+     end,
      fun(_) ->
-             %% re-instate the dvv_enabled default
-             application:set_env(riak_kv, dvv_enabled, true) end,
+             meck:unload(riak_core_bucket)
+     end,
      [
       {timeout, 300000, ?_assertEqual(true, quickcheck(numtests(1000, ?QC_OUT(prop()))))}
      ]}.

--- a/test/get_fsm_eqc.erl
+++ b/test/get_fsm_eqc.erl
@@ -64,10 +64,16 @@ setup() ->
     %% Start up mock servers and dependencies
     fsm_eqc_util:start_mock_servers(),
     fsm_eqc_util:start_fake_rng(?MODULE),
+    meck:new(riak_core_bucket),
+    meck:expect(riak_core_bucket, get_bucket,
+                fun(_Bucket) ->
+                        [dvv_enabled]
+                end),
     ok.
 
 cleanup(_) ->
     fsm_eqc_util:cleanup_mock_servers(),
+    meck:unload(riak_core_bucket),
     ok.
 
 %% Call unused callback functions to clear them in the coverage

--- a/test/put_fsm_eqc.erl
+++ b/test/put_fsm_eqc.erl
@@ -116,6 +116,13 @@ setup() ->
 
     %% Start up mock servers and dependencies
     fsm_eqc_util:start_mock_servers(),
+
+    meck:new(riak_core_bucket),
+    meck:expect(riak_core_bucket, get_bucket,
+                fun(_Bucket) ->
+                        [dvv_enabled]
+                end),
+
     start_javascript(),
     State.
 
@@ -123,6 +130,7 @@ cleanup(running) ->
     application:stop(lager),
     application:unload(lager),
     cleanup_javascript(),
+    meck:unload(riak_core_bucket),
     fsm_eqc_util:cleanup_mock_servers(),
     %% Cleanup the JS manager process
     %% since it tends to hang around too long.

--- a/test/riak_kv_schema_tests.erl
+++ b/test/riak_kv_schema_tests.erl
@@ -45,7 +45,6 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_kv.max_object_size", 52428800),
     cuttlefish_unit:assert_config(Config, "riak_kv.warn_siblings", 25),
     cuttlefish_unit:assert_config(Config, "riak_kv.max_siblings", 100),
-    cuttlefish_unit:assert_config(Config, "riak_kv.dvv_enabled", true),
 
     %% Default Bucket Properties
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.pr", 0),
@@ -60,6 +59,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.last_write_wins", false),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.default_bucket_props.precommit"),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.default_bucket_props.postcommit"),
+    cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.dvv_enabled", false),
     cuttlefish_unit:assert_config(Config, "riak_dt.binary_compression", 1),
     ok.
 
@@ -100,7 +100,7 @@ override_non_multi_backend_schema_test() ->
         {["object", "size", "maximum"], "100MB"},
         {["object", "siblings", "warning_threshold"], 250},
         {["object", "siblings", "maximum"], 1000},
-        {["object", "merge_strategy"], '1'},
+        {["buckets", "default",  "merge_strategy"], '2'},
         %% Default Bucket Properties
         {["buckets", "default", "pr"], quorum},
         {["buckets", "default", "r"], 2},
@@ -153,7 +153,6 @@ override_non_multi_backend_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_kv.max_object_size", 104857600),
     cuttlefish_unit:assert_config(Config, "riak_kv.warn_siblings", 250),
     cuttlefish_unit:assert_config(Config, "riak_kv.max_siblings", 1000),
-    cuttlefish_unit:assert_config(Config, "riak_kv.dvv_enabled", false),
 
     %% Default Bucket Properties
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.pr", quorum),
@@ -166,6 +165,7 @@ override_non_multi_backend_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.basic_quorum", true),
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.allow_mult", true),
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.last_write_wins", true),
+    cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.dvv_enabled", true),
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.precommit", [
       {struct, [
                 {<<"mod">>, <<"module">>},
@@ -226,7 +226,6 @@ multi_backend_test() ->
     cuttlefish_unit:assert_config(Config, "riak_kv.max_object_size", 52428800),
     cuttlefish_unit:assert_config(Config, "riak_kv.warn_siblings", 25),
     cuttlefish_unit:assert_config(Config, "riak_kv.max_siblings", 100),
-    cuttlefish_unit:assert_config(Config, "riak_kv.dvv_enabled", true),
 
     %% Default Bucket Properties
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.pr", 0),
@@ -241,6 +240,7 @@ multi_backend_test() ->
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.last_write_wins", false),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.default_bucket_props.precommit"),
     cuttlefish_unit:assert_not_configured(Config, "riak_core.default_bucket_props.postcommit"),
+    cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.dvv_enabled", false),
     cuttlefish_unit:assert_config(Config, "riak_dt.binary_compression", 1),
 
     cuttlefish_unit:assert_config(Config, "riak_kv.multi_backend_default", <<"backend_one">>),


### PR DESCRIPTION
Set it's default to `false` on legacy/default buckets
Set it's default to `true` on typed buckets

Update all the tests and associated places this change touches
