### PR TITLE
Update to use new breadth-first AAE exchange

### DIFF
--- a/src/riak_kv_exchange_fsm.erl
+++ b/src/riak_kv_exchange_fsm.erl
@@ -200,6 +200,10 @@ key_exchange(timeout, State=#state{local=LocalVN,
                      ok = disk_log:sync(Now),
                      ok = disk_log:close(Now),
                      ok;
+                (start_exchange_level, {_Level, _Buckets}) ->
+                     ok;
+                (start_exchange_segments, _Segments) ->
+                     ok;
                 (_X, _Y) ->
                      lager:error("~s LINE ~p: ~p ~p", [?MODULE, ?LINE, _X, _Y]),
                      ok

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -769,7 +769,7 @@ do_compare(Id, Remote, AccFun, Acc, From, State) ->
         {ok, Tree} ->
             spawn_link(fun() ->
                                Remote(init, self()),
-                               Result = hashtree:compare(Tree, Remote,
+                               Result = hashtree:compare2(Tree, Remote,
                                                          AccFun, Acc),
                                Remote(final, self()),
                                gen_server:reply(From, Result)


### PR DESCRIPTION
This commit updates riak_kv to work with the new breath-first AAE
exchange added to riak_core. This new level-by-level exchange is
necessary in order to support the new pipelined AAE-based fullsync
replication protocol in Riak Enterprise.

This is the 2.0 rebased version of #1023
