### PR TITLE
Clean up webmachine resource specs

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -69,13 +69,13 @@ riak_kv_vnode.erl:1886: Function delete_from_hashtree/3 has no local return
 riak_kv_vnode.erl:1890: The call riak_kv_index_hashtree:async_delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ({binary(),binary()} | [{binary(),binary()}],pid()) -> 'ok'
 riak_kv_vnode.erl:1893: The call riak_kv_index_hashtree:delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ([{binary(),binary()}],pid()) -> 'ok'
 riak_kv_vnode.erl:2029: Function update_index_delete_stats/1 will never be called
-riak_kv_wm_counter.erl:186: The call riak_core_security:check_permission({[46 | 95 | 97 | 101 | 103 | 105 | 107 | 112 | 114 | 116 | 117 | 118,...],{<<_:56>>,_}},Security::any()) breaks the contract (Permission::permission(),Context::context()) -> {'true',context()} | {'false',binary(),context()}
+riak_kv_wm_counter.erl:184: The call riak_core_security:check_permission({[46 | 95 | 97 | 101 | 103 | 105 | 107 | 112 | 114 | 116 | 117 | 118,...],{<<_:56>>,_}},Security::any()) breaks the contract (Permission::permission(),Context::context()) -> {'true',context()} | {'false',binary(),context()}
 riak_kv_wm_crdt.erl:387: Function produce_json/2 has no local return
 riak_kv_wm_crdt.erl:391: The call riak_kv_crdt_json:fetch_response_to_json(Type::'counter' | 'flag' | 'map' | 'register' | 'set' | 'undefined',Value::any(),'undefined' | binary(),[{'counter','riak_dt_pncounter'} | {'flag','riak_dt_od_flag'} | {'map','riak_dt_map'} | {'register','riak_dt_lwwreg'} | {'set','riak_dt_orswot'},...]) does not have an opaque term of type riak_kv_crdt_json:context() as 3rd argument
 riak_kv_wm_index.erl:135: The call riak_core_security:check_permission({[46 | 95 | 97 | 100 | 101 | 105 | 107 | 110 | 114 | 118 | 120,...],{<<_:56>>,binary()}},any()) breaks the contract (Permission::permission(),Context::context()) -> {'true',context()} | {'false',binary(),context()}
 riak_kv_wm_index.erl:214: Guard test is_integer(NormStart::'undefined' | binary()) can never succeed
-riak_kv_wm_keylist.erl:137: The call riak_core_security:check_permission({[46 | 95 | 97 | 101 | 105 | 107 | 108 | 114 | 115 | 116 | 118 | 121,...],{<<_:56>>,_}},any()) breaks the contract (Permission::permission(),Context::context()) -> {'true',context()} | {'false',binary(),context()}
-riak_kv_wm_utils.erl:283: The pattern {Scheme, _, Host, Port, _, _} can never match the type {'error','no_scheme' | {_,atom(),_}}
+riak_kv_wm_keylist.erl:135: The call riak_core_security:check_permission({[46 | 95 | 97 | 101 | 105 | 107 | 108 | 114 | 115 | 116 | 118 | 121,...],{<<_:56>>,_}},any()) breaks the contract (Permission::permission(),Context::context()) -> {'true',context()} | {'false',binary(),context()}
+riak_kv_wm_utils.erl:288: The pattern {Scheme, _, Host, Port, _, _} can never match the type {'error','no_scheme' | {_,atom(),_}}
 cluster_info:dump_all_connected/1
 cluster_info:dump_nodes/2
 cluster_info:format/3
@@ -103,4 +103,3 @@ Unknown types:
   riak_core_apl:preflist2/0
   riak_dt:operation/0
   riak_dt:value/0
-  wrq:reqdata/0

--- a/src/riak_kv_wm_buckets.erl
+++ b/src/riak_kv_wm_buckets.erl
@@ -49,7 +49,6 @@
          malformed_request/2
         ]).
 
-%% @type context() = term()
 -record(ctx, {
           bucket_type,  %% binary() - bucket type (from uri)
           api_version,  %% integer() - Determine which version of the API to use.
@@ -60,13 +59,14 @@
           timeout,      %% integer() - list buckets timeout
           security     %% security context
          }).
