### PR TITLE
Attempt to make vnodeids on the same node unique

### DIFF
--- a/src/riak_kv_get_core.erl
+++ b/src/riak_kv_get_core.erl
@@ -199,6 +199,13 @@ final_action(GetCore = #getcore{n = N, merged = Merged0, results = Results,
                       notfound ->
                           [];
                       _ -> % ok or tombstone
+                          %% Any object that is strictly descended by
+                          %% the merge result must be read-repaired,
+                          %% this ensures even tombstones get repaired
+                          %% so reap will work. We join the list of
+                          %% dominated (in need of repair) indexes and
+                          %% the list of not_found (in need of repair)
+                          %% indexes.
                           [{Idx, outofdate} || {Idx, {ok, RObj}} <- Results,
                                   riak_object:strict_descendant(MObj, RObj)] ++
                               [{Idx, notfound} || {Idx, {error, notfound}} <- Results]


### PR DESCRIPTION
When a node starts, it starts all its vnodes. Vnode IDs were
generated by each vnode using the nodeid + the current second.
This can lead to multiple vnodes with the same "unique" id.
In the case of imperfect preflists (think a single node "cluster"
as the extreme) multiple actors on a key can have the same id.
This breaks one of the fundamental invariants of version vectors: that
each actor is globally unique. In the worst cases this can lead to
silent dataloss.

This fix, though not perfect, attempts to lessen the likely hood of
vnodes claiming the same id. We use microseconds instead of seconds,
we use the monotonic `erlang:now/0` instead of `os:timestamp/0`. This pushes
the window of probablity from "vnode-starts-in-the-same-second" to
"vnode-starts-11.5-days-later-at-the-same-microsecond".

We have further work planned, but believe this is good enough for now.

Update tests for new id scheme

see https://github.com/basho/riak_test/blob/rdb/gh-kv679/tests/kv679_uid.erl for testings
