### PR TITLE
Check AAE throttle only when AAE is enabled

### DIFF
--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -309,9 +309,8 @@ handle_cast(_Msg, State) ->
     {noreply, State}.
 
 handle_info(tick, State) ->
-    State1 = query_and_set_aae_throttle(State),
-    State2 = maybe_tick(State1),
-    {noreply, State2};
+    State1 = maybe_tick(State),
+    {noreply, State1};
 handle_info(reset_build_tokens, State) ->
     State2 = reset_build_tokens(State),
     schedule_reset_build_tokens(),
@@ -508,7 +507,8 @@ maybe_tick(State) ->
 -spec tick(state()) -> state().
 tick(State) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
-    State2 = maybe_reload_hashtrees(Ring, State),
+    State1 = query_and_set_aae_throttle(State),
+    State2 = maybe_reload_hashtrees(Ring, State1),
     State3 = lists:foldl(fun(_,S) ->
                                  maybe_poke_tree(S)
                          end, State2, lists:seq(1,10)),


### PR DESCRIPTION
Move the AAE throttle check to the actual tick function to prevent it
from running when AAE is disabled.  Otherwise, users see AAE throttle
messages when AAE is not enabled and that is just plain confusing.

Some unit tests failed but they don't seem related.  I figured
I'd get this PR up as a start.

```
Failures:

  1) riak_kv_pb_object:empty_bucket_key_test_/0:398: RpbPutReq with empty key is disallowed
     Failure/Error: ?assertMatch({ ok , _ }, Result)
       expected: = { ok , _ }
            got: {error,closed}
     %% src/riak_kv_pb_object.erl:398:in `riak_kv_pb_object:-empty_bucket_key_test_/0-fun-1-/0`


  2) riak_kv_pb_object:empty_bucket_key_test_/0:402: RpbPutReq with empty bucket is disallowed
     Failure/Error: ?assertMatch({ ok , _ }, Result)
       expected: = { ok , _ }
            got: {error,closed}
     %% src/riak_kv_pb_object.erl:402:in `riak_kv_pb_object:-empty_bucket_key_test_/0-fun-3-/0`


  3) riak_kv_pb_object:empty_bucket_key_test_/0:406: RpbGetReq with empty key is disallowed
     Failure/Error: ?assertMatch({ ok , _ }, Result)
       expected: = { ok , _ }
            got: {error,closed}
     %% src/riak_kv_pb_object.erl:406:in `riak_kv_pb_object:-empty_bucket_key_test_/0-fun-5-/0`


  4) riak_kv_pb_object:empty_bucket_key_test_/0:409: RpbGetReq with empty bucket is disallowed
     Failure/Error: ?assertMatch({ ok , _ }, Result)
       expected: = { ok , _ }
            got: {error,closed}
     %% src/riak_kv_pb_object.erl:409:in `riak_kv_pb_object:-empty_bucket_key_test_/0-fun-7-/0`
```

This is meant to address the first part of #969.