+-type context() :: #ctx{}.
 
 -include_lib("webmachine/include/webmachine.hrl").
 -include("riak_kv_wm_raw.hrl").
 
 -define(DEFAULT_TIMEOUT, 5 * 60000).
 
-%% @spec init(proplist()) -> {ok, context()}
+-spec init(proplists:proplist()) -> {ok, context()}.
 %% @doc Initialize this resource.  This function extracts the
 %%      'prefix' and 'riak' properties from the dispatch args.
 init(Props) ->
@@ -78,8 +78,8 @@ init(Props) ->
       }}.
 
 
-%% @spec service_available(reqdata(), context()) ->
-%%          {boolean(), reqdata(), context()}
+-spec service_available(#wm_reqdata{}, context()) ->
+          {boolean(), #wm_reqdata{}, context()}.
 %% @doc Determine whether or not a connection to Riak
 %%      can be established.  This function also takes this
 %%      opportunity to extract the 'bucket' and 'key' path
@@ -137,16 +137,16 @@ forbidden(RD, Ctx) ->
             end
     end.
 
-%% @spec content_types_provided(reqdata(), context()) ->
-%%          {[{ContentType::string(), Producer::atom()}], reqdata(), context()}
+-spec content_types_provided(#wm_reqdata{}, context()) ->
+    {[{ContentType::string(), Producer::atom()}], #wm_reqdata{}, context()}.
 %% @doc List the content types available for representing this resource.
 %%      "application/json" is the content-type for bucket lists.
 content_types_provided(RD, Ctx) ->
     {[{"application/json", produce_bucket_list}], RD, Ctx}.
 
 
-%% @spec encodings_provided(reqdata(), context()) ->
-%%          {[{Encoding::string(), Producer::function()}], reqdata(), context()}
+-spec encodings_provided(#wm_reqdata{}, context()) ->
+    {[{Encoding::string(), Producer::function()}], #wm_reqdata{}, context()}.
 %% @doc List the encodings available for representing this resource.
 %%      "identity" and "gzip" are available for bucket lists.
 encodings_provided(RD, Ctx) ->
@@ -155,8 +155,8 @@ encodings_provided(RD, Ctx) ->
 malformed_request(RD, Ctx) ->
     malformed_timeout_param(RD, Ctx).
 
-%% @spec malformed_timeout_param(reqdata(), context()) ->
-%%          {boolean(), reqdata(), context()}
+-spec malformed_timeout_param(#wm_reqdata{}, context()) ->
+    {boolean(), #wm_reqdata{}, context()}.
 %% @doc Check that the timeout parameter is are a
 %%      string-encoded integer.  Store the integer value
 %%      in context() if so.
@@ -183,7 +183,8 @@ malformed_timeout_param(RD, Ctx) ->
 resource_exists(RD, #ctx{bucket_type=BType}=Ctx) ->
     {riak_kv_wm_utils:bucket_type_exists(BType), RD, Ctx}.
 
-%% @spec produce_bucket_list(reqdata(), context()) -> {binary(), reqdata(), context()}
+-spec produce_bucket_list(#wm_reqdata{}, context()) ->
+    {binary(), #wm_reqdata{}, context()}.
 %% @doc Produce the JSON response to a bucket-level GET.
 %%      Includes a list of known buckets if the "buckets=true" query
 %%      param is specified.

--- a/src/riak_kv_wm_counter.erl
+++ b/src/riak_kv_wm_counter.erl
@@ -84,7 +84,6 @@
          to_text/2
         ]).
 
-%% @type context() = term()
 -record(ctx, {api_version,  %% integer() - Determine which version of the API to use.
               bucket,       %% binary() - Bucket name (from uri)
               key,          %% binary() - Key (from uri)
@@ -105,15 +104,14 @@
               counter_op    :: integer() | undefined, %% The amount to add to the counter
               security      %% security context
              }).
-%% @type link() = {{Bucket::binary(), Key::binary()}, Tag::binary()}
-%% @type index_field() = {Key::string(), Value::string()}
+-type context() :: #ctx{}.
 
 -include_lib("webmachine/include/webmachine.hrl").
 -include("riak_kv_wm_raw.hrl").
 -include("riak_kv_types.hrl").
 
 
-%% @spec init(proplist()) -> {ok, context()}
+-spec init(proplists:proplist()) -> {ok, context()}.
 %% @doc Initialize this resource.  This function extracts the
 %%      'prefix' and 'riak' properties from the dispatch args.
 init(Props) ->

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -63,7 +63,6 @@
          produce_index_results/2
         ]).
 
-%% @type context() = term()
 -record(ctx, {
           client,       %% riak_client() - the store client
           riak,         %% local | {node(), atom()} - params for riak client
@@ -76,6 +75,7 @@
           pagination_sort :: boolean() | undefined,
           security        %% security context
          }).
+-type context() :: #ctx{}.
 
 -define(ALL_2I_RESULTS, all).
 
@@ -83,7 +83,7 @@
 -include("riak_kv_wm_raw.hrl").
 -include("riak_kv_index.hrl").
 
-%% @spec init(proplist()) -> {ok, context()}
+-spec init(proplists:proplist()) -> {ok, context()}.
 %% @doc Initialize this resource.
 init(Props) ->
     {ok, #ctx{
@@ -92,8 +92,8 @@ init(Props) ->
       }}.
 
 
-%% @spec service_available(reqdata(), context()) ->
-%%          {boolean(), reqdata(), context()}
+-spec service_available(#wm_reqdata{}, context()) ->
+    {boolean(), #wm_reqdata{}, context()}.
 %% @doc Determine whether or not a connection to Riak
 %%      can be established. Also, extract query params.
 service_available(RD, Ctx0=#ctx{riak=RiakProps}) ->
@@ -145,8 +145,8 @@ forbidden(RD, Ctx) ->
             end
     end.
 
-%% @spec malformed_request(reqdata(), context()) ->
-%%          {boolean(), reqdata(), context()}
+-spec malformed_request(#wm_reqdata{}, context()) ->
+    {boolean(), #wm_reqdata{}, context()}.
 %% @doc Determine whether query parameters are badly-formed.
 %%      Specifically, we check that the index operation is of
 %%      a known type.
@@ -296,16 +296,16 @@ normalize_boolean("true") ->
 normalize_boolean(_) ->
     malformed.
 
-%% @spec content_types_provided(reqdata(), context()) ->
-%%          {[{ContentType::string(), Producer::atom()}], reqdata(), context()}
+-spec content_types_provided(#wm_reqdata{}, context()) ->
+    {[{ContentType::string(), Producer::atom()}], #wm_reqdata{}, context()}.
 %% @doc List the content types available for representing this resource.
 %%      "application/json" is the content-type for bucket lists.
 content_types_provided(RD, Ctx) ->
     {[{"application/json", produce_index_results}], RD, Ctx}.
 
 
-%% @spec encodings_provided(reqdata(), context()) ->
-%%          {[{Encoding::string(), Producer::function()}], reqdata(), context()}
+-spec encodings_provided(#wm_reqdata{}, context()) ->
+    {[{Encoding::string(), Producer::function()}], #wm_reqdata{}, context()}.
 %% @doc List the encodings available for representing this resource.
 %%      "identity" and "gzip" are available for bucket lists.
 encodings_provided(RD, Ctx) ->
@@ -315,7 +315,8 @@ encodings_provided(RD, Ctx) ->
 resource_exists(RD, #ctx{bucket_type=BType}=Ctx) ->
     {riak_kv_wm_utils:bucket_type_exists(BType), RD, Ctx}.
 
-%% @spec produce_index_results(reqdata(), context()) -> {binary(), reqdata(), context()}
+-spec produce_index_results(#wm_reqdata{}, context()) ->
+    {binary(), #wm_reqdata{}, context()}.
 %% @doc Produce the JSON response to an index lookup.
 produce_index_results(RD, Ctx) ->
     case wrq:get_qs_value("stream", "false", RD) of

--- a/src/riak_kv_wm_keylist.erl
+++ b/src/riak_kv_wm_keylist.erl
@@ -56,7 +56,6 @@
          malformed_request/2
         ]).
 
-%% @type context() = term()
 -record(ctx, {api_version,  %% integer() - Determine which version of the API to use.
               bucket_type,  %% binary() - Bucket type (from uri)
               bucket,       %% binary() - Bucket name (from uri)
@@ -67,13 +66,12 @@
               timeout,      %% integer() - list keys timeout
               security      %% security context
              }).
-%% @type link() = {{Bucket::binary(), Key::binary()}, Tag::binary()}
-%% @type index_field() = {Key::string(), Value::string()}
+-type context() :: #ctx{}.
 
 -include_lib("webmachine/include/webmachine.hrl").
 -include("riak_kv_wm_raw.hrl").
 
-%% @spec init(proplist()) -> {ok, context()}
+-spec init(proplists:proplist()) -> {ok, context()}.
 %% @doc Initialize this resource.  This function extracts the
 %%      'prefix' and 'riak' properties from the dispatch args.
 init(Props) ->
@@ -84,8 +82,8 @@ init(Props) ->
               bucket_type=proplists:get_value(bucket_type, Props)
              }}.
 
-%% @spec service_available(reqdata(), context()) ->
-%%          {boolean(), reqdata(), context()}
+-spec service_available(#wm_reqdata{}, context()) ->
+    {boolean(), #wm_reqdata{}, context()}.
 %% @doc Determine whether or not a connection to Riak
 %%      can be established.  This function also takes this
 %%      opportunity to extract the 'bucket' and 'key' path
@@ -147,16 +145,16 @@ forbidden(RD, Ctx) ->
             end
     end.
 
-%% @spec content_types_provided(reqdata(), context()) ->
-%%          {[{ContentType::string(), Producer::atom()}], reqdata(), context()}
+-spec content_types_provided(#wm_reqdata{}, context()) ->
+    {[{ContentType::string(), Producer::atom()}], #wm_reqdata{}, context()}.
 %% @doc List the content types available for representing this resource.
 %%      "application/json" is the content-type for listing keys.
 content_types_provided(RD, Ctx) ->
     %% bucket-level: JSON description only
     {[{"application/json", produce_bucket_body}], RD, Ctx}.
 
-%% @spec encodings_provided(reqdata(), context()) ->
-%%          {[{Encoding::string(), Producer::function()}], reqdata(), context()}
+-spec encodings_provided(#wm_reqdata{}, context()) ->
+    {[{Encoding::string(), Producer::function()}], #wm_reqdata{}, context()}.
 %% @doc List the encodings available for representing this resource.
 %%      "identity" and "gzip" are available for listing keys.
 encodings_provided(RD, Ctx) ->
@@ -166,8 +164,8 @@ encodings_provided(RD, Ctx) ->
 malformed_request(RD, Ctx) ->
     malformed_timeout_param(RD, Ctx).
 
-%% @spec malformed_timeout_param(reqdata(), context()) ->
-%%          {boolean(), reqdata(), context()}
+-spec malformed_timeout_param(#wm_reqdata{}, context()) ->
+    {boolean(), #wm_reqdata{}, context()}.
 %% @doc Check that the timeout parameter is are a
 %%      string-encoded integer.  Store the integer value
 %%      in context() if so.
@@ -194,7 +192,8 @@ malformed_timeout_param(RD, Ctx) ->
 resource_exists(RD, Ctx) ->
     {riak_kv_wm_utils:bucket_type_exists(Ctx#ctx.bucket_type), RD, Ctx}.
 
-%% @spec produce_bucket_body(reqdata(), context()) -> {binary(), reqdata(), context()}
+-spec produce_bucket_body(#wm_reqdata{}, context()) ->
+    {binary(), #wm_reqdata{}, context()}.
 %% @doc Produce the JSON response to a bucket-level GET.
 %%      Includes the keys of the documents in the bucket unless the
 %%      "keys=false" query param is specified. If "keys=stream" query param

--- a/src/riak_kv_wm_mapred.erl
+++ b/src/riak_kv_wm_mapred.erl
@@ -94,8 +94,8 @@ forbidden(RD, State) ->
 allowed_methods(RD, State) ->
     {['GET','HEAD','POST'], RD, State}.
 
--spec known_content_type(wrq:reqdata(), state()) ->
-    {boolean(), wrq:reqdata(), state()}.
+-spec known_content_type(#wm_reqdata{}, state()) ->
+    {boolean(), #wm_reqdata{}, state()}.
 known_content_type(RD, State) ->
     {ctype_ok(RD), RD, State}.
 
@@ -125,13 +125,13 @@ format_error({error, Error}) when is_list(Error) ->
 format_error(_Error) ->
     mochijson2:encode({struct, [{error, map_reduce_error}]}).
 
--spec ctype_ok(wrq:reqdata()) -> boolean().
+-spec ctype_ok(#wm_reqdata{}) -> boolean().
 %% @doc Return true if the content type from
 %% this request is appropriate.
 ctype_ok(RD) ->
     valid_ctype(get_base_ctype(RD)).
 
--spec get_base_ctype(wrq:reqdata()) -> string().
+-spec get_base_ctype(#wm_reqdata{}) -> string().
 %% @doc Return the "base" content-type, that
 %% is, not including the subtype parameters
 get_base_ctype(RD) ->

--- a/src/riak_kv_wm_stats.erl
+++ b/src/riak_kv_wm_stats.erl
@@ -36,12 +36,13 @@
 -include_lib("webmachine/include/webmachine.hrl").
 
 -record(ctx, {}).
+-type context() :: #ctx{}.
 
 init(_) ->
     {ok, #ctx{}}.
 
-%% @spec encodings_provided(webmachine:wrq(), context()) ->
-%%         {[encoding()], webmachine:wrq(), context()}
+-spec encodings_provided(#wm_reqdata{}, context()) ->
+         {[term()], #wm_reqdata{}, context()}.
 %% @doc Get the list of encodings this resource provides.
 %%      "identity" is provided for all methods, and "gzip" is
 %%      provided for GET as well
@@ -54,8 +55,8 @@ encodings_provided(ReqData, Context) ->
             {[{"identity", fun(X) -> X end}], ReqData, Context}
     end.
 
-%% @spec content_types_provided(webmachine:wrq(), context()) ->
-%%          {[ctype()], webmachine:wrq(), context()}
+-spec content_types_provided(#wm_reqdata{}, context()) ->
+    {[term()], #wm_reqdata{}, context()}.
 %% @doc Get the list of content types this resource provides.
 %%      "application/json" and "text/plain" are both provided
 %%      for all requests.  "text/plain" is a "pretty-printed"
@@ -76,8 +77,8 @@ produce_body(ReqData, Ctx) ->
     Body = mochijson2:encode({struct, get_stats()}),
     {Body, ReqData, Ctx}.
 
-%% @spec pretty_print(webmachine:wrq(), context()) ->
-%%          {string(), webmachine:wrq(), context()}
+-spec pretty_print(#wm_reqdata{}, context()) ->
+          {string(), #wm_reqdata{}, context()}.
 %% @doc Format the respons JSON object is a "pretty-printed" style.
 pretty_print(RD1, C1=#ctx{}) ->
     {Json, RD2, C2} = produce_body(RD1, C1),

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -626,7 +626,6 @@ set_vclock(Object=#r_object{}, VClock) -> Object#r_object{vclock=VClock}.
 
 %% @doc  Increment the entry for ClientId in O's vclock.
 -spec increment_vclock(riak_object(), vclock:vclock_node()) -> riak_object().
-%% @spec increment_vclock(riak_object(), vclock:vclock_node()) -> riak_object()
 increment_vclock(Object=#r_object{bucket=B}, ClientId) ->
     NewClock = vclock:increment(ClientId, Object#r_object.vclock),
     {ok, Dot} = vclock:get_dot(ClientId, NewClock),
@@ -734,7 +733,7 @@ assemble_index_specs(Indexes, IndexOp) ->
 set_contents(Object=#r_object{}, MVs) when is_list(MVs) ->
     Object#r_object{contents=[#r_content{metadata=M,value=V} || {M, V} <- MVs]}.
 
-%% @spec vclock_header(riak_object()) -> {Name::string(), Value::string()}
+-spec vclock_header(riak_object()) -> {Name::string(), Value::string()}.
 %% @doc Transform the Erlang representation of the document's vclock
 %%      into something suitable for an HTTP header
 vclock_header(Doc) ->


### PR DESCRIPTION
- Remove use of reqdata(), which is not an exported type
- Change old-style @spec to -spec
- Create context() types where needed
- Remove some unused types
- Remove use of unknown types, replace with term() where I can't figure
  out what it would otherwise be
