### PR TITLE
Add basic stats for strongly consistent operations

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -97,16 +97,36 @@ consistent_get(Bucket, Key, Options, {?MODULE, [Node, _ClientId]}) ->
     BKey = {Bucket, Key},
     Ensemble = ensemble(BKey),
     Timeout = recv_timeout(Options),
-    case riak_ensemble_client:kget(Node, Ensemble, BKey, Timeout) of
-        {error, _}=Err ->
-            Err;
-        {ok, Obj} ->
-            case riak_object:get_value(Obj) of
-                notfound ->
-                    {error, notfound};
-                _ ->
-                    {ok, Obj}
-            end
+    StartTS = os:timestamp(),
+    Result = case riak_ensemble_client:kget(Node, Ensemble, BKey, Timeout) of
+                 {error, _}=Err ->
+                     Err;
+                 {ok, Obj} ->
+                     case riak_object:get_value(Obj) of
+                         notfound ->
+                             {error, notfound};
+                         _ ->
+                             {ok, Obj}
+                     end
+             end,
+    maybe_update_consistent_stat(Node, consistent_get, Bucket, StartTS, Result),
+    Result.
+
+maybe_update_consistent_stat(Node, Stat, Bucket, StartTS, Result) ->
+    case node() of
+        Node ->
+            Duration = timer:now_diff(os:timestamp(), StartTS),
+            ObjFmt = riak_core_capability:get({riak_kv, object_format}, v0),
+            ObjSize = case Result of
+                          {ok, Obj} ->
+                              riak_object:approximate_size(ObjFmt, Obj);
+                          _ ->
+                              undefined
+                      end,
+            riak_kv_stat:update({Stat, Bucket, Duration, ObjSize}),
+            ok;
+        _ ->
+            ok
     end.
 
 %% @spec get(riak_object:bucket(), riak_object:key(), options(), riak_client()) ->
@@ -199,10 +219,12 @@ normal_put(RObj, Options, {?MODULE, [Node, ClientId]}) ->
     wait_for_reqid(ReqId, Timeout).
 
 consistent_put(RObj, Options, {?MODULE, [Node, _ClientId]}) ->
-    BKey = {riak_object:bucket(RObj), riak_object:key(RObj)},
+    Bucket = riak_object:bucket(RObj),
+    BKey = {Bucket, riak_object:key(RObj)},
     Ensemble = ensemble(BKey),
     NewObj = riak_object:apply_updates(RObj),
     Timeout = recv_timeout(Options),
+    StartTS = os:timestamp(),
     Result = case consistent_put_type(RObj, Options) of
                  update ->
                      riak_ensemble_client:kupdate(Node, Ensemble, BKey, RObj, NewObj, Timeout);
@@ -212,6 +234,7 @@ consistent_put(RObj, Options, {?MODULE, [Node, _ClientId]}) ->
                  %overwrite ->
                      %riak_ensemble_client:kover(Node, Ensemble, BKey, NewObj, Timeout)
              end,
+    maybe_update_consistent_stat(Node, consistent_put, Bucket, StartTS, Result),
     ReturnBody = lists:member(returnbody, Options),
     case Result of
         {error, _}=Error ->

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -691,6 +691,10 @@ stats_from_update_arg({DT, actor_count, _Value}) ->
     [{{?APP, DT, actor_count}, {metric, [], histogram, undefined}}];
 stats_from_update_arg(late_put_fsm_coordinator_ack) ->
     [{{?APP, late_put_fsm_coordinator_ack}, {metric,[],counter,undefined}}];
+stats_from_update_arg({consistent_get, _Bucket, _Microsecs, _ObjSize}) ->
+    riak_core_stat_q:names_and_types([?APP, consistent, gets]);
+stats_from_update_arg({consistent_put, _Bucket, _Microsecs, _ObjSize}) ->
+    riak_core_stat_q:names_and_types([?APP, consistent, puts]);
 stats_from_update_arg(_) ->
     [].
 

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -274,9 +274,25 @@ do_update({fsm_destroy, Type}) ->
 do_update({Type, actor_count, Count}) ->
     ok = folsom_metrics:notify_existing_metric({?APP, Type, actor_count}, Count, histogram);
 do_update(late_put_fsm_coordinator_ack) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, late_put_fsm_coordinator_ack}, {inc, 1}, counter).
