### PR TITLE
Add capability and env_var to control binary format of map/set (riak#667)

### DIFF
--- a/include/riak_kv_types.hrl
+++ b/include/riak_kv_types.hrl
@@ -34,5 +34,8 @@
 
 -define(DATATYPE_STATS_DEFAULTS, [actor_count]).
 
+-define(R1_DATATYPE_VERSIONS, [{?COUNTER_TYPE, 2}]).
+-define(R2_DATATYPE_VERSIONS, [{?MAP_TYPE, 2}, {?SET_TYPE, 2}, {?COUNTER_TYPE, 2}]).
+
 -type crdt() :: ?CRDT{}.
 -type crdt_op() :: ?CRDT_OP{}.

--- a/include/riak_kv_types.hrl
+++ b/include/riak_kv_types.hrl
@@ -34,8 +34,12 @@
 
 -define(DATATYPE_STATS_DEFAULTS, [actor_count]).
 
--define(R1_DATATYPE_VERSIONS, [{?COUNTER_TYPE, 2}]).
--define(R2_DATATYPE_VERSIONS, [{?MAP_TYPE, 2}, {?SET_TYPE, 2}, {?COUNTER_TYPE, 2}]).
+%% These proplists represent the current versions of supported
+%% datatypes. The naming `EN_DATATYPE_VERSIONS' means `Epoch' and
+%% number. `N' is incremented when any new version of any datatype is
+%% introduced, thus bumping the data type `Epoch'.
+-define(E1_DATATYPE_VERSIONS, [{?COUNTER_TYPE, 2}]).
+-define(E2_DATATYPE_VERSIONS, [{?MAP_TYPE, 2}, {?SET_TYPE, 2}, {?COUNTER_TYPE, 2}]).
 
 -type crdt() :: ?CRDT{}.
 -type crdt_op() :: ?CRDT_OP{}.

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -191,6 +191,10 @@ start(_Type, _StartArgs) ->
                                           [?TOP_LEVEL_TYPES, [pncounter], []],
                                           []),
 
+            riak_core_capability:register({riak_kv, crdt_versions},
+                                          [?R2_DATATYPE_VERSIONS, ?R1_DATATYPE_VERSIONS],
+                                          ?R1_DATATYPE_VERSIONS),
+
             riak_core_capability:register({riak_kv, put_fsm_ack_execute},
                                           [enabled, disabled],
                                           disabled),

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -191,9 +191,9 @@ start(_Type, _StartArgs) ->
                                           [?TOP_LEVEL_TYPES, [pncounter], []],
                                           []),
 
