### PR TITLE
Fix PB List Keys to missing bucket type causes crash, hangs client

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -650,11 +650,11 @@ stream_list_buckets(Filter, Timeout, Type,
 stream_list_buckets(Filter, Timeout, Client, Type,
                     {?MODULE, [Node, _ClientId]}) ->
     ReqId = mk_reqid(),
-    {ok, _Pid} = riak_kv_buckets_fsm_sup:start_buckets_fsm(Node,
-                                                           [{raw, ReqId,
-                                                             Client},
-                                                            [Filter, Timeout,
-                                                             true, Type]]),
+    riak_kv_buckets_fsm_sup:start_buckets_fsm(Node,
+                                              [{raw, ReqId,
+                                                Client},
+                                               [Filter, Timeout,
+                                                true, Type]]),
     {ok, ReqId}.
 
 %% @spec get_index(Bucket :: binary(),

--- a/src/riak_kv_buckets_fsm.erl
+++ b/src/riak_kv_buckets_fsm.erl
@@ -62,9 +62,26 @@ init(From={_, _, ClientPid}, [ItemFilter, Timeout, Stream, BucketType]) ->
     ?DTRACE(?C_BUCKETS_INIT, [2, FilterX],
             [<<"other">>, ClientNode, PidStr]),
     %% Construct the bucket listing request
-    Req = ?KV_LISTBUCKETS_REQ{item_filter=ItemFilter},
-    {Req, allup, 1, 1, riak_kv, riak_kv_vnode_master, Timeout,
-     #state{from=From, stream=Stream, type=BucketType}}.
+    ModState = #state{from=From, stream=Stream, type=BucketType},
+    Exists = fun(_) ->
+      Req = ?KV_LISTBUCKETS_REQ{item_filter=ItemFilter},
+      {Req, allup, 1, 1, riak_kv, riak_kv_vnode_master, Timeout,
+        ModState}
+    end,
+    DoesNotExist = fun({error, _}=Error) -> 
+      finish(Error, ModState)
+    end,
+    maybe_bucket_type_exists(riak_core_bucket_type:get(BucketType), Exists, DoesNotExist).
+
+
+%% private
+%% TODO Move to the riak_core_bucket_type module as part of 2.1 clean up
+%%      See https://github.com/basho/riak_kv/issues/954 for more details
+maybe_bucket_type_exists(undefined, _ExistsFun, DoesNotExistFun) ->
+    DoesNotExistFun({error, no_type});
+maybe_bucket_type_exists(_=BucketType, ExistsFun, _DoesNotExistFun) ->
+    ExistsFun(BucketType).
+
 
 process_results(done, StateData) ->
     {done, StateData};


### PR DESCRIPTION
Per defect #875, list keys and buckets for an undefined bucket type failed to operate as expected.  Listing keys for an undefined bucket type caused a client hang while listing buckets for an undefined bucket type yielded an {ok, []}.  With this patch, both scenarios return {error, no_type}, and do not hang the client waiting for a reply.

This PR requires modifications to the riak_core_coverage_fsm provided by https://github.com/basho/riak_core/pull/594.

In order to properly squash the commits for this fix, a new branch was created -- requiring a new PR.  Therefore, this PR supersedes https://github.com/basho/riak_kv/pull/955.

/cc @kellymclaughlin @reiddraper @seancribbs 
