### PR TITLE
Ensure nodes don't transition to exiting too soon

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -38,16 +38,16 @@ riak_kv_put_fsm.erl:822: The pattern <[COP = {'counter_op', _Amt} | T], Acc> can
 riak_kv_put_fsm.erl:825: The pattern <[COP = {'crdt_op', _Op} | T], Acc> can never match the type <[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()},...],[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()}]>
 riak_kv_util.erl:294: The pattern 'error' can never match the type 'ok' | 'undefined'
 riak_kv_vnode.erl:23: Callback info about the riak_core_vnode behaviour is not available
-riak_kv_vnode.erl:818: The pattern Q = {'riak_kv_index_v3', _, _, _, _, _, _, _, _, RE, _} can never match the type 'undefined' | {_,_}
-riak_kv_vnode.erl:828: The pattern <{'riak_kv_index_v3', _, _, _, _, _, _, _, _, _, N}, DefaultSize> can never match the type <'undefined' | {_,_},'undefined' | pos_integer()>
-riak_kv_vnode.erl:1071: The call riak_kv_vnode:raw_put(HOTarget::atom(),Key::{binary() | {binary(),binary()},binary()},Obj::riak_object:riak_object()) will never return since it differs in the 1st argument from the success typing arguments: ({_,_},any(),any())
-riak_kv_vnode.erl:1188: Function raw_put/3 has no local return
-riak_kv_vnode.erl:1188: The pattern <{Idx, Node}, Key, Obj> can never match the type <atom(),{binary() | {binary(),binary()},binary()},riak_object:riak_object()>
-riak_kv_vnode.erl:1228: Function do_backend_delete/3 has no local return
-riak_kv_vnode.erl:1890: Function delete_from_hashtree/3 has no local return
-riak_kv_vnode.erl:1894: The call riak_kv_index_hashtree:async_delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ({binary(),binary()} | [{binary(),binary()}],pid()) -> 'ok'
-riak_kv_vnode.erl:1897: The call riak_kv_index_hashtree:delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ([{binary(),binary()}],pid()) -> 'ok'
-riak_kv_vnode.erl:2033: Function update_index_delete_stats/1 will never be called
+riak_kv_vnode.erl:819: The pattern Q = {'riak_kv_index_v3', _, _, _, _, _, _, _, _, RE, _} can never match the type 'undefined' | {_,_}
+riak_kv_vnode.erl:829: The pattern <{'riak_kv_index_v3', _, _, _, _, _, _, _, _, _, N}, DefaultSize> can never match the type <'undefined' | {_,_},'undefined' | pos_integer()>
+riak_kv_vnode.erl:1072: The call riak_kv_vnode:raw_put(HOTarget::atom(),Key::{binary() | {binary(),binary()},binary()},Obj::riak_object:riak_object()) will never return since it differs in the 1st argument from the success typing arguments: ({_,_},any(),any())
+riak_kv_vnode.erl:1194: Function raw_put/3 has no local return
+riak_kv_vnode.erl:1194: The pattern <{Idx, Node}, Key, Obj> can never match the type <atom(),{binary() | {binary(),binary()},binary()},riak_object:riak_object()>
+riak_kv_vnode.erl:1234: Function do_backend_delete/3 has no local return
+riak_kv_vnode.erl:1896: Function delete_from_hashtree/3 has no local return
+riak_kv_vnode.erl:1900: The call riak_kv_index_hashtree:async_delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ({binary(),binary()} | [{binary(),binary()}],pid()) -> 'ok'
+riak_kv_vnode.erl:1903: The call riak_kv_index_hashtree:delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ([{binary(),binary()}],pid()) -> 'ok'
+riak_kv_vnode.erl:2039: Function update_index_delete_stats/1 will never be called
 riak_kv_wm_crdt.erl:387: Function produce_json/2 has no local return
 riak_kv_wm_crdt.erl:391: The call riak_kv_crdt_json:fetch_response_to_json(Type::'counter' | 'flag' | 'map' | 'register' | 'set' | 'undefined',Value::any(),'undefined' | binary(),[{'counter','riak_dt_pncounter'} | {'flag','riak_dt_od_flag'} | {'map','riak_dt_map'} | {'register','riak_dt_lwwreg'} | {'set','riak_dt_orswot'},...]) does not have an opaque term of type riak_kv_crdt_json:context() as 3rd argument
 riak_kv_wm_index.erl:214: Guard test is_integer(NormStart::'undefined' | binary()) can never succeed

--- a/src/riak_kv_ensembles.erl
+++ b/src/riak_kv_ensembles.erl
@@ -35,7 +35,8 @@
          check_quorum/0,
          count_quorum/0,
          check_membership/0,
-         check_membership2/0]).
+         check_membership2/0,
+         local_ensembles/0]).
 
 %% Exported for debugging
 -export([required_ensembles/1,
@@ -54,6 +55,19 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
+
+local_ensembles() ->
+    Node = node(),
+    lists:foldl(fun(Ensemble, Acc) ->
+                    Members = riak_ensemble_manager:get_members(Ensemble),
+                    case lists:keyfind(Node, 2, Members) of
+                        false ->
+                            Acc;
+                        _ ->
+                            [Ensemble | Acc]
+                    end
+                end, [], ensembles()).
+                    
 ensembles() ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     required_ensembles(Ring).

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -71,7 +71,8 @@
          handle_handoff_data/2,
          encode_handoff_item/2,
          handle_exit/3,
-         handle_info/2]).
+         handle_info/2,
+         ready_to_exit/0]). %% Note: optional function of the behaviour
 
 -export([handoff_data_encoding_method/0]).
 -export([set_vnode_forwarding/2]).
@@ -1171,6 +1172,11 @@ handle_exit(_Pid, Reason, State) ->
     %% queue and never being processed.
     lager:error("Linked process exited. Reason: ~p", [Reason]),
     {stop, linked_process_crash, State}.
+
+%% Optional Callback. A node is about to exit. Ensure that this node doesn't
+%% have any current ensemble members.
+ready_to_exit() ->
+    [] =:= riak_kv_ensembles:local_ensembles().
 
 %% @private
 forward_put({Idx, Node}, Key, Obj, From) ->


### PR DESCRIPTION
Add ready_to_exit/0 callback to riak_kv_vnode and
riak_kv_ensembles:local_ensembles/0 to ensure that nodes don't
transition from leaving to exiting while they still have ensemble peers
in use.