-            riak_core_capability:register({riak_kv, crdt_versions},
-                                          [?R2_DATATYPE_VERSIONS, ?R1_DATATYPE_VERSIONS],
-                                          ?R1_DATATYPE_VERSIONS),
+            riak_core_capability:register({riak_kv, crdt_epoch_versions},
+                                          [?E2_DATATYPE_VERSIONS, ?E1_DATATYPE_VERSIONS],
+                                          ?E1_DATATYPE_VERSIONS),
 
             riak_core_capability:register({riak_kv, put_fsm_ack_execute},
                                           [enabled, disabled],

--- a/src/riak_kv_crdt.erl
+++ b/src/riak_kv_crdt.erl
@@ -349,7 +349,9 @@ new(B, K, Mod) ->
 to_binary(CRDT=?CRDT{mod=?V1_COUNTER_TYPE}) ->
     to_binary(CRDT, ?V1_VERS);
 to_binary(?CRDT{mod=Mod, value=Value}) ->
-    CRDTBin = Mod:to_binary(Value),
+    %% Store the CRDT in the version that is negotiated cluster wide
+    Version = crdt_version(Mod),
+    {ok, CRDTBin} = Mod:to_binary(Version, Value),
     Type = atom_to_binary(Mod, latin1),
     TypeLen = byte_size(Type),
     <<?TAG:8/integer, ?V2_VERS:8/integer, TypeLen:32/integer, Type:TypeLen/binary, CRDTBin/binary>>.
@@ -386,10 +388,13 @@ v1_counter_from_binary(CounterBin) ->
             {error, {Class, Err}}
         end.
 
-%% @private attempt to deserialize a v2 CRDT.
+%% @private attempt to deserialize a v2 CRDT (That is a data type, not a 1.4 counter)
 crdt_from_binary(<<TypeLen:32/integer, Type:TypeLen/binary, CRDTBin/binary>>) ->
     try
         Mod = binary_to_existing_atom(Type, latin1),
+        %% You don't need a target version, as Mod:from_binary/1 will
+        %% always give you the highest version you can work with,
+        %% assuming Mod:to_binary/2 was called before storing.
         {ok, Val} = Mod:from_binary(CRDTBin),
         to_record(Mod, Val) of
         ?CRDT{}=CRDT ->
@@ -414,6 +419,24 @@ to_record(?SET_TYPE, Val) ->
 %% @TODO what does this mean for Maps?
 supported(Mod) ->
     lists:member(Mod, riak_core_capability:get({riak_kv, crdt}, [])).
+
+%% @private get the binary version for a crdt mod, default to `1' for
+%% pre-versioned.
+-spec crdt_version(module()) -> pos_integer().
+crdt_version(Mod) ->
+    %% due to the riak-2.0.4 disaster where mixed format maps were
+    %% written to disk (see riak#667 for more) override the cluster
+    %% negotiated capability with an env var, this is to ensure that
+    %% in a multi-cluser environment, v1 binary format is used until
+    %% all clusters are v2 capable.
+    case app_helper:get_env(riak_kv, crdt_mixed_versions) of
+        true ->
+            %% If true is set for app_env, use the v1 values
+            proplists:get_value(Mod, ?R1_DATATYPE_VERSIONS, 1);
+        _ ->
+            %% use any term except true to unset app env
+            proplists:get_value(Mod, riak_core_capability:get({riak_kv, crdt_versions}, ?R1_DATATYPE_VERSIONS), 1)
+    end.
 
 %% @doc turn a string token / atom into a
 %% CRDT type

--- a/src/riak_kv_crdt.erl
+++ b/src/riak_kv_crdt.erl
@@ -416,7 +416,6 @@ to_record(?SET_TYPE, Val) ->
     ?SET_TYPE(Val).
 
 %% @doc Check cluster capability for crdt support
-%% @TODO what does this mean for Maps?
 supported(Mod) ->
     lists:member(Mod, riak_core_capability:get({riak_kv, crdt}, [])).
 
@@ -427,15 +426,15 @@ crdt_version(Mod) ->
     %% due to the riak-2.0.4 disaster where mixed format maps were
     %% written to disk (see riak#667 for more) override the cluster
     %% negotiated capability with an env var, this is to ensure that
-    %% in a multi-cluser environment, v1 binary format is used until
-    %% all clusters are v2 capable.
-    case app_helper:get_env(riak_kv, crdt_mixed_versions) of
-        true ->
-            %% If true is set for app_env, use the v1 values
-            proplists:get_value(Mod, ?R1_DATATYPE_VERSIONS, 1);
+    %% in a multi-cluster environment, Epoch 1 binary format is used until
+    %% all clusters are Epoch 2 capable.
+    case app_helper:get_env(riak_kv, mdc_crdt_epoch) of
+        1 ->
+            proplists:get_value(Mod, ?E1_DATATYPE_VERSIONS, 1);
         _ ->
-            %% use any term except true to unset app env
-            proplists:get_value(Mod, riak_core_capability:get({riak_kv, crdt_versions}, ?R1_DATATYPE_VERSIONS), 1)
+            %% use any term except true to unset app env. Default to
+            %% `1' for any unknown CRDT version
+            proplists:get_value(Mod, riak_core_capability:get({riak_kv, crdt_epoch_versions}, ?E1_DATATYPE_VERSIONS), 1)
     end.
 
 %% @doc turn a string token / atom into a

--- a/src/riak_kv_crdt.erl
+++ b/src/riak_kv_crdt.erl
@@ -432,9 +432,11 @@ crdt_version(Mod) ->
         1 ->
             proplists:get_value(Mod, ?E1_DATATYPE_VERSIONS, 1);
         _ ->
-            %% use any term except true to unset app env. Default to
-            %% `1' for any unknown CRDT version
-            proplists:get_value(Mod, riak_core_capability:get({riak_kv, crdt_epoch_versions}, ?E1_DATATYPE_VERSIONS), 1)
+            %% use any term except the integer `1' to unset app env
+            %% and use capability negotiated CRDT version epoch.
+            %% Default to 1 for any unknown CRDT version.
+            NegotiatedCap = riak_core_capability:get({riak_kv, crdt_epoch_versions}, ?E1_DATATYPE_VERSIONS),
+            proplists:get_value(Mod, NegotiatedCap, 1)
     end.
 
 %% @doc turn a string token / atom into a

--- a/src/riak_kv_crdt_json.erl
+++ b/src/riak_kv_crdt_json.erl
@@ -264,13 +264,13 @@ encode_fetch_response_test_() ->
                                      {<<"type">>, <<"map">>},
                                      {<<"value">>,
                                       {struct,
-                                       [% NB map sorts its keys
-                                        {<<"a_set">>, [<<"a">>, <<"b">>, <<"c">>]},
-                                        {<<"b_flag">>, true},
-                                        {<<"c_register">>, <<"sean">>},
-                                        {<<"d_map">>, {struct, [{<<"e_counter">>, 5}]}}
+                                       [ % NB sorted output
+                                         {<<"a_set">>, [<<"a">>, <<"b">>, <<"c">>]},
+                                         {<<"b_flag">>, true},
+                                         {<<"c_register">>, <<"sean">>},
+                                         {<<"d_map">>, {struct, [{<<"e_counter">>, 5}]}}
                                        ]}}
-                                     ]},
+                                    ]},
                            fetch_response_to_json(map, ?MAP_TYPE:value(Map), undefined, ?EMBEDDED_TYPES)
                            ),
               ?assertMatch({struct, [_Type, _Value, {<<"context">>, Bin}]} when is_binary(Bin),


### PR DESCRIPTION
See basho/riak#667 (RIAK-1436) (RIAK-1482) for more details.

This PR adds a capability for the binary output of Maps and Sets in riak. It also uses and app_env `{riak_kv, crdts_mixed_versions}` to override the capability so that an operator may force the riak cluster to use v1 binary format until all clusters in a multi-datacenter set up are upgraded to riak-2.0.x>4.

There is a cost associated with running in mixed cluster mode. See basho/riak_dt#111 for details. A `v2` map written to `v1` must fully recurse the structure to convert to a format readable by `v1`.
