### PR TITLE
Fixed erroring binary_to_exiting_atom

### DIFF
--- a/src/riak_kv_crdt_json.erl
+++ b/src/riak_kv_crdt_json.erl
@@ -209,9 +209,13 @@ set_op_from_json({<<"add">>, Bin}) when is_binary(Bin) -> {add, Bin};
 set_op_from_json({<<"remove">>, Bin}) when is_binary(Bin) -> {remove, Bin};
 set_op_from_json({Verb, BinList}=Op) when is_list(BinList), (Verb == <<"add_all">> orelse
                                                              Verb == <<"remove_all">>)->
+    AtomVerb = case Verb of
+        <<"add_all">> -> add_all;
+        <<"remove_all">> -> remove_all
+    end,
     case check_set_members(BinList) of
         true ->
-            {binary_to_existing_atom(Verb, utf8), BinList};
+            {AtomVerb, BinList};
         false ->
             bad_op(set, Op)
     end;


### PR DESCRIPTION
When attempting to do an add_all or remove_all on a set via the http
interface, there check for a valid verb was attempting to do
binary_to_exiting_atom/2 on the json binary verb. Becuase the atom version
of the verb was never used before, it was erroring it. The use of
binary_to_existing was redundant anyway as the guard expression for the
function clause the check was in already checked for valid content.

Before the fix: badarg error would probogate up, and the action would
fail. After fix: everything works as expected with the same guarentees.
