### PR TITLE
Optimize mapreduce by replacing listkeys+get with 2i query

### DIFF
--- a/src/riak_kv_pipe_index.erl
+++ b/src/riak_kv_pipe_index.erl
@@ -103,6 +103,15 @@ keysend_loop(ReqId, Partition, FittingDetails) ->
 
 keysend(_Bucket, [], _Partition, _FittingDetails) ->
     ok;
+keysend(Bucket, [{o,Key,BinRiakObj}|Keys], Partition, FittingDetails) ->
+    RiakObj = riak_object:from_binary(Bucket, Key, BinRiakObj),
+    Out = {ok, RiakObj, undefined},
+    case riak_pipe_vnode_worker:send_output(Out, Partition, FittingDetails) of
+        ok ->
+            keysend(Bucket, Keys, Partition, FittingDetails);
+        ER ->
+            ER
+    end;
 keysend(Bucket, [Key | Keys], Partition, FittingDetails) ->
     SKey = strip_index(Key),
     Out = if


### PR DESCRIPTION
Simple benchmark in CS showed 1.7x performance improvement:

```
(riak-cs@127.0.0.1)1> timer:tc(fun()->riak_cs_storage:sum_bucket(<<"test">>)end).
{4673368,
 {struct,[{<<"Objects">>,98407},{<<"Bytes">>,4341828394}]}}
(riak-cs@127.0.0.1)2> timer:tc(fun()->riak_cs_storage:sum_bucket2(<<"test">>)end).
{2810982,
 {struct,[{<<"Objects">>,98407},{<<"Bytes">>,4341828394}]}}
```

This performance gain stems from duplicate disk read from both
`riak_kv_pipe_listkeys` and `riak_kv_pipe_get` .
`riak_kv_pipe_listkeys` does not read from disk when the backend is
bitcask, but when the backend is leveldb, it reads the whole block
including not only keys but values (aka Riak objects). This pull
request replaces them with modified `riak_pipe_index` with
`return_body=true` and enable a vnode to just read from one time. This
is inspired by `riak_kv_pb_csbucket`.

This is originally for performance optimization of storage stats calculation
of Riak CS (https://github.com/basho/riak_cs/pull/1051) but also
contributes for other use cases folding a whole bucket with MapReduce.

Other discussion point is whether this optimization applies for inputs with
index `<<"$key">>` . I think this works, but too big change might break
something.
