### PR TITLE
Make read-repair stats be 'proplist' instead of 'value'

### DIFF
--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -672,7 +672,7 @@ read_repair_aggr_stats(Pfx) ->
     Spec = fun(Type, Reason) ->
                    {function,exometer,aggregate,
                     [ [{{[Pfx,?APP,node,gets,read_repairs,'_',Type,Reason],'_','_'},
-                        [], [true]}], [one,count] ], value, [one,count]}
+                        [], [true]}], [one,count] ], proplist, [one,count]}
            end,
     [
      {[read_repairs,primary,notfound], Spec(primary, notfound), [],


### PR DESCRIPTION
'value' is actually something that should practically never be
used in exometer function metrics. In this case, it causes the
return value to be wrong if the exometer:aggregate() function doesn't
find any detailed stats to aggregate.
