### PR TITLE
kv_vnode calling coverage_filter with 'all'

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -64,11 +64,10 @@ riak_kv_vnode.erl:1189: The pattern <{Idx, Node}, Key, Obj> can never match the 
 riak_kv_vnode.erl:1229: Function do_backend_delete/3 has no local return
 riak_kv_vnode.erl:1655: Function result_fun/1 will never be called
 riak_kv_vnode.erl:1656: The created fun has no local return
-riak_kv_vnode.erl:1680: The pattern <_, _, _> can never match since previous clauses completely covered the type <'keys','undefined' | integer(),_>
-riak_kv_vnode.erl:1886: Function delete_from_hashtree/3 has no local return
-riak_kv_vnode.erl:1890: The call riak_kv_index_hashtree:async_delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ({binary(),binary()} | [{binary(),binary()}],pid()) -> 'ok'
-riak_kv_vnode.erl:1893: The call riak_kv_index_hashtree:delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ([{binary(),binary()}],pid()) -> 'ok'
-riak_kv_vnode.erl:2029: Function update_index_delete_stats/1 will never be called
+riak_kv_vnode.erl:1884: Function delete_from_hashtree/3 has no local return
+riak_kv_vnode.erl:1888: The call riak_kv_index_hashtree:async_delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ({binary(),binary()} | [{binary(),binary()}],pid()) -> 'ok'
+riak_kv_vnode.erl:1891: The call riak_kv_index_hashtree:delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ([{binary(),binary()}],pid()) -> 'ok'
+riak_kv_vnode.erl:2027: Function update_index_delete_stats/1 will never be called
 riak_kv_wm_counter.erl:184: The call riak_core_security:check_permission({[46 | 95 | 97 | 101 | 103 | 105 | 107 | 112 | 114 | 116 | 117 | 118,...],{<<_:56>>,_}},Security::any()) breaks the contract (Permission::permission(),Context::context()) -> {'true',context()} | {'false',binary(),context()}
 riak_kv_wm_crdt.erl:387: Function produce_json/2 has no local return
 riak_kv_wm_crdt.erl:391: The call riak_kv_crdt_json:fetch_response_to_json(Type::'counter' | 'flag' | 'map' | 'register' | 'set' | 'undefined',Value::any(),'undefined' | binary(),[{'counter','riak_dt_pncounter'} | {'flag','riak_dt_od_flag'} | {'map','riak_dt_map'} | {'register','riak_dt_lwwreg'} | {'set','riak_dt_orswot'},...]) does not have an opaque term of type riak_kv_crdt_json:context() as 3rd argument

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -54,7 +54,6 @@ riak_kv_put_fsm.erl:818: The pattern <[COP = {'counter_op', _Amt} | T], Acc> can
 riak_kv_put_fsm.erl:821: The pattern <[COP = {'crdt_op', _Op} | T], Acc> can never match the type <[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()},...],[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()}]>
 riak_kv_util.erl:294: The pattern 'error' can never match the type 'ok' | 'undefined'
 riak_kv_vnode.erl:23: Callback info about the riak_core_vnode behaviour is not available
-riak_kv_vnode.erl:766: The call riak_kv_coverage_filter:build_filter('all',ItemFilter::'undefined' | fun(),'undefined') breaks the contract (bucket(),filter(),[index()]) -> filter()
 riak_kv_vnode.erl:817: The pattern Q = {'riak_kv_index_v3', _, _, _, _, _, _, _, _, RE, _} can never match the type 'undefined' | {_,_}
 riak_kv_vnode.erl:827: The pattern <{'riak_kv_index_v3', _, _, _, _, _, _, _, _, _, N}, DefaultSize> can never match the type <'undefined' | {_,_},'undefined' | pos_integer()>
 riak_kv_vnode.erl:962: The variable Err can never match since previous clauses completely covered the type {'ok',_} | {'error',_,_}

--- a/src/riak_kv_coverage_filter.erl
+++ b/src/riak_kv_coverage_filter.erl
@@ -30,7 +30,7 @@
 -module(riak_kv_coverage_filter).
 
 %% API
--export([build_filter/3]).
+-export([build_filter/1, build_filter/3]).
 
 -export_type([filter/0]).
 
@@ -53,6 +53,11 @@
 %% module. The list of tuples is composed into a function that is
 %% used to determine if an item should be included in the final 
 %% result set.
+-spec build_filter(filter()) -> filter().
+build_filter(Filter) ->
+    build_item_filter(Filter).
+
+
 -spec build_filter(bucket(), filter(), [index()]) -> filter().
 build_filter(Bucket, ItemFilterInput, FilterVNode) ->
     ItemFilter = build_item_filter(ItemFilterInput),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -514,7 +514,7 @@ handle_command(#riak_kv_listkeys_req_v2{bucket=Input, req_id=ReqId, caller=Calle
                 fun(Results) ->
                         Caller ! {ReqId, {kl, Idx, Results}}
                 end,
-            Extras = fold_extras(keys, Idx, Bucket),
+            Extras = fold_extras_keys(Idx, Bucket),
             FoldFun = fold_fun(keys, BufferMod, Filter, Extras),
             ModFun = fold_keys
     end,
@@ -883,7 +883,7 @@ handle_coverage_fold(FoldType, Bucket, ItemFilter, ResultFun,
     BufferMod = riak_kv_fold_buffer,
     BufferSize = proplists:get_value(buffer_size, Opts0, DefaultBufSz),
     Buffer = BufferMod:new(BufferSize, ResultFun),
-    Extras = fold_extras(keys, Index, Bucket),
+    Extras = fold_extras_keys(Index, Bucket),
     FoldFun = fold_fun(keys, BufferMod, Filter, Extras),
     FinishFun = finish_fun(BufferMod, Sender),
     {ok, Capabilities} = Mod:capabilities(Bucket, ModState),
@@ -1663,7 +1663,7 @@ result_fun(Bucket, Sender) ->
             riak_core_vnode:reply(Sender, {Bucket, Items})
     end.
 
-fold_extras(keys, Index, Bucket) ->
+fold_extras_keys(Index, Bucket) ->
     case app_helper:get_env(riak_kv, fold_preflist_filter, false) of
         true ->
             {ok, R} = riak_core_ring_manager:get_my_ring(),
@@ -1676,9 +1676,7 @@ fold_extras(keys, Index, Bucket) ->
             {Bucket, Index, N, NumPartitions};
         false ->
             undefined
-    end;
-fold_extras(_, _, _) ->
-    undefined.
+    end.
 
 %% wait for acknowledgement that results were received before
 %% continuing, as a way of providing backpressure for processes that

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -763,7 +763,7 @@ handle_coverage(?KV_LISTBUCKETS_REQ{item_filter=ItemFilter},
                              mod=Mod,
                              modstate=ModState}) ->
     %% Construct the filter function
-    Filter = riak_kv_coverage_filter:build_filter(all, ItemFilter, undefined),
+    Filter = riak_kv_coverage_filter:build_filter(ItemFilter),
     BufferMod = riak_kv_fold_buffer,
 
     Buffer = BufferMod:new(BufferSize, result_fun(Sender)),


### PR DESCRIPTION
In [this code](https://github.com/basho/riak_kv/blob/e66f3ffdc637d0e2385301f74d984c0632029493/src/riak_kv_vnode.erl#L766), kv_vnode calls riak_kv_coverage:build_filter with the atom `all` as the first argument. The type spec for this function expects a `binary()`. Digging through the call stack, I couldn't find any cases where we pattern match on an atom or specifically the atom `all`. Any ideas?

cc @kellymclaughlin, who I believe wrote this code.
