### PR TITLE
Bound eqc testing time

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,12 @@
 {erl_opts, [warnings_as_errors,
             {parse_transform, lager_transform},
             {d, 'TEST_FS2_BACKEND_IN_RIAK_KV'}]}.
-{eunit_opts, [verbose]}.
+
+{eunit_opts, [
+     no_tty,  %% This turns off the default output, MUST HAVE
+     {report, {eunit_progress, [colored, profile]}} %% Use `profile' to see test timing information
+     %% Uses the progress formatter with ANSI-colored output
+     ]}.
 
 {xref_checks, []}.
 %% XXX yz_kv is here becase Ryan has not yet made a generic hook interface for object modification
@@ -22,5 +27,6 @@
         {sext, ".*", {git, "git://github.com/basho/sext.git", {tag, "1.1p2"}}},
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {branch, "develop"}}},
         {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {branch, "develop"}}},
-        {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {branch, "develop"}}}
+        {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {branch, "develop"}}},
+        {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", "dab4291d191f0ca40c911179fd195c3942261667"}}
        ]}.

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -865,7 +865,7 @@ eqc_test_() ->
          fun setup/0,
          fun cleanup/1,
          [
-          {timeout, 60000,
+          {timeout, 180,
            [?_assertEqual(true,
                           backend_eqc:test(?MODULE,
                                            false,

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -1041,7 +1041,7 @@ eqc_test_() ->
          fun setup/0,
          fun cleanup/1,
          [
-          {timeout, 60000,
+          {timeout, 180,
             [?_assertEqual(true,
                           backend_eqc:test(?MODULE, false,
                                            [{data_root,

--- a/test/backend_eqc.erl
+++ b/test/backend_eqc.erl
@@ -61,7 +61,7 @@
          delete/5,
          init_backend/3]).
 
--define(TEST_ITERATIONS, 250).
+-define(TEST_SECONDS, 120).
 
 -record(qcst, {backend, % Backend module under test
                volatile, % Indicates if backend is volatile
@@ -86,7 +86,7 @@ test(Backend, Volatile, Config) ->
                    fun(BeState,_Olds) -> catch(Backend:stop(BeState)) end)).
 
 test(Backend, Volatile, Config, Cleanup) ->
-    test2(property(Backend, Volatile, Config, Cleanup, ?TEST_ITERATIONS)).
+    test2(property(Backend, Volatile, Config, Cleanup, ?TEST_SECONDS)).
 
 test(Backend, Volatile, Config, Cleanup, NumTests) ->
     test2(property(Backend, Volatile, Config, Cleanup, NumTests)).
@@ -105,11 +105,11 @@ property(Backend, Volatile, Config) ->
                 catch(Backend:stop(BeState)) end).
 
 property(Backend, Volatile, Config, Cleanup) ->
-    property(Backend, Volatile, Config, Cleanup, ?TEST_ITERATIONS).
+    property(Backend, Volatile, Config, Cleanup, ?TEST_SECONDS).
 
-property(Backend, Volatile, Config, Cleanup, NumTests) ->
-    eqc:numtests(NumTests,
-                 prop_backend(Backend, Volatile, Config, Cleanup)).
+property(Backend, Volatile, Config, Cleanup, NumSeconds) ->
+    eqc:testing_time(NumSeconds,
+                     prop_backend(Backend, Volatile, Config, Cleanup)).
 
 %% ====================================================================
 %% eqc property

--- a/test/get_fsm_eqc.erl
+++ b/test/get_fsm_eqc.erl
@@ -46,8 +46,8 @@ eqc_test_() ->
        fun setup/0,
        fun cleanup/1,
        [%% Run the quickcheck tests
-        {timeout, 60000, % do not trust the docs - timeout is in msec
-         ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(50, ?QC_OUT(prop_basic_get()))))}
+        {timeout, 70,
+         ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(60, ?QC_OUT(prop_basic_get()))))}
        ]
       }
      ]

--- a/test/put_fsm_eqc.erl
+++ b/test/put_fsm_eqc.erl
@@ -80,8 +80,8 @@ eqc_test_() ->
                                                              <<"function() { return 123; }">>},
                                                             []}, 5)),
         %% Run the quickcheck tests
-        {timeout, 60000, % do not trust the docs - timeout is in msec
-         ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(50, ?QC_OUT(prop_basic_put()))))}
+        {timeout, 70,
+         ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(60, ?QC_OUT(prop_basic_put()))))}
        ]
       }
      ]


### PR DESCRIPTION
And switch to using [eunit_formatters](https://github.com/seancribbs/eunit_formatters) for test results. This is a chance to try it out on a repository and see how it works for us.
