### PR TITLE
Backport put fsm forwarding.

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -180,6 +180,10 @@ start(_Type, _StartArgs) ->
                                           [[pncounter],[]],
                                           []),
 
+            riak_core_capability:register({riak_kv, put_fsm_ack_execute},
+                                          [enabled, disabled],
+                                          disabled),
+
             HealthCheckOn = app_helper:get_env(riak_kv, enable_health_checks, false),
             %% Go ahead and mark the riak_kv service as up in the node watcher.
             %% The riak_core_ring_handler blocks until all vnodes have been started

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -167,10 +167,14 @@ get_put_coordinator_failure_timeout() ->
     app_helper:get_env(riak_kv, put_coordinator_failure_timeout, 3000).
 
 make_ack_options(Options) ->
-    case riak_core_capability:get({riak_kv, put_fsm_ack_execute}, disabled) of
-        disabled ->
+    case (riak_core_capability:get(
+            {riak_kv, put_fsm_ack_execute}, disabled) == disabled
+          orelse
+          app_helper:get_env(
+            riak_kv, retry_put_coordinator_failure, on) == off) of
+        true ->
             {false, Options};
-        enabled ->
+        false ->
             case proplists:get_value(retry_put_coordinator_failure, Options, true) of
                 true ->
                     {true, [{ack_execute, self()}|Options]};

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -621,6 +621,8 @@ handle_sync_event(_Event, _From, _StateName, StateData) ->
 
 handle_info(request_timeout, StateName, StateData) ->
     ?MODULE:StateName(request_timeout, StateData);
+handle_info({ack, _Node, now_executing}, StateName, StateData) ->
+    {next_state, StateName, StateData};
 handle_info(_Info, _StateName, StateData) ->
     {stop,badmsg,StateData}.
 

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -157,7 +157,6 @@ start_link(From, Object, PutOptions) ->
     end.
 
 set_put_coordinator_failure_timeout(MS) when is_integer(MS), MS >= 0 ->
-    %% mochiglobal:put(put_coordinator_failure_timeout, MS);
     application:set_env(riak_kv, put_coordinator_failure_timeout, MS);
 set_put_coordinator_failure_timeout(Bad) ->
     lager:error("~s:set_put_coordinator_failure_timeout(~p) invalid",
@@ -165,7 +164,6 @@ set_put_coordinator_failure_timeout(Bad) ->
     set_put_coordinator_failure_timeout(3000).
 
 get_put_coordinator_failure_timeout() ->
-    %% mochiglobal:get(put_coordinator_failure_timeout).
     app_helper:get_env(riak_kv, put_coordinator_failure_timeout, 3000).
 
 make_ack_options(Options) ->

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -621,7 +621,9 @@ handle_sync_event(_Event, _From, _StateName, StateData) ->
 
 handle_info(request_timeout, StateName, StateData) ->
     ?MODULE:StateName(request_timeout, StateData);
-handle_info({ack, _Node, now_executing}, StateName, StateData) ->
+handle_info({ack, Node, now_executing}, StateName, StateData) ->
+    late_put_fsm_coordinator_ack(Node),
+    riak_kv_stat:update(late_put_fsm_coordinator_ack),
     {next_state, StateName, StateData};
 handle_info(_Info, _StateName, StateData) ->
     {stop,badmsg,StateData}.
@@ -982,3 +984,7 @@ atom2list(P) when is_pid(P)->
 
 dtrace_errstr(Term) ->
     io_lib:format("~P", [Term, 12]).
+
+%% This function is for dbg tracing purposes
+late_put_fsm_coordinator_ack(_Node) ->
+    ok.

--- a/src/riak_kv_put_fsm_sup.erl
+++ b/src/riak_kv_put_fsm_sup.erl
@@ -41,10 +41,6 @@ start_link() ->
 %% @spec init([]) -> SupervisorTree
 %% @doc supervisor callback.
 init([]) ->
-    %% Mochiglobal used this way is far slower than the application app ETS
-    %% CoordTimeout = app_helper:get_env(riak_kv, put_coordinator_failure_timeout, 3000),
-    %% riak_kv_put_fsm:set_put_coordinator_failure_timeout(CoordTimeout),
-
     PutFsmSpec = {undefined,
                {riak_kv_put_fsm, start_link, []},
                temporary, 5000, worker, [riak_kv_put_fsm]},

--- a/src/riak_kv_put_fsm_sup.erl
+++ b/src/riak_kv_put_fsm_sup.erl
@@ -41,6 +41,10 @@ start_link() ->
 %% @spec init([]) -> SupervisorTree
 %% @doc supervisor callback.
 init([]) ->
+    %% Mochiglobal used this way is far slower than the application app ETS
+    %% CoordTimeout = app_helper:get_env(riak_kv, put_coordinator_failure_timeout, 3000),
+    %% riak_kv_put_fsm:set_put_coordinator_failure_timeout(CoordTimeout),
+
     PutFsmSpec = {undefined,
                {riak_kv_put_fsm, start_link, []},
                temporary, 5000, worker, [riak_kv_put_fsm]},

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -238,7 +238,11 @@ do_update({list_create, Pid}) ->
 do_update(list_create_error) ->
     folsom_metrics:notify_existing_metric({?APP, list, fsm, create, error}, 1, spiral);
 do_update({fsm_destroy, Type}) ->
-    folsom_metrics:notify_existing_metric({?APP, Type, fsm, active}, {dec, 1}, counter).
+    folsom_metrics:notify_existing_metric({?APP, Type, fsm, active}, {dec, 1}, counter);
+do_update({Type, actor_count, Count}) ->
+    folsom_metrics:notify_existing_metric({?APP, Type, actor_count}, Count, histogram);
+do_update(late_put_fsm_coordinator_ack) ->
+    folsom_metrics:notify_existing_metric({?APP, late_put_fsm_coordinator_ack}, {inc, 1}, counter).
 
 %% private
 
@@ -374,7 +378,9 @@ stats() ->
      {precommit_fail, counter},
      {postcommit_fail, counter},
      {[vnode, backend, leveldb, read_block_error],
-      {function, {function, ?MODULE, leveldb_read_block_errors}}}].
+      {function, {function, ?MODULE, leveldb_read_block_errors}}},
+     {late_put_fsm_coordinator_ack, counter}
+    ].
 
 %% @doc register a stat with folsom
 do_register_stat(Name, spiral) ->
