### PR TITLE
Patch to prevent calculation of cpu stats.

### DIFF
--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -510,10 +510,15 @@ sidejob_put_fsm_stats() ->
 %% @doc Get stats on the cpu, as given by the cpu_sup module
 %%      of the os_mon application.
 cpu_stats() ->
-    [{cpu_nprocs, cpu_sup:nprocs()},
-     {cpu_avg1, cpu_sup:avg1()},
-     {cpu_avg5, cpu_sup:avg5()},
-     {cpu_avg15, cpu_sup:avg15()}].
+    case app_helper:get_env(riak_kv, disable_cpu_stats, false) of
+        true ->
+            [];
+        _ ->
+            [{cpu_nprocs, cpu_sup:nprocs()},
+             {cpu_avg1, cpu_sup:avg1()},
+             {cpu_avg5, cpu_sup:avg5()},
+             {cpu_avg15, cpu_sup:avg15()}]
+    end.
 
 %% @spec mem_stats() -> proplist()
 %% @doc Get stats on the memory, as given by the memsup module


### PR DESCRIPTION
For the Unices that aren't directly supported in the cpu_sup.c
(like FreeBSD) they make do multiple fork/execs to run system
utilities to gather stats.  If multiple instances of Riak
are running on a server (devrel or otherwise) it starts to stack up.

Add [{riak_kv, disable_cpu_stats, true}] to advanced.config to disable
reporting.  Will decide if this is a common enough setting to add to
cuttlefish at a future point.
