### PR TITLE
Edoc cleanup

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -62,7 +62,7 @@
 
 -export_type([riak_client/0]).
 
-%% @spec new(Node, ClientId) -> riak_client().
+%% @spec new(Node, ClientId) -> riak_client()
 %% @doc Return a riak client instance.
 new(Node, ClientId) ->
     {?MODULE, [Node,ClientId]}.
@@ -262,7 +262,7 @@ consistent_put_type(RObj, Options) ->
             put_once
     end.
 
-%% @spec put(RObj :: riak_object:riak_object(), riak_kv_put_fsm::options(), riak_client()) ->
+%% @spec put(RObj :: riak_object:riak_object(), riak_kv_put_fsm:options(), riak_client()) ->
 %%       ok |
 %%       {ok, details()} |
 %%       {ok, riak_object:riak_object()} |
@@ -270,7 +270,7 @@ consistent_put_type(RObj, Options) ->
 %%       {error, notfound} |
 %%       {error, timeout} |
 %%       {error, {n_val_violation, N::integer()}} |
-%%       {error, Err :: term()}
+%%       {error, Err :: term()} |
 %%       {error, Err :: term(), details()}
 %% @doc Store RObj in the cluster.
 put(RObj, Options, {?MODULE, [Node, _ClientId]}=THIS) when is_list(Options) ->
@@ -408,7 +408,7 @@ consistent_delete(Bucket, Key, Options, _Timeout, {?MODULE, [Node, _ClientId]}) 
 delete_vclock(Bucket,Key,VClock,{?MODULE, [_Node, _ClientId]}=THIS) ->
     delete_vclock(Bucket,Key,VClock,[{rw,default}],?DEFAULT_TIMEOUT,THIS).
 
