### PR TITLE
Verify bucket type existence for list keys and buckets operations

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -584,7 +584,7 @@ end
 %% @see background_manager
 {mapping, "handoff.use_background_manager", "riak_kv.handoff_use_background_manager", [
     {datatype, flag},
-    {default, on},
+    {default, off},
     hidden
 ]}.
 
@@ -595,6 +595,6 @@ end
 %% @see background_manager
 {mapping, "anti_entropy.use_background_manager", "riak_kv.aae_use_background_manager", [
     {datatype, flag},
-    {default, on},
+    {default, off},
     hidden
 ]}.

--- a/src/riak_kv_crdt.erl
+++ b/src/riak_kv_crdt.erl
@@ -23,7 +23,7 @@
 -module(riak_kv_crdt).
 
 -export([update/3, merge/1, value/2, new/3,
-         supported/1, to_mod/1, from_mod/1, mod_map/1]).
+         supported/1, to_mod/1, from_mod/1, from_mod/2,  mod_map/1]).
 -export([to_binary/2, to_binary/1, from_binary/1]).
 -export([log_merge_errors/4, meta/2, merge_value/2]).
 %% MR helper funs
@@ -429,12 +429,16 @@ to_mod(Type) ->
     proplists:get_value(Type, ?MOD_MAP).
 
 from_mod(Mod) ->
-    case lists:keyfind(Mod, 2, ?MOD_MAP) of
+    from_mod(Mod, ?MOD_MAP).
+
+from_mod(Mod, ModMap) ->
+    case lists:keyfind(Mod, 2, ModMap) of
         {Type, Mod} ->
             Type;
         false ->
             undefined
     end.
+
 %% @doc mapping of atom/shortname types (map, set, counter etc) to
 %% actual modules that implement them. Notice the mod map for maps is
 %% different since embedded types are different.

--- a/test/riak_kv_schema_tests.erl
+++ b/test/riak_kv_schema_tests.erl
@@ -61,8 +61,8 @@ basic_schema_test() ->
     cuttlefish_unit:assert_not_configured(Config, "riak_core.default_bucket_props.postcommit"),
     cuttlefish_unit:assert_config(Config, "riak_core.default_bucket_props.dvv_enabled", false),
     cuttlefish_unit:assert_config(Config, "riak_dt.binary_compression", 1),
-    cuttlefish_unit:assert_config(Config, "riak_kv.handoff_use_background_manager", true),
-    cuttlefish_unit:assert_config(Config, "riak_kv.aae_use_background_manager", true),
+    cuttlefish_unit:assert_config(Config, "riak_kv.handoff_use_background_manager", false),
+    cuttlefish_unit:assert_config(Config, "riak_kv.aae_use_background_manager", false),
     ok.
 
 override_non_multi_backend_schema_test() ->
@@ -117,8 +117,8 @@ override_non_multi_backend_schema_test() ->
         {["buckets", "default", "precommit"], "module:function javascriptFunction"},
         {["buckets", "default", "postcommit"], "module2:function2"},
         {["datatypes", "compression_level"], "off"},
-        {["handoff", "use_background_manager"], off},
-        {["anti_entropy", "use_background_manager"], off}
+        {["handoff", "use_background_manager"], on},
+        {["anti_entropy", "use_background_manager"], on}
     ],
 
     Config = cuttlefish_unit:generate_templated_config(
@@ -185,8 +185,8 @@ override_non_multi_backend_schema_test() ->
                ]}
     ]),
     cuttlefish_unit:assert_config(Config, "riak_dt.binary_compression", false),
-    cuttlefish_unit:assert_config(Config, "riak_kv.handoff_use_background_manager", false),
-    cuttlefish_unit:assert_config(Config, "riak_kv.aae_use_background_manager", false),
+    cuttlefish_unit:assert_config(Config, "riak_kv.handoff_use_background_manager", true),
+    cuttlefish_unit:assert_config(Config, "riak_kv.aae_use_background_manager", true),
 
     ok.
 


### PR DESCRIPTION
Per defect #875, the client hangs when attempting to list keys or buckets for an undefined bucket types.

This fix represents a time/risk compromise for the [previous proposed solution](https://github.com/basho/riak_kv/pull/958) which made a deeper change to the riak_core_coverage_fsm -- pushing the check for bucket definition down to the state machine ensuring that all bucket type uses are consistently checked.  #965 has been opened to revisit this approach when we have the time to address the issue more holistically.

Supersedes previous FSM-based implementation [PR 958](https://github.com/basho/riak_kv/pull/958).

/cc @kellymclaughlin @seancribbs @reiddraper 