@@ -547,6 +553,8 @@ stats_from_update_arg({list_create, _Pid}) ->
      {{?APP, list, fsm, active}, {metric, [], counter, undefined}}];
 stats_from_update_arg(list_create_error) ->
     [{{?APP, list, fsm, create, error}, {metric, [], spiral, undefined}}];
+stats_from_update_arg(late_put_fsm_coordinator_ack) ->
+    [{{?APP, late_put_fsm_coordinator_ack}, {metric,[],counter,undefined}}];
 stats_from_update_arg(_) ->
     [].
 

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -269,7 +269,8 @@ legacy_stat_map() ->
      {list_fsm_active, {riak_kv, list, fsm, active}, counter},
      {pbc_active, {riak_api, pbc_connects, active}, function},
      {pbc_connects, {{riak_api, pbc_connects}, one}, spiral},
-     {pbc_connects_total, {{riak_api, pbc_connects}, count}, spiral}] ++ legacy_fsm_stats().
+     {pbc_connects_total, {{riak_api, pbc_connects}, count}, spiral},
+     {late_put_fsm_coordinator_ack, {riak_kv, late_put_fsm_coordinator_ack}, counter}] ++ legacy_fsm_stats().
 
 legacy_fsm_stats() ->
     %% When not using sidejob to manage FSMs, include the legacy FSM stats.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -190,7 +190,23 @@ put(Preflist, BKey, Obj, ReqId, StartTime, Options) when is_integer(StartTime) -
 
 put(Preflist, BKey, Obj, ReqId, StartTime, Options, Sender)
   when is_integer(StartTime) ->
-    riak_core_vnode_master:command(Preflist,
+    %% Reminder: command_unreliable() = "even more unreliable"
+    %%
+    %% If the Riak put FSM is our caller, then the "unreliable" use is
+    %% ok: a new coordinator will be chosen if this message is
+    %% dropped.
+    %%
+    %% If the local put coordinator is our caller, then it has already
+    %% done its local write successfully before we reached here.  If
+    %% the coordinator were to block on a regular command() to the 1st
+    %% in the preflist after its own entry, then that message send can
+    %% hang and prevent sending the put op to the rest of the preflist
+    %% ... thus blocking the coordinator.  If later vnodes in the
+    %% preflist *could* satisfy the d/dw/pw conditions but, we need to
+    %% give them their chance by allowing the coordinator to proceed
+    %% without blocking here.
+    riak_core_vnode_master:command_unreliable(
+                                   Preflist,
                                    ?KV_PUT_REQ{
                                       bkey = BKey,
                                       object = Obj,


### PR DESCRIPTION
Takes #627, #700, and #913 and puts them in one pull request to take the put fsm forwarding feature from 2.0 and place it in 1.4.

Tasks remaining:
- [ ] Create an r_t to test the feature. If that cannot be done in the next 3 days (EOD Friday) at least be able to create a step-by-step manual verification process.
- [ ] If commit c927c7faa8b (or its descendants) is correct & is well-reviewed, then it should also be applied to `develop`.
