### PR TITLE
Add Maxreg, Minreg and RangeReg as new supported types

### DIFF
--- a/include/riak_kv_types.hrl
+++ b/include/riak_kv_types.hrl
@@ -16,6 +16,15 @@
 -define(MAP_TYPE, riak_dt_map).
 -define(MAP_TYPE(Val), #crdt{mod=?MAP_TYPE, ctype="application/riak_map", value=Val}).
 
+-define(MAXREG_TYPE, riak_dt_maxreg).
+-define(MAXREG_TYPE(Val), #crdt{mod=?MAXREG_TYPE, ctype="application/riak_maxreg", value=Val}).
+
+-define(MINREG_TYPE, riak_dt_minreg).
+-define(MINREG_TYPE(Val), #crdt{mod=?MINREG_TYPE, ctype="application/riak_minreg", value=Val}).
+
+-define(RANGEREG_TYPE, riak_dt_rangereg).
+-define(RANGEREG_TYPE(Val), #crdt{mod=?RANGEREG_TYPE, ctype="application/riak_rangereg", value=Val}).
+
 %% Internal Only Key->Map->Field->Type types
 -define(FLAG_TYPE, riak_dt_od_flag).
 -define(REG_TYPE, riak_dt_lwwreg).
@@ -23,14 +32,22 @@
 
 -define(V1_TOP_LEVEL_TYPES, [pncounter]).
 -define(V2_TOP_LEVEL_TYPES, [?COUNTER_TYPE, ?SET_TYPE, ?MAP_TYPE]).
--define(TOP_LEVEL_TYPES, ?V1_TOP_LEVEL_TYPES ++ ?V2_TOP_LEVEL_TYPES).
--define(ALL_TYPES, ?TOP_LEVEL_TYPES ++ [?FLAG_TYPE, ?REG_TYPE]).
+-define(V2_REST_TYPES,      [?FLAG_TYPE, ?REG_TYPE]).
+
+-define(V3_TOP_LEVEL_TYPES, [?MAXREG_TYPE, ?MINREG_TYPE, ?RANGEREG_TYPE | ?V2_TOP_LEVEL_TYPES]).
+-define(V3_REST_TYPES,      ?V2_REST_TYPES).
+
+-define(TOP_LEVEL_TYPES, ?V1_TOP_LEVEL_TYPES ++ ?V3_TOP_LEVEL_TYPES).
+-define(ALL_TYPES, ?TOP_LEVEL_TYPES ++ ?V3_REST_TYPES).
+
 -define(EMBEDDED_TYPES, [{map, ?MAP_TYPE}, {set, ?SET_TYPE},
                          {counter, ?EMCNTR_TYPE}, {flag, ?FLAG_TYPE},
-                         {register, ?REG_TYPE}]).
+                         {register, ?REG_TYPE}, {maxreg, ?MAXREG_TYPE},
+                         {minreg, ?MINREG_TYPE}, {rangereg, ?RANGEREG_TYPE}]).
 
 -define(MOD_MAP, [{map, ?MAP_TYPE}, {set, ?SET_TYPE},
-                  {counter, ?COUNTER_TYPE}]).
+                  {counter, ?COUNTER_TYPE}, {maxreg, ?MAXREG_TYPE},
+                  {minreg, ?MINREG_TYPE}, {rangereg, ?RANGEREG_TYPE}]).
 
 -define(DATATYPE_STATS_DEFAULTS, [actor_count]).
 


### PR DESCRIPTION
for 2.next

Goes with basho/riak_dt#59 - my work creating these simple data types.

This adds them both as top-level types, and as embedded types (within maps). The former should work very simply (though perhaps would make tiny riak_objects), the latter is untested but it's in my queue to do.

TODO:
- [ ] merge basho/riak_dt#59
- [ ] update basho/riak_pb to support these as top-level types
- [ ] test these all the way through the stack
