### PR TITLE
Bound testing time for riak_object_dvv_statem

### DIFF
--- a/test/riak_object_dvv_statem.erl
+++ b/test/riak_object_dvv_statem.erl
@@ -67,7 +67,9 @@ eqc_test_() ->
      fun(_) ->
              meck:unload(riak_core_bucket)
      end,
-     [{timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:numtests(1000, ?QC_OUT(prop_merge()))))}]
+     %% Kelly and Andrew T. have both recommended setting the eunit
+     %% timeout at 2x the `eqc:testing_time'.
+     [{timeout, 120, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(60, ?QC_OUT(prop_merge()))))}]
     }.
 
 run() ->


### PR DESCRIPTION
On my box, this test was timing before it reached the required 1k tests.
This change uses testing_time instead of a fixed number of iterations.
On my box, I find that I still get close to 1k iteratons in.
