### PR TITLE
Fix hashtree test missing function

### DIFF
--- a/src/hashtree.erl
+++ b/src/hashtree.erl
@@ -1127,6 +1127,10 @@ delta_test() ->
 %%%===================================================================
 
 -ifdef(EQC).
+
+esha(Bin) ->
+        crypto:sha(Bin).
+
 sha_test_() ->
     {spawn,
      {timeout, 120,


### PR DESCRIPTION
The 1.4 branch riak_kv repo had an EQC test failing due to a missing function as a result of a backport. This fixes it.

You can verify by running only the hashtree test. Make sure you have quickcheck installed, then in riak_kv:

```
$ rebar deps_dir=.. skip_deps=true eunit suites=hashtree
or, if standalone riak_kv:
$ rebar skip_deps=true eunit suites=hashtree
```

Before and after applying this fix.
