### PR TITLE
Implement AAE-based ensemble syncing

### DIFF
--- a/src/riak_kv_entropy_info.erl
+++ b/src/riak_kv_entropy_info.erl
@@ -29,6 +29,7 @@
          compute_exchange_info/2,
          compute_tree_info/0,
          compute_tree_info/1,
+         exchanges/2,
          all_exchanges/2]).
 
 -define(ETS, ets_riak_kv_entropy).
@@ -131,6 +132,20 @@ compute_tree_info(Type) ->
     KnownInfo = [{Index, Info#index_info.build_time}
                  || {{Type2, Index}, Info} <- all_index_info(), Type2 == Type],
     merge_to_first(KnownInfo, Defaults).
+
+%% Return information about all exchanges for given index/index_n
+exchanges(Index, IndexN) ->
+    case lists:keyfind({riak_kv, Index}, 1, all_index_info()) of
+        {_, #index_info{exchanges=Exchanges}} ->
+            [{Idx, Time, Repaired}
+             || {{Idx,IdxN}, #exchange_info{time=Time,
+                                            repaired=Repaired}} <- Exchanges,
+                IdxN =:= IndexN,
+                Time =/= undefined];
+        _ ->
+            %% TODO: Should this really be empty list?
+            []
+    end.
 
 %%%===================================================================
 %%% Internal functions

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -585,12 +585,13 @@ handle_command({ensemble_repair, BKey, Target, From}, _Sender,
         {ok, Obj} ->
             {Partition, Node} = Target,
             Proxy = riak_core_vnode_proxy:reg_name(riak_kv_vnode, Partition),
-            {Proxy, Node} ! {ensemble_repair, BKey, Obj, From};
+            {Proxy, Node} ! {ensemble_repair, BKey, Obj, From},
+            {noreply, State};
         _ ->
             %% TODO: Send back actual error/reason?
-            riak_kv_ensemble_backend:reply(From, {failed, local_get_failed})
-    end,
-    {noreply, State};
+            riak_kv_ensemble_backend:reply(From, {failed, local_get_failed}),
+            {noreply, State}
+    end;
 
 handle_command({refresh_index_data, BKey, OldIdxData}, Sender,
                State=#state{mod=Mod, modstate=ModState}) ->


### PR DESCRIPTION
This is the sibling pull-request for basho/riak_ensemble#14

This builds on #887, which has not yet been merged to `develop`, so this pull-request was created against the `jdb-ensemble-overhaul` branch. Both branches will be merged to `develop` after review.

---

This commit updates riak_kv to work with the new ensemble syncing behavior added to riak_ensemble. The purpose of peer syncing is to detect and repair corrupted/missing ensemble backend data.

For riak_kv_ensemble_backend, syncing is implemented using AAE. Anytime a vnode is restarted it is considered untrusted until the vnode performs AAE exchange with a majority of sibling vnodes.

To support AAE syncing, riak_kv_vnode was extended with a new ensemble_repair command and the riak_kv_exchange_fsm was extended to use this command to repair consistent keys. This change is needed because consistent data does not yet support read repair. Likewise, even when consistent data supports read repair, it will only do so when a given ensemble is stable. However, syncing is required to operate even when an ensemble is not stable (eg. peers may be required to sync before they can proceed to elect a leader).
