### PR TITLE
Verify strong consistency configuration on startup

### DIFF
--- a/src/riak_kv_ensembles.erl
+++ b/src/riak_kv_ensembles.erl
@@ -149,6 +149,7 @@ maybe_bootstrap_ensembles() ->
         false ->
             ok;
         true ->
+	    _ = maybe_aae_configuration_valid(app_helper:get_env(riak_kv, anti_entropy)),
             {ok, Ring, CHBin} = riak_core_ring_manager:get_raw_ring_chashbin(),
             IsClaimant = (riak_core_ring:claimant(Ring) == node()),
             IsReady = riak_core_ring:ring_ready(Ring),
@@ -159,6 +160,13 @@ maybe_bootstrap_ensembles() ->
                     ok
             end
     end.
+
+-spec maybe_aae_configuration_valid(atom() | any()) -> boolean().
+maybe_aae_configuration_valid(on) ->
+    true;
+maybe_aae_configuration_valid(_) ->
+    lager:warning("Strong consistency has been enabled without AAE -- all consistent operations will timeout until AAE is enabled."),
+    false.
 
 bootstrap_preflists(Ring, CHBin) ->
     %% TODO: We have no notion of deleting ensembles. Nor do we check if


### PR DESCRIPTION
 When strong configuration is enabled and AAE is disabled, emit a warning to log informing the user that strong consistency operations will fail until AAE is enabled. 

This change addresses the issue raised in defect #959.
