### PR TITLE
Rename security permission from riak_search.query to search.query

### DIFF
--- a/src/riak_kv_mapred_term.erl
+++ b/src/riak_kv_mapred_term.erl
@@ -184,11 +184,11 @@ get_required_permissions(Inputs, _Query) ->
         {search, Bucket, _SearchQuery} when is_binary(Bucket) ->
             %% needs search AND mapreduce permissions
             [{"riak_kv.mapreduce", Bucket},
-             {"riak_search.query", Bucket}];
+             {"search.query", Bucket}];
         {search, Bucket, _SearchQuery, _SearchFilter} when is_binary(Bucket) ->
             %% needs search AND mapreduce permissions
             [{"riak_kv.mapreduce", Bucket},
-             {"riak_search.query", Bucket}];
+             {"search.query", Bucket}];
         {Bucket, Filters} when is_binary(Bucket),
                                is_list(Filters) ->
             [{"riak_kv.list_keys", {<<"default">>, Bucket}},

--- a/src/riak_kv_mapred_term.erl
+++ b/src/riak_kv_mapred_term.erl
@@ -184,11 +184,11 @@ get_required_permissions(Inputs, _Query) ->
         {search, Bucket, _SearchQuery} when is_binary(Bucket) ->
             %% needs search AND mapreduce permissions
             [{"riak_kv.mapreduce", Bucket},
-             {"search.query", Bucket}];
+             {"search.query", {<<"index">>, Bucket}}];
         {search, Bucket, _SearchQuery, _SearchFilter} when is_binary(Bucket) ->
             %% needs search AND mapreduce permissions
             [{"riak_kv.mapreduce", Bucket},
-             {"search.query", Bucket}];
+             {"search.query", {<<"index">>, Bucket}}];
         {Bucket, Filters} when is_binary(Bucket),
                                is_list(Filters) ->
             [{"riak_kv.list_keys", {<<"default">>, Bucket}},


### PR DESCRIPTION
The current name of the permission is `search.query`
See https://github.com/basho/yokozuna/blob/develop/include/yokozuna.hrl#L148
