### PR TITLE
Introduce exometer metrics into 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .PHONY: deps test
 
+# Limit exometer dependencies
+EXOMETER_PACKAGES="(basic), +afunix"
+export EXOMETER_PACKAGES
+
 DIALYZER_FLAGS =
 
 all: deps compile

--- a/rebar.config
+++ b/rebar.config
@@ -30,5 +30,5 @@
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {branch, "2.0"}}},
         {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {branch, "2.0"}}},
         {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {branch, "2.0"}}},
-        {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", "dab4291d191f0ca40c911179fd195c3942261667"}}
+        {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag, "0.1.2"}}}
        ]}.

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -49,13 +49,19 @@ start(_Type, _StartArgs) ->
     riak_core_util:start_app_deps(riak_kv),
 
     FSM_Limit = app_helper:get_env(riak_kv, fsm_limit, ?DEFAULT_FSM_LIMIT),
-    case FSM_Limit of
-        undefined ->
-            ok;
-        _ ->
-            sidejob:new_resource(riak_kv_put_fsm_sj, sidejob_supervisor, FSM_Limit),
-            sidejob:new_resource(riak_kv_get_fsm_sj, sidejob_supervisor, FSM_Limit)
-    end,
+    Status = case FSM_Limit of
+                 undefined ->
+                     disabled;
+                 _ ->
+                     sidejob:new_resource(riak_kv_put_fsm_sj, sidejob_supervisor, FSM_Limit),
+                     sidejob:new_resource(riak_kv_get_fsm_sj, sidejob_supervisor, FSM_Limit),
+                     enabled
+             end,
+    Base = [riak_core_stat:prefix(), riak_kv],
+    riak_kv_exometer_sidejob:new_entry(Base ++ [put_fsm, sidejob],
+                                       riak_kv_put_fsm_sj, [{status, Status}]),
+    riak_kv_exometer_sidejob:new_entry(Base ++ [get_fsm, sidejob],
+                                       riak_kv_get_fsm_sj, [{status, Status}]),
 
     case app_helper:get_env(riak_kv, direct_stats, false) of
         true ->

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -175,15 +175,11 @@ down([Node]) ->
 -spec(status([]) -> ok).
 status([]) ->
     try
