### PR TITLE
Add prototype support for composition by reference.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ebin
 /.eqc-info
 /current_counterexample.eqc
 .local_dialyzer_plt
+tags


### PR DESCRIPTION
Prototype based on the work in the following PaPEC '14 submission:

On The Composability of the Riak DT Map: Expanding From Embedded To Multi-Key Structures (work in progress report), Christopher Meiklejohn

http://eventos.fct.unl.pt/papec/pages/program

Some caveats here:

1.) Because each referenced is modeled as a LWW-register supporting the
    reference, concurrent additions and removals of the same field
    results in resolution using the last-writer-wins strategy.  A better
    solution is discussed in the paper.
2.) Rather then writing each dependent object to it's own hashed
    preference list based on the unique key, use the same preference
    list to ensure we can provide causal consistency between objects.
3.) Garbage collection of partial writes is not currently addressed.
4.) We've only implemented this solution on the HTTP interface, with
    some backwards incompatible changes for the PB API that will need
    to be addressed.
5.) This PR converts all updates to maps as composition by reference,
    which would ideally need to be parameterized.
6.) Stats are not addressed.
7.) This requires systems buckets for each datatype, specifically to
    store the referenced counter, set, and map objects.

Do not merge.

@russelldb @seancribbs
