### PR TITLE
Fix some AAE dialyzer errors

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -18,20 +18,6 @@ riak_core_pb.erl:201: The pattern <Binary, 'string'> can never match the type <_
 riak_core_pb.erl:221: The pattern <Types, [{Fnum, Bytes} | Tail], Acc> can never match the type <_,[],[{_,_}]>
 riak_kv_bitcask_backend.erl:600: Guard test Dir1TS::nonempty_string() == [] can never succeed
 riak_kv_bitcask_backend.erl:602: Guard test Dir2TS::nonempty_string() == [] can never succeed
-riak_kv_entropy_info.erl:78: Function exchange_complete/4 has no local return
-riak_kv_entropy_info.erl:83: Function exchange_complete/5 has no local return
-riak_kv_entropy_info.erl:84: The call riak_kv_entropy_info:update_index_info({_,_},{'exchange_complete',_,_,_}) will never return since it differs in the 2nd argument from the success typing arguments: ({_,_},{'tree_built',_})
-riak_kv_entropy_info.erl:161: Record construction #index_info{exchanges::[]} violates the declared type of field repaired::pos_integer() and last_exchange::{non_neg_integer(),{non_neg_integer(),pos_integer()}}
-riak_kv_entropy_info.erl:194: The call riak_kv_entropy_info:update_simple_stat(Repaired::'undefined' | pos_integer(),pos_integer()) will never return since it differs in the 2nd argument from the success typing arguments: (any(),'undefined' | #simple_stat{count::number(),sum::number()})
-riak_kv_entropy_info.erl:208: Function compute_exchange_info/4 has no local return
-riak_kv_entropy_info.erl:218: The call riak_kv_entropy_info:stat_tuple(Repaired::pos_integer()) will never return since it differs in the 1st argument from the success typing arguments: ('undefined' | #simple_stat{count::integer(),sum::integer()})
-riak_kv_entropy_info.erl:225: Function update_simple_stat/2 has no local return
-riak_kv_entropy_info.erl:225: The pattern <Value, 'undefined'> can never match the type <'undefined' | pos_integer(),pos_integer()>
-riak_kv_entropy_info.erl:227: The pattern <Value, Stat = {'simple_stat', _, Min, Max, Cnt, Sum}> can never match the type <'undefined' | pos_integer(),pos_integer()>
-riak_kv_entropy_info.erl:234: Function stat_tuple/1 has no local return
-riak_kv_entropy_info.erl:234: The pattern 'undefined' can never match the type pos_integer()
-riak_kv_entropy_info.erl:236: The pattern {'simple_stat', Last, Min, Max, Cnt, Sum} can never match the type pos_integer()
-riak_kv_exchange_fsm.erl:379: Function exchange_complete/4 has no local return
 riak_kv_gcounter.erl:64: Invalid type specification for function riak_kv_gcounter:new/2. The success typing is (_,pos_integer()) -> {'ok',riak_kv_gcounter:gcounter()}
 riak_kv_gcounter.erl:75: Invalid type specification for function riak_kv_gcounter:update/3. The success typing is ('increment' | {'increment',pos_integer()},_,riak_kv_gcounter:gcounter()) -> {'ok',riak_kv_gcounter:gcounter()}
 riak_kv_gcounter.erl:85: Function merge/2 has no local return

--- a/src/riak_kv_entropy_info.erl
+++ b/src/riak_kv_entropy_info.erl
@@ -43,6 +43,8 @@
 
 -record(simple_stat, {last, min, max, count, sum}).
 
+-type simple_stat() :: #simple_stat{}.
+
 -type repair_stats() :: {Last :: pos_integer(),
                          Min  :: pos_integer(),
                          Max  :: pos_integer(),
@@ -53,10 +55,10 @@
 
 -type exchange_info() :: #exchange_info{}.
 
--record(index_info, {build_time    = undefined     :: t_now(),
-                     repaired      = undefined     :: pos_integer(),
+-record(index_info, {build_time    :: t_now(),
+                     repaired      :: simple_stat(),
                      exchanges     = orddict:new() :: orddict(exchange_id(), exchange_info()),
-                     last_exchange = undefined     :: exchange_id()}).
+                     last_exchange :: exchange_id()}).
 
 -type index_info() :: #index_info{}.
 


### PR DESCRIPTION
This commit fixes all the dialyzer errors for `riak_kv_entropy_info`
as well as an error for `riak_kv_exchange_fsm`.  The main change was
to fix the spec for `#index_info.repaired` which is actually a
`#simple_stat{}` not a `pos_integer()`. However, even after that
dialyzer was not happy with the explicit default values of `undefined`
without corresponding entries in the type definition. This seemed like
a waste to me given that Erlang will implicitly default records values
to `undefined` and insert the appropriate type spec. This is discussed
in the following reference manual:

http://www.erlang.org/doc/reference_manual/typespec.html#typeinrecords

Here is the full list of dialyzer errors which have been fixed:

```
riak_kv_entropy_info.erl:78: Function exchange_complete/4 has no local
return
riak_kv_entropy_info.erl:83: Function exchange_complete/5 has no local
return
riak_kv_entropy_info.erl:84: The call
riak_kv_entropy_info:update_index_info({_,_},{'exchange_complete',_,_,_})
will never return since it differs in the 2nd argument fr
riak_kv_entropy_info.erl:161: Record construction
repaired::pos_integer() and last_exchange::{non_neg_inte
riak_kv_entropy_info.erl:194: The call
riak_kv_entropy_info:update_simple_stat(Repaired::'undefined' |
pos_integer(),pos_integer()) will never return since it differs in
riak_kv_entropy_info.erl:208: Function compute_exchange_info/4 has no
local return
riak_kv_entropy_info.erl:218: The call
riak_kv_entropy_info:stat_tuple(Repaired::pos_integer()) will never
return since it differs in the 1st argument from the success t
riak_kv_entropy_info.erl:225: Function update_simple_stat/2 has no local
return
riak_kv_entropy_info.erl:225: The pattern <Value, 'undefined'> can never
match the type <'undefined' | pos_integer(),pos_integer()>
riak_kv_entropy_info.erl:227: The pattern <Value, Stat = {'simple_stat',
_, Min, Max, Cnt, Sum}> can never match the type <'undefined' |
pos_integer(),pos_integer()>
riak_kv_entropy_info.erl:234: Function stat_tuple/1 has no local return
riak_kv_entropy_info.erl:234: The pattern 'undefined' can never match
the type pos_integer()
riak_kv_entropy_info.erl:236: The pattern {'simple_stat', Last, Min,
Max, Cnt, Sum} can never match the type pos_integer()
riak_kv_exchange_fsm.erl:379: Function exchange_complete/4 has no local
return
```