+    ok = folsom_metrics:notify_existing_metric({?APP, late_put_fsm_coordinator_ack}, {inc, 1}, counter);
+do_update({consistent_get, _Bucket, Microsecs, ObjSize}) ->
+    ok = notify_existing({?APP, consistent, gets}, 1, spiral),
+    ok = notify_existing({?APP, consistent, gets, time}, Microsecs, histogram),
+    ok = maybe_notify_existing({?APP, consistent, gets, objsize}, ObjSize, histogram);
+do_update({consistent_put, _Bucket, Microsecs, ObjSize}) ->
+    ok = notify_existing({?APP, consistent, puts}, 1, spiral),
+    ok = notify_existing({?APP, consistent, puts, time}, Microsecs, histogram),
+    ok = maybe_notify_existing({?APP, consistent, puts, objsize}, ObjSize, histogram).
 
 %% private
+
+notify_existing(Name, Event, Type) ->
+    folsom_metrics:notify_existing_metric(Name, Event, Type).
+
+maybe_notify_existing(_, undefined, _) ->
+    ok;
+maybe_notify_existing(Name, Event, Type) ->
+    notify_existing(Name, Event, Type).
 
 add_monitor(Type, Pid) ->
     gen_server:cast(?SERVER, {monitor, Type, Pid}).
@@ -477,7 +493,13 @@ stats() ->
      {[object, set, merge, time], histogram},
      {[object, map, merge], spiral},
      {[object, map, merge, time], histogram},
-     {late_put_fsm_coordinator_ack, counter}
+     {late_put_fsm_coordinator_ack, counter},
+     {[consistent, gets], spiral},
+     {[consistent, gets, time], histogram},
+     {[consistent, gets, objsize], histogram},
+     {[consistent, puts], spiral},
+     {[consistent, puts, time], histogram},
+     {[consistent, puts, objsize], histogram}
     ].
 
 %% @doc register a stat with folsom

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -413,7 +413,8 @@ legacy_stat_map() ->
      {map_actor_counts_95,  {{riak_kv,map,actor_count}, 95}, histogram_percentile},
      {map_actor_counts_99,  {{riak_kv,map,actor_count}, 99}, histogram_percentile},
      {map_actor_counts_100, {{riak_kv,map,actor_count}, max}, histogram},
-     {late_put_fsm_coordinator_ack, {riak_kv, late_put_fsm_coordinator_ack}, counter}] ++ legacy_fsm_stats().
+     {late_put_fsm_coordinator_ack, {riak_kv, late_put_fsm_coordinator_ack}, counter}]
+        ++ legacy_fsm_stats() ++ consistent_stats().
 
 legacy_fsm_stats() ->
     %% When not using sidejob to manage FSMs, include the legacy FSM stats.
@@ -438,6 +439,35 @@ legacy_put_fsm_stats() ->
         _ ->
             []
     end.
