### PR TITLE
prevent secondary systems (e.g. yz) from blocking vnode handoff forever

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -588,6 +588,19 @@ end
     hidden
 ]}.
 
+%% @doc The maximum number of times that a secondary system like Riak
+%% Search 2.0 can block handoff of primary key-value data. The
+%% approximate maximum duration handoff of a vnode can be blocked for
+%% can be determined by multiplying this number by the value of
+%% "vnode_management_timer". To prevent handoff from ever being
+%% blocked by a secondary system set this value to 0.
+%% @see vnode_management_timer
+{mapping, "handoff.max_rejects", "riak_kv.handoff_rejected_max", [
+    {datatype, integer},
+    {default, "6"},
+    hidden
+]}.
+
 %% @doc Whether to use the background manager to limit AAE tree
 %% rebuilds. This will help to prevent system response degradation
 %% under times of heavy load from multiple background tasks that

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -122,6 +122,7 @@
                 async_folding :: boolean(),
                 in_handoff = false :: boolean(),
                 handoff_target :: node(),
+                handoffs_rejected = 0 :: integer(),
                 forward :: node() | [{integer(), node()}],
                 hashtrees :: pid(),
                 md_cache :: ets:tab(),
@@ -931,12 +932,13 @@ request_hash(?KV_DELETE_REQ{bkey=BKey}) ->
 request_hash(_Req) ->
     undefined.
 
-handoff_starting({_HOType, TargetNode}=_X, State) ->
-    case ?YZ_SHOULD_HANDOFF(_X) of
+handoff_starting({_HOType, TargetNode}=_X, State=#state{handoffs_rejected=RejectCount}) ->
+    MaxRejects = app_helper:get_env(riak_kv, handoff_rejected_max, 6),
+    case MaxRejects =< RejectCount orelse ?YZ_SHOULD_HANDOFF(_X) of
         true ->
             {true, State#state{in_handoff=true, handoff_target=TargetNode}};
         false ->
-            {false, State#state{in_handoff=false, handoff_target=undefined}}
+            {false, State#state{in_handoff=false, handoff_target=undefined, handoffs_rejected=RejectCount + 1 }}
     end.
 
 %% @doc Optional callback that is exported, but not part of the behaviour.

--- a/test/riak_kv_schema_tests.erl
+++ b/test/riak_kv_schema_tests.erl
@@ -35,6 +35,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_kv.vnode_md_cache_size", 0),
     cuttlefish_unit:assert_not_configured(Config, "riak_kv.memory_backend.max_memory"),
     cuttlefish_unit:assert_not_configured(Config, "riak_kv.memory_backend.ttl"),
+    cuttlefish_unit:assert_config(Config, "riak_kv.handoff_rejected_max", 6),
 
     %% make sure multi backend is not on by shell_default
     cuttlefish_unit:assert_not_configured(Config, "riak_kv.multi_backend_default"),
@@ -118,6 +119,7 @@ override_non_multi_backend_schema_test() ->
         {["buckets", "default", "postcommit"], "module2:function2"},
         {["datatypes", "compression_level"], "off"},
         {["handoff", "use_background_manager"], on},
+        {["handoff", "max_rejects"], 10},
         {["anti_entropy", "use_background_manager"], on}
     ],
 
@@ -147,6 +149,7 @@ override_non_multi_backend_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_kv.object_format", v0),
     cuttlefish_unit:assert_config(Config, "riak_kv.memory_backend.max_memory", 8192),
     cuttlefish_unit:assert_config(Config, "riak_kv.memory_backend.ttl", 86400),
+    cuttlefish_unit:assert_config(Config, "riak_kv.handoff_rejected_max", 10),
 
     %% make sure multi backend is not on by shell_default
     cuttlefish_unit:assert_not_configured(Config, "riak_kv.multi_backend_default"),


### PR DESCRIPTION
- add a recejection count and maximum number of rejections (configurable)
- includes changes to riak_kv.schema

addresses: https://github.com/basho/yokozuna/issues/417
test: https://github.com/basho/yokozuna/pull/418
test depends on: https://github.com/basho/riak_test/pull/671
riak_kv.schema doc changes depend on: https://github.com/basho/riak_core/pull/621
