### PR TITLE
Use binary_to_atom/2 instead of binary_to_existing_atom/2.

### DIFF
--- a/src/riak_kv_crdt_json.erl
+++ b/src/riak_kv_crdt_json.erl
@@ -211,7 +211,7 @@ set_op_from_json({Verb, BinList}=Op) when is_list(BinList), (Verb == <<"add_all"
                                                              Verb == <<"remove_all">>)->
     case check_set_members(BinList) of
         true ->
-            {binary_to_existing_atom(Verb, utf8), BinList};
+            {binary_to_atom(Verb, utf8), BinList};
         false ->
             bad_op(set, Op)
     end;


### PR DESCRIPTION
There's a possibility that the riak_dt code that contains the set operation
atoms hasn't been loaded when riak_kv_crdt_json:set_op_from_json/1 is invoked,
meaning binary_to_existing_atom/2 will raise a badarg. We are already checking 
the incoming operation as a binary via a guard on the relevant function
clause, so it is safe to use binary_to_atom/2 instead.
