### PR TITLE
Fix MOD_MAP when datatype update request includes return_body=true

### DIFF
--- a/src/riak_kv_pb_crdt.erl
+++ b/src/riak_kv_pb_crdt.erl
@@ -188,8 +188,9 @@ process_update_response({ok, RObj}, State) ->
     #state{type=Type, mod=Mod, return_key=Key, return_ctx=ReturnCtx} = State,
     {{Ctx, Value}, Stats} = riak_kv_crdt:value(RObj, Mod),
     [ riak_kv_stat:update(S) || S <- Stats ],
+    ModMap = riak_kv_crdt:mod_map(Type),
     Resp = riak_pb_dt_codec:encode_update_response(Type, Value, Key,
-                                                   get_context(Ctx, ReturnCtx), ?MOD_MAP),
+                                                   get_context(Ctx, ReturnCtx), ModMap),
     {reply, Resp, State};
 process_update_response({error, notfound}, State) ->
     {reply, #dtupdateresp{}, State};


### PR DESCRIPTION
This was an oversight in the previous review. /cc @russelldb 
