### PR TITLE
SC ensemble peers should wait for riak_kv service

### DIFF
--- a/src/riak_kv_ensemble_backend.erl
+++ b/src/riak_kv_ensemble_backend.erl
@@ -29,7 +29,7 @@
 -export([init/3, new_obj/4]).
 -export([obj_epoch/1, obj_seq/1, obj_key/1, obj_value/1]).
 -export([set_obj_epoch/2, set_obj_seq/2, set_obj_value/2]).
--export([get/3, put/4, tick/5, ping/2]).
+-export([get/3, put/4, tick/5, ping/2, ready_to_start/0]).
 -export([trusted/1, sync_request/2, sync/2]).
 -export([reply/2]).
 -export([obj_newer/2]).
@@ -294,3 +294,8 @@ maybe_async_update(Changes, State=#state{async=Async}) ->
 ping(From, State=#state{proxy=Proxy}) ->
     catch Proxy ! {ensemble_ping, From},
     {async, State}.
+
+-spec ready_to_start() -> boolean().
+ready_to_start() ->
+    lists:member(riak_kv, riak_core_node_watcher:services(node())).
+


### PR DESCRIPTION
Addresses https://github.com/basho/riak_kv/issues/984. Avoids certain nasty races by preventing the ensemble peers from starting until the riak_kv service is up. 

This requires this ensemble PR: https://github.com/basho/riak_ensemble/pull/32
