### PR TITLE
Bugfix for precondition_context test failures.

### DIFF
--- a/src/riak_kv_crdt_json.erl
+++ b/src/riak_kv_crdt_json.erl
@@ -265,10 +265,11 @@ encode_fetch_response_test_() ->
                                      {<<"value">>,
                                       {struct,
                                        [% NB map sorts its keys
-                                        {<<"a_set">>, [<<"a">>, <<"b">>, <<"c">>]}]}},
+                                        {<<"a_set">>, [<<"a">>, <<"b">>, <<"c">>]},
                                         {<<"b_flag">>, true},
                                         {<<"c_register">>, <<"sean">>},
                                         {<<"d_map">>, {struct, [{<<"e_counter">>, 5}]}}
+                                       ]}}
                                      ]},
                            fetch_response_to_json(map, ?MAP_TYPE:value(Map), undefined, ?EMBEDDED_TYPES)
                            ),

--- a/src/riak_kv_crdt_json.erl
+++ b/src/riak_kv_crdt_json.erl
@@ -247,7 +247,7 @@ encode_fetch_response_test_() ->
                            fetch_response_to_json(set, ?SET_TYPE:value(Set), undefined, ?MOD_MAP)),
               ?assertMatch({struct, [_Type, _Value, {<<"context">>, Bin}]} when is_binary(Bin),
                            fetch_response_to_json(set, ?SET_TYPE:value(Set),
-                                                  ?SET_TYPE:to_binary(?SET_TYPE:precondition_context(Set)),
+                                                  riak_dt_vclock:to_binary(?SET_TYPE:precondition_context(Set)),
                                                   ?MOD_MAP))
       end},
      {"encode map",
@@ -274,7 +274,7 @@ encode_fetch_response_test_() ->
                            ),
               ?assertMatch({struct, [_Type, _Value, {<<"context">>, Bin}]} when is_binary(Bin),
                            fetch_response_to_json(map, ?MAP_TYPE:value(Map),
-                                                  ?MAP_TYPE:to_binary(?MAP_TYPE:precondition_context(Map)),
+                                                  riak_dt_vclock:to_binary(?MAP_TYPE:precondition_context(Map)),
                                                   ?EMBEDDED_TYPES))
       end}
     ].
@@ -330,7 +330,7 @@ decode_update_request_test_() ->
                            update_request_from_json(set, {struct, [{<<"increment">>, 5}]}, ?MOD_MAP)),
               %% Context should be extracted properly
               {ok, Set} = ?SET_TYPE:update({add_all, [<<"a">>, <<"b">>, <<"c">>]}, a, ?SET_TYPE:new()),
-              BinContext = ?SET_TYPE:to_binary(?SET_TYPE:precondition_context(Set)),
+              BinContext = riak_dt_vclock:to_binary(?SET_TYPE:precondition_context(Set)),
               {struct, [_Type, _Value, {<<"context">>, JSONCtx}]} = fetch_response_to_json(set, ?SET_TYPE:value(Set),
                                                                                        BinContext,
                                                                                        ?MOD_MAP),
@@ -373,7 +373,7 @@ decode_update_request_test_() ->
                                              {update, {<<"d">>, ?MAP_TYPE},
                                               {update, [{update, {<<"e">>, ?EMCNTR_TYPE}, {increment,5}}]}}
                                             ]}, a, ?MAP_TYPE:new()),
-              BinContext = ?MAP_TYPE:to_binary(?MAP_TYPE:precondition_context(Map)),
+              BinContext = riak_dt_vclock:to_binary(?MAP_TYPE:precondition_context(Map)),
               {struct, [_Type, _Value, {<<"context">>, JSONCtx}]} = fetch_response_to_json(set, ?MAP_TYPE:value(Map),
                                                                                            BinContext,
                                                                                            ModMap),

--- a/src/riak_kv_crdt_json.erl
+++ b/src/riak_kv_crdt_json.erl
@@ -264,11 +264,11 @@ encode_fetch_response_test_() ->
                                      {<<"type">>, <<"map">>},
                                      {<<"value">>,
                                       {struct,
-                                       [ % NB inverse order from the order of update-application
-                                        {<<"d_map">>, {struct, [{<<"e_counter">>, 5}]}},
-                                        {<<"c_register">>, <<"sean">>},
+                                       [% NB map sorts its keys
+                                        {<<"a_set">>, [<<"a">>, <<"b">>, <<"c">>]}]}},
                                         {<<"b_flag">>, true},
-                                        {<<"a_set">>, [<<"a">>, <<"b">>, <<"c">>]}]}}
+                                        {<<"c_register">>, <<"sean">>},
+                                        {<<"d_map">>, {struct, [{<<"e_counter">>, 5}]}}
                                      ]},
                            fetch_response_to_json(map, ?MAP_TYPE:value(Map), undefined, ?EMBEDDED_TYPES)
                            ),


### PR DESCRIPTION
Previously every riak_dt type simply called riak_dt:to_binary/1 for 
serialization, and before 2.0.0 optimizations, was an entire copy of the 
datatype. This meant that the precondition context was handled through the
type's to_binary/1 function. The 2.0.0 optimizations use only a VV as the
context, however, so we don't need to serialize via the type's to_binary/1
call, we can call riak_dt_vclock:to_binary/1 directly.

This bug was uncovered by basho/riak_dt#110, which changes how the sets and maps are
manipulated before serialization.