-%% @spec delete_vclock(riak_object:bucket(), riak_object:key(), vclock::vclock(),
+%% @spec delete_vclock(riak_object:bucket(), riak_object:key(), vclock:vclock(),
 %%                     RW :: integer(), riak_client()) ->
 %%        ok |
 %%       {error, too_many_fails} |
@@ -487,7 +487,8 @@ list_keys(Bucket, {?MODULE, [_Node, _ClientId]}=THIS) ->
 list_keys(Bucket, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
     list_keys(Bucket, none, Timeout, THIS).
 
-%% @spec list_keys(riak_object:bucket(), TimeoutMillisecs :: integer(), riak_client()) ->
+%% @spec list_keys(riak_object:bucket(), Filter :: term(),
+%% TimeoutMillisecs :: integer(), riak_client()) ->
 %%       {ok, [Key :: riak_object:key()]} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}
@@ -567,7 +568,7 @@ stream_list_keys(Input, Timeout, Client, {?MODULE, [Node, _ClientId]}) when is_p
 filter_keys(Bucket, Fun, {?MODULE, [_Node, _ClientId]}=THIS) ->
     list_keys(Bucket, Fun, ?DEFAULT_TIMEOUT, THIS).
 
-%% @spec filter_keys(riak_object:bucket(), Fun :: function(), TimeoutMillisecs :: integer()
+%% @spec filter_keys(riak_object:bucket(), Fun :: function(), TimeoutMillisecs :: integer(),
 %%                   riak_client()) ->
 %%       {ok, [Key :: riak_object:key()]} |
 %%       {error, timeout} |
@@ -592,7 +593,7 @@ filter_keys(Bucket, Fun, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
 list_buckets({?MODULE, [_Node, _ClientId]}=THIS) ->
     list_buckets(none, ?DEFAULT_TIMEOUT, <<"default">>, THIS).
 
-%% @spec list_buckets(timeout()) ->
+%% @spec list_buckets(timeout(), riak_client()) ->
 %%       {ok, [Bucket :: riak_object:bucket()]} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}
@@ -607,7 +608,8 @@ list_buckets(undefined, {?MODULE, [_Node, _ClientId]}=THIS) ->
 list_buckets(Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
     list_buckets(none, Timeout, <<"default">>, THIS).
 
-%% @spec list_buckets(TimeoutMillisecs :: integer(), riak_client()) ->
+%% @spec list_buckets(TimeoutMillisecs :: integer(), Filter :: term(),
+%% riak_client()) ->
 %%       {ok, [Bucket :: riak_object:bucket()]} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}
@@ -654,7 +656,8 @@ stream_list_buckets(Filter, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
 
 %% @spec stream_list_buckets(FilterFun :: fun(),
 %%                           TimeoutMillisecs :: integer(),
-%%                           Client :: pid()) ->
+%%                           Client :: pid(),
+%%                           riak_client()) ->
 %%       {ok, [Bucket :: riak_object:bucket()]} |
 %%       {error, timeout} |
 %%       {error, Err :: term()}
@@ -686,8 +689,7 @@ stream_list_buckets(Filter, Timeout, Client, Type,
 %%                 riak_client()) ->
 %%       {ok, [Key :: riak_object:key()]} |
 %%       {error, timeout} |
-%%       {error, Err :: term()}.
-%%
+%%       {error, Err :: term()}
 %% @doc Run the provided index query.
 get_index(Bucket, Query, {?MODULE, [_Node, _ClientId]}=THIS) ->
     get_index(Bucket, Query, [{timeout, ?DEFAULT_TIMEOUT}], THIS).
@@ -698,8 +700,7 @@ get_index(Bucket, Query, {?MODULE, [_Node, _ClientId]}=THIS) ->
 %%                 riak_client()) ->
 %%       {ok, [Key :: riak_object:key()]} |
 %%       {error, timeout} |
-%%       {error, Err :: term()}.
-%%
+%%       {error, Err :: term()}
 %% @doc Run the provided index query.
 get_index(Bucket, Query, Opts, {?MODULE, [Node, _ClientId]}) ->
     Timeout = proplists:get_value(timeout, Opts, ?DEFAULT_TIMEOUT),

--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -57,16 +57,16 @@
 %% it did before the FSM timeout bug was "fixed"
 -define(DEFAULT_TIMEOUT, infinity).
 
-%% @type data_type_defs()  :: [data_type_def()].
-%% @type data_type_def()   :: {MatchFunction::function(), ParseFunction::function()}.
-%% @type failure_reason()  :: {unknown_field_type, Field :: binary()}
+%% @type data_type_defs()  = [data_type_def()].
+%% @type data_type_def()   = {MatchFunction :: function(), ParseFunction :: function()}.
+%% @type failure_reason()  = {unknown_field_type, Field :: binary()}
 %%                          | {field_parsing_failed, {Field :: binary(), Value :: binary()}}.
 
-%% @type bucketname()      :: binary().
-%% @type index_field()     :: binary().
-%% @type index_value()     :: binary() | integer().
-%% @type query_element()   :: {eq,    index_field(), [index_value()]},
-%%                         :: {range, index_field(), [index_value(), index_value()}
+%% @type bucketname()      = binary().
+%% @type index_field()     = binary().
+%% @type index_value()     = binary() | integer().
+%% @type query_element()   = {eq,    index_field(), index_value()} |
+%%                           {range, index_field(), index_value(), index_value()}
 
 -type query_def() :: {ok, term()} | {error, term()} | {term(), {error, term()}}.
 -export_type([query_def/0]).
@@ -85,14 +85,13 @@ mapred_index(_Pipe, [Bucket, Query], Timeout) ->
     {ok, Bucket, ReqId}.
 
 %% @spec parse_object_hook(riak_object:riak_object()) ->
-%%         riak_object:riak_object() | {fail, [failure_reason()]}.
-%%
+%%         riak_object:riak_object() | {fail, [failure_reason()]}
 %% @doc Parse the index fields stored in object metadata. Conforms to
 %%      the pre-commit hook interface. Return the new object with
 %%      parsed fields stuffed into the matadata if validation was
 %%      successful, or {fail, [Reasons]} if validation failed. Reason
-%%      is either `{unknown_field_type, Field}` or
-%%      `{field_parsing_failed, {Field, Value}}.`
+%%      is either `{unknown_field_type, Field}' or
+%%      `{field_parsing_failed, {Field, Value}}.'
 parse_object_hook(RObj) ->
     %% Ensure that the object only has a single metadata, or fail
     %% loudly.
@@ -118,13 +117,12 @@ parse_object_hook(RObj) ->
     end.
 
 %% @spec parse_object(riak_object:riak_object()) -> {ok, [{Field::binary(), Val :: term()}]}
-%%                                                | {error, [failure_reason()]}.
-%%
+%%                                                | {error, [failure_reason()]}
 %% @doc Pull out index fields stored in the metadata of the provided
 %%      Riak Object. Parse the fields, and return {ok, [{Field,
 %%      Value}]} if successful, or {error, [Reasons]} on error. Reason
-%%      is either `{unknown_field_type, Field}` or
-%%      `{field_parsing_failed, {Field, Value}}.`
+%%      is either `{unknown_field_type, Field}' or
+%%      `{field_parsing_failed, {Field, Value}}.'
 parse_object(RObj) ->
     %% For each object metadata, pull out any IndexFields. This could
     %% be called on a write with siblings, so we need to examine *all*
@@ -142,13 +140,12 @@ parse_object(RObj) ->
     %% Now parse the fields, returning the result.
     parse_fields(IndexFields).
 
-%% @spec parse_fields([Field :: {Key:binary(), Value :: binary()}]) ->
-%%       {ok, [{Field :: binary(), Value :: term()}]} | {error, [failure_reason()]}.
-%%
+%% @spec parse_fields([Field :: {Key :: binary(), Value :: binary()}]) ->
+%%       {ok, [{Field :: binary(), Value :: term()}]} | {error, [failure_reason()]}
 %% @doc Parse the provided index fields. Returns {ok, Fields} if the
 %%      parsing was successful, or {error, Reasons} if parsing
-%%      failed. Reason is either `{unknown_field_type, Field}` or
-%%      `{field_parsing_failed, {Field, Value}}.`
+%%      failed. Reason is either `{unknown_field_type, Field}' or
+%%      `{field_parsing_failed, {Field, Value}}.'
 parse_fields(IndexFields) ->
     %% Call parse_field on each field, and accumulate in ResultAcc or
     %% ErrorAcc, depending on whether the operation was successful.
@@ -174,12 +171,11 @@ parse_fields(IndexFields) ->
 
 
 %% @spec parse_field(Key::binary(), Value::binary(), Types::data_type_defs()) ->
-%%         {ok, Value} | {error, Reason}.
-%%
+%%         {ok, Value} | {error, Reason}
 %% @doc Parse an index field. Return {ok, Value} on success, or
 %%      {error, Reason} if there is a problem. Reason is either
-%%      `{unknown_field_type, Field}` or `{field_parsing_failed,
-%%      {Field, Value}}.`
+%%      `{unknown_field_type, Field}' or `{field_parsing_failed,
+%%      {Field, Value}}.'
 parse_field(Key, Value, [Type|Types]) ->
     %% Run the regex to check if the key suffix matches this data
     %% type.
@@ -205,8 +201,7 @@ parse_field(Key, _Value, []) ->
 
 
 %% @private
-%% @spec is_field_match(Key :: binary(), Suffix :: binary()) -> boolean().
-%% 
+%% @spec is_field_match(Key :: binary(), Suffix :: binary()) -> boolean()
 %% @doc Return true if the Key matches the suffix. Special case for $bucket
 %% and $key.
 is_field_match(Key, ?BUCKETFIELD) ->
@@ -228,8 +223,7 @@ is_field_match(Key, Suffix) when size(Suffix) < size(Key) ->
 is_field_match(_, _) ->
     false.
 
-%% @spec format_failure_reason(FailureReason :: {atom(), term()}) -> string().
-%%
+%% @spec format_failure_reason(FailureReason :: {atom(), term()}) -> string()
 %% @doc Given a failure reason, turn it into a human-readable string.
 format_failure_reason(FailureReason) ->
     case FailureReason of
@@ -239,8 +233,7 @@ format_failure_reason(FailureReason) ->
             io_lib:format("Could not parse field '~s', value '~s'.~n", [Field, Value])
     end.
 
-%% @spec timestamp() -> integer().
-%%
+%% @spec timestamp() -> integer()
 %% @doc Get a timestamp, the number of milliseconds returned by
 %%      erlang:now().
 timestamp() ->
@@ -518,8 +511,7 @@ add_timeout_opt(0, Opts) ->
 add_timeout_opt(Timeout, Opts) ->
     [{timeout, Timeout} | Opts].
 
-%% @spec field_types() -> data_type_defs().
-%%
+%% @spec field_types() -> data_type_defs()
 %% @doc Return a list of {MatchFunction, ParseFunction} tuples that
 %%      map a field name to a field type.
 field_types() ->

--- a/src/riak_kv_bucket.erl
+++ b/src/riak_kv_bucket.erl
@@ -88,7 +88,8 @@
 %%
 %% There is no way to _remove_ a property
 %%
-%% @see validate_dt_props/3, assert_no_datatype/1
+%% @see validate_dt_props/3
+%% @see assert_no_datatype/1
 -spec validate(create | update,
                {riak_core_bucket_type:bucket_type(), undefined | binary()} | binary(),
                undefined | props(),

--- a/src/riak_kv_counter.erl
+++ b/src/riak_kv_counter.erl
@@ -24,7 +24,7 @@
 %% @doc Backwards compatibility with 1.4 counters `value' function as
 %% used in the CRDT cookbook.
 %%
-%% @see riak_kv_crdt.erl
+%% @see riak_kv_crdt
 %% @end
 
 -module(riak_kv_counter).

--- a/src/riak_kv_crdt.erl
+++ b/src/riak_kv_crdt.erl
@@ -228,7 +228,7 @@ counter_op(N) ->
 %% the operation then apply the operation to the local merged replica,
 %% and risk precondition errors and unexpected behaviour.
 %%
-%% @see split_ops/1 for more explanation
+%% @see split_ops/1
 -spec update_crdt(orddict:orddict(), riak_dt:actor(), crdt_op() | non_neg_integer()) ->
                          orddict:orddict() | precondition_error().
 update_crdt(Dict, Actor, Amt) when is_integer(Amt) ->
@@ -450,7 +450,7 @@ mod_map(_) ->
 
 
 
-%% @Doc the update context can be empty for some types.
+%% @doc the update context can be empty for some types.
 %% Those that support an precondition_context should supply
 %% a smaller than Type:to_binary(Value) binary context.
 get_context(Type, Value) ->

--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -48,9 +48,6 @@ start_link(ReqId, Bucket, Key, Options, Timeout, Client, ClientId, VClock) ->
                                                Options, Timeout, Client, ClientId,
                                                VClock])}.
 
-%% @spec delete(ReqId :: binary(), riak_object:bucket(), riak_object:key(),
-%%             RW :: integer(), TimeoutMillisecs :: integer(), Client :: pid())
-%%           -> term()
 %% @doc Delete the object at Bucket/Key.  Direct return value is uninteresting,
 %%      see riak_client:delete/3 for expected gen_server replies to Client.
 delete(ReqId,Bucket,Key,Options,Timeout,Client,ClientId,undefined) ->

--- a/src/riak_kv_gcounter.erl
+++ b/src/riak_kv_gcounter.erl
@@ -27,7 +27,7 @@
 %% can only be incremented. Borrows liberally from argv0 and Justin Sheehy's vclock module
 %% in implementation.
 %%
-%% @see riak_kv_pncounter.erl for a counter that can be decremented
+%% @see riak_kv_pncounter
 %%
 %% @reference Marc Shapiro, Nuno Preguiça, Carlos Baquero, Marek Zawirski (2011) A comprehensive study of
 %% Convergent and Commutative Replicated Data Types. http://hal.upmc.fr/inria-00555588/

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -732,7 +732,6 @@ ttl_test_() ->
      ?_assertEqual({error, not_found, State}, get(Bucket, Key, State))
     ].
 
-%% @private
 max_memory_test_() ->
     %% Set max size to 1.5kb
     Config = [{max_memory, 1.5 * (1 / 1024)}],

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -20,6 +20,35 @@
 %%
 %% -------------------------------------------------------------------
 
+%% @doc riak_kv_multi_backend allows you to run multiple backends within a
+%% single Riak instance. The 'backend' property of a bucket specifies
+%% the backend in which the object should be stored. If no 'backend'
+%% is specified, then the 'multi_backend_default' setting is used.
+%% If this is unset, then the first defined backend is used.
+%%
+%% === Configuration ===
+%%
+%%     {storage_backend, riak_kv_multi_backend},
+%%     {multi_backend_default, first_backend},
+%%     {multi_backend, [
+%%       % format: {name, module, [Configs]}
+%%       {first_backend, riak_xxx_backend, [
+%%         {config1, ConfigValue1},
+%%         {config2, ConfigValue2}
+%%       ]},
+%%       {second_backend, riak_yyy_backend, [
+%%         {config1, ConfigValue1},
+%%         {config2, ConfigValue2}
+%%       ]}
+%%     ]}
+%%
+%%
+%% Then, tell a bucket which one to use...
+%%
+%%     riak_core_bucket:set_bucket(&lt;&lt;"MY_BUCKET"&gt;&gt;, [{backend, second_backend}])
+%%
+%%
+
 -module (riak_kv_multi_backend).
 -behavior(riak_kv_backend).
 
@@ -59,35 +88,6 @@
 
 -type state() :: #state{}.
 -type config() :: [{atom(), term()}].
-
-%% @doc riak_kv_multi_backend allows you to run multiple backends within a
-%% single Riak instance. The 'backend' property of a bucket specifies
-%% the backend in which the object should be stored. If no 'backend'
-%% is specified, then the 'multi_backend_default' setting is used.
-%% If this is unset, then the first defined backend is used.
-%%
-%% === Configuration ===
-%%
-%%     {storage_backend, riak_kv_multi_backend},
-%%     {multi_backend_default, first_backend},
-%%     {multi_backend, [
-%%       % format: {name, module, [Configs]}
-%%       {first_backend, riak_xxx_backend, [
-%%         {config1, ConfigValue1},
-%%         {config2, ConfigValue2}
-%%       ]},
-%%       {second_backend, riak_yyy_backend, [
-%%         {config1, ConfigValue1},
-%%         {config2, ConfigValue2}
-%%       ]}
-%%     ]}
-%%
-%%
-%% Then, tell a bucket which one to use...
-%%
-%%     riak_core_bucket:set_bucket(&lt;&lt;"MY_BUCKET"&gt;&gt;, [{backend, second_backend}])
-%%
-%%
 
 %% ===================================================================
 %% Public API
@@ -598,7 +598,6 @@ backend_can_index_reformat(Mod, ModState) ->
 %% ===================================================================
 -ifdef(TEST).
 
-%% @private
 multi_backend_test_() ->
     {foreach,
      fun() ->
@@ -674,7 +673,6 @@ multi_backend_test_() ->
 
 -ifdef(EQC).
 
-%% @private
 eqc_test_() ->
     {spawn,
      [{inorder,

--- a/src/riak_kv_pipe_index.erl
+++ b/src/riak_kv_pipe_index.erl
@@ -119,7 +119,7 @@ keysend(Bucket, [Key | Keys], Partition, FittingDetails) ->
             ER
     end.
 
-%% @Doc remove the index term from the
+%% @doc remove the index term from the
 %% 2i result
 strip_index({_IndexTerm, Key}) ->
     Key;

--- a/src/riak_kv_pncounter.erl
+++ b/src/riak_kv_pncounter.erl
@@ -25,7 +25,7 @@
 %% one for decrements. The value of the counter is the difference between the value of the
 %% Positive G-Counter and the value of the Negative G-Counter.
 %%
-%% @see riak_kv_gcounter.erl
+%% @see riak_kv_gcounter
 %%
 %% @reference Marc Shapiro, Nuno Preguiça, Carlos Baquero, Marek Zawirski (2011) A comprehensive study of
 %% Convergent and Commutative Replicated Data Types. http://hal.upmc.fr/inria-00555588/

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -23,7 +23,7 @@
 
 %% @doc riak_kv_stat_bc is a module that maps the new riak_kv_stats metrics
 %% to the old set of stats. It exists to maintain backwards compatibility for
-%% those using the `/stats` endpoint and `riak-admin status`. This module
+%% those using the `/stats' endpoint and `riak-admin status'. This module
 %% should be considered soon to be deprecated and temporary.
 %%
 %%      Legacy stats:
@@ -38,7 +38,7 @@
 %%<dt> vnode_index_reads
 %%</dt><dd> The number of index reads handled by all vnodes on this node.
 %%          Each query counts as an index read.
-%%</dd><
+%%</dd>
 %%<dt> vnode_index_writes
 %%</dt><dd> The number of batched writes handled by all vnodes on this node.
 %%</dd>
@@ -138,7 +138,7 @@
 
 -compile(export_all).
 
-%% @spec produce_stats(state(), integer()) -> proplist()
+%% @spec produce_stats() -> proplist()
 %% @doc Produce a proplist-formatted view of the current aggregation
 %%      of stats.
 produce_stats() ->

--- a/src/riak_kv_test_util.erl
+++ b/src/riak_kv_test_util.erl
@@ -40,9 +40,9 @@
 
 -define(SETUPTHUNK, fun(_) -> ok end).
 
-%% @doc Creates a setup function for tests that need Riak KV stood
+%% Creates a setup function for tests that need Riak KV stood
 %% up in an isolated fashion.
-%% @see setup/3
+%% see setup/3
 -spec common_setup(TestName::atom() | string()) -> fun().
 common_setup(T) when is_atom(T) ->
     common_setup(atom_to_list(T));
@@ -55,9 +55,9 @@ common_setup(T, S) when is_atom(T) ->
 common_setup(TestName, Setup) ->
     fun() -> setup(TestName, Setup) end.
 
-%% @doc Creates a cleanup function for tests that need Riak KV stood up in
+%% Creates a cleanup function for tests that need Riak KV stood up in
 %% an isolated fashion.
-%% @see cleanup/3
+%% see cleanup/3
 -spec common_cleanup(TestName::atom() | string()) -> fun().
 common_cleanup(T) when is_atom(T) ->
     common_cleanup(atom_to_list(T));
@@ -70,7 +70,7 @@ common_cleanup(T, C) when is_atom(T) ->
 common_cleanup(TestName, Cleanup) ->
     fun(X) -> cleanup(TestName, Cleanup, X) end.
 
-%% @doc Calls gen_fsm functions that might not have been touched by a
+%% Calls gen_fsm functions that might not have been touched by a
 %% test
 -spec call_unused_fsm_funs(module()) -> any().
 call_unused_fsm_funs(Mod) ->
@@ -80,7 +80,7 @@ call_unused_fsm_funs(Mod) ->
     Mod:terminate(reason, statename, state),
     Mod:code_change(oldvsn, statename, state, extra).
 
-%% @doc Stop a running pid - unlink and exit(kill) the process
+%% Stop a running pid - unlink and exit(kill) the process
 stop_process(undefined) ->
     ok;
 stop_process(RegName) when is_atom(RegName) ->
@@ -90,7 +90,7 @@ stop_process(Pid) when is_pid(Pid) ->
     exit(Pid, shutdown),
     ok = wait_for_pid(Pid).
 
-%% @doc Wait for a pid to exit
+%% Wait for a pid to exit
 wait_for_pid(Pid) ->
     Mref = erlang:monitor(process, Pid),
     receive
@@ -101,7 +101,7 @@ wait_for_pid(Pid) ->
             {error, didnotexit, Pid, erlang:process_info(Pid)}
     end.
 
-%% @doc Wait for registered process to exit.
+%% Wait for registered process to exit.
 -spec wait_for_unregister(Mod::atom()) ->
                                  ok |
                                  {error, didnotexit, pid(), term()}.
@@ -151,7 +151,7 @@ wait_for_children(PPid) ->
             ok
     end.
 
-%% @doc Performs generic, riak_kv-specific and test-specific setup
+%% Performs generic, riak_kv-specific and test-specific setup
 %% when used within a test fixture. This includes cleaning up any
 %% leaky state from previous tests (internally calling `cleanup/3'),
 %% loading dependent applications, starting distributed Erlang,
@@ -165,7 +165,7 @@ wait_for_children(PPid) ->
 %% good practice to use the same function in the `SetupFun' as the
 %% `CleanupFun' given to `cleanup/3'.
 %%
-%% @see common_setup/2, dep_apps/2, do_dep_apps/2
+%% see common_setup/2, dep_apps/2, do_dep_apps/2
 -spec setup(TestName::string(), fun((load|start|stop) -> any())) -> ok.
 setup(TestName, SetupFun) ->
     %% Cleanup in case a previous test did not
@@ -188,13 +188,13 @@ setup(TestName, SetupFun) ->
     riak_core:wait_for_service(riak_kv),
     AllApps.
 
-%% @doc Performs generic, riak_kv-specific and test-specific cleanup
+%% Performs generic, riak_kv-specific and test-specific cleanup
 %% when used within a test fixture. This includes stopping dependent
 %% applications, stopping distributed Erlang, and killing pernicious
 %% processes. The given `CleanupFun' will be called with the argument
 %% `stop' before other components are stopped.
 %%
-%% @see common_cleanup/2, dep_apps/2, do_dep_apps/2
+%% see common_cleanup/2, dep_apps/2, do_dep_apps/2
 -spec cleanup(Test::string(), CleanupFun::fun((stop) -> any()), SetupResult::setup | atom()) -> ok.
 cleanup(Test, CleanupFun, setup) ->
     %% Remove existing ring files so we have a fresh ring
@@ -227,7 +227,7 @@ cleanup(Test, CleanupFun, StartedApps) ->
     application:set_env(riak_core, vnode_modules, []),
     ok.
 
-%% @doc Calculates a list of dependent applications and functions that
+%% Calculates a list of dependent applications and functions that
 %% can be passed to do_deps_apps/2 to perform the lifecycle phase on
 %% them all at once. This ensures that applications start and stop in
 %% the correct order and the test also has a chance to inject its own
@@ -243,7 +243,7 @@ cleanup(Test, CleanupFun, StartedApps) ->
 %% The `Extra' function takes an atom which represents the phase of
 %% application lifecycle, one of `load', `start' or `stop'.
 %%
-%% @see common_setup/2, common_cleanup/2
+%% see common_setup/2, common_cleanup/2
 -spec dep_apps(Test::string(), Extra::fun((load | start | stop) -> any())) -> [ atom() | fun() ].
 dep_apps(Test, Extra) ->
     Silencer = fun(load) ->
@@ -278,9 +278,9 @@ dep_apps(Test, Extra) ->
      DefaultSetupFun, Extra].
 
 
-%% @doc Runs the application-lifecycle phase across all of the given
+%% Runs the application-lifecycle phase across all of the given
 %% applications and functions.
-%% @see dep_apps/2
+%% see dep_apps/2
 -spec do_dep_apps(load | start | stop, [ atom() | fun() ]) -> [ any() ].
 do_dep_apps(start, Apps) ->
     lists:foldl(fun(A, Acc) when is_atom(A) ->
@@ -307,7 +307,7 @@ do_dep_apps(LoadStop, Apps) ->
                       F(LoadStop)
               end, Apps).
 
-%% @doc Determines whether a given application should be modified in
+%% Determines whether a given application should be modified in
 %% the given phase. If this returns false, the application will not be
 %% loaded, started, or stopped by `do_dep_apps/2'.
 -spec include_app_phase(Phase::load | start | stop, Application::atom()) -> true | false.

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -364,7 +364,7 @@ md5(Bin) ->
     crypto:md5(Bin).
 -endif.
 
-%% @Doc vtag creation function
+%% @doc vtag creation function
 -spec make_vtag(erlang:timestamp()) -> list().
 make_vtag(Now) ->
     <<HashAsNum:128/integer>> = md5(term_to_binary({node(), Now})),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1355,7 +1355,7 @@ prepare_put(#state{vnodeid=VId,
             end
     end.
 
-%% @Doc in the case that this a co-ordinating put, prepare the object.
+%% @doc in the case that this a co-ordinating put, prepare the object.
 prepare_new_put(true, RObj, VId, StartTime, undefined) ->
     riak_object:increment_vclock(RObj, VId, StartTime);
 prepare_new_put(true, RObj, VId, StartTime, CRDTOp) ->

--- a/src/riak_kv_wm_counter.erl
+++ b/src/riak_kv_wm_counter.erl
@@ -55,12 +55,12 @@
 %%
 %%   Quorum values (r/pr/w/pw/dw):
 %%     <dl>
-%%       <dt>default</dt<dd>Whatever the bucket default is. This is the value used
+%%       <dt>default</dt><dd>Whatever the bucket default is. This is the value used
 %%                          for any absent value.</dd>
 %%      <dt>quorum</dt><dd>(Bucket N val / 2) + 1</dd>
 %%      <dt>all</dt><dd>All replicas must respond</dd>
 %%      <dt>one</dt><dd>Any one response is enough</dd>
-%%      <dt>Integer</dt><dd>That specific number of vnodes must respond. Must be =< N</dd>
+%%      <dt>Integer</dt><dd>That specific number of vnodes must respond. Must be `=<' N</dd>
 %%    </dl>
 %% Please see http://docs.basho.com for details of all the quorum values and there effect.
 

--- a/src/riak_kv_wm_crdt.erl
+++ b/src/riak_kv_wm_crdt.erl
@@ -99,12 +99,12 @@
 %%
 %%   Quorum values (r/pr/w/pw/dw):
 %%     <dl>
-%%      <dt>default</dt<dd>Whatever the bucket default is. This is the value used
+%%      <dt>default</dt><dd>Whatever the bucket default is. This is the value used
 %%                          for any absent value.</dd>
 %%      <dt>quorum</dt><dd>(Bucket N val / 2) + 1</dd>
 %%      <dt>all</dt><dd>All replicas must respond</dd>
 %%      <dt>one</dt><dd>Any one response is enough</dd>
-%%      <dt>Integer</dt><dd>That specific number of vnodes must respond. Must be =< N</dd>
+%%      <dt>Integer</dt><dd>That specific number of vnodes must respond. Must be `=<' N</dd>
 %%    </dl>
 %%
 %% Please see http://docs.basho.com for details of all the quorum values and their effects.

--- a/src/riak_kv_wm_index.erl
+++ b/src/riak_kv_wm_index.erl
@@ -481,7 +481,7 @@ last_result([]) ->
 last_result(L) ->
     lists:last(L).
 
-%% @Doc if this is a paginated query make a continuation
+%% @doc if this is a paginated query make a continuation
 -spec make_continuation(Max::non_neg_integer() | undefined,
                         list(),
                         ResultCount::non_neg_integer()) -> binary() | undefined.

--- a/src/riak_kv_yessir_backend.erl
+++ b/src/riak_kv_yessir_backend.erl
@@ -37,7 +37,7 @@
 %%   previously-put keys or to correlate get values with previously-put
 %%   values.
 %%   - Get operation keys that are formatted in with the convention
-%%     <<"yessir.{integer}.anything">> will use integer (interpreted in
+%%     `<<"yessir.{integer}.anything">>' will use integer (interpreted in
 %%     base 10) as the returned binary's Size.
 %%
 %% fold_keys and fold_objects are implemented for both sync and async.
@@ -51,8 +51,10 @@
 %%
 %% This backend is the Riak storage manager equivalent of:
 %%
-%% * cat > /dev/null
-%% * cat < /dev/zero
+%% <ul>
+%% <li>`cat > /dev/null'</li>
+%% <li>`cat < /dev/zero'</li>
+%% </ul>
 %%
 %% === Configuration Options ===
 %%
@@ -66,27 +68,27 @@
 %%                                  the BKey asked for.  The returned object's
 %%                                  BKey is constant, so any part of Riak that
 %%                                  cares about matching/valid BKey inside of
-%%                                  the object will be confused and/or break.
+%%                                  the object will be confused and/or break.</li>
 %% <li>`yessir_aae_mode_encoding' - Specify which mode of behavior to
 %%                                  use when interacting with Riak KV's
-%%                                  anti-entropy mode for put & put_object
+%%                                  anti-entropy mode for put and put_object
 %%                                  calls.
 %%   <ul>
 %%   <li>`constant_binary' - The default mode: lie to AAE by returning
-%%                           a constant binary, <<>>.</li>  This will cause
+%%                           a constant binary, `<<>>'. This will cause
 %%                           AAE to maintain a tiny tree of order-size(1).
 %%                           This is the fastest mode but also causes the
 %%                           least amount of AAE work and thus may or may
 %%                           not meet all users' needs. </li>
-%%   <li>`bkey' </li> - Return term_to_binary({Bucket, Key}), which will
+%%   <li>`bkey' - Return term_to_binary({Bucket, Key}), which will
 %%                      cause AAE's tree to churn with order-size(NumKeys)
 %%                      but will be much smaller than the entire serialized
 %%                      #r_object{}, so AAE will spend less CPU time during
 %%                      its processing. </li>
-%%   <li>`r_object' </li> - Serialize the entire #r_object{}, like Riak KV
+%%   <li>`r_object' - Serialize the entire #r_object{}, like Riak KV
 %%                          does in normal operation.  This mode has the
 %%                          highest overhead per operation. </li>
-%%   </ul>
+%%   </ul></li>
 %% <li>`yessir_default_size' - The number of bytes of generated data for the value.</li>
 %% <li>`yessir_key_count'    - The number of keys that will be folded over, e.g. list_keys().</li>
 %% <li>`yessir_bucket_prefix_list'  - A list {BucketPrefixBin, {Module, Fun}}
@@ -101,8 +103,8 @@
 %%     for some simulations.
 %% * Is there a need for simulations for get to return different vclocks?
 %% * Add variable latency before responding.  This callback API is
-%%   synchronous, but adding constant- & uniform- & pareto-distributed
-%%   delays would simulate disk I/O latencies because all other backend
+%%   synchronous, but adding constant- and uniform- and pareto-distributed
+%%   delays would simulate disk `I/O' latencies because all other backend
 %%   APIs are also synchronous.
 
 -module(riak_kv_yessir_backend).

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -317,7 +317,8 @@ compare(A=#r_content{value=VA}, B=#r_content{value=VB}) ->
 %% size. Called by an ordering function, this too is an ordering
 %% function.
 %%
-%% @see compare/2, lists:usort/3
+%% @see compare/2
+%% @see lists:usort/3
 compare_metadata(#r_content{metadata=MA}, #r_content{metadata=MB}) ->
     ASize = dict:size(MA),
     BSize = dict:size(MB),

--- a/tools.mk
+++ b/tools.mk
@@ -1,5 +1,8 @@
 REBAR ?= ./rebar
 
+.PHONY: compile-no-deps test docs xref dialyzer-run dialyzer-quick dialyzer \
+		cleanplt
+
 compile-no-deps:
 	${REBAR} compile skip_deps=true
 


### PR DESCRIPTION
## Fix Edoc generation errors
- See basho/tools.mk#5 for notes on the new tools.mk version
- Fixes all Edoc syntax errors

`rm -rf doc && make docs; echo $?` should now return `0`.
