### PR TITLE
Fix two places where the bucket-type was hard-coded "default" in securit...

### DIFF
--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -133,7 +133,7 @@ forbidden(RD, Ctx) ->
         false ->
             Bucket = list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, wrq:path_info(bucket, RD))),
             Res = riak_core_security:check_permission({"riak_kv.index",
-                                                       {<<"default">>,
+                                                       {Ctx#ctx.bucket_type,
                                                         Bucket}},
                                                       Ctx#ctx.security),
             case Res of

--- a/src/riak_kv_wm_keylist.erl
+++ b/src/riak_kv_wm_keylist.erl
@@ -133,7 +133,7 @@ forbidden(RD, Ctx) ->
             {true, RD, Ctx};
         false ->
             Res = riak_core_security:check_permission({"riak_kv.list_keys",
-                                                       {<<"default">>,
+                                                       {Ctx#ctx.bucket_type,
                                                         Ctx#ctx.bucket}},
                                                       Ctx#ctx.security),
             case Res of


### PR DESCRIPTION
...y checks.

When testing manually with ibrowse, as below, we get this error:

```
17> ibrowse:send_req("https://127.0.0.1:11018/types/list-keys-test/buckets/hello/keys?stream=true", [{"Authorization", "Basic " ++ base64:encode_to_string("user:password")}], get, [], [{stream_to, self()}, {is_ssl, true}, {ssl_options, [{verify, verify_none}]}]).
{ibrowse_req_id,{1400,354827,993451}}
18> flush().
Shell got {ibrowse_async_headers,{1400,354827,993451},
                                 "403",
                                 [{"Server",
                                   "MochiWeb/1.1 WebMachine/1.10.5 (jokes are better explained)"},
                                  {"Date","Sat, 17 May 2014 19:27:08 GMT"},
                                  {"Content-Type","text/plain"},
                                  {"Content-Length","81"}]}
Shell got {ibrowse_async_response,{1400,354827,993451},
                                  "Permission denied: User 'user' does not have 'riak_kv.list_keys' on default/hello"}
```

Note the incorrect bucket-type in the denial message, even though the user has been granted list-keys on the `<<"list-keys-test">>` bucket type. Here's the output after the patch is applied:

```
3> ibrowse:send_req("https://127.0.0.1:11018/types/list-keys-test/buckets/hello/keys?stream=true", [{"Authorization", "Basic " ++ base64:encode_to_string("user:password")}], get, [], [{stream_to, self()}, {is_ssl, true}, {ssl_options, [{verify, verify_none}]}]).
{ibrowse_req_id,{1400,355177,337429}}
4> flush().
Shell got {ibrowse_async_headers,{1400,355177,337429},
                                 "200",
                                 [{"Vary","Accept-Encoding"},
                                  {"Server",
                                   "MochiWeb/1.1 WebMachine/1.10.5 (jokes are better explained)"},
                                  {"Date","Sat, 17 May 2014 19:32:57 GMT"},
                                  {"Content-Type","application/json"},
                                  {"Content-Length","2"}]}
Shell got {ibrowse_async_response,{1400,355177,337429},"{}"}
Shell got {ibrowse_async_response_end,{1400,355177,337429}}
ok
```

A patch to the `http_security` riak_test is forthcoming.
