### PR TITLE
riak_core_security:check_permission/2 usage

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -53,12 +53,9 @@ riak_kv_vnode.erl:1884: Function delete_from_hashtree/3 has no local return
 riak_kv_vnode.erl:1888: The call riak_kv_index_hashtree:async_delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ({binary(),binary()} | [{binary(),binary()}],pid()) -> 'ok'
 riak_kv_vnode.erl:1891: The call riak_kv_index_hashtree:delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ([{binary(),binary()}],pid()) -> 'ok'
 riak_kv_vnode.erl:2027: Function update_index_delete_stats/1 will never be called
-riak_kv_wm_counter.erl:184: The call riak_core_security:check_permission({[46 | 95 | 97 | 101 | 103 | 105 | 107 | 112 | 114 | 116 | 117 | 118,...],{<<_:56>>,_}},Security::any()) breaks the contract (Permission::permission(),Context::context()) -> {'true',context()} | {'false',binary(),context()}
 riak_kv_wm_crdt.erl:387: Function produce_json/2 has no local return
 riak_kv_wm_crdt.erl:391: The call riak_kv_crdt_json:fetch_response_to_json(Type::'counter' | 'flag' | 'map' | 'register' | 'set' | 'undefined',Value::any(),'undefined' | binary(),[{'counter','riak_dt_pncounter'} | {'flag','riak_dt_od_flag'} | {'map','riak_dt_map'} | {'register','riak_dt_lwwreg'} | {'set','riak_dt_orswot'},...]) does not have an opaque term of type riak_kv_crdt_json:context() as 3rd argument
-riak_kv_wm_index.erl:135: The call riak_core_security:check_permission({[46 | 95 | 97 | 100 | 101 | 105 | 107 | 110 | 114 | 118 | 120,...],{<<_:56>>,binary()}},any()) breaks the contract (Permission::permission(),Context::context()) -> {'true',context()} | {'false',binary(),context()}
 riak_kv_wm_index.erl:214: Guard test is_integer(NormStart::'undefined' | binary()) can never succeed
-riak_kv_wm_keylist.erl:135: The call riak_core_security:check_permission({[46 | 95 | 97 | 101 | 105 | 107 | 108 | 114 | 115 | 116 | 118 | 121,...],{<<_:56>>,_}},any()) breaks the contract (Permission::permission(),Context::context()) -> {'true',context()} | {'false',binary(),context()}
 riak_kv_wm_utils.erl:288: The pattern {Scheme, _, Host, Port, _, _} can never match the type {'error','no_scheme' | {_,atom(),_}}
 cluster_info:dump_all_connected/1
 cluster_info:dump_nodes/2


### PR DESCRIPTION
The types in `riak_core_security:check_permission/2` expect strings. But [we call it with binaries](https://github.com/basho/riak_kv/blob/e66f3ffdc637d0e2385301f74d984c0632029493/src/riak_kv_wm_counter.erl#L185). I can't tell if the `bucket/0` type in `riak_core_security` should be updated to accept binaries, or the code in riak_kv should be changed.

cc @Vagabond
