### PR TITLE
Better error handling from basho/riak_kv#935

### DIFF
--- a/src/riak_kv_env.erl
+++ b/src/riak_kv_env.erl
@@ -146,16 +146,18 @@ check_erlang_limits() ->
               end,
 
     %% ets tables
-    ETSLimit = erlang:system_info(ets_limit),
-    ETSMsg = case ETSLimit < 256000 of
-                 true ->
-                     {warn,"ETS table count limit of ~p is low, at least "
-                      "256000 is recommended.", [ETSLimit]};
-                 false ->
-                     {info, "ETS table count limit: ~p",
-                      [ETSLimit]}
-             end,
-
+    ETSMsg = try erlang:system_info(ets_limit) of
+        ETSLimit when ETSLimit < 256000 ->
+            {warn,"ETS table count limit of ~p is low, at least "
+                  "256000 is recommended.", [ETSLimit]};
+        ETSLimit ->
+            {info, "ETS table count limit: ~p",
+                   [ETSLimit]}
+    catch
+        error:badarg ->
+            {warn, "ETS table count limit cannot be determined on this "
+                   "version of Erlang", []}
+    end,
     %% fullsweep_after
     {fullsweep_after, GCGens} = erlang:system_info(fullsweep_after),
     GCMsg = {info, "Generations before full sweep: ~p", [GCGens]},


### PR DESCRIPTION
If this was run on a version of Erlang less than R16B02-basho5 or R16B03, you'd get this error. 

```
(riak@127.0.0.1)1> riak_kv_env:doc_env().
** exception error: bad argument
     in function  erlang:system_info/1
        called as erlang:system_info(ets_limit)
     in call from riak_kv_env:check_erlang_limits/0 (src/riak_kv_env.erl, line 149)
     in call from riak_kv_env:doc_env/0 (src/riak_kv_env.erl, line 48)
```

With this patch, you'll get no error, and this in the logs:

```
2014-05-12 14:52:50.753 [warning] <0.2271.0> riak_kv_env: ETS table count limit cannot be determined on this version of Erlang
```

Of course, if you have the right Erlang, you'll still see this:

```
2014-05-12 14:58:37.119 [info] <0.2266.0> riak_kv_env: ETS table count limit: 256000
```
