### PR TITLE
Fix mem backend to honor various settings correctly.

### DIFF
--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -116,13 +116,19 @@ capabilities(_, _) ->
 %% @doc Start the memory backend
 -spec start(integer(), config()) -> {ok, state()}.
 start(Partition, Config) ->
-    TTL = app_helper:get_prop_or_env(ttl, Config, memory_backend),
-    MemoryMB = app_helper:get_prop_or_env(max_memory, Config, memory_backend),
+    TTL = riak_kv_util:get_backend_config(ttl, Config, memory_backend),
+    MemoryMB = riak_kv_util:get_backend_config(max_memory, Config, memory_backend),
+    %% leave this one alone, it is only for testing
+    NormalTableOpts = [ordered_set],
+    TestTableOpts = app_helper:get_prop_or_env(test_table_opts,
+                                               Config,
+                                               memory_backend,
+                                               [named_table, public]),
     TableOpts = case app_helper:get_prop_or_env(test, Config, memory_backend) of
                     true ->
-                        [ordered_set, public, named_table];
+                        NormalTableOpts ++ TestTableOpts;
                     _ ->
-                        [ordered_set]
+                        NormalTableOpts
                 end,
     case MemoryMB of
         undefined ->

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -211,7 +211,7 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, State=#state{data_ref=DataRef,
         _ ->
             {{ts, Now}, Val}
     end,
-    OldSize = 
+    OldSize =
         case ets:lookup(DataRef, {Bucket, PrimaryKey}) of
             [] ->
                 0;
@@ -244,7 +244,6 @@ delete(Bucket, Key, IndexSpecs, State=#state{data_ref=DataRef,
                                              index_ref=IndexRef,
                                              time_ref=TimeRef,
                                              used_memory=UsedMemory}) ->
-    
     [Object] = ets:lookup(DataRef, {Bucket, Key}),
     case TimeRef of
         undefined ->

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -211,6 +211,13 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, State=#state{data_ref=DataRef,
         _ ->
             {{ts, Now}, Val}
     end,
+    OldSize = 
+        case ets:lookup(DataRef, {Bucket, PrimaryKey}) of
+            [] ->
+                0;
+            [OldObject] ->
+                object_size(OldObject)
+        end,
     {ok, Size} = do_put(Bucket, PrimaryKey, Val1, IndexSpecs, DataRef, IndexRef),
     NoMemChange = (MaxMemory =:= undefined) orelse (Val =:= undefined),
     UsedMemory1 =
@@ -227,7 +234,8 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, State=#state{data_ref=DataRef,
                                     0),
             UsedMemory + Size - Freed
     end,
-    {ok, State#state{used_memory=UsedMemory1}}.
+    UsedMemory2 = UsedMemory1 - OldSize,
+    {ok, State#state{used_memory=UsedMemory2}}.
 
 %% @doc Delete an object from the memory backend
 -spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
@@ -236,22 +244,23 @@ delete(Bucket, Key, IndexSpecs, State=#state{data_ref=DataRef,
                                              index_ref=IndexRef,
                                              time_ref=TimeRef,
                                              used_memory=UsedMemory}) ->
+    
+    [Object] = ets:lookup(DataRef, {Bucket, Key}),
     case TimeRef of
         undefined ->
-            UsedMemory1 = UsedMemory;
+            ok;
         _ ->
             %% Lookup the object so we can delete its
             %% entry from the time table and account
             %% for the memory used.
-            [Object] = ets:lookup(DataRef, {Bucket, Key}),
             case Object of
                 {_, {{ts, Timestamp}, _}} ->
-                    ets:delete(TimeRef, Timestamp),
-                    UsedMemory1 = UsedMemory - object_size(Object);
+                    ets:delete(TimeRef, Timestamp);
                 _ ->
-                    UsedMemory1 = UsedMemory
+                    ok
             end
     end,
+    UsedMemory1 = UsedMemory - object_size(Object),
     update_indexes(Bucket, Key, IndexSpecs, IndexRef),
     ets:delete(DataRef, {Bucket, Key}),
     {ok, State#state{used_memory=UsedMemory1}}.

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -43,6 +43,7 @@
          puts_active/0,
          exact_puts_active/0,
          gets_active/0,
+         get_backend_config/3,
          overload_reply/1]).
 
 -include_lib("riak_kv_vnode.hrl").
@@ -372,6 +373,22 @@ gets_active() ->
         _ ->
             sidejob_resource_stats:usage(riak_kv_get_fsm_sj)
     end.
+
+%% @doc Get backend config for backends without an associated application
+%% eg, yessir, memory
+get_backend_config(Key, Config, Category) ->
+    case proplists:get_value(Key, Config) of
+        undefined ->
+            case proplists:get_value(Category, Config) of
+                undefined ->
+                    undefined;
+                InnerConfig ->
+                    proplists:get_value(Key, InnerConfig)
+            end;
+        Val ->
+            Val
+    end.
+
 
 %% ===================================================================
 %% EUnit tests


### PR DESCRIPTION
@angrycub is testing.

test grid spreadsheet (basho-only):
https://docs.google.com/a/basho.com/spreadsheet/ccc?key=0AkSRjImmlw_HdG5TeVZ2dFRtUFpiZjI2YThQRHFGRWc#gid=0

Without this patch, the memory backend can 'run out of space' in that all of its memory is marked as used, while there is plenty of memory available.  Expiry can do similar things.  This patch makes sure that the state tuple is preserved through all vnode actions, as well.

This should be ported to 2.0 prior to the RC.  

cc @reiddraper re #717 
