### PR TITLE
Optimize riak_kv_entropy_info:exchanges/2

### DIFF
--- a/src/riak_kv_entropy_info.erl
+++ b/src/riak_kv_entropy_info.erl
@@ -135,8 +135,8 @@ compute_tree_info(Type) ->
 
 %% Return information about all exchanges for given index/index_n
 exchanges(Index, IndexN) ->
-    case lists:keyfind({riak_kv, Index}, 1, all_index_info()) of
-        {_, #index_info{exchanges=Exchanges}} ->
+    case ets:lookup(?ETS, {index, {riak_kv, Index}}) of
+        [{_, #index_info{exchanges=Exchanges}}] ->
             [{Idx, Time, Repaired}
              || {{Idx,IdxN}, #exchange_info{time=Time,
                                             repaired=Repaired}} <- Exchanges,


### PR DESCRIPTION
This commit changes `riak_kv_entropy_info:exchanges/2` from being an `O(num_primary_vnodes)` operation to an `O(1)` operation. Since `exchanges/2` is used heavily for `riak_ensemble` based syncing, this change significantly improves `riak_ensemble` usage for large rings.

Sibling pull-request: basho/riak_ensemble#21
Together with above sibling pull-request, resolves issue basho/riak_ensemble#15
