### PR TITLE
Fix 'undefined' bucket type issue.

### DIFF
--- a/src/riak_kv_pb_bucket.erl
+++ b/src/riak_kv_pb_bucket.erl
@@ -163,7 +163,7 @@ process_stream({ReqId, Error}, ReqId,
 do_list_buckets(Type, Timeout, true, Req, #state{client=C}=State) ->
     {ok, ReqId} = C:stream_list_buckets(none, Timeout, Type),
     {reply, {stream, ReqId}, State#state{req = Req, req_ctx = ReqId}};
-do_list_buckets(Type, Timeout, false, _Req, #state{client=C}=State) ->
+do_list_buckets(Type, Timeout, _Stream, _Req, #state{client=C}=State) ->
     case C:list_buckets(none, Timeout, Type) of
         {ok, Buckets} ->
             {reply, #rpblistbucketsresp{buckets = Buckets}, State};

--- a/src/riak_kv_pb_bucket.erl
+++ b/src/riak_kv_pb_bucket.erl
@@ -93,21 +93,12 @@ encode(Message) ->
     {ok, riak_pb_codec:encode(Message)}.
 
 %% @doc process/2 callback. Handles an incoming request message.
-process(#rpblistbucketsreq{type = Type, timeout=T, stream=S}=Req,
-        #state{client=C} = State) -> 
-    case {maybe_bucket_type_exists(Type), S} of
-       {true, true} ->
-	   {ok, ReqId} = C:stream_list_buckets(none, T, Type),
-	   {reply, {stream, ReqId}, State#state{req = Req, req_ctx = ReqId}};
-       {true, false} ->
-	   case C:list_buckets(none, T, Type) of
-	       {ok, Buckets} ->
-		   {reply, #rpblistbucketsresp{buckets = Buckets}, State};
-		   {error, Reason} ->
-			   {error, {format, Reason}, State}
-	   end;
-        _ ->
-	    {error, {format, "No bucket-type named '~s'", [Type]}, State}
+process(#rpblistbucketsreq{type = Type, timeout=T, stream=S}=Req, State) ->
+    case check_bucket_type(Type) of
+        {ok, GoodType} ->
+            do_list_buckets(GoodType, T, S, Req, State);
+        error ->
+            {error, {format, "No bucket-type named '~s'", [Type]}, State}
     end;
 
 %% this should remain for backwards compatibility
@@ -117,12 +108,13 @@ process(rpblistbucketsreq, State) ->
 %% Start streaming in list keys
 process(#rpblistkeysreq{type = Type, bucket=B,timeout=T}=Req, #state{client=C} = State) ->
     %% stream_list_keys results will be processed by process_stream/3
-    case maybe_create_bucket_type(Type, B) of
-	{error, no_type} ->
-	    {error, {format, "No bucket-type named '~s'", [Type]}, State};
-	Bucket ->
+    case check_bucket_type(Type) of
+        {ok, GoodType} ->
+            Bucket = maybe_create_bucket_type(GoodType, B),
 	    {ok, ReqId} = C:stream_list_keys(Bucket, T),
-	    {reply, {stream, ReqId}, State#state{req = Req, req_ctx = ReqId}}
+	    {reply, {stream, ReqId}, State#state{req = Req, req_ctx = ReqId}};
+        error ->
+            {error, {format, "No bucket-type named '~s'", [Type]}, State}
     end.
 
 %% @doc process_stream/3 callback. Handles streaming keys messages and
@@ -167,25 +159,29 @@ process_stream({ReqId, Error}, ReqId,
                State=#state{ req=#rpblistbucketsreq{}, req_ctx=ReqId}) ->
     {error, {format, Error}, State#state{req = undefined, req_ctx = undefined}}.
 
--spec maybe_bucket_type_exists(BucketExists :: atom() | binary() | list()) -> atom().
-maybe_bucket_type_exists(undefined) ->
-    false;
-maybe_bucket_type_exists(Type) when is_list(Type) ->
-    true;
-maybe_bucket_type_exists(Type) when is_binary(Type) ->
-    maybe_bucket_type_exists(riak_core_bucket_type:get(Type)).
 
--spec maybe_create_bucket_type(Type :: binary() | atom(), Bucket :: binary()) -> any() | { binary(), list() } | { atom() | atom() }.
+do_list_buckets(Type, Timeout, true, Req, #state{client=C}=State) ->
+    {ok, ReqId} = C:stream_list_buckets(none, Timeout, Type),
+    {reply, {stream, ReqId}, State#state{req = Req, req_ctx = ReqId}};
+do_list_buckets(Type, Timeout, false, _Req, #state{client=C}=State) ->
+    case C:list_buckets(none, Timeout, Type) of
+        {ok, Buckets} ->
+            {reply, #rpblistbucketsresp{buckets = Buckets}, State};
+        {error, Reason} ->
+            {error, {format, Reason}, State}
+    end.
+
+check_bucket_type(undefined) -> {ok, <<"default">>};
+check_bucket_type(<<"default">>) -> {ok, <<"default">>};
+check_bucket_type(Type) ->
+    case riak_core_bucket_type:get(Type) of
+        Props when is_list(Props) ->
+            {ok, Type};
+        _ ->
+            error
+    end.
+
 maybe_create_bucket_type(<<"default">>, Bucket) ->
     Bucket;
-maybe_create_bucket_type(undefined, Bucket) ->
-    Bucket;
 maybe_create_bucket_type(Type, Bucket) when is_binary(Type) ->
-    maybe_create_bucket_type(maybe_bucket_type_exists(Type), Type, Bucket).
-
--spec maybe_create_bucket_type(BucketExists :: boolean(), Type :: binary() | any(), Bucket :: list() | any()) -> { binary(), list() } | { atom() | atom() }.
-maybe_create_bucket_type(true, Type, Bucket) when is_binary(Type) ->
-    {Type, Bucket};
-maybe_create_bucket_type(false, _Type, _Bucket) ->
-    {error, no_type}.
-
+    {Type, Bucket}.

--- a/src/riak_kv_pb_bucket.erl
+++ b/src/riak_kv_pb_bucket.erl
@@ -41,6 +41,7 @@
 
 -module(riak_kv_pb_bucket).
 
+-type optional(A) :: A | undefined.
 -include_lib("riak_pb/include/riak_kv_pb.hrl").
 
 -behaviour(riak_api_pb_service).
@@ -160,6 +161,9 @@ process_stream({ReqId, Error}, ReqId,
     {error, {format, Error}, State#state{req = undefined, req_ctx = undefined}}.
 
 
+-spec do_list_buckets(binary(), optional(pos_integer()), optional(boolean()), #rpblistbucketsreq{}, #state{}) ->
+                             {reply, tuple(), #state{}} |
+                             {error, {format, iodata()}, #state{}}.
 do_list_buckets(Type, Timeout, true, Req, #state{client=C}=State) ->
     {ok, ReqId} = C:stream_list_buckets(none, Timeout, Type),
     {reply, {stream, ReqId}, State#state{req = Req, req_ctx = ReqId}};
@@ -171,6 +175,7 @@ do_list_buckets(Type, Timeout, _Stream, _Req, #state{client=C}=State) ->
             {error, {format, Reason}, State}
     end.
 
+-spec check_bucket_type(optional(binary())) -> {ok, binary()} | error.
 check_bucket_type(undefined) -> {ok, <<"default">>};
 check_bucket_type(<<"default">>) -> {ok, <<"default">>};
 check_bucket_type(Type) ->
@@ -181,6 +186,7 @@ check_bucket_type(Type) ->
             error
     end.
 
+-spec maybe_create_bucket_type(binary(), binary()) -> binary() | {binary(), binary()}.
 maybe_create_bucket_type(<<"default">>, Bucket) ->
     Bucket;
 maybe_create_bucket_type(Type, Bucket) when is_binary(Type) ->

--- a/tools.mk
+++ b/tools.mk
@@ -1,5 +1,8 @@
 REBAR ?= ./rebar
 
+compile-no-deps:
+	${REBAR} compile skip_deps=true
+
 test: compile
 	${REBAR} eunit skip_deps=true
 
@@ -31,7 +34,7 @@ ${LOCAL_PLT}: compile
 		fi \
 	fi
 
-dialyzer: ${PLT} ${LOCAL_PLT}
+dialyzer-run:
 	@echo "==> $(shell basename $(shell pwd)) (dialyzer)"
 	@if [ -f $(LOCAL_PLT) ]; then \
 		PLTS="$(PLT) $(LOCAL_PLT)"; \
@@ -50,6 +53,10 @@ dialyzer: ${PLT} ${LOCAL_PLT}
 	else \
 		dialyzer $(DIALYZER_FLAGS) --plts $${PLTS} -c ebin; \
 	fi
+
+dialyzer-quick: compile-no-deps dialyzer-run
+
+dialyzer: ${PLT} ${LOCAL_PLT} dialyzer-run
 
 cleanplt:
 	@echo


### PR DESCRIPTION
This was broken by #970. The client is not required to send a bucket-type in the request, therefore it can be the atom 'undefined', which corresponds to the "default" bucket-type. Also untangled the logic into a separate "check" for the presence of the bucket-type.

This was found by the Python client suite here: http://buildbot.bos1/builders/python-client-test/builds/60/steps/make%20test/logs/stdio

Also updated tools.mk.

@kellymclaughlin 
