### PR TITLE
Consuming the vnode_status output in stats was brittle

### DIFF
--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -558,8 +558,13 @@ leveldb_read_block_errors() ->
 
 vnode_status(Idx) ->
     PList = [{Idx, node()}],
-    [{Idx, [Status]}] = riak_kv_vnode:vnode_status(PList),
-    Status.
+    [{Idx, Status}] = riak_kv_vnode:vnode_status(PList),
+    case lists:keyfind(backend_status, 1, Status) of
+        false ->
+            {error, no_backend_status};
+        BEStatus ->
+            BEStatus
+    end.
 
 leveldb_read_block_errors({backend_status, riak_kv_eleveldb_backend, Status}) ->
     rbe_val(proplists:get_value(read_block_error, Status));

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -561,6 +561,8 @@ vnode_status(Idx) ->
     [{Idx, Status}] = riak_kv_vnode:vnode_status(PList),
     case lists:keyfind(backend_status, 1, Status) of
         false ->
+            %% if for some reason backend_status is absent from the
+            %% status list
             {error, no_backend_status};
         BEStatus ->
             BEStatus


### PR DESCRIPTION
Fix to expect a list of more than one element

Or there is this way. With this test https://github.com/basho/riak_test/pull/690

Note that this way means extra output on `riak-admin vnode_status` as the vnodeid will be present.

See https://github.com/basho/riak_kv/pull/1034 for the other choice (and it's test)
