### PR TITLE
Forward port of client mode delete from 1.4

### DIFF
--- a/include/riak_kv_vnode.hrl
+++ b/include/riak_kv_vnode.hrl
@@ -45,6 +45,11 @@
           bkey :: {binary(), binary()},
           req_id :: non_neg_integer()}).
 
+-record(riak_kv_delete_req_v2, {
+          bkey :: {binary(), binary()},
+          req_id :: non_neg_integer(),
+          delete_mode :: undefined | keep | immediate | pos_integer() }).
+
 -record(riak_kv_map_req_v1, {
           bkey :: {binary(), binary()},
           qterm :: term(),
@@ -61,7 +66,7 @@
 -define(KV_LISTKEYS_REQ, #riak_kv_listkeys_req_v4).
 -define(KV_INDEX_REQ, #riak_kv_index_req_v2).
 -define(KV_VNODE_STATUS_REQ, #riak_kv_vnode_status_req_v1).
--define(KV_DELETE_REQ, #riak_kv_delete_req_v1).
+-define(KV_DELETE_REQ, #riak_kv_delete_req_v2).
 -define(KV_MAP_REQ, #riak_kv_map_req_v1).
 -define(KV_VCLOCK_REQ, #riak_kv_vclock_req_v1).
 

--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -63,7 +63,8 @@ delete(ReqId,Bucket,Key,Options,Timeout,Client,ClientId,undefined) ->
         {R, PR, PassThruOpts} ->
             RealStartTime = riak_core_util:moment(),
             {ok, C} = riak:local_client(),
-            case C:get(Bucket,Key,[{r,R},{pr,PR},{timeout,Timeout}]++PassThruOpts) of
+            DeleteMode = [ KV || {delete_mode, _}=KV <- Options ],
+            case C:get(Bucket,Key,[{r,R},{pr,PR},{timeout,Timeout}]++PassThruOpts++DeleteMode) of
                 {ok, OrigObj} ->
                     RemainingTime = Timeout - (riak_core_util:moment() - RealStartTime),
                     delete(ReqId,Bucket,Key,Options,RemainingTime,Client,ClientId,riak_object:vclock(OrigObj));
@@ -90,12 +91,13 @@ delete(ReqId,Bucket,Key,Options,Timeout,Client,ClientId,VClock) ->
             Reply = C:put(Tombstone, [{w,W},{pw,PW},{dw, DW},{timeout,Timeout}]++PassThruOptions),
             Client ! {ReqId, Reply},
             HasCustomN_val = proplists:get_value(n_val, Options) /= undefined,
+            DeleteMode = [ KV || {delete_mode, _}=KV <- Options ],
             case Reply of
                 ok when HasCustomN_val == false ->
                     ?DTRACE(?C_DELETE_INIT2, [1], [<<"reap">>]),
                     {ok, C2} = riak:local_client(),
                     AsyncTimeout = 60*1000,     % Avoid client-specified value
-                    Res = C2:get(Bucket, Key, all, AsyncTimeout),
+                    Res = C2:get(Bucket, Key, [{r, all}, {timeout, AsyncTimeout} | DeleteMode ]),
                     ?DTRACE(?C_DELETE_REAPER_GET_DONE, [1], [<<"reap">>]),
                     Res;
                 _ ->


### PR DESCRIPTION
Manually applied patch generated from diff of PR@1022 on 1.4 branch.
The branch invovled a number of other modules that weren't needed
and made the merge too hard.

Original PR #1022 merged against 1.4 (for 1.4.11 release)
in commit 1fbb8156068e203cfe3997c79fa50bef1a03b9ee
