### PR TITLE
Change application:get_env/2 -> app_helper:get_env

### DIFF
--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -233,7 +233,7 @@ test_link(From, Object, PutOptions, StateProps) ->
 init([From, RObj, Options0, Monitor]) ->
     BKey = {Bucket, Key} = {riak_object:bucket(RObj), riak_object:key(RObj)},
     CoordTimeout = get_put_coordinator_failure_timeout(),
-    Trace = application:get_env(riak_kv, fsm_trace_enabled),
+    Trace = app_helper:get_env(riak_kv, fsm_trace_enabled),
     Options = proplists:unfold(Options0),
     StateData = #state{from = From,
                        robj = RObj,


### PR DESCRIPTION
If the key is found, `application:get_env/2` returns an {ok, Value}`wrapper which is *not* stripped off elsewhere in this module.  The`app_helper:get_env/2` function will strip it off, as we need.
