### PR TITLE
Fix PB List Keys to missing bucket type causes crash, hangs client

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -84,3 +84,4 @@ Unknown types:
   riak_core_apl:preflist2/0
   riak_dt:operation/0
   riak_dt:value/0
+riak_kv_wm_utils.erl:289: The pattern {Scheme, _, Host, Port, _, _} can never match the type {'error','no_scheme' | {_,atom(),_}}

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -84,4 +84,4 @@ Unknown types:
   riak_core_apl:preflist2/0
   riak_dt:operation/0
   riak_dt:value/0
-riak_kv_wm_utils.erl:289: The pattern {Scheme, _, Host, Port, _, _} can never match the type {'error','no_scheme' | {_,atom(),_}}
+

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -84,4 +84,3 @@ Unknown types:
   riak_core_apl:preflist2/0
   riak_dt:operation/0
   riak_dt:value/0
-

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -650,11 +650,11 @@ stream_list_buckets(Filter, Timeout, Type,
 stream_list_buckets(Filter, Timeout, Client, Type,
                     {?MODULE, [Node, _ClientId]}) ->
     ReqId = mk_reqid(),
-    {ok, _Pid} = riak_kv_buckets_fsm_sup:start_buckets_fsm(Node,
-                                                           [{raw, ReqId,
-                                                             Client},
-                                                            [Filter, Timeout,
-                                                             true, Type]]),
+    riak_kv_buckets_fsm_sup:start_buckets_fsm(Node,
+                                              [{raw, ReqId,
+                                                Client},
+                                              [Filter, Timeout,
+                                                true, Type]]),
     {ok, ReqId}.
 
 %% @spec get_index(Bucket :: binary(),

--- a/src/riak_kv_buckets_fsm.erl
+++ b/src/riak_kv_buckets_fsm.erl
@@ -79,13 +79,9 @@ init(From={_, _, ClientPid}, [ItemFilter, Timeout, Stream, BucketType]) ->
 %% TODO Move to the riak_core_bucket_type module as part of 2.1 clean up
 %%      See https://github.com/basho/riak_kv/issues/954 for more details
 maybe_bucket_type_exists(undefined, _ExistsFun, DoesNotExistFun) ->
-<<<<<<< HEAD
     DoesNotExistFun({error, no_type});
 maybe_bucket_type_exists(_=BucketType, ExistsFun, _DoesNotExistFun) ->
     ExistsFun(BucketType).
-=======
-    DoesNotExistFun({error, no_type}).
->>>>>>> - Modified the riak_kv_buckets_fsm:init/3 function to directly call
 
 
 process_results(done, StateData) ->

--- a/src/riak_kv_buckets_fsm.erl
+++ b/src/riak_kv_buckets_fsm.erl
@@ -65,14 +65,13 @@ init(From={_, _, ClientPid}, [ItemFilter, Timeout, Stream, BucketType]) ->
     %% Construct the bucket listing request
     ModState = #state{from=From, stream=Stream, type=BucketType},
     Exists = fun(_) ->
-  	    Req = ?KV_LISTBUCKETS_REQ{item_filter=ItemFilter},
-	    {Req, allup, 1, 1, riak_kv, riak_kv_vnode_master, Timeout,
-	    ModState}
+      Req = ?KV_LISTBUCKETS_REQ{item_filter=ItemFilter},
+      {Req, allup, 1, 1, riak_kv, riak_kv_vnode_master, Timeout,
+        ModState}
     end,
     DoesNotExist = fun({error, _}=Error) -> 
-	    finish(Error, ModState) 
+      finish(Error, ModState)
     end,
-
     maybe_bucket_type_exists(riak_core_bucket_type:get(BucketType), Exists, DoesNotExist).
 
 

--- a/src/riak_kv_buckets_fsm.erl
+++ b/src/riak_kv_buckets_fsm.erl
@@ -62,9 +62,14 @@ init(From={_, _, ClientPid}, [ItemFilter, Timeout, Stream, BucketType]) ->
     ?DTRACE(?C_BUCKETS_INIT, [2, FilterX],
             [<<"other">>, ClientNode, PidStr]),
     %% Construct the bucket listing request
-    Req = ?KV_LISTBUCKETS_REQ{item_filter=ItemFilter},
-    {Req, allup, 1, 1, riak_kv, riak_kv_vnode_master, Timeout,
-     #state{from=From, stream=Stream, type=BucketType}}.
+    ModState =  #state{from=From, stream=Stream, type=BucketType},
+    case riak_core_bucket_type:get(BucketType) of
+	{error, _}=Error -> finish(Error, ModState);
+	_ ->
+	    Req = ?KV_LISTBUCKETS_REQ{item_filter=ItemFilter},
+	    {Req, allup, 1, 1, riak_kv, riak_kv_vnode_master, Timeout,
+	    ModState}
+    end.
 
 process_results(done, StateData) ->
     {done, StateData};

--- a/src/riak_kv_buckets_fsm.erl
+++ b/src/riak_kv_buckets_fsm.erl
@@ -64,7 +64,7 @@ init(From={_, _, ClientPid}, [ItemFilter, Timeout, Stream, BucketType]) ->
     %% Construct the bucket listing request
     ModState =  #state{from=From, stream=Stream, type=BucketType},
     case riak_core_bucket_type:get(BucketType) of
-	{error, _}=Error -> finish(Error, ModState);
+	undefined -> finish({error, no_type}, ModState);
 	_ ->
 	    Req = ?KV_LISTBUCKETS_REQ{item_filter=ItemFilter},
 	    {Req, allup, 1, 1, riak_kv, riak_kv_vnode_master, Timeout,

--- a/src/riak_kv_buckets_fsm.erl
+++ b/src/riak_kv_buckets_fsm.erl
@@ -64,7 +64,7 @@ init(From={_, _, ClientPid}, [ItemFilter, Timeout, Stream, BucketType]) ->
 
     %% Construct the bucket listing request
     ModState = #state{from=From, stream=Stream, type=BucketType},
-    Exists = fun(_) ->
+    Exists = fun([]) ->
   	    Req = ?KV_LISTBUCKETS_REQ{item_filter=ItemFilter},
 	    {Req, allup, 1, 1, riak_kv, riak_kv_vnode_master, Timeout,
 	    ModState}

--- a/src/riak_kv_buckets_fsm.erl
+++ b/src/riak_kv_buckets_fsm.erl
@@ -64,16 +64,16 @@ init(From={_, _, ClientPid}, [ItemFilter, Timeout, Stream, BucketType]) ->
 
     %% Construct the bucket listing request
     ModState = #state{from=From, stream=Stream, type=BucketType},
-    exists = fun(_) ->
+    Exists = fun(_) ->
   	    Req = ?KV_LISTBUCKETS_REQ{item_filter=ItemFilter},
 	    {Req, allup, 1, 1, riak_kv, riak_kv_vnode_master, Timeout,
 	    ModState}
     end,
-    does_not_exist = fun({error, _}=Error) -> 
+    DoesNotExist = fun({error, _}=Error) -> 
 	    finish(Error, ModState) 
     end,
 
-    maybe_bucket_type_exists(BucketType, exists, does_not_exist).
+    maybe_bucket_type_exists(BucketType, Exists, DoesNotExist).
 
 
 %% private

--- a/src/riak_kv_buckets_fsm.erl
+++ b/src/riak_kv_buckets_fsm.erl
@@ -79,9 +79,13 @@ init(From={_, _, ClientPid}, [ItemFilter, Timeout, Stream, BucketType]) ->
 %% TODO Move to the riak_core_bucket_type module as part of 2.1 clean up
 %%      See https://github.com/basho/riak_kv/issues/954 for more details
 maybe_bucket_type_exists(undefined, _ExistsFun, DoesNotExistFun) ->
+<<<<<<< HEAD
     DoesNotExistFun({error, no_type});
 maybe_bucket_type_exists(_=BucketType, ExistsFun, _DoesNotExistFun) ->
     ExistsFun(BucketType).
+=======
+    DoesNotExistFun({error, no_type}).
+>>>>>>> - Modified the riak_kv_buckets_fsm:init/3 function to directly call
 
 
 process_results(done, StateData) ->

--- a/src/riak_kv_buckets_fsm.erl
+++ b/src/riak_kv_buckets_fsm.erl
@@ -73,7 +73,7 @@ init(From={_, _, ClientPid}, [ItemFilter, Timeout, Stream, BucketType]) ->
 	    finish(Error, ModState) 
     end,
 
-    maybe_bucket_type_exists(BucketType, Exists, DoesNotExist).
+    maybe_bucket_type_exists(riak_core_bucket_type:get(BucketType), Exists, DoesNotExist).
 
 
 %% private
@@ -82,9 +82,7 @@ init(From={_, _, ClientPid}, [ItemFilter, Timeout, Stream, BucketType]) ->
 maybe_bucket_type_exists([]=BucketType, ExistsFun, _DoesNotExistFun) ->
     ExistsFun(BucketType);
 maybe_bucket_type_exists(undefined, _ExistsFun, DoesNotExistFun) ->
-    DoesNotExistFun({error, no_type});
-maybe_bucket_type_exists(BucketType, ExistsFun, DoesNotExistFun) ->
-    maybe_bucket_type_exists(riak_core_bucket_type:get(BucketType), ExistsFun, DoesNotExistFun).
+    DoesNotExistFun({error, no_type}).
 
 
 process_results(done, StateData) ->

--- a/src/riak_kv_buckets_fsm.erl
+++ b/src/riak_kv_buckets_fsm.erl
@@ -64,7 +64,7 @@ init(From={_, _, ClientPid}, [ItemFilter, Timeout, Stream, BucketType]) ->
 
     %% Construct the bucket listing request
     ModState = #state{from=From, stream=Stream, type=BucketType},
-    Exists = fun([]) ->
+    Exists = fun(_) ->
   	    Req = ?KV_LISTBUCKETS_REQ{item_filter=ItemFilter},
 	    {Req, allup, 1, 1, riak_kv, riak_kv_vnode_master, Timeout,
 	    ModState}

--- a/src/riak_kv_buckets_fsm.erl
+++ b/src/riak_kv_buckets_fsm.erl
@@ -69,7 +69,7 @@ init(From={_, _, ClientPid}, [ItemFilter, Timeout, Stream, BucketType]) ->
 	    {Req, allup, 1, 1, riak_kv, riak_kv_vnode_master, Timeout,
 	    ModState}
     end,
-    does_not_exist = fun(Error) -> 
+    does_not_exist = fun({error, _}=Error) -> 
 	    finish(Error, ModState) 
     end,
 

--- a/src/riak_kv_buckets_fsm.erl
+++ b/src/riak_kv_buckets_fsm.erl
@@ -79,10 +79,10 @@ init(From={_, _, ClientPid}, [ItemFilter, Timeout, Stream, BucketType]) ->
 %% private
 %% TODO Move to the riak_core_bucket_type module as part of 2.1 clean up
 %%      See https://github.com/basho/riak_kv/issues/954 for more details
-maybe_bucket_type_exists([]=BucketType, ExistsFun, _DoesNotExistFun) ->
-    ExistsFun(BucketType);
 maybe_bucket_type_exists(undefined, _ExistsFun, DoesNotExistFun) ->
-    DoesNotExistFun({error, no_type}).
+    DoesNotExistFun({error, no_type});
+maybe_bucket_type_exists(_=BucketType, ExistsFun, _DoesNotExistFun) ->
+    ExistsFun(BucketType).
 
 
 process_results(done, StateData) ->

--- a/src/riak_kv_entropy_info.erl
+++ b/src/riak_kv_entropy_info.erl
@@ -137,8 +137,8 @@ compute_tree_info(Type) ->
 
 %% Return information about all exchanges for given index/index_n
 exchanges(Index, IndexN) ->
-    case lists:keyfind({riak_kv, Index}, 1, all_index_info()) of
-        {_, #index_info{exchanges=Exchanges}} ->
+    case ets:lookup(?ETS, {index, {riak_kv, Index}}) of
+        [{_, #index_info{exchanges=Exchanges}}] ->
             [{Idx, Time, Repaired}
              || {{Idx,IdxN}, #exchange_info{time=Time,
                                             repaired=Repaired}} <- Exchanges,

--- a/src/riak_kv_keys_fsm.erl
+++ b/src/riak_kv_keys_fsm.erl
@@ -90,14 +90,15 @@ init(From={_, _, ClientPid}, [Bucket, ItemFilter, Timeout]) ->
             [<<"other">>, ClientNode, PidStr]),
     %% Get the bucket n_val for use in creating a coverage plan
     ModState = #state{from=From},
-    case riak_core_bucket:get_bucket(Bucket) of
-	{error, Reason} -> finish({error, Reason}, ModState); 
-	BucketProps ->
-	    NVal = proplists:get_value(n_val, BucketProps),
-	    %% Construct the key listing request
-	    Req = req(Bucket, ItemFilter),
-	    {Req, all, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout, ModState}
-    end.
+    maybe_complete_init(Bucket, ItemFilter, Timeout, ModState, riak_core_bucket:get_bucket(Bucket)).
+
+maybe_complete_init(_Bucket, _ItemFilter, _Timeout, ModState, {error, _}=Error) ->
+    finish(Error, ModState);
+maybe_complete_init(Bucket, ItemFilter, Timeout, ModState, BucketProps) ->
+    NVal = proplists:get_value(n_val, BucketProps),
+    %% Construct the key listing request
+    Req = req(Bucket, ItemFilter),
+    {Req, all, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout, ModState}.
 
 process_results({From, Bucket, Keys},
                 StateData=#state{from={raw, ReqId, ClientPid}}) ->

--- a/src/riak_kv_keys_fsm.erl
+++ b/src/riak_kv_keys_fsm.erl
@@ -89,13 +89,14 @@ init(From={_, _, ClientPid}, [Bucket, ItemFilter, Timeout]) ->
     ?DTRACE(?C_KEYS_INIT, [2, FilterX],
             [<<"other">>, ClientNode, PidStr]),
     %% Get the bucket n_val for use in creating a coverage plan
+    ModState = #state{from=From},
     case riak_core_bucket:get_bucket(Bucket) of
-	{error, Reason} -> {error, Reason}; 
+	{error, Reason} -> {error, Reason, ModState}; 
 	BucketProps ->
 	    NVal = proplists:get_value(n_val, BucketProps),
 	    %% Construct the key listing request
 	    Req = req(Bucket, ItemFilter),
-	    {Req, all, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout, #state{from=From}}
+	    {Req, all, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout, ModState}
     end.
 
 process_results({From, Bucket, Keys},

--- a/src/riak_kv_keys_fsm.erl
+++ b/src/riak_kv_keys_fsm.erl
@@ -92,6 +92,7 @@ init(From={_, _, ClientPid}, [Bucket, ItemFilter, Timeout]) ->
     ModState = #state{from=From},
     maybe_complete_init(Bucket, ItemFilter, Timeout, ModState, riak_core_bucket:get_bucket(Bucket)).
 
+
 maybe_complete_init(_Bucket, _ItemFilter, _Timeout, ModState, {error, _}=Error) ->
     finish(Error, ModState);
 maybe_complete_init(Bucket, ItemFilter, Timeout, ModState, BucketProps) ->
@@ -99,6 +100,7 @@ maybe_complete_init(Bucket, ItemFilter, Timeout, ModState, BucketProps) ->
     %% Construct the key listing request
     Req = req(Bucket, ItemFilter),
     {Req, all, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout, ModState}.
+
 
 process_results({From, Bucket, Keys},
                 StateData=#state{from={raw, ReqId, ClientPid}}) ->

--- a/src/riak_kv_keys_fsm.erl
+++ b/src/riak_kv_keys_fsm.erl
@@ -91,7 +91,7 @@ init(From={_, _, ClientPid}, [Bucket, ItemFilter, Timeout]) ->
     %% Get the bucket n_val for use in creating a coverage plan
     ModState = #state{from=From},
     case riak_core_bucket:get_bucket(Bucket) of
-	{error, Reason} -> {error, Reason, ModState}; 
+	{error, Reason} -> finish({error, Reason}, ModState); 
 	BucketProps ->
 	    NVal = proplists:get_value(n_val, BucketProps),
 	    %% Construct the key listing request

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -225,14 +225,14 @@ forbidden(RD, Ctx) ->
         true ->
             {true, RD, Ctx};
         false ->
-            validate_unforbidden(RD, Ctx)
+            validate(RD, Ctx)
     end.
 
--spec validate_unforbidden(#wm_reqdata{}, context()) -> term().
-validate_unforbidden(RD, Ctx=#ctx{security=undefined}) ->
-    validate_resource(RD, Ctx, method_to_perm(Ctx#ctx.method));
-validate_unforbidden(RD, Ctx=#ctx{security=Security}) ->
-    Perm = method_to_perm(Ctx#ctx.method),
+-spec validate(#wm_reqdata{}, context()) -> term().
+validate(RD, Ctx=#ctx{security=undefined}) ->
+    validate_resource(RD, Ctx, riak_kv_wm_utils:method_to_perm(Ctx#ctx.method));
+validate(RD, Ctx=#ctx{security=Security}) ->
+    Perm = riak_kv_wm_utils:method_to_perm(Ctx#ctx.method),
     Res = riak_core_security:check_permission({Perm,
                                               {Ctx#ctx.bucket_type,
                                               Ctx#ctx.bucket}},
@@ -258,18 +258,6 @@ validate_resource(RD, Ctx, Perm) when (Perm == "riak_kv.get" orelse Perm == "ria
 validate_resource(RD, Ctx, _Perm) ->
     %% Ensure the bucket type exists, otherwise 404 early.
     validate_bucket_type(RD, Ctx).
-
--spec method_to_perm(atom()) -> string().
-method_to_perm(Method) when Method == 'POST' ->
-                    "riak_kv.put";
-method_to_perm(Method) when Method == 'PUT' ->
-                    "riak_kv.put";
-method_to_perm(Method) when Method == 'HEAD' ->
-                    "riak_kv.get";
-method_to_perm(Method) when Method == 'GET' ->
-                    "riak_kv.get";
-method_to_perm(Method) when Method == 'DELETE' ->
-                    "riak_kv.delete".
 
 %% @doc Detects whether fetching the requested object results in an
 %% error.

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -264,14 +264,15 @@ forbidden(RD, Ctx=#ctx{security=Security}) ->
                              unicode:characters_to_binary(Error, utf8, utf8),
                              RD1), Ctx};
                 {true, _} ->
-                    case Perm of
-                        "riak_kv.get" ->
+                    case (Perm == "riak_kv.get" orelse
+                          Perm == "riak_kv.delete") of
+                        true ->
                             %% Ensure the key is here, otherwise 404
                             %% we do this early as it used to be done in the
                             %% malformed check, so the rest of the resource
                             %% assumes that the key is present.
                             forbidden_check_doc(RD, Ctx);
-                        _ ->
+                        false ->
                             %% Ensure the bucket type exists, otherwise 404 early.
                             forbidden_check_bucket_type(RD, Ctx)
                     end

--- a/src/riak_kv_wm_props.erl
+++ b/src/riak_kv_wm_props.erl
@@ -153,7 +153,9 @@ forbidden(RD, Ctx=#ctx{security=Security}) ->
                 'GET' ->
                     "riak_core.get_bucket";
                 'HEAD' ->
-                    "riak_core.get_bucket"
+                    "riak_core.get_bucket";
+		'DELETE' ->
+                    "riak_core.set_bucket"
             end,
 
             Res = riak_core_security:check_permission({Perm,

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -286,8 +286,6 @@ referer_tuple(RD) ->
             case http_uri:parse(Url) of
                 {ok, {Scheme, _, Host, Port, _, _}} -> %R15+
                     {Scheme, Host, Port};
-                {Scheme, _, Host, Port, _, _} -> % R14 and below
-                    {Scheme, Host, Port};
                 {error, _} ->
                     {invalid, Url}
             end

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -41,7 +41,8 @@
          erlify_bucket_prop/1,
          ensure_bucket_type/3,
          bucket_type_exists/1,
-         maybe_bucket_type/2
+         maybe_bucket_type/2,
+         method_to_perm/1
         ]).
 
 -include_lib("webmachine/include/webmachine.hrl").
@@ -420,3 +421,16 @@ maybe_bucket_type(<<"default">>, B) ->
     B;
 maybe_bucket_type(T, B) ->
     {T, B}.
+
+%% @doc Maps an HTTP method to an internal permission
+%%-spec method_to_perm(atom()) -> string().
+method_to_perm('POST') ->
+    "riak_kv.put";
+method_to_perm('PUT') ->
+    "riak_kv.put";
+method_to_perm('HEAD') ->
+    "riak_kv.get";
+method_to_perm('GET') ->
+    "riak_kv.get";
+method_to_perm('DELETE') ->
+    "riak_kv.delete".


### PR DESCRIPTION
Per defect #875, list keys and buckets for an undefined bucket type failed to operate as expected.  Listing keys for an undefined bucket type caused a client hang while listing buckets for an undefined bucket type yielded an {ok, []}.  With this patch, both scenarios return {error, no_type}, and do not hang the client waiting for a reply.

This PR requires modifications to the riak_core_coverage_fsm provided by https://github.com/basho/riak_core/pull/594.
