### PR TITLE
Implement key count estimation via AAE trees

### DIFF
--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -43,6 +43,8 @@
          determine_data_root/0,
          exchange_bucket/4,
          exchange_segment/3,
+         estimate_keys/1,
+         estimate_keys/2,
          hash_index_data/1,
          hash_object/2,
          update/2,
@@ -213,6 +215,14 @@ clear(Tree) ->
 expire(Tree) ->
     gen_server:call(Tree, expire, infinity).
 
+%% @doc Estimate total number of keys in index_hashtree
+estimate_keys(Tree) ->
+    gen_server:call(Tree, estimate_keys, infinity).
+
+%% @doc Estimate total number of keys in index_hashtree
+estimate_keys(Tree, IndexN) ->
+    gen_server:call(Tree, {estimate_keys, IndexN}, infinity).
+
 %%%===================================================================
 %%% gen_server callbacks
 %%%===================================================================
@@ -315,6 +325,21 @@ handle_call(expire, _From, State) ->
     State2 = State#state{expired=true},
     lager:info("Manually expired tree: ~p", [State#state.index]),
     {reply, ok, State2};
+
+handle_call(estimate_keys, _From,  State=#state{trees=Trees}) ->
+    EstimateNrKeys =
+        orddict:fold(fun(_, Tree, Acc) ->
+                             {ok, Value} = hashtree:estimate_keys(Tree) ,
+                             Value + Acc
+                     end,
+                     0, Trees),
+    {reply, {ok, EstimateNrKeys}, State};
+
+handle_call({estimate_keys, IndexN}, _From,  State=#state{trees=Trees}) ->
+    {ok, Tree} = orddict:find(IndexN, Trees),
+     lager:info("emiklix ~p ~p ~p", [IndexN, Trees, Tree]),
+    {ok, EstimateNrKeys} = hashtree:estimate_keys(Tree),
+    {reply, {ok, EstimateNrKeys}, State};
 
 handle_call(_Request, _From, State) ->
     Reply = ok,

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -336,10 +336,13 @@ handle_call(estimate_keys, _From,  State=#state{trees=Trees}) ->
     {reply, {ok, EstimateNrKeys}, State};
 
 handle_call({estimate_keys, IndexN}, _From,  State=#state{trees=Trees}) ->
-    {ok, Tree} = orddict:find(IndexN, Trees),
-     lager:info("emiklix ~p ~p ~p", [IndexN, Trees, Tree]),
-    {ok, EstimateNrKeys} = hashtree:estimate_keys(Tree),
-    {reply, {ok, EstimateNrKeys}, State};
+    case orddict:find(IndexN, Trees) of
+        {ok, Tree} ->
+            {ok, EstimateNrKeys} = hashtree:estimate_keys(Tree),
+            {reply, {ok, EstimateNrKeys}, State};
+        error ->
+            {reply, not_responsible, State}
+    end;
 
 handle_call(_Request, _From, State) ->
     Reply = ok,


### PR DESCRIPTION
This pull-request updates `riak_kv_index_hashtree` to provide an API around the new AAE-based key count estimation feature added to the `hashtree` module in `riak_core`.

This provides a mechanism to estimate the number of keys in a given K/V vnode based on its AAE trees.

This estimate is used to enable an improvement in the operation of AAE-based fullsync replication in Riak Enterprise.

Sibling pull-requests: basho/riak_core#633, basho/riak_repl#623
