### PR TITLE
Remove afunix from EXOMETER_PACKAGES.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: deps test
 
 # Limit exometer dependencies
-EXOMETER_PACKAGES="(basic), +afunix"
+EXOMETER_PACKAGES="(basic)"
 export EXOMETER_PACKAGES
 
 DIALYZER_FLAGS =


### PR DESCRIPTION
Afunix is not used at this time, and may cause build issues on some
platforms.
