### PR TITLE
Fix AAE on/off detection

### DIFF
--- a/src/riak_kv_ensembles.erl
+++ b/src/riak_kv_ensembles.erl
@@ -161,10 +161,10 @@ maybe_bootstrap_ensembles() ->
             end
     end.
 
--spec maybe_aae_configuration_valid(atom() | any()) -> boolean().
-maybe_aae_configuration_valid(on) ->
+-spec maybe_aae_configuration_valid({on|off,_}) -> boolean().
+maybe_aae_configuration_valid({on, _}) ->
     true;
-maybe_aae_configuration_valid(_) ->
+maybe_aae_configuration_valid({off, _}) ->
     lager:warning("Strong consistency has been enabled without AAE -- all consistent operations will timeout until AAE is enabled."),
     false.
 


### PR DESCRIPTION
riak_kv/anti_entropy takes a value of the form {on|off, Opts}, not on
off.

This fixes basho/riak_kv#988

Without this fix, you would see messages like this:

```
2014-06-17 12:00:05.829 [warning] <0.384.0>@riak_kv_ensembles:maybe_aae_configuration_valid:168 Strong consistency has been enabled without AAE -- all consistent operations will timeout until AAE is enabled.
```

Even with active anti-entropy enabled. Now, these messages are only shown if anti_entropy is set to passive.  When it is active or active-debug, they will not show up
