### PR TITLE
Bugfix/ku/add probe logmsg

### DIFF
--- a/src/riak_kv_mrc_sink.erl
+++ b/src/riak_kv_mrc_sink.erl
@@ -293,7 +293,7 @@ handle_info({'DOWN', _, process, Pid, Reason}, _,
     %% don't stop when the builder exits 'normal', because that's
     %% probably just the pipe shutting down normally - wait for the
     %% owner to ask for the last outputs
-    _ = lager:error("Pipe builder down. Reason: ~p", [Reason]),
+    _ = lager:warning("Pipe builder down. Reason: ~p", [Reason]),
     {stop, normal, State};
 handle_info(_, StateName, State) ->
     {next_state, StateName, State}.

--- a/src/riak_kv_mrc_sink.erl
+++ b/src/riak_kv_mrc_sink.erl
@@ -293,6 +293,7 @@ handle_info({'DOWN', _, process, Pid, Reason}, _,
     %% don't stop when the builder exits 'normal', because that's
     %% probably just the pipe shutting down normally - wait for the
     %% owner to ask for the last outputs
+    _ = lager:error("Pipe builder down. Reason: ~p", [Reason]),
     {stop, normal, State};
 handle_info(_, StateName, State) ->
     {next_state, StateName, State}.

--- a/src/riak_kv_pb_mapred.erl
+++ b/src/riak_kv_pb_mapred.erl
@@ -143,7 +143,7 @@ process_stream(#kv_mrc_sink{ref=ReqId,
              clear_state_req(State)}
     end;
 
-process_stream({'DOWN', Ref, process, Pid, Reason}, Ref,
+process_stream({'DOWN', Ref, process, Pid, Reason}, _PipeRef,
                State=#state{req=#rpbmapredreq{},
                             req_ctx=#pipe_ctx{sender={Pid, Ref}}=PipeCtx}) ->
     %% the async input sender exited
@@ -160,7 +160,7 @@ process_stream({'DOWN', Ref, process, Pid, Reason}, Ref,
             {error, {format, "Error sending inputs: ~p", [Reason]},
              clear_state_req(State)}
     end;
-process_stream({'DOWN', Mon, process, Pid, Reason}, _,
+process_stream({'DOWN', Mon, process, Pid, Reason}, _PipeRef,
                State=#state{req=#rpbmapredreq{},
                             req_ctx=#pipe_ctx{sink={Pid, Mon}}=PipeCtx}) ->
     %% the sink died, which it shouldn't be able to do before


### PR DESCRIPTION
This patch adds a log message line when pipe fitting died and MapReduce failed with ambiguous error. This is also a probe when a customer issue (zd://9291) reproduced. At the same time this adds fix for #1054 . CC: https://github.com/basho/riak_pipe/pull/92
