### PR TITLE
Cleaner output for bucket type creation errors

### DIFF
--- a/src/riak_kv_bucket.erl
+++ b/src/riak_kv_bucket.erl
@@ -268,7 +268,7 @@ validate_create_consistent_props(false, New) ->
 validate_create_consistent_props(undefined, New) ->
     {New, [], []};
 validate_create_consistent_props(Invalid, New) ->
-    Err = lists:flatten(io_lib:format("~p is not a valid value for consistent. use \"true\" or \"false\"", [Invalid])),
+    Err = lists:flatten(io_lib:format("~p is not a valid value for consistent. Use \"true\" or \"false\"", [Invalid])),
     {lists:keydelete(consistent, 1, New), [], [{consistent, Err}]}.
 
 

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -557,7 +557,9 @@ bucket_type_update(Type, _) ->
 bucket_type_print_update_result(Type, ok) ->
     io:format("~ts updated~n", [Type]);
 bucket_type_print_update_result(Type, {error, Reason}) ->
-    io:format("Error updating bucket type ~ts: ~p~n", [Type, Reason]),
+    io:format("Error updating bucket type ~ts:~n", [Type]),
+    io:format(bucket_error_xlate(Reason)),
+    io:format("~n"),
     error.
 
 bucket_type_reset([TypeStr]) ->


### PR DESCRIPTION
Could probably be further enhanced, but handles the problem reported by @jrwest in #893 much more gracefully.

```
$ ./riak-admin bucket-type create foo '{"props": {"r": "fred", "n_val": "abc", "consistent": "abc", "allow_mult": "x"}}'
Error creating bucket type foo:
r must be an integer or (one|quorum|all)
n_val must be an integer
allow_mult should be true or false
<<"abc">> is not a valid value for consistent. Use "true" or "false"
```