+
+consistent_stats() ->
+    [%% consistent gets
+     {consistent_gets, {{riak_kv,consistent,gets}, one}, spiral},
+     {consistent_gets_total, {{riak_kv,consistent,gets}, count}, spiral},
+     {consistent_get_objsize_mean, {{riak_kv,consistent,gets,objsize}, arithmetic_mean}, histogram},
+     {consistent_get_objsize_median, {{riak_kv,consistent,gets,objsize}, median}, histogram},
+     {consistent_get_objsize_95, {{riak_kv,consistent,gets,objsize}, 95}, histogram_percentile},
+     {consistent_get_objsize_99, {{riak_kv,consistent,gets,objsize}, 99}, histogram_percentile},
+     {consistent_get_objsize_100, {{riak_kv,consistent,gets,objsize}, max}, histogram},
+     {consistent_get_time_mean, {{riak_kv,consistent,gets,time}, arithmetic_mean}, histogram},
+     {consistent_get_time_median, {{riak_kv,consistent,gets,time}, median}, histogram},
+     {consistent_get_time_95, {{riak_kv,consistent,gets,time}, 95}, histogram_percentile},
+     {consistent_get_time_99, {{riak_kv,consistent,gets,time}, 99}, histogram_percentile},
+     {consistent_get_time_100, {{riak_kv,consistent,gets,time}, max}, histogram},
+
+     %% consistent puts
+     {consistent_puts, {{riak_kv,consistent,puts}, one}, spiral},
+     {consistent_puts_total, {{riak_kv,consistent,puts}, count}, spiral},
+     {consistent_put_objsize_mean, {{riak_kv,consistent,puts,objsize}, arithmetic_mean}, histogram},
+     {consistent_put_objsize_median, {{riak_kv,consistent,puts,objsize}, median}, histogram},
+     {consistent_put_objsize_95, {{riak_kv,consistent,puts,objsize}, 95}, histogram_percentile},
+     {consistent_put_objsize_99, {{riak_kv,consistent,puts,objsize}, 99}, histogram_percentile},
+     {consistent_put_objsize_100, {{riak_kv,consistent,puts,objsize}, max}, histogram},
+     {consistent_put_time_mean, {{riak_kv,consistent,puts,time}, arithmetic_mean}, histogram},
+     {consistent_put_time_median, {{riak_kv,consistent,puts,time}, median}, histogram},
+     {consistent_put_time_95, {{riak_kv,consistent,puts,time}, 95}, histogram_percentile},
+     {consistent_put_time_99, {{riak_kv,consistent,puts,time}, 99}, histogram_percentile},
+     {consistent_put_time_100, {{riak_kv,consistent,puts,time}, max}, histogram}].
 
 sidejob_stats() ->
     sidejob_get_fsm_stats() ++ sidejob_put_fsm_stats().

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1060,7 +1060,7 @@ handle_info({ensemble_put, Key, Obj, From}, State=#state{handoff_target=HOTarget
                                                          forward=Fwd}) ->
     case Fwd of
         undefined ->
-            {Result, State2} = actual_put(Key, Obj, [], false, undefined, State),
+            {Result, State2} = actual_put_tracked(Key, Obj, [], false, undefined, State),
             Reply = case Result of
                         {dw, _Idx, _Obj, _ReqID} ->
                             Obj;
@@ -1105,7 +1105,7 @@ handle_info({ensemble_repair, Key, Obj, From}, State=#state{idx=_Idx, forward=Fw
     end;
 
 handle_info({raw_forward_put, Key, Obj, From}, State) ->
-    {Result, State2} = actual_put(Key, Obj, [], false, undefined, State),
+    {Result, State2} = actual_put_tracked(Key, Obj, [], false, undefined, State),
     Reply = case Result of
                 {dw, _Idx, _Obj, _ReqID} ->
                     Obj;
@@ -1127,7 +1127,7 @@ handle_info({raw_forward_get, Key, From}, State) ->
     riak_kv_ensemble_backend:reply(From, Reply),
     {ok, State2};
 handle_info({raw_put, Key, Obj}, State) ->
-    {_, State2} = actual_put(Key, Obj, [], false, undefined, State),
+    {_, State2} = actual_put_tracked(Key, Obj, [], false, undefined, State),
     {ok, State2};
 
 handle_info(retry_create_hashtree, State=#state{hashtrees=undefined}) ->
@@ -1453,6 +1453,12 @@ actual_put(BKey={Bucket, Key}, Obj, IndexSpecs, RB, ReqID,
             Reply = {fail, Idx, Reason}
     end,
     {Reply, State#state{modstate=UpdModState}}.
+
+actual_put_tracked(BKey, Obj, IndexSpecs, RB, ReqId, State) ->
+    StartTS = os:timestamp(),
+    Result = actual_put(BKey, Obj, IndexSpecs, RB, ReqId, State),
+    update_vnode_stats(vnode_put, State#state.idx, StartTS),
+    Result.
 
 do_reformat({Bucket, Key}=BKey, State=#state{mod=Mod, modstate=ModState}) ->
     case do_get_object(Bucket, Key, Mod, ModState) of


### PR DESCRIPTION
Consistent gets/puts now correctly increment `vnode_gets`/`vnode_puts` the same as normal gets/puts. Prior to this commit, gets incremented the relevant stat but puts did not.

Consistent operations now maintain per-operation stats that are similar to the node/FSM stats for normal gets/puts. This includes operation counts, latency percentiles, and object size percentiles.

Future work is needed to support per-bucket stats, detailed `riak_ensemble` stats that track FSM stages / interesting events (eg. object rewrites after leader change), etc. But, these basic stats should be good enough for 2.0.

Addresses #876 