-        case riak_kv_status:statistics() of
-            [] ->
-                io:format("riak_kv_stat is not enabled.\n", []);
-            Stats ->
-                StatString = format_stats(Stats,
+        Stats = riak_kv_status:statistics(),
+	StatString = format_stats(Stats,
                     ["-------------------------------------------\n",
-                        io_lib:format("1-minute stats for ~p~n",[node()])]),
-                io:format("~s\n", [StatString])
-        end
+		     io_lib:format("1-minute stats for ~p~n",[node()])]),
+	io:format("~s\n", [StatString])
     catch
         Exception:Reason ->
             lager:error("Status failed ~p:~p", [Exception,
@@ -317,7 +313,7 @@ aae_status([]) ->
     io:format("~n"),
     aae_repair_status(ExchangeInfo).
 
-aae_exchange_status(ExchangeInfo) -> 
+aae_exchange_status(ExchangeInfo) ->
     io:format("~s~n", [string:centre(" Exchanges ", 79, $=)]),
     io:format("~-49s  ~-12s  ~-12s~n", ["Index", "Last (ago)", "All (ago)"]),
     io:format("~79..-s~n", [""]),
@@ -664,7 +660,7 @@ repair_2i(Args) ->
                     _ = [io:format("\t~p\n", [Idx]) || Idx <- IdxList],
                     ok;
                 false ->
-                    io:format("Will repair 2i data on ~p partitions\n", 
+                    io:format("Will repair 2i data on ~p partitions\n",
                               [length(IdxList)]),
                     ok
             end,

--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -555,7 +555,7 @@ enqueue_exchange(E={Index, _RemoteIdx, _IndexN}, State) ->
         false ->
             State
     end;
-enqueue_exchange({Index, IndexN}, State) -> 
+enqueue_exchange({Index, IndexN}, State) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     Exchanges = all_pairwise_exchanges(Index, Ring),
     Exchanges2 = [Exchange || Exchange={_, _, IdxN} <- Exchanges,
@@ -760,7 +760,11 @@ set_aae_throttle_kill(Bool) when Bool == true; Bool == false ->
 
 get_max_local_vnodeq() ->
     try
-        {element(2,lists:keyfind(riak_kv_vnodeq_max, 1, riak_core_stat:get_stats())), node()}
+	{ok, [{max,M}]} =
+	    exometer:get_value(
+	      [riak_core_stat:prefix(),riak_core,vnodeq,riak_kv_vnode],
+	      [max]),
+	{M, node()}
     catch _X:_Y ->
             %% This can fail locally if riak_core & riak_kv haven't finished their setup.
             {0, node()}

--- a/src/riak_kv_exometer_sidejob.erl
+++ b/src/riak_kv_exometer_sidejob.erl
@@ -1,0 +1,80 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_exometer_sidejob: Access sidejob stats via the Exometer API
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc riak_kv_exometer_sidejob is a wrapper module making sidejob
+%% stats available via the Exometer API. It adds no overhead to the
+%% stats update, nor interfere with the 'old' way of reading the
+%% sidejob stats; it is purely complementary.
+%% @end
+
+-module(riak_kv_exometer_sidejob).
+
+-behaviour(exometer_entry).
+
+%% API
+-export([new_entry/3]).
+
+%% Callback API
+-export([behaviour/0,
+	 new/3, delete/3, get_value/4, update/4, reset/3, sample/3,
+         get_datapoints/3, setopts/3]).
+
+behaviour() ->
+    entry.
+
+new_entry(Name, SjName, Opts) ->
+    exometer:new(Name, ad_hoc, [{module, ?MODULE},
+				{type, sidejob},
+				{sj_name, SjName}|Opts]).
+
+-define(UNSUP, {error, unsupported}).
+
+new(_Name, _Type, Options) ->
+    {_, SjName} = lists:keyfind(sj_name, 1, Options),
+    {ok, SjName}.
+
+delete(_Name, _Type, _Ref) ->
+    ok.
+
+get_value(_Name, _Type, SjName, DPs) ->
+    try filter_datapoints(sidejob_resource_stats:stats(SjName), DPs)
+    catch
+        error:_ ->
+            unavailable
+    end.
+
+get_datapoints(_, _, _) ->
+    [usage,rejected, in_rate, out_rate, usage_60s, rejected_60s,
+     avg_in_rate_60s, max_in_rate_60s, avg_out_rate_60s,
+     max_out_rate_60s, usage_total, rejected_total,
+     avg_in_rate_total, max_in_rate_total, avg_out_rate_total].
+
+update(_Name, _Type, _Ref, _Value) -> ?UNSUP.
+reset(_Name, _Type, _Ref)  -> ?UNSUP.
+sample(_Name, _Type, _Ref) -> ?UNSUP.
+setopts(_Entry, _Options, _NewStatus) -> ok.
+
+filter_datapoints(Stats, default) ->
+    Stats;
+filter_datapoints(Stats, DPs) ->
+    [S || {K, _} = S <- Stats,
+          lists:member(K, DPs)].

--- a/src/riak_kv_http_cache.erl
+++ b/src/riak_kv_http_cache.erl
@@ -1,0 +1,54 @@
+-module(riak_kv_http_cache).
+
+-export([start_link/0,
+	 get_stats/0]).
+
+-export([init/1,
+	 handle_call/3,
+	 handle_cast/2,
+	 handle_info/2,
+	 terminate/2,
+	 code_change/3]).
+
+-define(SERVER, ?MODULE).
+
+-record(st, {ts, stats = []}).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+get_stats() ->
+    gen_server:call(?MODULE, get_stats).
+
+init(_) ->
+    {ok, #st{}}.
+
+handle_call(get_stats, _From, #st{} = S) ->
+    #st{stats = Stats} = S1 = check_cache(S),
+    {reply, Stats, S1}.
+
+handle_cast(_, S) ->
+    {noreply, S}.
+
+handle_info(_, S) ->
+    {noreply, S}.
+
+terminate(_, _) ->
+    ok.
+
+code_change(_, S, _) ->
+    {ok, S}.
+
+check_cache(#st{ts = undefined} = S) ->
+    S#st{ts = os:timestamp(), stats = do_get_stats()};
+check_cache(#st{ts = Then} = S) ->
+    Now = os:timestamp(),
+    case timer:now_diff(Now, Then) < 1000000 of
+	true ->
+	    S;
+	false ->
+	    S#st{ts = Now, stats = do_get_stats()}
+    end.
+
+do_get_stats() ->
+    riak_kv_wm_stats:get_stats().

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -43,9 +43,11 @@
 %% API
 -export([start_link/0, get_stats/0,
          update/1, perform_update/1, register_stats/0, produce_stats/0,
-         leveldb_read_block_errors/0, stop/0]).
+         leveldb_read_block_errors/0, stat_update_error/3, stop/0]).
 -export([track_bucket/1, untrack_bucket/1]).
 -export([active_gets/0, active_puts/0]).
+
+-export([report_legacy/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -55,50 +57,43 @@
 
 -define(SERVER, ?MODULE).
 -define(APP, riak_kv).
+-define(PFX, riak_core_stat:prefix()).
 
 start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
-    _ = [(catch folsom_metrics:delete_metric(Stat)) ||
-            Stat <- folsom_metrics:get_metrics(),
-            is_tuple(Stat), element(1, Stat) == ?APP],
-    _ = [do_register_stat(stat_name(Name), Type) || {Name, Type} <- stats()],
-    riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
+    riak_core_stat:register_stats(?APP, stats()).
 
 %% @spec get_stats() -> proplist()
 %% @doc Get the current aggregation of stats.
 get_stats() ->
-    case riak_core_stat_cache:get_stats(?APP) of
-        {ok, Stats, _TS} ->
-            Stats;
-        Error -> Error
-    end.
+    riak_kv_wm_stats:get_stats().
+
 
 %% Creation of a dynamic stat _must_ be serialized.
 register_stat(Name, Type) ->
-    gen_server:call(?SERVER, {register, Name, Type}).
+    do_register_stat(Name, Type).
+%% gen_server:call(?SERVER, {register, Name, Type}).
 
 update(Arg) ->
-    case erlang:module_loaded(riak_kv_stat_sj) of
-        true ->
-            %% Dispatch request to sidejob worker
-            riak_kv_stat_worker:update(Arg);
-        false ->
-            perform_update(Arg)
-    end.
+    maybe_dispatch_to_sidejob(erlang:module_loaded(riak_kv_stat_sj), Arg).
+
+maybe_dispatch_to_sidejob(true, Arg) ->
+    riak_kv_stat_worker:update(Arg);
+maybe_dispatch_to_sidejob(false, Arg) ->
+    try perform_update(Arg) catch Class:Error ->
+       stat_update_error(Arg, Class, Error)
+    end,
+    ok.
+
+stat_update_error(Arg, Class, Error) ->
+    lager:error("Failed to update stat ~p due to (~p) ~p.", [Arg, Class, Error]).
 
 %% @doc
 %% Callback used by a {@link riak_kv_stat_worker} to perform actual update
 perform_update(Arg) ->
-    try do_update(Arg) of
-        _ ->
-            ok
-    catch
-        ErrClass:Err ->
-            lager:warning("~p:~p updating stat ~p.", [ErrClass, Err, Arg]),
-            gen_server:cast(?SERVER, {re_register_stat, Arg})
-    end.
+    do_update(Arg).
 
 track_bucket(Bucket) when is_binary(Bucket) ->
     riak_core_bucket:set_bucket(Bucket, [{stat_tracked, true}]).
@@ -108,11 +103,19 @@ untrack_bucket(Bucket) when is_binary(Bucket) ->
 
 %% The current number of active get fsms in riak
 active_gets() ->
-    folsom_metrics:get_metric_value({?APP, node, gets, fsm, active}).
+    counter_value([?PFX, ?APP, node, gets, fsm, active]).
 
 %% The current number of active put fsms in riak
 active_puts() ->
-    folsom_metrics:get_metric_value({?APP, node, puts, fsm, active}).
+    counter_value([?PFX, ?APP, node, puts, fsm, active]).
+
+counter_value(Name) ->
+    case exometer:get_value(Name, [value]) of
+	{ok, [{value, N}]} ->
+	    N;
+	_ ->
+	    0
+    end.
 
 stop() ->
     gen_server:cast(?SERVER, stop).
@@ -131,17 +134,6 @@ handle_call({register, Name, Type}, _From, State) ->
     Rep = do_register_stat(Name, Type),
     {reply, Rep, State}.
 
-handle_cast({re_register_stat, Arg}, State) ->
-    %% To avoid massive message queues
-    %% riak_kv stats are updated in the calling process
-    %% @see `update/1'.
-    %% The downside is that errors updating a stat don't crash
-    %% the server, so broken stats stay broken.
-    %% This re-creates the same behaviour as when a brokwn stat
-    %% crashes the gen_server by re-registering that stat.
-    #state{repair_mon={Pid, _Mon}} = State,
-    Pid ! {re_register_stat, Arg},
-    {noreply, State};
 handle_cast({monitor, Type, Pid}, State) ->
     case proplists:get_value(Type, State#state.monitors) of
         Monitor when is_pid(Monitor) ->
@@ -169,130 +161,142 @@ code_change(_OldVsn, State, _Extra) ->
 
 %% @doc Update the given stat
 do_update({vnode_get, Idx, USecs}) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, vnode, gets}, 1, spiral),
-    create_or_update({?APP, vnode, gets, time}, USecs, histogram),
+    P = ?PFX,
+    ok = exometer:update([P, ?APP, vnode, gets], 1),
+    ok = create_or_update([P, ?APP, vnode, gets, time], USecs, histogram),
     do_per_index(gets, Idx, USecs);
 do_update({vnode_put, Idx, USecs}) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, vnode, puts}, 1, spiral),
-    create_or_update({?APP, vnode, puts, time}, USecs, histogram),
+    P = ?PFX,
+    ok = exometer:update([P, ?APP, vnode, puts], 1),
+    ok = create_or_update([P, ?APP, vnode, puts, time], USecs, histogram),
     do_per_index(puts, Idx, USecs);
 do_update(vnode_index_refresh) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, vnode, index, refreshes}, 1, spiral);
+    P = ?PFX,
+    exometer:update([P, ?APP, vnode, index, refreshes], 1);
 do_update(vnode_index_read) ->
-    folsom_metrics:notify_existing_metric({?APP, vnode, index, reads}, 1, spiral);
+    P = ?PFX,
+    exometer:update([P, ?APP, vnode, index, reads], 1);
 do_update({vnode_index_write, PostingsAdded, PostingsRemoved}) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, vnode, index, writes}, 1, spiral),
-    ok = folsom_metrics:notify_existing_metric({?APP, vnode, index, writes, postings}, PostingsAdded, spiral),
-    ok = folsom_metrics:notify_existing_metric({?APP, vnode, index, deletes, postings}, PostingsRemoved, spiral);
+    P = ?PFX,
+    ok = exometer:update([P, ?APP, vnode, index, writes], 1),
+    ok = exometer:update([P, ?APP, vnode, index, writes, postings], PostingsAdded),
+    exometer:update([P, ?APP, vnode, index, deletes, postings], PostingsRemoved);
 do_update({vnode_index_delete, Postings}) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, vnode, index, deletes}, Postings, spiral),
-    ok = folsom_metrics:notify_existing_metric({?APP, vnode, index, deletes, postings}, Postings, spiral);
+    P = riak_core_stat:prefix(),
+    ok = exometer:update([P, ?APP, vnode, index, deletes], Postings),
+    exometer:update([P, ?APP, vnode, index, deletes, postings], Postings);
 do_update({vnode_dt_update, Mod, Micros}) ->
+    P = ?PFX,
     Type = riak_kv_crdt:from_mod(Mod),
-    ok = folsom_metrics:notify_existing_metric({?APP, vnode, Type, update}, 1, spiral),
-    ok = folsom_metrics:notify_existing_metric({?APP, vnode, Type, update, time}, Micros, histogram);
-do_update({riak_object_merge, undefined,  Micros}) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, object, merge}, 1, spiral),
-    ok = folsom_metrics:notify_existing_metric({?APP, object, merge, time}, Micros, histogram);
+    ok = create_or_update([P, ?APP, vnode, Type, update], 1, spiral),
+    create_or_update([P, ?APP, vnode, Type, update, time], Micros, histogram);
+do_update({riak_object_merge, undefined, Micros}) ->
+    P = ?PFX,
+    ok = exometer:update([P, ?APP, object, merge], 1),
+    exometer:update([P, ?APP, object, merge, time], Micros);
 do_update({riak_object_merge, Mod, Micros}) ->
+    P = ?PFX,
     Type = riak_kv_crdt:from_mod(Mod),
-    ok = folsom_metrics:notify_existing_metric({?APP, object, Type, merge}, 1, spiral),
-    ok = folsom_metrics:notify_existing_metric({?APP, object, Type, merge, time}, Micros, histogram);
+    ok = create_or_update([P, ?APP, object, Type, merge], 1, spiral),
+    create_or_update([P, ?APP, object, Type, merge, time], Micros, histogram);
 do_update({get_fsm, Bucket, Microsecs, Stages, undefined, undefined, PerBucket, undefined}) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, node, gets}, 1, spiral),
-    ok = folsom_metrics:notify_existing_metric({?APP, node, gets, time}, Microsecs, histogram),
-    do_stages([?APP, node, gets, time], Stages),
+    P = riak_core_stat:prefix(),
+    ok = exometer:update([P, ?APP, node, gets], 1),
+    ok = exometer:update([P, ?APP, node, gets, time], Microsecs),
+    ok = do_stages([P, ?APP, node, gets, time], Stages),
     do_get_bucket(PerBucket, {Bucket, Microsecs, Stages, undefined, undefined});
 do_update({get_fsm, Bucket, Microsecs, Stages, NumSiblings, ObjSize, PerBucket, undefined}) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, node, gets}, 1, spiral),
-    ok = folsom_metrics:notify_existing_metric({?APP, node, gets, time}, Microsecs, histogram),
-    ok = folsom_metrics:notify_existing_metric({?APP, node, gets, siblings}, NumSiblings, histogram),
-    ok = folsom_metrics:notify_existing_metric({?APP, node, gets, objsize}, ObjSize, histogram),
-    do_stages([?APP, node, gets, time], Stages),
+    P = riak_core_stat:prefix(),
+    ok = exometer:update([P, ?APP, node, gets], 1),
+    ok = exometer:update([P, ?APP, node, gets, time], Microsecs),
+    ok = exometer:update([P, ?APP, node, gets, siblings], NumSiblings),
+    ok = exometer:update([P, ?APP, node, gets, objsize], ObjSize),
+    ok = do_stages([P, ?APP, node, gets, time], Stages),
     do_get_bucket(PerBucket, {Bucket, Microsecs, Stages, NumSiblings, ObjSize});
 do_update({get_fsm, Bucket, Microsecs, Stages, undefined, undefined, PerBucket, CRDTMod}) ->
+    P = riak_core_stat:prefix(),
     Type = riak_kv_crdt:from_mod(CRDTMod),
-    ok = folsom_metrics:notify_existing_metric({?APP, node, gets, Type}, 1, spiral),
-    ok = folsom_metrics:notify_existing_metric({?APP, node, gets, Type, time}, Microsecs, histogram),
-    do_stages([?APP, node, gets, Type, time], Stages),
+    ok = create_or_update([P, ?APP, node, gets, Type], 1, spiral),
+    ok = create_or_update([P, ?APP, node, gets, Type, time], Microsecs, histogram),
+    ok = do_stages([P, ?APP, node, gets, Type, time], Stages),
     do_get_bucket(PerBucket, {Bucket, Microsecs, Stages, undefined, undefined, Type});
 do_update({get_fsm, Bucket, Microsecs, Stages, NumSiblings, ObjSize, PerBucket, CRDTMod}) ->
+    P = ?PFX,
     Type = riak_kv_crdt:from_mod(CRDTMod),
-    ok = folsom_metrics:notify_existing_metric({?APP, node, gets, Type}, 1, spiral),
-    ok = folsom_metrics:notify_existing_metric({?APP, node, gets, Type, time}, Microsecs, histogram),
-    ok = folsom_metrics:notify_existing_metric({?APP, node, gets, Type, siblings}, NumSiblings, histogram),
-    ok = folsom_metrics:notify_existing_metric({?APP, node, gets, Type, objsize}, ObjSize, histogram),
-    do_stages([?APP, node, gets, Type, time], Stages),
+    ok = create_or_update([P, ?APP, node, gets, Type], 1, spiral),
+    ok = create_or_update([P, ?APP, node, gets, Type, time], Microsecs, histogram),
+    ok = create_or_update([P, ?APP, node, gets, Type, siblings], NumSiblings, histogram),
+    ok = create_or_update([P, ?APP, node, gets, Type, objsize], ObjSize, histogram),
+    ok = do_stages([P, ?APP, node, gets, Type, time], Stages),
     do_get_bucket(PerBucket, {Bucket, Microsecs, Stages, NumSiblings, ObjSize, Type});
 do_update({put_fsm_time, Bucket,  Microsecs, Stages, PerBucket, undefined}) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, node, puts}, 1, spiral),
-    ok = folsom_metrics:notify_existing_metric({?APP, node, puts, time}, Microsecs, histogram),
-    do_stages([?APP, node, puts, time], Stages),
+    P = ?PFX,
+    ok = exometer:update([P, ?APP, node, puts], 1),
+    ok = exometer:update([P, ?APP, node, puts, time], Microsecs),
+    ok = do_stages([P, ?APP, node, puts, time], Stages),
     do_put_bucket(PerBucket, {Bucket, Microsecs, Stages});
 do_update({put_fsm_time, Bucket,  Microsecs, Stages, PerBucket, CRDTMod}) ->
+    P = ?PFX,
     Type = riak_kv_crdt:from_mod(CRDTMod),
-    ok = folsom_metrics:notify_existing_metric({?APP, node, puts, Type}, 1, spiral),
-    ok = folsom_metrics:notify_existing_metric({?APP, node, puts, Type, time}, Microsecs, histogram),
-    do_stages([?APP, node, puts, Type, time], Stages),
+    ok = create_or_update([P, ?APP, node, puts, Type], 1, spiral),
+    ok = create_or_update([P, ?APP, node, puts, Type, time], Microsecs, histogram),
+    ok = do_stages([P, ?APP, node, puts, Type, time], Stages),
     do_put_bucket(PerBucket, {Bucket, Microsecs, Stages, Type});
 do_update({read_repairs, Indices, Preflist}) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, node, gets, read_repairs}, 1, spiral),
+    ok = exometer:update([?PFX, ?APP, node, gets, read_repairs], 1),
     do_repairs(Indices, Preflist);
 do_update(coord_redir) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, node, puts, coord_redirs}, {inc, 1}, counter);
+    exometer:update([?PFX, ?APP, node, puts, coord_redirs], 1);
 do_update(mapper_start) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, mapper_count}, {inc, 1}, counter);
+    exometer:update([?PFX, ?APP, mapper_count], 1);
 do_update(mapper_end) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, mapper_count}, {dec, 1}, counter);
+    exometer:update([?PFX, ?APP, mapper_count], -1);
 do_update(precommit_fail) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, precommit_fail}, {inc, 1}, counter);
+    exometer:update([?PFX, ?APP, precommit_fail], 1);
 do_update(postcommit_fail) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, postcommit_fail}, {inc, 1}, counter);
+    exometer:update([?PFX, ?APP, postcommit_fail], 1);
 do_update({fsm_spawned, Type}) when Type =:= gets; Type =:= puts ->
-    ok = folsom_metrics:notify_existing_metric({?APP, node, Type, fsm, active}, {inc, 1}, counter);
+    exometer:update([?PFX, ?APP, node, Type, fsm, active], 1);
 do_update({fsm_exit, Type}) when Type =:= gets; Type =:= puts  ->
-    ok = folsom_metrics:notify_existing_metric({?APP, node, Type, fsm,  active}, {dec, 1}, counter);
+    exometer:update([?PFX, ?APP, node, Type, fsm, active], -1);
 do_update({fsm_error, Type}) when Type =:= gets; Type =:= puts ->
     ok = do_update({fsm_exit, Type}),
-    ok = folsom_metrics:notify_existing_metric({?APP, node, Type, fsm, errors}, 1, spiral);
+    exometer:update([?PFX, ?APP, node, Type, fsm, errors], 1);
 do_update({index_create, Pid}) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, index, fsm, create}, 1, spiral),
-    ok = folsom_metrics:notify_existing_metric({?APP, index, fsm, active}, {inc, 1}, counter),
+    P = ?PFX,
+    ok = exometer:update([P, ?APP, index, fsm, create], 1),
+    ok = exometer:update([P, ?APP, index, fsm, active], 1),
     add_monitor(index, Pid),
     ok;
 do_update(index_create_error) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, index, fsm, create, error}, 1, spiral);
+    exometer:update([?PFX, ?APP, index, fsm, create, error], 1);
 do_update({list_create, Pid}) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, list, fsm, create}, 1, spiral),
-    ok = folsom_metrics:notify_existing_metric({?APP, list, fsm, active}, {inc, 1}, counter),
+    P = ?PFX,
+    ok = exometer:update([P, ?APP, list, fsm, create], 1),
+    ok = exometer:update([P, ?APP, list, fsm, active], 1),
     add_monitor(list, Pid),
     ok;
 do_update(list_create_error) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, list, fsm, create, error}, 1, spiral);
+    exometer:update([?PFX, ?APP, list, fsm, create, error], 1);
 do_update({fsm_destroy, Type}) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, Type, fsm, active}, {dec, 1}, counter);
+    exometer:update([?PFX, ?APP, Type, fsm, active], -1);
 do_update({Type, actor_count, Count}) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, Type, actor_count}, Count, histogram);
+    exometer:update([?PFX, ?APP, Type, actor_count], Count);
 do_update(late_put_fsm_coordinator_ack) ->
-    ok = folsom_metrics:notify_existing_metric({?APP, late_put_fsm_coordinator_ack}, {inc, 1}, counter);
+    exometer:update([?PFX, ?APP, late_put_fsm_coordinator_ack], 1);
 do_update({consistent_get, _Bucket, Microsecs, ObjSize}) ->
-    ok = notify_existing({?APP, consistent, gets}, 1, spiral),
-    ok = notify_existing({?APP, consistent, gets, time}, Microsecs, histogram),
-    ok = maybe_notify_existing({?APP, consistent, gets, objsize}, ObjSize, histogram);
+    P = ?PFX,
+    ok = exometer:update([P, ?APP, consistent, gets], 1),
+    ok = exometer:update([P, ?APP, consistent, gets, time], Microsecs),
+    create_or_update([P, ?APP, consistent, gets, objsize], ObjSize, histogram);
 do_update({consistent_put, _Bucket, Microsecs, ObjSize}) ->
-    ok = notify_existing({?APP, consistent, puts}, 1, spiral),
-    ok = notify_existing({?APP, consistent, puts, time}, Microsecs, histogram),
-    ok = maybe_notify_existing({?APP, consistent, puts, objsize}, ObjSize, histogram).
+    P = ?PFX,
+    ok = exometer:update([P, ?APP, consistent, puts], 1),
+    ok = exometer:update([P, ?APP, consistent, puts, time], Microsecs),
+    create_or_update([P, ?APP, consistent, puts, objsize], ObjSize, histogram).
+
 
 %% private
-
-notify_existing(Name, Event, Type) ->
-    folsom_metrics:notify_existing_metric(Name, Event, Type).
-
-maybe_notify_existing(_, undefined, _) ->
-    ok;
-maybe_notify_existing(Name, Event, Type) ->
-    notify_existing(Name, Event, Type).
 
 add_monitor(Type, Pid) ->
     gen_server:cast(?SERVER, {monitor, Type, Pid}).
@@ -300,78 +304,80 @@ add_monitor(Type, Pid) ->
 monitor_loop(Type) ->
     receive
         {add_pid, Pid} ->
-            erlang:monitor(process, Pid),
-            ok;
+            erlang:monitor(process, Pid);
         {'DOWN', _Ref, process, _Pid, _Reason} ->
-            ok = do_update({fsm_destroy, Type}),
-            ok
+            do_update({fsm_destroy, Type})
     end,
     monitor_loop(Type).
 
 %% Per index stats (by op)
 do_per_index(Op, Idx, USecs) ->
     IdxAtom = list_to_atom(integer_to_list(Idx)),
-    create_or_update({?APP, vnode, Op, IdxAtom}, 1, spiral),
-    create_or_update({?APP, vnode, Op, time, IdxAtom}, USecs, histogram).
+    P = riak_core_stat:prefix(),
+    create_or_update([P, ?APP, vnode, Op, IdxAtom], 1, spiral),
+    create_or_update([P, ?APP, vnode, Op, time, IdxAtom], USecs, histogram).
 
 %%  per bucket get_fsm stats
 do_get_bucket(false, _) ->
     ok;
 do_get_bucket(true, {Bucket, Microsecs, Stages, NumSiblings, ObjSize}=Args) ->
-    case (catch folsom_metrics:notify_existing_metric({?APP, node, gets, Bucket}, 1, spiral)) of
+    P = riak_core_stat:prefix(),
+    case exometer:update([P, ?APP, node, gets, Bucket], 1) of
         ok ->
-            _ = [ok = folsom_metrics:notify_existing_metric({?APP, node, gets, Dimension, Bucket}, Arg, histogram)
+            [exometer:update([P, ?APP, node, gets, Dimension, Bucket], Arg)
              || {Dimension, Arg} <- [{time, Microsecs},
                                      {siblings, NumSiblings},
                                      {objsize, ObjSize}], Arg /= undefined],
-            do_stages([?APP, node, gets, time, Bucket], Stages);
-        {'EXIT', _} ->
-            ok = folsom_metrics:new_spiral({?APP, node, gets, Bucket}),
-            _ = [register_stat({?APP, node, gets, Dimension, Bucket}, histogram) || Dimension <- [time,
-                                                                                  siblings,
-                                                                                  objsize]],
+            do_stages([P, ?APP, node, gets, time, Bucket], Stages);
+        {error, not_found} ->
+            exometer:new([P, ?APP, node, gets, Bucket], spiral),
+            [register_stat([P, ?APP, node, gets, Dimension, Bucket], histogram) || Dimension <- [time,
+                                                                                                 siblings,
+                                                                                                 objsize]],
             do_get_bucket(true, Args)
     end;
 do_get_bucket(true, {Bucket, Microsecs, Stages, NumSiblings, ObjSize, Type}=Args) ->
-    case (catch folsom_metrics:notify_existing_metric({?APP, node, gets, Type, Bucket}, 1, spiral)) of
-        ok ->
-            _ = [ok = folsom_metrics:notify_existing_metric({?APP, node, gets, Type, Dimension, Bucket}, Arg, histogram)
-             || {Dimension, Arg} <- [{time, Microsecs},
-                                     {siblings, NumSiblings},
-                                     {objsize, ObjSize}], Arg /= undefined],
-            do_stages([?APP, node, gets, Type, time, Bucket], Stages);
-        {'EXIT', _} ->
-            ok = folsom_metrics:new_spiral({?APP, node, gets, Type, Bucket}),
-            _ = [register_stat({?APP, node, gets, Type, Dimension, Bucket}, histogram) || Dimension <- [time,
-                                                                                  siblings,
-                                                                                  objsize]],
-            do_get_bucket(true, Args)
+    P = riak_core_stat:prefix(),
+    case exometer:update([P, ?APP, node, gets, Type, Bucket], 1) of
+	ok ->
+	    [exometer:update([P, ?APP, node, gets, Dimension, Bucket], Arg)
+	     || {Dimension, Arg} <- [{time, Microsecs},
+				     {siblings, NumSiblings},
+				     {objsize, ObjSize}], Arg /= undefined],
+	    do_stages([P, ?APP, node, gets, Type, time, Bucket], Stages);
+	{error, not_found} ->
+	    exometer:new([P, ?APP, node, gets, Type, Bucket], spiral),
+	    [register_stat([P, ?APP, node, gets, Type, Dimension, Bucket], histogram)
+	     || Dimension <- [time, siblings, objsize]],
+	    do_get_bucket(true, Args)
     end.
-
 
 %% per bucket put_fsm stats
 do_put_bucket(false, _) ->
     ok;
 do_put_bucket(true, {Bucket, Microsecs, Stages}=Args) ->
-    case (catch folsom_metrics:notify_existing_metric({?APP, node, puts, Bucket}, 1, spiral)) of
+    P = riak_core_stat:prefix(),
+    case exometer:update([P, ?APP, node, puts, Bucket], 1) of
         ok ->
-            ok = folsom_metrics:notify_existing_metric({?APP, node, puts, time, Bucket}, Microsecs, histogram),
-            do_stages([?APP, node, puts, time, Bucket], Stages);
-        {'EXIT', _} ->
-            register_stat({?APP, node, puts, Bucket}, spiral),
-            register_stat({?APP, node, puts, time, Bucket}, histogram),
+            exometer:update([P, ?APP, node, puts, time, Bucket], Microsecs),
+            do_stages([P, ?APP, node, puts, time, Bucket], Stages);
+        {error, _} ->
+            register_stat([P, ?APP, node, puts, Bucket], spiral),
+            register_stat([P, ?APP, node, puts, time, Bucket], histogram),
             do_put_bucket(true, Args)
     end;
 do_put_bucket(true, {Bucket, Microsecs, Stages, Type}=Args) ->
-    case (catch folsom_metrics:notify_existing_metric({?APP, node, puts, Type, Bucket}, 1, spiral)) of
-        ok ->
-            ok = folsom_metrics:notify_existing_metric({?APP, node, puts, Type, time, Bucket}, Microsecs, histogram),
-            do_stages([?APP, node, puts, Type, time, Bucket], Stages);
-        {'EXIT', _} ->
-            register_stat({?APP, node, puts, Type, Bucket}, spiral),
-            register_stat({?APP, node, puts, Type, time, Bucket}, histogram),
-            do_put_bucket(true, Args)
+    P = riak_core_stat:prefix(),
+    case exometer:update([P, ?APP, node, puts, Type, Bucket], 1) of
+	ok ->
+	    exometer:update([P, ?APP, node, puts, Type, time, Bucket], Microsecs),
+	    do_stages([P, ?APP, node, puts, Type, time, Bucket], Stages);
+	{error, not_found} ->
+	    register_stat([P, ?APP, node, puts, Type, Bucket], spiral),
+	    register_stat([P, ?APP, node, puts, Type, time, Bucket], histogram),
+	    do_put_bucket(true, Args)
     end.
+
 
 %% Path is list that provides a conceptual path to a stat
 %% folsom uses the tuple as flat name
@@ -383,19 +389,20 @@ do_put_bucket(true, {Bucket, Microsecs, Stages, Type}=Args) ->
 do_stages(_Path, []) ->
     ok;
 do_stages(Path, [{Stage, Time}|Stages]) ->
-    create_or_update(list_to_tuple(Path ++ [Stage]), Time, histogram),
+    create_or_update(Path ++ [Stage], Time, histogram),
     do_stages(Path, Stages).
 
 %% create dimensioned stats for read repairs.
 %% The indexes are from get core [{Index, Reason::notfound|outofdate}]
 %% preflist is a preflist of [{{Index, Node}, Type::primary|fallback}]
 do_repairs(Indices, Preflist) ->
+    Pfx = riak_core_stat:prefix(),
     lists:foreach(fun({{Idx, Node}, Type}) ->
                           case proplists:get_value(Idx, Indices) of
                               undefined ->
                                   ok;
                               Reason ->
-                                  create_or_update({?APP, node, gets,  read_repairs, Node, Type, Reason}, 1, spiral)
+                                  create_or_update([Pfx, ?APP, node, gets, read_repairs, Node, Type, Reason], 1, spiral)
                           end
                   end,
                   Preflist).
@@ -403,25 +410,15 @@ do_repairs(Indices, Preflist) ->
 %% for dynamically created / dimensioned stats
 %% that can't be registered at start up
 create_or_update(Name, UpdateVal, Type) ->
-    case (catch folsom_metrics:notify_existing_metric(Name, UpdateVal, Type)) of
-        ok ->
-            ok;
-        {'EXIT', _} ->
-            register_stat(Name, Type),
-            create_or_update(Name, UpdateVal, Type)
-    end.
+    exometer:update_or_create(Name, UpdateVal, Type, []).
 
-%% Stats are namespaced by APP in folsom
-%% so that we don't need to co-ordinate on naming
-%% between apps.
-stat_name(Name) when is_list(Name) ->
-    list_to_tuple([?APP] ++ Name);
-stat_name(Name) when is_atom(Name) ->
-    {?APP, Name}.
+report_legacy() ->
+    riak_kv_wm_stats:legacy_report_map().
 
 %% @doc list of {Name, Type} for static
 %% stats that we can register at start up
 stats() ->
+    Pfx = riak_core_stat:prefix(),
     [{[vnode, gets], spiral},
      {[vnode, gets, time], histogram},
      {[vnode, puts], spiral},
@@ -481,7 +478,7 @@ stats() ->
      {precommit_fail, counter},
      {postcommit_fail, counter},
      {[vnode, backend, leveldb, read_block_error],
-      {function, {function, ?MODULE, leveldb_read_block_errors}}},
+      {function, ?MODULE, leveldb_read_block_errors, [], match, value}},
      {[counter, actor_count], histogram},
      {[set, actor_count], histogram},
      {[map, actor_count], histogram},
@@ -499,32 +496,25 @@ stats() ->
      {[consistent, gets, objsize], histogram},
      {[consistent, puts], spiral},
      {[consistent, puts, time], histogram},
-     {[consistent, puts, objsize], histogram}
+     {[consistent, puts, objsize], histogram},
+     {[storage_backend], {function, app_helper, get_env, [riak_kv, storage_backend], match, value}},
+     {[ring_stats], {function, riak_kv_stat_bc, ring_stats, [], proplist, [ring_members,
+									   ring_num_partitions,
+									   ring_ownership]}}
+     | read_repair_aggr_stats(Pfx)].
+
+read_repair_aggr_stats(Pfx) ->
+    [{[read_repairs,Type,Reason],
+      {function,exometer,aggregate,
+       [ [{{[Pfx,?APP,node,gets,read_repairs,'_',Type,Reason],'_','_'},
+	   [], [true]}], [one,count] ], value, [one,count]}}
+     || Type <- [primary, fallback],
+	Reason <- [notfound, outofdate]
     ].
 
-%% @doc register a stat with folsom
-do_register_stat(Name, spiral) ->
-    folsom_metrics:new_spiral(Name);
-do_register_stat(Name, counter) ->
-    folsom_metrics:new_counter(Name);
-do_register_stat(Name, histogram) ->
-    %% get the global default histo type
-    {SampleType, SampleArgs} = get_sample_type(Name),
-    folsom_metrics:new_histogram(Name, SampleType, SampleArgs);
-do_register_stat(Name, {function, F}) ->
-    %% store the function in a gauge metric
-    ok = folsom_metrics:new_gauge(Name),
-    folsom_metrics:notify({Name, F}).
 
-%% @doc the histogram sample type may be set in app.config
-%% use key `stat_sample_type' in the `riak_kv' section. Or the
-%% name of an `histogram' stat.
-%% Check the folsom homepage for available types.
-%% Defaults to `{slide_uniform, {60, 1028}}' (a uniform sliding window
-%% of 60 seconds, with a uniform sample of at most 1028 entries)
-get_sample_type(Name) ->
-    SampleType0 = app_helper:get_env(riak_kv, stat_sample_type, {slide_uniform, {60, 1028}}),
-    app_helper:get_env(riak_kv, Name, SampleType0).
+do_register_stat(Name, Type) ->
+    exometer:new(Name, Type).
 
 %% @doc produce the legacy blob of stats for display.
 produce_stats() ->
@@ -607,9 +597,6 @@ rbe_val(_) ->
 %% This loop is spawned as a process to avoid that.
 stat_repair_loop() ->
     receive
-        {re_register_stat, Arg} ->
-            re_register_stat(Arg),
-            stat_repair_loop();
         {'DOWN', _, process, _, _} ->
             ok;
         _ ->
@@ -620,107 +607,24 @@ stat_repair_loop(Dad) ->
     erlang:monitor(process, Dad),
     stat_repair_loop().
 
-re_register_stat(Arg) ->
-    case (catch do_update(Arg)) of
-        {'EXIT', _} ->
-            Stats = stats_from_update_arg(Arg),
-            _ = [begin
-                 (catch folsom_metrics:delete_metric(Name)),
-                 do_register_stat(Name, Type)
-             end || {Name, {metric, _, Type, _}} <- Stats],
-            ok;
-        ok ->
-            ok
-    end.
-
-%% Map from application argument used in call to `update/1' to
-%% folsom stat names and types.
-%% Updates that create dynamic stats must select all
-%% related stats.
-stats_from_update_arg({vnode_get, _, _}) ->
-    riak_core_stat_q:names_and_types([?APP, vnode, gets]);
-stats_from_update_arg({vnode_put, _, _}) ->
-    riak_core_stat_q:names_and_types([?APP, vnode, puts]);
-stats_from_update_arg(vnode_index_refresh) ->
-    riak_core_stat_q:names_and_types([?APP, vnode, index, refreshes]);
-stats_from_update_arg(vnode_index_read) ->
-    riak_core_stat_q:names_and_types([?APP, vnode, index, reads]);
-stats_from_update_arg({vnode_index_write, _, _}) ->
-    riak_core_stat_q:names_and_types([?APP, vnode, index, writes]) ++
-        riak_core_stat_q:names_and_types([?APP, vnode, index, deletes]);
-stats_from_update_arg({vnode_index_delete, _}) ->
-    riak_core_stat_q:names_and_types([?APP, vnode, index, deletes]);
-stats_from_update_arg({vnode_dt_update, Mod, _}) ->
-    Type = riak_kv_crdt:from_mod(Mod),
-    [{{?APP, vnode, Type, update}, {metric, [], spiral, undefined}},
-     {{?APP, vnode, Type, update, time}, {metric, [], histogram, undefined}}];
-stats_from_update_arg({riak_object_merge, undefined, _}) ->
-    [{{?APP, object, merge}, {metric, [], spiral, undefined}},
-     {{?APP, object, merge, time}, {metric, [], histogram, undefined}}];
-stats_from_update_arg({riak_object_merge, Mod, _}) ->
-    Type = riak_kv_crdt:from_mod(Mod),
-    [{{?APP, object, Type, merge}, {metric, [], spiral, undefined}},
-     {{?APP, object, Type, merge, time}, {metric, [], histogram, undefined}}];
-stats_from_update_arg({get_fsm, _, _, _, _, _, _, _}) ->
-    riak_core_stat_q:names_and_types([?APP, node, gets]);
-stats_from_update_arg({put_fsm_time, _, _, _, _}) ->
-    riak_core_stat_q:names_and_types([?APP, node, puts]);
-stats_from_update_arg({read_repairs, _, _}) ->
-    riak_core_stat_q:names_and_types([?APP, nodes, gets, read_repairs]);
-stats_from_update_arg(coord_redirs) ->
-    [{{?APP, node, puts, coord_redirs}, {metric,[],counter,undefined}}];
-stats_from_update_arg(mapper_start) ->
-    [{{?APP, mapper_count}, {metric,[],counter,undefined}}];
-stats_from_update_arg(mapper_end) ->
-    stats_from_update_arg(mapper_start);
-stats_from_update_arg(precommit_fail) ->
-    [{{?APP, precommit_fail}, {metric,[],counter,undefined}}];
-stats_from_update_arg(postcommit_fail) ->
-    [{{?APP, postcommit_fail}, {metric,[],counter,undefined}}];
-stats_from_update_arg({fsm_spawned, Type}) ->
-    [{{?APP, node, Type, fsm, active}, {metric,[],counter,undefined}}];
-stats_from_update_arg({fsm_exit, Type}) ->
-    stats_from_update_arg({fsm_spawned, Type});
-stats_from_update_arg({fsm_error, Type}) ->
-    stats_from_update_arg({fsm_spawned, Type}) ++
-        [{{?APP, node, Type, fsm, errors}, {metric,[], spiral, undefined}}];
-stats_from_update_arg({index_create, _Pid}) ->
-    [{{?APP, index, fsm, create}, {metric, [], spiral, undefined}},
-     {{?APP, index, fsm, active}, {metric, [], counter, undefined}}];
-stats_from_update_arg(index_create_error) ->
-    [{{?APP, index, fsm, create, error}, {metric, [], spiral, undefined}}];
-stats_from_update_arg({list_create, _Pid}) ->
-    [{{?APP, list, fsm, create}, {metric, [], spiral, undefined}},
-     {{?APP, list, fsm, active}, {metric, [], counter, undefined}}];
-stats_from_update_arg(list_create_error) ->
-    [{{?APP, list, fsm, create, error}, {metric, [], spiral, undefined}}];
-stats_from_update_arg({DT, actor_count, _Value}) ->
-    [{{?APP, DT, actor_count}, {metric, [], histogram, undefined}}];
-stats_from_update_arg(late_put_fsm_coordinator_ack) ->
-    [{{?APP, late_put_fsm_coordinator_ack}, {metric,[],counter,undefined}}];
-stats_from_update_arg({consistent_get, _Bucket, _Microsecs, _ObjSize}) ->
-    riak_core_stat_q:names_and_types([?APP, consistent, gets]);
-stats_from_update_arg({consistent_put, _Bucket, _Microsecs, _ObjSize}) ->
-    riak_core_stat_q:names_and_types([?APP, consistent, puts]);
-stats_from_update_arg(_) ->
-    [].
-
 -ifdef(TEST).
 -define(LEVEL_STATUS(Idx, Val),  [{Idx, [{backend_status, riak_kv_eleveldb_backend,
-                                                      [{read_block_error, Val}]}]}]).
+                                          [{read_block_error, Val}]}]}]).
 -define(BITCASK_STATUS(Idx),  [{Idx, [{backend_status, riak_kv_bitcask_backend,
-                                                      []}]}]).
+                                       []}]}]).
 -define(MULTI_STATUS(Idx, Val), [{Idx,  [{backend_status, riak_kv_multi_backend, Val}]}]).
 
 leveldb_rbe_test_() ->
     {foreach,
      fun() ->
+	     exometer:start(),
              meck:new(riak_core_ring_manager),
              meck:new(riak_core_ring),
              meck:new(riak_kv_vnode),
              meck:expect(riak_core_ring_manager, get_my_ring, fun() -> {ok, [fake_ring]} end)
      end,
      fun(_) ->
+	     exometer:stop(),
              meck:unload(riak_kv_vnode),
              meck:unload(riak_core_ring),
              meck:unload(riak_core_ring_manager)
@@ -731,6 +635,40 @@ leveldb_rbe_test_() ->
       {"Bitcask Backend", fun bitcask_backend/0},
       {"Multi Backend", fun multi_backend/0}]
     }.
+
+start_exometer_test_env() ->
+    ok = exometer:start(),
+    ok = meck:new(riak_core_ring_manager),
+    ok = meck:new(riak_core_ring),
+    ok = meck:new(riak_kv_vnode),
+    ok = meck:expect(riak_core_stat, vnodeq_stats, fun() -> [] end),
+    meck:expect(riak_core_ring_manager, get_my_ring, fun() -> {ok, [fake_ring]} end).
+
+stop_exometer_test_env() ->
+    ok = exometer:stop(),
+    ok = meck:unload(riak_kv_vnode),
+    ok = meck:unload(riak_core_ring),
+    meck:unload(riak_core_ring_manager).
+
+create_or_update_histogram_test() ->
+    ok = start_exometer_test_env(),
+
+    Metric = [riak_kv,put_fsm,counter,time],
+    ok = repeat_create_or_update(Metric, 1, histogram, 100),
+    ?assertNotEqual(exometer:get_value(Metric), 0),
+    Stats = get_stats(),
+    %%lager:info("stats prop list ~s", [Stats]),
+    ?assertNotEqual(proplists:get_value({node_put_fsm_counter_time_mean}, Stats), 0),
+
+    ok = stop_exometer_test_env().
+
+repeat_create_or_update(Name, UpdateVal, Type, Times) when Times > 0 ->
+    repeat_create_or_update(Name, UpdateVal, Type, Times, 0).
+repeat_create_or_update(Name, UpdateVal, Type, Times, Ops) when Ops < Times ->
+    ok = create_or_update(Name, UpdateVal, Type),
+    repeat_create_or_update(Name, UpdateVal, Type, Times, Ops + 1);
+repeat_create_or_update(_Name, _UpdateVal, _Type, Times, Ops) when Ops >= Times ->
+    ok.
 
 zero_indexes() ->
     meck:expect(riak_core_ring, my_indices, fun(_R) -> [] end),
@@ -759,21 +697,21 @@ multi_backend() ->
     %% some backends, none level
     meck:expect(riak_kv_vnode, vnode_status, fun([{Idx, _}]) ->
                                                      ?MULTI_STATUS(Idx,
-                                                              [{name1, [{mod, bitcask}]},
-                                                               {name2, [{mod, fired_chicked}]}]
-                                                       )
+                                                                   [{name1, [{mod, bitcask}]},
+                                                                    {name2, [{mod, fired_chicked}]}]
+                                                                  )
                                              end),
     ?assertEqual(undefined, leveldb_read_block_errors()),
 
     %% one or movel leveldb backends (first level answer is returned)
     meck:expect(riak_kv_vnode, vnode_status, fun([{Idx, _}]) ->
-                                                    ?MULTI_STATUS(Idx,
-                                                              [{name1, [{mod, bitcask}]},
-                                                               {name2, [{mod, riak_kv_eleveldb_backend},
-                                                                        {read_block_error, <<"99">>}]},
-                                                               {name2, [{mod, riak_kv_eleveldb_backend},
-                                                                        {read_block_error, <<"1000">>}]}]
-                                                       )
+                                                     ?MULTI_STATUS(Idx,
+                                                                   [{name1, [{mod, bitcask}]},
+                                                                    {name2, [{mod, riak_kv_eleveldb_backend},
+                                                                             {read_block_error, <<"99">>}]},
+                                                                    {name2, [{mod, riak_kv_eleveldb_backend},
+                                                                             {read_block_error, <<"1000">>}]}]
+                                                                  )
                                              end),
     ?assertEqual(99, leveldb_read_block_errors()).
 

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -148,16 +148,31 @@ produce_stats() ->
        read_repair_stats(),
        level_stats(),
        pipe_stats(),
-       cpu_stats(),
+       %% cpu_stats(),
        mem_stats(),
        disk_stats(),
        system_stats(),
        ring_stats(),
        config_stats(),
        app_stats(),
-       memory_stats(),
-       yz_stat:search_stats()
+       memory_stats()
       ]).
+
+%% This is a temporary fix. We should be able to get these through exometer
+%% (actually, read_repair_stats() *are* - only not aggregated)
+other_stats() ->
+    S = [sidejob_stats(),
+         read_repair_stats(),
+         level_stats(),
+         pipe_stats(),
+         mem_stats(),
+	 disk_stats(),
+         system_stats(),
+         ring_stats(),
+         config_stats(),
+         app_stats(),
+         memory_stats()],
+    lists:append(S).
 
 %% Stats in folsom are stored with tuples as keys, the
 %% tuples mimic an hierarchical structure. To be free of legacy
@@ -179,33 +194,40 @@ get_stat(Name, Type, Cache) ->
 get_stat(Name, Type, Cache, ValFun) ->
     case proplists:get_value(Name, Cache) of
         undefined ->
-            case riak_core_stat_q:calc_stat({Name, Type}) of
-                unavailable -> {unavailable, Cache};
-                Stat ->
-                    {ValFun(Stat), [{Name, Stat} | Cache]}
-            end;
+            Value = case riak_core_stat_q:calc_stat({Name, Type}) of
+			unavailable -> [];
+			Stat        -> Stat
+		    end,
+	    {ValFun(Value), [{Name, Value} | Cache]};
         Cached -> {ValFun(Cached), Cache}
     end.
 
-bc_stat({Old, {NewName, Field}, histogram}, Acc, Cache) ->
-    ValFun = fun(Stat) -> trunc(proplists:get_value(Field, Stat)) end,
+bc_stat({Old, {NewName, Field}, histogram} = _X, Acc, Cache) ->
+    try
+    ValFun = fun(Stat) ->
+                     trunc(proplists:get_value(Field, Stat, 0)) end,
     {Val, Cache1} = get_stat(NewName, histogram, Cache, ValFun),
-    {[{Old, Val} | Acc], Cache1};
+    {[{Old, Val} | Acc], Cache1}
+    catch
+        error:_ -> {[{Old,error} | Acc], Cache}
+    end;
 bc_stat({Old, {NewName, Field}, histogram_percentile}, Acc, Cache) ->
     ValFun = fun(Stat) ->
-                     Percentile = proplists:get_value(percentile, Stat),
-                     Val = proplists:get_value(Field, Percentile),
+                     Val = proplists:get_value(Field, Stat, 0),
                      trunc(Val) end,
     {Val, Cache1} = get_stat(NewName, histogram, Cache, ValFun),
     {[{Old, Val} | Acc], Cache1};
 bc_stat({Old, {NewName, Field}, spiral}, Acc, Cache) ->
     ValFun = fun(Stat) ->
-                     proplists:get_value(Field, Stat)
+                     proplists:get_value(Field, Stat, 0)
              end,
     {Val, Cache1} = get_stat(NewName, spiral, Cache, ValFun),
     {[{Old, Val} | Acc], Cache1};
 bc_stat({Old, NewName, counter}, Acc, Cache) ->
-    {Val, Cache1} = get_stat(NewName, counter, Cache),
+    ValFun = fun(Stat) ->
+                     proplists:get_value(value, Stat, 0)
+             end,
+    {Val, Cache1} = get_stat(NewName, counter, Cache, ValFun),
     {[{Old, Val} | Acc], Cache1};
 bc_stat({Old, NewName, function}, Acc, Cache) ->
     {Val, Cache1} = get_stat(NewName, gauge, Cache),
@@ -224,6 +246,8 @@ legacy_stat_map() ->
      {vnode_index_refreshes_total, {{riak_kv, vnode, index, refreshes}, count}, spiral},
      {vnode_index_reads, {{riak_kv, vnode, index, reads}, one}, spiral},
      {vnode_index_reads_total, {{riak_kv, vnode, index, reads}, count}, spiral},
+     {vnode_index_refreshes, {{riak_kv, vnode, index, refreshes}, one}, spiral},
+     {vnode_index_refreshes_total, {{riak_kv, vnode, index, refreshes}, count}, spiral},
      {vnode_index_writes, {{riak_kv, vnode, index, writes}, one}, spiral},
      {vnode_index_writes_total, {{riak_kv, vnode, index, writes}, count}, spiral},
      {vnode_index_writes_postings, {{riak_kv,vnode,index,writes,postings}, one}, spiral},
@@ -283,17 +307,17 @@ legacy_stat_map() ->
      {vnode_map_update_time_100, {{riak_kv, vnode, map, update, time}, max}, histogram},
      {node_gets, {{riak_kv,node,gets}, one}, spiral},
      {node_gets_total, {{riak_kv,node,gets}, count}, spiral},
-     {node_get_fsm_siblings_mean, {{riak_kv,node,gets,siblings}, arithmetic_mean}, histogram},
+     {node_get_fsm_siblings_mean, {{riak_kv,node,gets,siblings}, mean}, histogram},
      {node_get_fsm_siblings_median, {{riak_kv,node,gets,siblings}, median}, histogram},
      {node_get_fsm_siblings_95, {{riak_kv,node,gets,siblings}, 95}, histogram_percentile},
      {node_get_fsm_siblings_99, {{riak_kv,node,gets,siblings}, 99}, histogram_percentile},
      {node_get_fsm_siblings_100, {{riak_kv,node,gets,siblings}, max}, histogram},
-     {node_get_fsm_objsize_mean, {{riak_kv,node,gets,objsize}, arithmetic_mean}, histogram},
+     {node_get_fsm_objsize_mean, {{riak_kv,node,gets,objsize}, mean}, histogram},
      {node_get_fsm_objsize_median, {{riak_kv,node,gets,objsize}, median}, histogram},
      {node_get_fsm_objsize_95, {{riak_kv,node,gets,objsize}, 95}, histogram_percentile},
      {node_get_fsm_objsize_99, {{riak_kv,node,gets,objsize}, 99}, histogram_percentile},
      {node_get_fsm_objsize_100, {{riak_kv,node,gets,objsize}, max}, histogram},
-     {node_get_fsm_time_mean, {{riak_kv,node,gets,time}, arithmetic_mean}, histogram},
+     {node_get_fsm_time_mean, {{riak_kv,node,gets,time}, mean}, histogram},
      {node_get_fsm_time_median, {{riak_kv,node,gets,time}, median}, histogram},
      {node_get_fsm_time_95, {{riak_kv,node,gets,time}, 95}, histogram_percentile},
      {node_get_fsm_time_99, {{riak_kv,node,gets,time}, 99}, histogram_percentile},
@@ -351,7 +375,7 @@ legacy_stat_map() ->
      {node_get_fsm_map_time_100, {{riak_kv,node,gets,map,time}, max}, histogram},
      {node_puts, {{riak_kv,node, puts}, one}, spiral},
      {node_puts_total, {{riak_kv,node, puts}, count}, spiral},
-     {node_put_fsm_time_mean, {{riak_kv,node, puts, time}, arithmetic_mean}, histogram},
+     {node_put_fsm_time_mean, {{riak_kv,node, puts, time}, mean}, histogram},
      {node_put_fsm_time_median, {{riak_kv,node, puts, time}, median}, histogram},
      {node_put_fsm_time_95,  {{riak_kv,node, puts, time}, 95}, histogram_percentile},
      {node_put_fsm_time_99,  {{riak_kv,node, puts, time}, 99}, histogram_percentile},
@@ -510,10 +534,15 @@ sidejob_put_fsm_stats() ->
 %% @doc Get stats on the cpu, as given by the cpu_sup module
 %%      of the os_mon application.
 cpu_stats() ->
-    [{cpu_nprocs, cpu_sup:nprocs()},
-     {cpu_avg1, cpu_sup:avg1()},
-     {cpu_avg5, cpu_sup:avg5()},
-     {cpu_avg15, cpu_sup:avg15()}].
+    DPs = case exometer:get_value([riak_core_stat:prefix(),common,cpu_stats]) of
+              {ok, L} -> L;
+              _ -> []
+          end,
+    [{N, proplists:get_value(K,DPs,0)} ||
+        {N,K} <- [{cpu_nprocs, nprocs},
+                  {cpu_avg1, avg1},
+                  {cpu_avg5, avg5},
+                  {cpu_avg15, avg15}]].
 
 %% @spec mem_stats() -> proplist()
 %% @doc Get stats on the memory, as given by the memsup module
@@ -612,14 +641,14 @@ bc_stat(Name, Val) ->
 %% would be two stats, of NAME_count and NAME_one
 %% let's do that
 bc_stat_val(StatName, Val) when is_list(Val) ->
-    [{join([StatName, ValName]), ValVal} || {ValName, ValVal} <- Val];
+    [{join(StatName ++ [ValName]), ValVal} || {ValName, ValVal} <- Val];
 bc_stat_val(StatName, Val) ->
     {StatName, Val}.
 
 %% Leveldb stats are a last minute new edition to the blob
 level_stats() ->
     Stats = riak_core_stat_q:get_stats([riak_kv, vnode, backend, leveldb, read_block_error]),
-    [{join(lists:nthtail(3, tuple_to_list(Name))), Val} || {Name, Val} <- Stats].
+    [{join(lists:nthtail(3, Name)), Val} || {Name, Val} <- Stats].
 
 %% Read repair stats are a new edition to the legacy blob.
 %% Added to the blob since the stat query interface was not ready for the 1.3
@@ -629,7 +658,8 @@ level_stats() ->
 %% The CSEs are only interested in aggregations of Type and Reason
 %% which are elements 6 and 7 in the key.
 read_repair_stats() ->
-    aggregate(read_repairs, [riak_kv, node, gets, read_repairs, '_', '_', '_'], [6,7]).
+    Pfx = riak_core_stat:prefix(),
+    aggregate(read_repairs, [Pfx, riak_kv, node, gets, read_repairs, '_', '_', '_'], [7,8]).
 
 %% TODO generalise for riak_core_stat_q
 %% aggregates spiral values for stats retrieved by `Query'
@@ -637,14 +667,14 @@ read_repair_stats() ->
 %% produces a flat list of `BaseName_NameOfFieldAtIndex[_count]'
 %% to fit in with the existing naming convention in the legacy stat blob
 aggregate(BaseName, Query, Fields) ->
-    Stats = riak_core_stat_q:get_stats(Query),
+    Stats = exometer:get_values(Query),
     Aggregates = do_aggregate(Stats, Fields),
     FlatStats = flatten_aggregate_stats(BaseName, Aggregates),
     lists:flatten(FlatStats).
 
 do_aggregate(Stats, Fields) ->
     lists:foldl(fun({Name, [{count, C0}, {one, O0}]}, Acc) ->
-                        Key = key_from_fields(Name, Fields),
+                        Key = key_from_fields(list_to_tuple(Name), Fields),
                         [{count, C}, {one, O}] = case orddict:find(Key, Acc) of
                                                      error -> [{count, 0}, {one, 0}];
                                                      {ok, V} -> V

--- a/src/riak_kv_stat_worker.erl
+++ b/src/riak_kv_stat_worker.erl
@@ -48,9 +48,10 @@ handle_call(_Request, _From, State) ->
     {reply, ok, State}.
 
 handle_cast({update, Arg}, State) ->
-    riak_kv_stat:perform_update(Arg),
+    try riak_kv_stat:perform_update(Arg) catch Class:Error ->
+        riak_kv_stat:stat_update_error(Arg, Class, Error)
+    end,
     {noreply, State}.
-
 handle_info(_Info, State) ->
     {noreply, State}.
 

--- a/src/riak_kv_status.erl
+++ b/src/riak_kv_status.erl
@@ -22,6 +22,7 @@
 -module(riak_kv_status).
 
 -export([statistics/0,
+         get_stats/1,
          ringready/0,
          transfers/0,
          vnode_status/0,
@@ -35,7 +36,7 @@
 
 -spec(statistics() -> [any()]).
 statistics() ->
-    riak_kv_stat:get_stats() ++ riak_core_stat:get_stats().
+    get_stats(console).
 
 ringready() ->
     riak_core_status:ringready().
@@ -48,8 +49,7 @@ transfers() ->
 vnode_status() ->
     %% Get the kv vnode indexes and the associated pids for the node.
     PrefLists = riak_core_vnode_manager:all_index_pid(riak_kv_vnode),
-    %% Using the Pids for this request byepasses overload protection
-    riak_kv_vnode:vnode_status([{Idx, node()} || {Idx, _Pid} <- PrefLists]).
+    riak_kv_vnode:vnode_status(PrefLists).
 
 %% @doc Get status of 2i reformat. If the backend requires reformatting, a boolean
 %%      value is returned indicating if all partitions on the node have completed
@@ -81,3 +81,154 @@ are_indexes_fixed(riak_kv_eleveldb_backend, Status) ->
 are_indexes_fixed(riak_kv_multi_backend, {_Idx, [{backend_status,_,Status}]}) ->
     Statuses = [S || {_, S} <- Status, lists:member({mod, riak_kv_eleveldb_backend}, Status)],
     fixed_index_status(riak_kv_eleveldb_backend, Statuses).
+
+
+
+get_stats(web) ->
+    legacy_stats(legacy_stat_map1())
+        ++ riak_kv_stat_bc:read_repair_stats()
+        ++ riak_kv_stat_bc:level_stats()
+        ++ legacy_stats(legacy_pipe_stat_map())
+        ++ riak_kv_stat_bc:cpu_stats()
+        ++ riak_kv_stat_bc:mem_stats()
+        ++ riak_kv_stat_bc:system_stats()
+        ++ riak_kv_stat_bc:app_stats()
+        ++ riak_kv_stat_bc:memory_stats()
+        ++ expand_disk_stats(riak_kv_stat_bc:disk_stats())
+        ++ legacy_stats(legacy_core_stat_map())
+        ++ transform_vnodeq(riak_core_stat:vnodeq_stats());
+get_stats(console) ->
+    legacy_stats(legacy_stat_map1())
+        ++ riak_kv_stat_bc:read_repair_stats()
+        ++ riak_kv_stat_bc:level_stats()
+        ++ legacy_stats(legacy_pipe_stat_map())
+        ++ riak_kv_stat_bc:cpu_stats()
+        ++ riak_kv_stat_bc:mem_stats()
+        ++ riak_kv_stat_bc:system_stats()
+        ++ riak_kv_stat_bc:app_stats()
+        ++ riak_kv_stat_bc:memory_stats().
+
+expand_disk_stats([{disk, Stats}]) ->
+    [{disk, [{struct, [{id, list_to_binary(Id)}, {size, Size}, {used, Used}]}
+             || {Id, Size, Used} <- Stats]}].
+
+legacy_stats(Map) ->
+    P = riak_core_stat:prefix(),
+    lists:foldr(
+      fun({K, DPs}, Acc) ->
+              case exometer:get_value([P|K], [D || {D,_} <- DPs]) of
+                  {ok, Vs} when is_list(Vs) ->
+                      lists:foldr(fun({D,V}, Acc1) ->
+                                          {_,N} = lists:keyfind(D,1,DPs),
+                                          [{N,V}|Acc1]
+                                  end, Acc, Vs);
+                  _ ->
+                      lists:foldr(fun({_,N}, Acc1) ->
+                                          [{N,0}|Acc1]
+                                  end, Acc, DPs)
+              end
+      end, [], Map).
+
+
+legacy_stat_map1() ->
+    [{[riak_kv,vnode,gets], [{one, vnode_gets},
+                             {count, vnode_gets_total}]},
+     {[riak_kv,vnode,puts], [{one, vnode_puts},
+                             {count, vnode_puts_total}]},
+     {[riak_kv,vnode,index,reads], [{one, vnode_index_reads},
+                                    {count, vnode_index_reads_total}]},
+     {[riak_kv,vnode,index,writes], [{one, vnode_index_writes},
+                                     {count, vnode_index_writes_total}]},
+     {[riak_kv,vnode,index,writes,postings], [{one, vnode_index_writes_postings},
+                                              {count, vnode_index_writes_postings_total}]},
+     {[riak_kv,vnode,index,deletes], [{one, vnode_index_deletes},
+                                      {count, vnode_index_deletes_total}]},
+     {[riak_kv,vnode,index,deletes,postings], [{one, vnode_index_deletes_postings},
+                                               {count, vnode_index_deletes_postings_total}]},
+     {[riak_kv,node,gets], [{one, node_gets},
+                            {count, node_gets_total}]},
+     {[riak_kv,node,gets,siblings], [{mean, node_get_fsm_siblings_mean},
+                                     {median, node_get_fsm_siblings_median},
+                                     {95, node_get_fsm_siblings_95},
+                                     {99, node_get_fsm_siblings_99},
+                                     {max, node_get_fsm_siblings_100}]},
+     {[riak_kv,node,gets,objsize], [{mean,node_get_fsm_objsize_mean},
+                                    {median,node_get_fsm_objsize_median},
+                                    {95,node_get_fsm_objsize_95},
+                                    {99,node_get_fsm_objsize_99},
+                                    {max,node_get_fsm_objsize_100}]},
+     {[riak_kv,node,gets,time], [{mean,node_get_fsm_time_mean},
+                                 {median,node_get_fsm_time_median},
+                                 {95,node_get_fsm_time_95},
+                                 {99,node_get_fsm_time_99},
+                                 {max,node_get_fsm_time_100}]},
+     {[riak_kv,node,puts], [{one, node_puts},
+                            {count, node_puts_total}]},
+     {[riak_kv,node,puts,time], [{mean, node_put_fsm_time_mean},
+                                 {median, node_put_fsm_time_median},
+                                 {95, node_put_fsm_time_95},
+                                 {99, node_put_fsm_time_99},
+                                 {max, node_put_fsm_time_100}]},
+     {[riak_kv,node,gets,read_repairs], [{one, read_repairs},
+                                         {count, read_repairs_total}]},
+     {[riak_kv,node,puts,coord_redirs], [{value,coord_redirs_total}]},
+     {[riak_kv,mapper_count], [{value, executing_mappers}]},
+     {[riak_kv,precommit_fail], [{value, precommit_fail}]},
+     {[riak_kv,postcommit_fail], [{value, postcommit_fail}]},
+     {[riak_kv,index,fsm,create], [{one, index_fsm_create}]},
+     {[riak_kv,index,fsm,create,error], [{one, index_fsm_create_error}]},
+     {[riak_kv,index,fsm,active], [{value, index_fsm_active}]},
+     {[riak_kv,list,fsm,active], [{value, list_fsm_active}]},
+     {[riak_api,pbc_connects,active], [{value, pbc_active}]},
+     {[riak_api,pbc_connects], [{one, pbc_connects},
+                                {count, pbc_connects_total}]},
+     {[riak_kv,get_fsm], [{usage, node_get_fsm_active},
+                          {usage_60s, node_get_fsm_active_60s},
+                          {in_rate, node_get_fsm_in_rate},
+                          {out_rate, node_get_fsm_out_rate},
+                          {rejected, node_get_fsm_rejected},
+                          {rejected_60s, node_get_fsm_rejected_60s},
+                          {rejected_total, node_get_fsm_rejected_total}]},
+     {[riak_kv,put_fsm], [{usage, node_put_fsm_active},
+                          {usage_60s, node_put_fsm_active_60s},
+                          {in_rate, node_put_fsm_in_rate},
+                          {out_rate, node_put_fsm_out_rate},
+                          {rejected, node_put_fsm_rejected},
+                          {rejected_60s, node_put_fsm_rejected_60s},
+                          {rejected_total, node_put_fsm_rejected_total}]}].
+
+
+legacy_pipe_stat_map() ->
+    [{[riak_pipe,pipeline,create], [{count, pipeline_create_count},
+                                    {one, pipeline_create_one}]},
+     {[riak_pipe,pipeline,create,error], [{count, pipeline_create_error_count},
+                                          {one, pipeline_create_error_one}]},
+     {[riak_pipe,pipeline,active], [{value, pipeline_active}]}].
+
+legacy_core_stat_map() ->
+    [{[riak_core,ignored_gossip_total], [{value, ignored_gossip_total}]},
+     {[riak_core,rings_reconciled], [{count, rings_reconciled_total},
+                                     {one, rings_reconciled}]},
+     {[riak_core,gossip_received], [{one, gossip_received}]},
+     {[riak_core,rejected_handoffs], [{value, rejected_handoffs}]},
+     {[riak_core,handoff_timeouts], [{value, handoff_timeouts}]},
+     {[riak_core,dropped_vnode_requests_total], [{value,dropped_vnode_requests_total}]},
+     {[riak_core,converge_delay], [{min, converge_delay_min},
+                                   {max, converge_delay_max},
+                                   {last, converge_delay_last}]},
+     {[riak_core,rebalance_delay], [{min, rebalance_delay_min},
+                                    {max, rebalance_delay_max},
+                                    {mean, rebalance_delay_mean},
+                                    {last, rebalance_delay_last}]}].
+
+transform_vnodeq(Stats) ->
+    lists:flatmap(
+      fun({[_, riak_core,N], [{value, V}]}) ->
+              [{N, V}];
+         ({[_, riak_core, N], Vals}) ->
+              [{join(N, K), V} || {K, V} <- Vals]
+      end, Stats).
+
+join(A, B) ->
+    binary_to_list(<< (atom_to_binary(A, latin1))/binary, "_",
+                      (atom_to_binary(B, latin1))/binary >>).

--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -61,6 +61,9 @@ init([]) ->
                   {riak_kv_js_manager, start_link,
                   [?JSPOOL_HOOK, read_js_pool_size(hook_js_vm_count, "hook callback")]},
                   permanent, 30000, worker, [riak_kv_js_manager]},
+    HTTPCache = {riak_kv_http_cache,
+		 {riak_kv_http_cache, start_link, []},
+		 permanent, 5000, worker, [riak_kv_http_cache]},
     JSSup = {riak_kv_js_sup,
              {riak_kv_js_sup, start_link, []},
              permanent, infinity, supervisor, [riak_kv_js_sup]},
@@ -111,7 +114,8 @@ init([]) ->
         JSSup,
         MapJSPool,
         ReduceJSPool,
-        HookJSPool
+        HookJSPool,
+        HTTPCache
     ]),
 
     % Run the proesses...

--- a/src/riak_kv_test_util.erl
+++ b/src/riak_kv_test_util.erl
@@ -212,7 +212,6 @@ cleanup(Test, CleanupFun, StartedApps) ->
     %% Cleanup potentially runaway processes
     catch exit(whereis(riak_kv_vnode_master), kill),
     catch exit(whereis(riak_sysmon_filter), kill),
-    catch riak_core_stat_cache:stop(),
     %% Need to specifically wait for riak_kv_stat to unregister, since
     %% otherwise we get a specific error
     %% {{already_started,Pid},#child{...}}  from supervisor:start_child/2
@@ -254,7 +253,6 @@ dep_apps(Test, Extra) ->
                        error_logger:tty(false);
                   (_) -> ok
                end,
-
     DefaultSetupFun =
         fun(load) ->
                 %% Set some missing env vars that are normally part of
@@ -272,8 +270,8 @@ dep_apps(Test, Extra) ->
            (_) -> ok
         end,
 
-    [sasl, Silencer, runtime_tools, erlang_js, mochiweb, webmachine,
-     sidejob, poolboy, basho_stats, bitcask, goldrush, lager, folsom, protobuffs,
+    [sasl, Silencer, goldrush, lager, exometer, runtime_tools, erlang_js,
+     mochiweb, webmachine, sidejob, poolboy, basho_stats, bitcask, protobuffs,
      eleveldb, riak_core, riak_pipe, riak_api, riak_dt, riak_pb, riak_kv,
      DefaultSetupFun, Extra].
 
@@ -286,7 +284,7 @@ do_dep_apps(start, Apps) ->
     lists:foldl(fun(A, Acc) when is_atom(A) ->
                         case include_app_phase(start, A) of
                             true ->
-                                {ok, Started} = start_app_and_deps(A, Acc),
+				{ok, Started} = start_app_and_deps(A, Acc),
                                 Started;
                             _ ->
                                 Acc
@@ -312,7 +310,6 @@ do_dep_apps(LoadStop, Apps) ->
 %% loaded, started, or stopped by `do_dep_apps/2'.
 -spec include_app_phase(Phase::load | start | stop, Application::atom()) -> true | false.
 include_app_phase(stop, crypto) -> false;
-include_app_phase(start, folsom) -> false;
 include_app_phase(_Phase, _App) -> true.
 
 %% Make sure an application and all of its dependent applications are started.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -2428,8 +2428,7 @@ list_buckets_test_() ->
              clean_test_dirs(),
              application:start(sasl),
              Env = application:get_all_env(riak_kv),
-             application:start(folsom),
-             riak_core_stat_cache:start_link(),
+	     exometer:start(),
              riak_kv_stat:register_stats(),
              {ok, _} = riak_core_bg_manager:start(),
              riak_core_metadata_manager:start_link([{data_dir, "kv_vnode_test_meta"}]),
@@ -2437,10 +2436,9 @@ list_buckets_test_() ->
      end,
      fun(Env) ->
              riak_core_ring_manager:cleanup_ets(test),
-             riak_core_stat_cache:stop(),
              riak_kv_test_util:stop_process(riak_core_metadata_manager),
              riak_kv_test_util:stop_process(riak_core_bg_manager),
-             application:stop(folsom),
+	     exometer:stop(),
              application:stop(sasl),
              [application:unset_env(riak_kv, K) ||
                  {K, _V} <- application:get_all_env(riak_kv)],

--- a/src/riak_kv_wm_stats.erl
+++ b/src/riak_kv_wm_stats.erl
@@ -30,19 +30,21 @@
          service_available/2,
          forbidden/2,
          produce_body/2,
-         pretty_print/2
+         pretty_print/2,
+	 legacy_stat_map/0,
+	 legacy_report_map/0
         ]).
+-export([get_stats/0]).
 
 -include_lib("webmachine/include/webmachine.hrl").
 
 -record(ctx, {}).
--type context() :: #ctx{}.
 
 init(_) ->
     {ok, #ctx{}}.
 
--spec encodings_provided(#wm_reqdata{}, context()) ->
-         {[term()], #wm_reqdata{}, context()}.
+%% @spec encodings_provided(webmachine:wrq(), context()) ->
+%%         {[encoding()], webmachine:wrq(), context()}
 %% @doc Get the list of encodings this resource provides.
 %%      "identity" is provided for all methods, and "gzip" is
 %%      provided for GET as well
@@ -55,8 +57,8 @@ encodings_provided(ReqData, Context) ->
             {[{"identity", fun(X) -> X end}], ReqData, Context}
     end.
 
--spec content_types_provided(#wm_reqdata{}, context()) ->
-    {[term()], #wm_reqdata{}, context()}.
+%% @spec content_types_provided(webmachine:wrq(), context()) ->
+%%          {[ctype()], webmachine:wrq(), context()}
 %% @doc Get the list of content types this resource provides.
 %%      "application/json" and "text/plain" are both provided
 %%      for all requests.  "text/plain" is a "pretty-printed"
@@ -74,17 +76,379 @@ forbidden(RD, Ctx) ->
     {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx}.
 
 produce_body(ReqData, Ctx) ->
-    Body = mochijson2:encode({struct, get_stats()}),
+    Stats= riak_kv_http_cache:get_stats(),
+    Body = mochijson2:encode({struct, Stats}),
     {Body, ReqData, Ctx}.
 
--spec pretty_print(#wm_reqdata{}, context()) ->
-          {string(), #wm_reqdata{}, context()}.
+%% @spec pretty_print(webmachine:wrq(), context()) ->
+%%          {string(), webmachine:wrq(), context()}
 %% @doc Format the respons JSON object is a "pretty-printed" style.
 pretty_print(RD1, C1=#ctx{}) ->
     {Json, RD2, C2} = produce_body(RD1, C1),
     {json_pp:print(binary_to_list(list_to_binary(Json))), RD2, C2}.
 
+
 get_stats() ->
-    {value, {disk, Disk}, Stats} = lists:keytake(disk, 1, riak_kv_stat:get_stats()),
-    DiskFlat = [{struct, [{id, list_to_binary(Id)}, {size, Size}, {used, Used}]} || {Id, Size, Used} <- Disk],
-    lists:append([Stats, [{disk, DiskFlat}], riak_core_stat:get_stats(), yz_stat:search_stats()]).
+    legacy_stats(legacy_stat_map())
+        ++ legacy_stats(legacy_pipe_stat_map())
+        ++ riak_kv_stat_bc:mem_stats()
+        ++ riak_kv_stat_bc:system_stats()
+        ++ riak_kv_stat_bc:app_stats()
+        ++ riak_kv_stat_bc:memory_stats()
+        ++ expand_disk_stats(riak_kv_stat_bc:disk_stats())
+        ++ legacy_stats(legacy_core_stat_map())
+        ++ transform_vnodeq(riak_core_stat:vnodeq_stats()).
+
+expand_disk_stats([{disk, Stats}]) ->
+    [{disk, [{struct, [{id, list_to_binary(Id)}, {size, Size}, {used, Used}]}
+             || {Id, Size, Used} <- Stats]}].
+
+legacy_stats(Map) ->
+    P = riak_core_stat:prefix(),
+    lists:foldr(
+      fun({K, DPs}, Acc) ->
+              case exometer:get_value([P|K], [D || {D,_} <- DPs]) of
+                  {ok, Vs} when is_list(Vs) ->
+                      lists:foldr(fun({D,V}, Acc1) ->
+                                          {_,N} = lists:keyfind(D,1,DPs),
+                                          [{N,V}|Acc1]
+                                  end, Acc, Vs);
+                  Other ->
+		      Val = case Other of
+				{ok, disabled} -> undefined;
+				_ -> 0
+			    end,
+                      lists:foldr(fun({_,N}, Acc1) ->
+                                          [{N,Val}|Acc1]
+                                  end, Acc, DPs)
+              end
+      end, [], Map).
+
+legacy_report_map() ->
+    P = riak_core_stat:prefix(),
+    Map = legacy_stat_map(),
+    I = app_helper:get_env(riak_kv, report_interval, 10000),
+    lists:flatmap(
+      fun({E, DPs}) ->
+	      E1 = [P|E],
+	      [{main, E1, D, I, true} || {D,_} <- DPs]
+      end, Map).
+
+legacy_stat_map() ->
+    [
+     {[riak_kv,object,merge], [{one  , object_merge},
+			       {count, object_merge_total}]},
+     {[riak_kv,object,map,merge], [{one  , object_map_merge},
+				   {count, object_map_merge_total}]},
+     {[riak_kv,object,merge,time], [{mean  , object_merge_time_mean},
+				    {median, object_merge_time_median},
+				    {95    , object_merge_time_95},
+				    {99    , object_merge_time_99},
+				    {max   , object_merge_time_100}]},
+     {[riak_kv,vnode,map,update,time], [{mean  , vnode_map_update_time_mean},
+					{median, vnode_map_update_time_median},
+					{95    , vnode_map_update_time_95},
+					{99    , vnode_map_update_time_99},
+					{max   , vnode_map_update_time_100}]},
+     {[riak_kv,vnode,gets], [{one  , vnode_gets},
+                             {count, vnode_gets_total}]},
+     {[riak_kv,vnode,puts], [{one  , vnode_puts},
+                             {count, vnode_puts_total}]},
+     {[riak_kv,vnode,index,reads], [{one  , vnode_index_reads},
+                                    {count, vnode_index_reads_total}]},
+     {[riak_kv,vnode,index,refreshes], [{one  ,vnode_index_refreshes},
+					{count, vnode_index_refreshes_total}]},
+     {[riak_kv,vnode,index,writes], [{one  , vnode_index_writes},
+                                     {count, vnode_index_writes_total}]},
+     {[riak_kv,vnode,index,writes,postings], [{one  , vnode_index_writes_postings},
+                                              {count, vnode_index_writes_postings_total}]},
+     {[riak_kv,vnode,index,deletes], [{one  , vnode_index_deletes},
+                                      {count, vnode_index_deletes_total}]},
+     {[riak_kv,vnode,index,deletes,postings], [{one  , vnode_index_deletes_postings},
+                                               {count, vnode_index_deletes_postings_total}]},
+     {[riak_kv,vnode,backend,leveldb,read_block_error],
+      [{value, leveldb_read_block_error}]},
+     {[riak_kv,object,map,merge,time], [{mean  , object_map_merge_time_mean},
+					{median, object_map_merge_time_median},
+					{95    , object_map_merge_time_95},
+					{99    , object_map_merge_time_99},
+					{max   , object_map_merge_time_100}]},
+     {[riak_kv,node,gets], [{one  , node_gets},
+                            {count, node_gets_total}]},
+     {[riak_kv,node,gets,siblings], [{mean  , node_get_fsm_siblings_mean},
+                                     {median, node_get_fsm_siblings_median},
+                                     {95    , node_get_fsm_siblings_95},
+                                     {99    , node_get_fsm_siblings_99},
+                                     {max   , node_get_fsm_siblings_100}]},
+     {[riak_kv,node,gets,set,siblings], [{mean  , node_get_fsm_set_siblings_mean},
+					 {median, node_get_fsm_set_siblings_median},
+					 {95    , node_get_fsm_set_siblings_95},
+					 {99    , node_get_fsm_set_siblings_99},
+					 {max   , node_get_fsm_set_siblings_100}]},
+     {[riak_kv,node,gets,objsize], [{mean  , node_get_fsm_objsize_mean},
+                                    {median, node_get_fsm_objsize_median},
+                                    {95    , node_get_fsm_objsize_95},
+                                    {99    , node_get_fsm_objsize_99},
+                                    {max   , node_get_fsm_objsize_100}]},
+     {[riak_kv,node,gets,set,objsize], [{mean  , node_get_fsm_set_objsize_mean},
+					{median, node_get_fsm_set_objsize_median},
+					{95    , node_get_fsm_set_objsize_95},
+					{99    , node_get_fsm_set_objsize_99},
+					{max   , node_get_fsm_set_objsize_100}]},
+     {[riak_kv,node,gets,time], [{mean  , node_get_fsm_time_mean},
+                                 {median, node_get_fsm_time_median},
+                                 {95    , node_get_fsm_time_95},
+                                 {99    , node_get_fsm_time_99},
+                                 {max   , node_get_fsm_time_100}]},
+     {[riak_kv,node,gets,map,siblings], [{mean  , node_get_fsm_map_siblings_mean},
+					 {median, node_get_fsm_map_siblings_median},
+					 {95    , node_get_fsm_map_siblings_95},
+					 {99    , node_get_fsm_map_siblings_99},
+					 {max   , node_get_fsm_map_siblings_100}]},
+     {[riak_kv,node,gets,map,objsize], [{mean  , node_get_fsm_map_objsize_mean},
+					{median, node_get_fsm_map_objsize_median},
+					{95    , node_get_fsm_map_objsize_95},
+					{99    , node_get_fsm_map_objsize_99},
+					{max   , node_get_fsm_map_objsize_100}]},
+     {[riak_kv,node,gets,map,time], [{mean  , node_get_fsm_map_time_mean},
+				     {median, node_get_fsm_map_time_median},
+				     {95    , node_get_fsm_map_time_95},
+				     {99    , node_get_fsm_map_time_99},
+				     {max   , node_get_fsm_map_time_100}]},
+     {[riak_kv,node,gets,set,time], [{mean  , node_get_fsm_set_time_mean},
+				     {median, node_get_fsm_set_time_median},
+				     {95    , node_get_fsm_set_time_95},
+				     {99    , node_get_fsm_set_time_99},
+				     {max   , node_get_fsm_set_time_100}]},
+     {[riak_kv,node,gets,set], [{one  , node_gets_set},
+				{count, node_gets_set_total}]},
+     {[riak_kv,node,puts], [{one, node_puts},
+                            {count, node_puts_total}]},
+     {[riak_kv,node,puts,time], [{mean  , node_put_fsm_time_mean},
+                                 {median, node_put_fsm_time_median},
+                                 {95    , node_put_fsm_time_95},
+                                 {99    , node_put_fsm_time_99},
+                                 {max   , node_put_fsm_time_100}]},
+     {[riak_kv,node,gets,counter,objsize], [{mean  , node_get_fsm_counter_objsize_mean},
+					    {median, node_get_fsm_counter_objsize_median},
+					    {95    , node_get_fsm_counter_objsize_95},
+					    {99    , node_get_fsm_counter_objsize_99},
+					    {max   , node_get_fsm_counter_objsize_100}]},
+     {[riak_kv,node,gets,read_repairs], [{one, read_repairs},
+                                         {count, read_repairs_total}]},
+     {[riak_kv,node,gets,counter], [{one  , node_gets_counter},
+				    {count, node_gets_counter_total}]},
+     {[riak_kv,node,gets,counter,siblings], [{mean  , node_get_fsm_counter_siblings_mean},
+					     {median, node_get_fsm_counter_siblings_median},
+					     {95    , node_get_fsm_counter_siblings_95},
+					     {99    , node_get_fsm_counter_siblings_99},
+					     {max   , node_get_fsm_counter_siblings_100}]},
+     {[riak_kv,node,gets,counter,time], [{mean  , node_get_fsm_counter_time_mean},
+					 {median, node_get_fsm_counter_time_median},
+					 {95    , node_get_fsm_counter_time_95},
+					 {99    , node_get_fsm_counter_time_99},
+					 {max   , node_get_fsm_counter_time_100}]},
+     {[riak_kv,node,puts,coord_redirs], [{value,coord_redirs_total}]},
+     {[riak_kv,mapper_count], [{value, executing_mappers}]},
+     {[riak_kv,object,counter,merge], [{one, object_counter_merge},
+				       {count, object_counter_merge_total}]},
+     {[riak_kv,object,counter,merge,time], [{mean  , object_counter_merge_time_mean},
+					    {median, object_counter_merge_time_median},
+					    {95    , object_counter_merge_time_95},
+					    {99    , object_counter_merge_time_99},
+					    {max   , object_counter_merge_time_100}]},
+     {[riak_kv,object,set,merge], [{one  , object_set_merge},
+				   {count, object_set_merge_total}]},
+     {[riak_kv,object,set,merge,time], [{mean  , object_set_merge_time_mean},
+					{median, object_set_merge_time_median},
+					{95    , object_set_merge_time_95},
+					{99    , object_set_merge_time_99},
+					{max   , object_set_merge_time_100}]},
+     {[riak_kv,precommit_fail], [{value, precommit_fail}]},
+     {[riak_kv,postcommit_fail], [{value, postcommit_fail}]},
+     {[riak_kv,index,fsm,create], [{one, index_fsm_create}]},
+     {[riak_kv,index,fsm,create,error], [{one, index_fsm_create_error}]},
+     {[riak_kv,index,fsm,active], [{value, index_fsm_active}]},
+     {[riak_kv,list,fsm,active], [{value, list_fsm_active}]},
+     {[riak_kv,consistent,gets], [{one, consistent_gets},
+				  {count, consistent_gets_total}]},
+     {[riak_kv,consistent,gets,objsize], [{mean  , consistent_get_objsize_mean},
+					  {median, consistent_get_objsize_median},
+					  {95    , consistent_get_objsize_95},
+					  {99    , consistent_get_objsize_99},
+					  {max   , consistent_get_objsize_100}]},
+     {[riak_kv,consistent,gets,time], [{mean  , consistent_get_time_mean},
+				       {median, consistent_get_time_median},
+				       {95    , consistent_get_time_95},
+				       {99    , consistent_get_time_99},
+				       {max   , consistent_get_time_100}]},
+     {[riak_kv,consistent,puts], [{one, consistent_puts},
+				  {count, consistent_puts_total}]},
+     {[riak_kv,consistent,puts,objsize], [{mean  , consistent_put_objsize_mean},
+					  {median, consistent_put_objsize_median},
+					  {95    , consistent_put_objsize_95},
+					  {99    , consistent_put_objsize_99},
+					  {max   , consistent_put_objsize_100}]},
+     {[riak_kv,consistent,puts,time], [{mean  , consistent_put_time_mean},
+				       {median, consistent_put_time_median},
+				       {95    , consistent_put_time_95},
+				       {99    , consistent_put_time_99},
+				       {max   , consistent_put_time_100}]},
+     {[riak_api,pbc_connects,active], [{value, pbc_active}]},
+     {[riak_api,pbc_connects], [{one, pbc_connects},
+                                {count, pbc_connects_total}]},
+     {[riak_kv,get_fsm,sidejob], [{usage, node_get_fsm_active},
+				  {usage_60s, node_get_fsm_active_60s},
+				  {in_rate, node_get_fsm_in_rate},
+				  {out_rate, node_get_fsm_out_rate},
+				  {rejected, node_get_fsm_rejected},
+				  {rejected_60s, node_get_fsm_rejected_60s},
+				  {rejected_total, node_get_fsm_rejected_total}]},
+     {[riak_kv,put_fsm,sidejob], [{usage, node_put_fsm_active},
+				  {usage_60s, node_put_fsm_active_60s},
+				  {in_rate, node_put_fsm_in_rate},
+				  {out_rate, node_put_fsm_out_rate},
+				  {rejected, node_put_fsm_rejected},
+				  {rejected_60s, node_put_fsm_rejected_60s},
+				  {rejected_total, node_put_fsm_rejected_total}]},
+     {[riak_kv,node,puts,counter,time], [{mean  , node_put_fsm_counter_time_mean},
+                                    {median, node_put_fsm_counter_time_median},
+				    {95    , node_put_fsm_counter_time_95},
+				    {99    , node_put_fsm_counter_time_99},
+				    {max   , node_put_fsm_counter_time_100}]},
+     {[riak_kv,node,puts,set,time], [{mean  , node_put_fsm_set_time_mean},
+				   {median, node_put_fsm_set_time_median},
+				   {95    , node_put_fsm_set_time_95},
+				   {99    , node_put_fsm_set_time_99},
+				   {max   , node_put_fsm_set_time_100}]},
+     {[riak_kv,node,puts,counter], [{one  , node_puts_counter},
+				    {count, node_puts_counter_total}]},
+     {[riak_kv,node,puts,set], [{one  , node_puts_set},
+				{count, node_puts_set_total}]},
+     {[riak_kv,node,gets,map], [{one  , node_gets_map},
+				{count, node_gets_map_total}]},
+     {[riak_kv,node,gets,counter,read_repairs], [{one  , read_repairs_counter},
+						 {count, read_repairs_counter_total}]},
+     {[riak_kv,node,puts,map], [{one  , node_puts_map},
+				{count, node_puts_map_total}]},
+     {[riak_kv,node,puts,map,time], [{mean  , node_put_fsm_map_time_mean},
+				     {median, node_put_fsm_map_time_median},
+				     {95    , node_put_fsm_map_time_95},
+				     {99    , node_put_fsm_map_time_99},
+				     {max   , node_put_fsm_map_time_100}]},
+     {[riak_kv,node,gets,set,read_repairs], [{one  , read_repairs_set},
+					     {count, read_repairs_set_total}]},
+     {[riak_kv,node,gets,map,read_repairs,map], [{one  , read_repairs_map},
+						 {count, read_repairs_map_total}]},
+     {[riak_kv,node,gets,read_repairs,primary,notfound],
+      [{one  , read_repairs_primary_notfound_one},
+       {count, read_repairs_primary_notfound_count}]},
+     {[riak_kv,node,gets,read_repairs,primary,outofdate],
+      [{one  , read_repairs_primary_outofdate_one},
+       {count, read_repairs_primary_outofdate_count}]},
+     {[riak_kv,list,fsm,create], [{one  , list_fsm_create},
+				  {count, list_fsm_create_total}]},
+     {[riak_kv,list,fsm,create,error], [{one  , list_fsm_create_error},
+					{count, list_fsm_create_error_total}]},
+     {[riak_kv,counter,actor_count], [{mean  , counter_actor_counts_mean},
+				      {median, counter_actor_counts_median},
+				      {95    , counter_actor_counts_95},
+				      {99    , counter_actor_counts_99},
+				      {max   , counter_actor_counts_100}]},
+     {[riak_kv,set,actor_count], [{mean  , set_actor_counts_mean},
+				  {median, set_actor_counts_median},
+				  {95    , set_actor_counts_95},
+				  {99    , set_actor_counts_99},
+				  {max   , set_actor_counts_100}]},
+     {[riak_kv,map,actor_count], [{mean  , map_actor_counts_mean},
+				  {median, map_actor_counts_median},
+				  {95    , map_actor_counts_95},
+				  {99    , map_actor_counts_99},
+				  {max   , map_actor_counts_100}]},
+     {[riak_kv,late_put_fsm_coordinator_ack], [{value, late_put_fsm_coordinator_ack}]},
+     {[riak_kv,vnode,counter,update], [{one  , vnode_counter_update},
+				       {count, vnode_counter_update_total}]},
+     {[riak_kv,vnode,counter,update,time], [{mean  , vnode_counter_update_time_mean},
+					    {median, vnode_counter_update_time_median},
+					    {95    , vnode_counter_update_time_95},
+					    {99    , vnode_counter_update_time_99},
+					    {max   , vnode_counter_update_time_100}]},
+     {[riak_kv,vnode,map,update],  [{one  , vnode_map_update},
+				    {count, vnode_map_update_total}]},
+     {[riak_kv,vnode,set,update], [{one  , vnode_set_update},
+				   {count, vnode_set_update_total}]},
+     {[riak_kv,vnode,set,update,time], [{mean  , vnode_set_update_time_mean},
+					{median, vnode_set_update_time_median},
+					{95    , vnode_set_update_time_95},
+					{99    , vnode_set_update_time_99},
+					{max   , vnode_set_update_time_100}]},
+     {[riak_kv,ring_stats], [{ring_members       , ring_members},
+			     {ring_num_partitions, ring_num_partitions},
+			     {ring_ownership     , ring_ownership}]},
+     {[riak_core,ring_creation_size], [{value, ring_creation_size}]},
+     {[riak_kv,storage_backend], [{value, storage_backend}]},
+     {[common,cpu_stats], [{nprocs, cpu_nprocs},
+			   {avg1  , cpu_avg1},
+			   {avg5  , cpu_avg5},
+			   {avg15 , cpu_avg15}]},
+     {[riak_core_stat_ts], [{value, riak_core_stat_ts}]},
+     {[riak_kv_stat_ts]  , [{value, riak_kv_stat_ts}]},
+     {[riak_pipe_stat_ts], [{value, riak_pipe_stat_ts}]},
+     {[yokozuna,index,fail], [{count,search_index_fail_count},
+			      {one  ,search_index_fail_one}]},
+     {[yokozuna,index,latency], [{95    , search_index_latency_95},
+				 {99    , search_index_latency_99},
+				 {999   , search_index_latency_999},
+				 {max   , search_index_latency_max},
+				 {median, search_index_latency_median},
+				 {min   , search_index_latency_min}]},
+     {[yokozuna,index,throughput], [{count, search_index_throughput_count},
+				    {one  , search_index_throughtput_one}]},
+     {[yokozuna,'query',fail], [{count, search_search_query_fail_count},
+				{one  , search_query_fail_one}]},
+     {[yokozuna,'query',latency], [{95    , search_query_latency_95},
+				   {99    , search_query_latency_99},
+				   {999   , search_query_latency_999},
+				   {max   , search_query_latency_max},
+				   {median, search_query_latency_median},
+				   {min   , search_query_latency_min}]},
+     {[yokozuna,'query',throughput], [{count,search_query_throughput_count},
+				      {one  ,search_query_throughput_one}]}
+    ].
+
+
+legacy_pipe_stat_map() ->
+    [{[riak_pipe,pipeline,create], [{count, pipeline_create_count},
+                                    {one, pipeline_create_one}]},
+     {[riak_pipe,pipeline,create,error], [{count, pipeline_create_error_count},
+                                          {one, pipeline_create_error_one}]},
+     {[riak_pipe,pipeline,active], [{value, pipeline_active}]}].
+
+legacy_core_stat_map() ->
+    [{[riak_core,ignored_gossip_total], [{value, ignored_gossip_total}]},
+     {[riak_core,rings_reconciled], [{count, rings_reconciled_total},
+                                     {one, rings_reconciled}]},
+     {[riak_core,gossip_received], [{one, gossip_received}]},
+     {[riak_core,rejected_handoffs], [{value, rejected_handoffs}]},
+     {[riak_core,handoff_timeouts], [{value, handoff_timeouts}]},
+     {[riak_core,dropped_vnode_requests_total], [{value,dropped_vnode_requests_total}]},
+     {[riak_core,converge_delay], [{mean, converge_delay_mean},
+				   {min, converge_delay_min},
+                                   {max, converge_delay_max},
+                                   {last, converge_delay_last}]},
+     {[riak_core,rebalance_delay], [{min, rebalance_delay_min},
+                                    {max, rebalance_delay_max},
+                                    {mean, rebalance_delay_mean},
+                                    {last, rebalance_delay_last}]}].
+
+transform_vnodeq(Stats) ->
+    lists:flatmap(
+      fun({[_, riak_core,N], [{value, V}]}) ->
+              [{N, V}];
+         ({[_, riak_core, N], Vals}) ->
+              [{join(N, K), V} || {K, V} <- Vals]
+      end, Stats).
+
+join(A, B) ->
+    binary_to_list(<< (atom_to_binary(A, latin1))/binary, "_",
+                      (atom_to_binary(B, latin1))/binary >>).

--- a/test/fsm_eqc_util.erl
+++ b/test/fsm_eqc_util.erl
@@ -171,6 +171,7 @@ cycle(Zs, N, []) ->
     cycle(Zs, N, Zs).
 
 start_mock_servers() ->
+
     %% Start new core_vnode based EQC FSM test mock
     case whereis(fsm_eqc_vnode) of
         undefined -> ok;
@@ -182,12 +183,12 @@ start_mock_servers() ->
     {ok, _Pid3} = fsm_eqc_vnode:start_link(),
     application:load(riak_core),
     application:start(crypto),
-    application:start(folsom),
+    exometer:start(),
     start_fake_get_put_monitor(),
-    riak_core_stat_cache:start_link(),
     riak_kv_stat:register_stats(),
     riak_core_metadata_manager:start_link([{data_dir, "fsm_eqc_test_data"}]),
     riak_core_ring_events:start_link(),
+    riak_core_ring_manager:start_link(test),
     riak_core_node_watcher_events:start_link(),
     riak_core_node_watcher:start_link(),
     riak_core_node_watcher:service_up(riak_kv, self()),
@@ -196,8 +197,10 @@ start_mock_servers() ->
 cleanup_mock_servers() ->
     stop_fake_get_put_monitor(),
     riak_kv_test_util:stop_process(riak_core_metadata_manager),
+    riak_kv_test_util:stop_process(riak_core_ring_manager),
     application:stop(folsom),
-    application:stop(riak_core).
+    application:stop(riak_core),
+    exometer:stop().
 
 make_options([], Options) ->
     Options;

--- a/test/get_fsm_eqc.erl
+++ b/test/get_fsm_eqc.erl
@@ -219,11 +219,11 @@ prop_basic_get() ->
         {SoftCap, HardCap, Actual, Roll} = RRAbort,
         application:set_env(riak_kv, read_repair_soft, SoftCap),
         application:set_env(riak_kv, read_repair_max, HardCap),
-        FolsomKey = {riak_kv, node, gets, fsm, active},
+        StatKey = [riak, riak_kv, node, gets, fsm, active],
         % don't really care if the key doesn't exist when we delete it.
-        catch folsom_metrics:delete_metric(FolsomKey),
-        folsom_metrics:new_counter(FolsomKey),
-        folsom_metrics:notify({FolsomKey, {inc, Actual}}),
+        _ = exometer:delete(StatKey),
+        exometer:new(StatKey, counter),
+        exometer:update(StatKey, Actual),
         fsm_eqc_util:set_fake_rng(?MODULE, Roll),
 
         {ok, GetPid} = riak_kv_get_fsm:test_link({raw, ReqId, self()},

--- a/test/get_put_monitor_eqc.erl
+++ b/test/get_put_monitor_eqc.erl
@@ -64,7 +64,7 @@ exit_gracefully(S) ->
     [end_and_wait(Pid, normal) || Pid <- PutList ++ GetList].
 
 reset_test_state() ->
-    Servers = [riak_kv_stat, riak_core_stat_cache],
+    Servers = [riak_kv_stat],
     [riak_kv_test_util:wait_for_unregister(Server) || Server <- Servers],
     application:stop(folsom),
     ok = application:start(folsom),

--- a/test/put_fsm_eqc.erl
+++ b/test/put_fsm_eqc.erl
@@ -108,6 +108,10 @@ setup() ->
     error_logger:tty(false),
     error_logger:logfile({open, "put_fsm_eqc.log"}),
 
+    %% Exometer starts lager.  Therefore, we need start it before lager to ensure
+    %% that cconfiguration customizations in this test case are not inadvertantly
+    %% overwritten ...
+    ok = exometer:start(),
     application:stop(lager),
     application:load(lager),
     application:set_env(lager, handlers,


### PR DESCRIPTION
This PR is an adaptation of PR #1006 ("Use exometer metrics"), which was relative to the 'develop' branch.

The current PR is relative to the 2.0 branch. Note that rebar.config is not affected.
