### PR TITLE
Fix dataloss bug caused by reusing causal histories

### DIFF
--- a/src/riak_kv_backend.erl
+++ b/src/riak_kv_backend.erl
@@ -244,7 +244,7 @@ fold_objects(Backend, State) ->
                                               State2),
                      lists:sort(ObjFilter(Objects))
                  end),
-    empty_check(Backend, State).
+    empty_check(Backend, State2).
 
 empty_check(Backend, State) ->
     {B1, _B2, K1, _K2} = make_bs_and_ks(Backend),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_kv_vnode: VNode Implementation
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -110,6 +110,24 @@
                 reqid :: term(),
                 target :: pid()}).
 
+-record(counter_state, {
+          %% kill switch, if for any reason one wants disable per-key-epochc, then set
+          %% [{riak_kv, [{per_key_epoch, false}]}].
+          use = true :: boolean(),
+          %% The number of new epoch writes co-ordinated by this vnode
+          %% What even is a "key epoch?" It is any time a key is
+          %% (re)created. A new write, a write not yet coordinated by
+          %% this vnode, a write where local state is unreadable.
+          cnt = 0 :: non_neg_integer(),
+          %% Counter leased up-to. For totally new state/id
+          %% this will be that flush threshold See config value
+          %% `{riak_kv, counter_lease_size}'
+          lease = 0 :: non_neg_integer(),
+          lease_size = 0 :: non_neg_integer(),
+          %% Has a lease been requested but not granted yet
+          leasing = false :: boolean()
+         }).
+
 -record(state, {idx :: partition(),
                 mod :: module(),
                 modstate :: term(),
@@ -126,15 +144,42 @@
                 forward :: node() | [{integer(), node()}],
                 hashtrees :: pid(),
                 md_cache :: ets:tab(),
-                md_cache_size :: pos_integer() }).
+                md_cache_size :: pos_integer(),
+                counter :: #counter_state{},
+                status_mgr_pid :: pid() %% a process that manages vnode status persistence
+               }).
 
 -type index_op() :: add | remove.
 -type index_value() :: integer() | binary().
 -type index() :: non_neg_integer().
 -type state() :: #state{}.
+-type vnodeid() :: binary().
+-type counter_lease_error() :: {error, counter_lease_max_errors | counter_lease_timeout}.
 
 -define(MD_CACHE_BASE, "riak_kv_vnode_md_cache").
 -define(DEFAULT_HASHTREE_TOKENS, 90).
+
+%% default value for `counter_lease' in `#counter_state{}'
+%% NOTE: these MUST be positive integers!
+%% @see non_neg_env/3
+-define(DEFAULT_CNTR_LEASE, 10000).
+%% On advise/review from Scott decided to cap the size of leases. 50m
+%% is a lot of new epochs for a single vnode, and it saves us from
+%% buring through vnodeids in the worst case.
+-define(MAX_CNTR_LEASE, 50000000).
+%% Should these cuttlefish-able?  If it takes more than 20 attempts to
+%% fsync the vnode counter to disk, die. (NOTE this is not ERRS*TO but
+%% first to trip see blocking_lease_counter/3)
+-define(DEFAULT_CNTR_LEASE_ERRS, 20).
+%% If it takes more than 20 seconds to fsync the vnode counter to disk,
+%% die
+-define(DEFAULT_CNTR_LEASE_TO, 20000). % 20 seconds!
+
+
+%% Erlang's if Bool -> thing; true -> thang end. syntax hurts my
+%% brain. It scans as if true -> thing; true -> thang end. So, here is
+%% a macro, ?ELSE to use in if statements. You're welcome.
+-define(ELSE, true).
 
 -record(putargs, {returnbody :: boolean(),
                   coord:: boolean(),
@@ -398,7 +443,13 @@ init([Index]) ->
     IndexBufSize = app_helper:get_env(riak_kv, index_buffer_size, 100),
     KeyBufSize = app_helper:get_env(riak_kv, key_buffer_size, 100),
     WorkerPoolSize = app_helper:get_env(riak_kv, worker_pool_size, 10),
-    {ok, VId} = get_vnodeid(Index),
+    UseEpochCounter = app_helper:get_env(riak_kv, use_epoch_counter, true),
+    %%  This _has_ to be a non_neg_integer(), and really, if it is
+    %%  zero, you are fsyncing every.single.key epoch.
+    CounterLeaseSize = min(?MAX_CNTR_LEASE,
+                           non_neg_env(riak_kv, counter_lease_size, ?DEFAULT_CNTR_LEASE)),
+    {ok, StatusMgr} = riak_kv_vnode_status_mgr:start_link(self(), Index, UseEpochCounter),
+    {ok, {VId, CounterState}} = get_vnodeid_and_counter(StatusMgr, CounterLeaseSize, UseEpochCounter),
     DeleteMode = app_helper:get_env(riak_kv, delete_mode, 3000),
     AsyncFolding = app_helper:get_env(riak_kv, async_folds, true) == true,
     MDCacheSize = app_helper:get_env(riak_kv, vnode_md_cache_size),
@@ -421,6 +472,8 @@ init([Index]) ->
                            mod=Mod,
                            modstate=ModState,
                            vnodeid=VId,
+                           counter=CounterState,
+                           status_mgr_pid=StatusMgr,
                            delete_mode=DeleteMode,
                            bucket_buf_size=BucketBufSize,
                            index_buf_size=IndexBufSize,
@@ -678,9 +731,13 @@ handle_command(?KV_VNODE_STATUS_REQ{},
                State=#state{idx=Index,
                             mod=Mod,
                             modstate=ModState,
+                            counter=CS,
                             vnodeid=VId}) ->
     BackendStatus = {backend_status, Mod, Mod:status(ModState)},
-    VNodeStatus = [BackendStatus, {vnodeid, VId}],
+    #counter_state{cnt=Cnt, lease=Lease, lease_size=LeaseSize, leasing=Leasing} = CS,
+    CounterStatus = [{counter, Cnt}, {counter_lease, Lease},
+                     {counter_lease_size, LeaseSize}, {counter_leasing, Leasing}],
+    VNodeStatus = [BackendStatus, {vnodeid, VId} | CounterStatus],
     {reply, {vnode_status, Index, VNodeStatus}, State};
 handle_command({reformat_object, BKey}, _Sender, State) ->
     {Reply, UpdState} = do_reformat(BKey, State),
@@ -1045,17 +1102,17 @@ maybe_calc_handoff_size(#state{mod=Mod,modstate=ModState}) ->
         false -> undefined
     end.
 
-delete(State=#state{idx=Index,mod=Mod, modstate=ModState}) ->
+delete(State=#state{status_mgr_pid=StatusMgr, mod=Mod, modstate=ModState}) ->
     %% clear vnodeid first, if drop removes data but fails
     %% want to err on the side of creating a new vnodeid
-    {ok, cleared} = clear_vnodeid(Index),
-    case Mod:drop(ModState) of
-        {ok, UpdModState} ->
-            ok;
-        {error, Reason, UpdModState} ->
-            lager:error("Failed to drop ~p. Reason: ~p~n", [Mod, Reason]),
-            ok
-    end,
+    {ok, cleared} = clear_vnodeid(StatusMgr),
+    UpdModState = case Mod:drop(ModState) of
+                      {ok, S} ->
+                          S;
+                      {error, Reason, S2} ->
+                          lager:error("Failed to drop ~p. Reason: ~p~n", [Mod, Reason]),
+                          S2
+                  end,
     case State#state.hashtrees of
         undefined ->
             ok;
@@ -1171,8 +1228,35 @@ handle_info({final_delete, BKey, RObjHash}, State = #state{mod=Mod, modstate=Mod
                    {{error, _}, ModState1} ->
                        State#state{modstate=ModState1}
                end,
-    {ok, UpdState}.
+    {ok, UpdState};
+handle_info({counter_lease, {FromPid, VnodeId, NewLease}}, State=#state{status_mgr_pid=FromPid, vnodeid=VnodeId}) ->
+    #state{counter=CounterState} = State,
+    CS1 = CounterState#counter_state{lease=NewLease, leasing=false},
+    State2 = State#state{counter=CS1},
+    {ok, State2};
+handle_info({counter_lease, {FromPid, NewVnodeId, NewLease}}, State=#state{status_mgr_pid=FromPid, idx=Idx}) ->
+    %% Lease rolled over MAX_INT (new vnodeid signifies this) so reset counter
+    #state{counter=CounterState} = State,
+    CS1 = CounterState#counter_state{lease=NewLease, leasing=false, cnt=1},
+    State2 = State#state{vnodeid=NewVnodeId, counter=CS1},
+    lager:info("New Vnode id for ~p. Epoch counter rolled over.", [Idx]),
+    {ok, State2}.
 
+handle_exit(Pid, Reason, State=#state{status_mgr_pid=Pid, idx=Index, counter=CntrState}) ->
+    lager:error("Vnode status manager exit ~p", [Reason]),
+    %% The status manager died, start a new one
+    #counter_state{lease_size=LeaseSize, leasing=Leasing, use=UseEpochCounter} = CntrState,
+    {ok, NewPid} = riak_kv_vnode_status_mgr:start_link(self(), Index, UseEpochCounter),
+
+    if Leasing ->
+            %% Crashed when getting a lease, try again pathalogical
+            %% bad case here is that the lease gets to disk and the
+            %% manager crashes, meaning an ever growing lease/new ids
+            ok = riak_kv_vnode_status_mgr:lease_counter(NewPid, LeaseSize);
+       ?ELSE ->
+            ok
+    end,
+    {noreply, State#state{status_mgr_pid=NewPid}};
 handle_exit(_Pid, Reason, State) ->
     %% A linked processes has died so the vnode
     %% process should take appropriate action here.
@@ -1211,18 +1295,18 @@ raw_put({Idx, Node}, Key, Obj) ->
 %% @private
 %% upon receipt of a client-initiated put
 do_put(Sender, {Bucket,_Key}=BKey, RObj, ReqID, StartTime, Options, State) ->
-    case proplists:get_value(bucket_props, Options) of
-        undefined ->
-            BProps = riak_core_bucket:get_bucket(Bucket);
-        BProps ->
-            BProps
-    end,
-    case proplists:get_value(rr, Options, false) of
-        true ->
-            PruneTime = undefined;
-        false ->
-            PruneTime = StartTime
-    end,
+    BProps =  case proplists:get_value(bucket_props, Options) of
+                  undefined ->
+                      riak_core_bucket:get_bucket(Bucket);
+                  Props ->
+                      Props
+              end,
+    PruneTime = case proplists:get_value(rr, Options, false) of
+                    true ->
+                        undefined;
+                    false ->
+                        StartTime
+                end,
     Coord = proplists:get_value(coord, Options, false),
     CRDTOp = proplists:get_value(counter_op, Options, proplists:get_value(crdt_op, Options, undefined)),
     PutArgs = #putargs{returnbody=proplists:get_value(returnbody,Options,false) orelse Coord,
@@ -1235,8 +1319,8 @@ do_put(Sender, {Bucket,_Key}=BKey, RObj, ReqID, StartTime, Options, State) ->
                        starttime=StartTime,
                        prunetime=PruneTime,
                        crdt_op = CRDTOp},
-    {PrepPutRes, UpdPutArgs} = prepare_put(State, PutArgs),
-    {Reply, UpdState} = perform_put(PrepPutRes, State, UpdPutArgs),
+    {PrepPutRes, UpdPutArgs, State2} = prepare_put(State, PutArgs),
+    {Reply, UpdState} = perform_put(PrepPutRes, State2, UpdPutArgs),
     riak_core_vnode:reply(Sender, Reply),
 
     update_index_write_stats(UpdPutArgs#putargs.is_index, UpdPutArgs#putargs.index_specs),
@@ -1287,19 +1371,21 @@ prepare_put(State=#state{vnodeid=VId,
             ObjToStore =
                 case Coord of
                     true ->
+                        %% Do we need to use epochs here? I guess we
+                        %% don't care, and since we don't read, we
+                        %% can't.
                         riak_object:increment_vclock(RObj, VId, StartTime);
                     false ->
                         RObj
                 end,
-            {{true, ObjToStore}, PutArgs#putargs{is_index = false}};
+            {{true, ObjToStore}, PutArgs#putargs{is_index = false}, State};
         false ->
             prepare_put(State, PutArgs, IndexBackend)
     end.
-prepare_put(#state{vnodeid=VId,
-                   mod=Mod,
-                   modstate=ModState,
-                   idx=Idx,
-                   md_cache=MDCache},
+prepare_put(State=#state{mod=Mod,
+                         modstate=ModState,
+                         idx=Idx,
+                         md_cache=MDCache},
             PutArgs=#putargs{bkey={Bucket, Key}=BKey,
                              robj=RObj,
                              bprops=BProps,
@@ -1316,12 +1402,12 @@ prepare_put(#state{vnodeid=VId,
             undefined ->
                 true;
             Clock ->
-                case vclock:descends(riak_object:vclock(RObj), Clock) of
-                    true ->
-                        false;
-                    _ ->
-                        true
-                end
+                %% We need to perform a local get, to merge contents,
+                %% if the local object has events unseen by the
+                %% incoming object. If the incoming object descends
+                %% the cache (i.e. has seen all its events) no need to
+                %% do a local get and merge, just overwrite.
+                not riak_object:vclock_descends(RObj, Clock)
         end,
     GetReply =
         case RequiresGet of
@@ -1345,20 +1431,22 @@ prepare_put(#state{vnodeid=VId,
                 false ->
                     IndexSpecs = []
             end,
-            case prepare_new_put(Coord, RObj, VId, StartTime, CRDTOp) of
+            %% local not found, start a per key epoch
+            {EpochId, State2} = new_key_epoch(State),
+            case prepare_new_put(Coord, RObj, EpochId, StartTime, CRDTOp) of
                 {error, E} ->
-                    {{fail, Idx, E}, PutArgs};
+                    {{fail, Idx, E}, PutArgs, State2};
                 ObjToStore ->
                     {{true, ObjToStore},
                      PutArgs#putargs{index_specs=IndexSpecs,
-                                     is_index=IndexBackend}}
+                                     is_index=IndexBackend}, State2}
             end;
         {ok, OldObj} ->
-            case put_merge(Coord, LWW, OldObj, RObj, VId, StartTime) of
+            {ActorId, State2} = maybe_new_key_epoch(Coord, State, OldObj, RObj),
+            case put_merge(Coord, LWW, OldObj, RObj, ActorId, StartTime) of
                 {oldobj, OldObj1} ->
-                    {{false, OldObj1}, PutArgs};
+                    {{false, OldObj1}, PutArgs, State2};
                 {newobj, NewObj} ->
-                    VC = riak_object:vclock(NewObj),
                     AMObj = enforce_allow_mult(NewObj, BProps),
                     IndexSpecs = case IndexBackend of
                                      true ->
@@ -1372,30 +1460,28 @@ prepare_put(#state{vnodeid=VId,
                                                  riak_object:diff_index_specs(AMObj,
                                                                               OldObj)
                                          end;
-                                    false ->
+                                     false ->
                                          []
-                    end,
+                                 end,
                     ObjToStore = case PruneTime of
                                      undefined ->
                                          AMObj;
                                      _ ->
-                                         riak_object:set_vclock(AMObj,
-                                                                vclock:prune(VC,
-                                                                             PruneTime,
-                                                                             BProps))
-                    end,
-                    case handle_crdt(Coord, CRDTOp, VId, ObjToStore) of
+                                         riak_object:prune_vclock(AMObj, PruneTime, BProps)
+                                 end,
+                    case handle_crdt(Coord, CRDTOp, ActorId, ObjToStore) of
                         {error, E} ->
-                            {{fail, Idx, E}, PutArgs};
+                            {{fail, Idx, E}, PutArgs, State2};
                         ObjToStore2 ->
                             {{true, ObjToStore2},
                              PutArgs#putargs{index_specs=IndexSpecs,
-                                             is_index=IndexBackend}}
+                                             is_index=IndexBackend}, State2}
                     end
             end
     end.
 
-%% @doc in the case that this a co-ordinating put, prepare the object.
+%% @Doc in the case that this a co-ordinating put, prepare the object.
+%% NOTE the `VId' is a new epoch actor for this object
 prepare_new_put(true, RObj, VId, StartTime, undefined) ->
     riak_object:increment_vclock(RObj, VId, StartTime);
 prepare_new_put(true, RObj, VId, StartTime, CRDTOp) ->
@@ -1405,6 +1491,8 @@ prepare_new_put(true, RObj, VId, StartTime, CRDTOp) ->
     %% Make a new crdt, stuff it in the riak_object
     do_crdt_update(VClockUp, VId, CRDTOp);
 prepare_new_put(false, RObj, _VId, _StartTime, _CounterOp) ->
+    %% @TODO Not coordindating, not found local, is there an entry for
+    %% us in the clock? If so, mark as dirty
     RObj.
 
 handle_crdt(_, undefined, _VId, RObj) ->
@@ -1521,11 +1609,19 @@ select_newest_content(Mult) ->
 
 %% @private
 put_merge(false, true, _CurObj, UpdObj, _VId, _StartTime) -> % coord=false, LWW=true
+    %% @TODO Do we need to mark the clock dirty here? I think so
+    %% @TODO Check the clock of the incoming object, if it is more advanced
+    %% for our actor than we are then something is amiss, and we need
+    %% to mark the actor as dirty for this key
     {newobj, UpdObj};
 put_merge(false, false, CurObj, UpdObj, _VId, _StartTime) -> % coord=false, LWW=false
     %% a downstream merge, or replication of a coordinated PUT
     %% Merge the value received with local replica value
     %% and store the value IFF it is different to what we already have
+    %%
+    %% @TODO Check the clock of the incoming object, if it is more advanced
+    %% for our actor than we are then something is amiss, and we need
+    %% to mark the actor as dirty for this key
     ResObj = riak_object:syntactic_merge(CurObj, UpdObj),
     case riak_object:equal(ResObj, CurObj) of
         true ->
@@ -1534,6 +1630,8 @@ put_merge(false, false, CurObj, UpdObj, _VId, _StartTime) -> % coord=false, LWW=
             {newobj, ResObj}
     end;
 put_merge(true, LWW, CurObj, UpdObj, VId, StartTime) ->
+    %% @TODO If the current object has a dirty clock, we need to start
+    %% a new per key epoch and mark clock as clean.
     {newobj, riak_object:update(LWW, CurObj, UpdObj, VId, StartTime)}.
 
 %% @private
@@ -1941,91 +2039,23 @@ max_hashtree_tokens() ->
                        anti_entropy_max_async,
                        ?DEFAULT_HASHTREE_TOKENS).
 
-%% @private
-%% Get the vnodeid, assigning and storing if necessary
-get_vnodeid(Index) ->
-    F = fun(Status) ->
-                case proplists:get_value(vnodeid, Status, undefined) of
-                    undefined ->
-                        %% using now as we want different values per
-                        %% vnode id on a node
-                        assign_vnodeid(erlang:now(),
-                                       riak_core_nodeid:get(),
-                                       Status);
-                    VnodeId ->
-                        {VnodeId, Status}
-                end
-        end,
-    update_vnode_status(F, Index). % Returns {ok, VnodeId} | {error, Reason}
-
-%% Assign a unique vnodeid, making sure the timestamp is unique by incrementing
-%% into the future if necessary.
-assign_vnodeid(Now, NodeId, Status) ->
-    {_Mega, Sec, Micro} = Now,
-    NowEpoch = 1000000*Sec + Micro,
-    LastVnodeEpoch = proplists:get_value(last_epoch, Status, 0),
-    VnodeEpoch = erlang:max(NowEpoch, LastVnodeEpoch+1),
-    VnodeId = <<NodeId/binary, VnodeEpoch:32/integer>>,
-    UpdStatus = [{vnodeid, VnodeId}, {last_epoch, VnodeEpoch} |
-                 proplists:delete(vnodeid,
-                                  proplists:delete(last_epoch, Status))],
-    {VnodeId, UpdStatus}.
+%% @private Get the vnodeid, assigning and storing if necessary.  Also
+%% get the current op counter, using the (new?) threshold to assign
+%% and store a new leased counter if needed. NOTE: this is different
+%% to the previous function, as it will now _always_ store a new
+%% status to disk as it will grab a new lease.
+%%
+%%  @TODO document the need for, and invariants of the counter
+-spec get_vnodeid_and_counter(pid(), non_neg_integer(), boolean()) ->
+                                     {ok, {vnodeid(), #counter_state{}}} |
+                                     {error, Reason::term()}.
+get_vnodeid_and_counter(StatusMgr, CounterLeaseSize, UseEpochCounter) ->
+    {ok, {VId, Counter, Lease}} = riak_kv_vnode_status_mgr:get_vnodeid_and_counter(StatusMgr, CounterLeaseSize),
+    {ok, {VId, #counter_state{cnt=Counter, lease=Lease, lease_size=CounterLeaseSize, use=UseEpochCounter}}}.
 
 %% Clear the vnodeid - returns {ok, cleared}
-clear_vnodeid(Index) ->
-    F = fun(Status) ->
-                {cleared, proplists:delete(vnodeid, Status)}
-        end,
-    update_vnode_status(F, Index). % Returns {ok, VnodeId} | {error, Reason}
-
-update_vnode_status(F, Index) ->
-    VnodeFile = vnode_status_filename(Index),
-    ok = filelib:ensure_dir(VnodeFile),
-    case read_vnode_status(VnodeFile) of
-        {ok, Status} ->
-            update_vnode_status2(F, Status, VnodeFile);
-        {error, enoent} ->
-            update_vnode_status2(F, [], VnodeFile);
-        ER ->
-            ER
-    end.
-
-update_vnode_status2(F, Status, VnodeFile) ->
-    case F(Status) of
-        {Ret, Status} -> % No change
-            {ok, Ret};
-        {Ret, UpdStatus} ->
-            case write_vnode_status(UpdStatus, VnodeFile) of
-                ok ->
-                    {ok, Ret};
-                ER ->
-                    ER
-            end
-    end.
-
-vnode_status_filename(Index) ->
-    P_DataDir = app_helper:get_env(riak_core, platform_data_dir),
-    VnodeStatusDir = app_helper:get_env(riak_kv, vnode_status,
-                                        filename:join(P_DataDir, "kv_vnode")),
-    filename:join(VnodeStatusDir, integer_to_list(Index)).
-
-read_vnode_status(File) ->
-    case file:consult(File) of
-        {ok, [Status]} when is_list(Status) ->
-            {ok, proplists:delete(version, Status)};
-        ER ->
-            ER
-    end.
-
-write_vnode_status(Status, File) ->
-    VersionedStatus = [{version, 1} | proplists:delete(version, Status)],
-    TmpFile = File ++ "~",
-    case file:write_file(TmpFile, io_lib:format("~p.", [VersionedStatus])) of
-        ok ->
-            file:rename(TmpFile, File);
-        ER ->
-            ER
-    end.
+clear_vnodeid(StatusMgr) ->
+    riak_kv_vnode_status_mgr:clear_vnodeid(StatusMgr).
 
 %% @private
 wait_for_vnode_status_results([], _ReqId, Acc) ->
@@ -2323,102 +2353,300 @@ new_md_cache(VId) ->
     %% term format is {TimeStamp, Key, ValueTuple}
     ets:new(MDCacheName, [ordered_set, {keypos,2}]).
 
+%% @private increment the per vnode coordinating put counter,
+%% flushing/leasing if needed
+-spec update_counter(state()) -> state().
+update_counter(State=#state{counter=CounterState}) ->
+    #counter_state{cnt=Counter0} = CounterState,
+    Counter = Counter0 +  1,
+    maybe_lease_counter(State#state{counter=CounterState#counter_state{cnt=Counter}}).
+
+
+%% @private we can never use a counter that is greater or equal to the
+%% one fsynced to disk. If the incremented counter is == to the
+%% current Lease, we must block until the new Lease is stored. If the
+%% current counter is 80% through the current lease, and we have not
+%% asked for a new lease, ask for one.  If we're less than 80% through
+%% the lease, do nothing.  If not yet blocking(equal) and we already
+%% asked for a new lease, do nothing.
+maybe_lease_counter(#state{vnodeid=VId, counter=#counter_state{cnt=Cnt, lease=Lease}})
+  when Cnt > Lease ->
+    %% Holy broken invariant. Log and crash.
+    lager:error("Broken invariant, epoch counter ~p greater than lease ~p for vnode ~p. Crashing.",
+                [Cnt, Lease, VId]),
+    exit(epoch_counter_invariant_broken);
+maybe_lease_counter(State=#state{counter=#counter_state{cnt=Lease, lease=Lease,
+                                                        leasing=true}}) ->
+    %% Block until we get a new lease, or crash the vnode
+    {ok, NewState} = blocking_lease_counter(State),
+    NewState;
+maybe_lease_counter(State=#state{counter=#counter_state{leasing=true}}) ->
+    %% not yet at the blocking stage, waiting on a lease
+    State;
+maybe_lease_counter(State) ->
+    #state{status_mgr_pid=MgrPid, counter=CS=#counter_state{cnt=Cnt, lease=Lease,
+                                                            lease_size=LeaseSize}} = State,
+    %% @TODO (rdb) configurable??
+    %% has more than 80% of the lease been used?
+    CS2 = if (Lease - Cnt) =< 0.2 * LeaseSize  ->
+                  ok = riak_kv_vnode_status_mgr:lease_counter(MgrPid, LeaseSize),
+                  CS#counter_state{leasing=true};
+             ?ELSE ->
+                  CS
+          end,
+    State#state{counter=CS2}.
+
+%% @private by now, we have to be waiting for a lease, or an exit,
+%% from the mgr. Block until we receive a lease. If we get an exit,
+%% retry a number of times. If we get neither in a reasonable time,
+%% return an error.
+-spec blocking_lease_counter(#state{}) ->
+                                    {ok, #state{}} |
+                                    counter_lease_error().
+blocking_lease_counter(State) ->
+    {MaxErrs, MaxTime} = get_counter_wait_values(),
+    blocking_lease_counter(State, {0, MaxErrs, MaxTime}).
+
+-spec blocking_lease_counter(#state{}, {Errors :: non_neg_integer(),
+                                        MaxErrors :: non_neg_integer(),
+                                        TimeRemainingMillis :: non_neg_integer()}
+                            ) ->
+                                    {ok, #state{}} |
+                                    counter_lease_error().
+blocking_lease_counter(_State, {MaxErrs, MaxErrs, _MaxTime}) ->
+    {error, counter_lease_max_errors};
+blocking_lease_counter(State, {ErrCnt, MaxErrors, MaxTime}) ->
+    #state{idx=Index, vnodeid=VId, status_mgr_pid=Pid, counter=CounterState} = State,
+    #counter_state{lease_size=LeaseSize, use=UseEpochCounter} = CounterState,
+    Start = os:timestamp(),
+    receive
+        {'EXIT', Pid, Reason} ->
+            lager:error("Failed to lease counter for ~p : ~p", [Index, Reason]),
+            {ok, NewPid} = riak_kv_vnode_status_mgr:start_link(self(), Index, UseEpochCounter),
+            ok = riak_kv_vnode_status_mgr:lease_counter(NewPid, LeaseSize),
+            NewState = State#state{status_mgr_pid=NewPid},
+            Elapsed = timer:now_diff(os:timestamp(), Start),
+            blocking_lease_counter(NewState, {ErrCnt+1, MaxErrors, MaxTime - Elapsed});
+        {counter_lease, {Pid, VId, NewLease}} ->
+            NewCS = CounterState#counter_state{lease=NewLease, leasing=false},
+            {ok, State#state{counter=NewCS}};
+        {counter_lease, {Pid, NewVId, NewLease}} ->
+            lager:info("New Vnode id for ~p. Epoch counter rolled over.", [Index]),
+            NewCS = CounterState#counter_state{lease=NewLease, leasing=false, cnt=1},
+            {ok, State#state{vnodeid=NewVId, counter=NewCS}}
+    after
+        MaxTime ->
+            {error, counter_lease_timeout}
+    end.
+
+%% @private get the configured values for blocking waiting on
+%% lease/ID. Ensure that non invalid values come in.
+-spec get_counter_wait_values() ->
+                                     {MaxErrors :: non_neg_integer(),
+                                      MaxTime :: non_neg_integer()}.
+get_counter_wait_values() ->
+    MaxErrors = non_neg_env(riak_kv, counter_lease_errors, ?DEFAULT_CNTR_LEASE_ERRS),
+    MaxTime = non_neg_env(riak_kv, counter_lease_timeout, ?DEFAULT_CNTR_LEASE_TO),
+    {MaxErrors, MaxTime}.
+
+%% @private we don't want to crash riak because of a dodgy config
+%% value, and by this point, cuttlefish be praised, we should have
+%% sane values. However, if not, ignore negative values for timeout
+%% and max errors, use the defaults, and log the insanity. Note this
+%% expects the macro configured defaults to be positive integers!
+-spec non_neg_env(atom(), atom(), pos_integer()) -> pos_integer().
+non_neg_env(App, EnvVar, Default) when is_integer(Default),
+                                       Default > 0 ->
+    case app_helper:get_env(App, EnvVar, Default) of
+        N when is_integer(N),
+               N > 0 ->
+            N;
+        X ->
+            lager:warning("Non-integer/Negative integer ~p for vnode counter config ~p."
+                          " Using default ~p",
+                          [X, EnvVar, Default]),
+            Default
+    end.
+
+%% @private to keep put_merge/6 side effect free (as it is exported
+%% for testing) introspect the state and local/incoming objects and
+%% return the actor ID for a put, and possibly updated state. NOTE
+%% side effects, in that the vnode status on disk can change.
+%% Why might we need a new key epoch?
+%% 1. local not found (handled in prepare_put/3
+%% 2. local found, but never acted on this key before (or don't remember it!)
+%% 3. local found, local acted, but incoming has greater count or actor epoch
+%%    This one is tricky, since it indicates some byzantine failure somewhere.
+-spec maybe_new_key_epoch(boolean(), #state{},
+                          riak_object:riak_object(),
+                          riak_object:riak_object()) ->
+                                 {binary(), #state{}}.
+maybe_new_key_epoch(false, State, _, _) ->
+    %% Never add a new key epoch when not coordinating
+    %% @TODO (rdb) need to mark actor as dirty though.
+    {State#state.vnodeid, State};
+maybe_new_key_epoch(true, State=#state{counter=#counter_state{use=false}, vnodeid=VId}, _, _) ->
+    %% Per-Key-Epochs is off, use the base vnodeid
+    {VId, State};
+maybe_new_key_epoch(true, State, LocalObj, IncomingObj) ->
+    #state{vnodeid=VId} = State,
+    %% @TODO (rdb) maybe optimise since highly likey both objects
+    %% share the majority of actors, maybe a single umerged list of
+    %% actors, somehow tagged by local | incoming?
+    case highest_actor(VId, LocalObj) of
+        {undefined, 0, 0} -> %% Not present locally
+            %% Never acted on this object before, new epoch.
+            new_key_epoch(State);
+        {LocalId, LocalEpoch, LocalCntr} -> %% Present locally
+            case highest_actor(VId, IncomingObj) of
+                {_InId, InEpoch, InCntr} when InEpoch > LocalEpoch;
+                                              InCntr > LocalCntr ->
+                    %% In coming actor-epoch or counter greater than
+                    %% local, some byzantine failure, new epoch.
+                    B = riak_object:bucket(LocalObj),
+                    K = riak_object:key(LocalObj),
+
+                    lager:error("Inbound clock entry for ~p in ~p/~p greater than local",
+                               [VId, B, K]),
+                    new_key_epoch(State);
+                _ ->
+                    %% just use local id
+                    %% Return the highest local epoch ID for this
+                    %% key. This may be the pre-epoch ID (i.e. no
+                    %% epoch), which is good, no reason to force a new
+                    %% epoch on all old keys.
+                    {LocalId, State}
+            end
+    end.
+
+%% @private generate an epoch actor, and update the vnode state.
+-spec new_key_epoch(#state{}) -> {EpochActor :: binary(), #state{}}.
+new_key_epoch(State=#state{vnodeid=VId, counter=#counter_state{use=false}}) ->
+    {VId, State};
+new_key_epoch(State) ->
+    NewState=#state{counter=#counter_state{cnt=Cntr}, vnodeid=VId} = update_counter(State),
+    EpochId = key_epoch_actor(VId, Cntr),
+    {EpochId, NewState}.
+
+%% @private generate a new epoch ID for a key
+-spec key_epoch_actor(vnodeid(), pos_integer()) -> binary().
+key_epoch_actor(ActorBin, Cntr) ->
+    <<ActorBin/binary, Cntr:32/integer>>.
+
+%% @private highest actor is the latest/greatest epoch actor for a
+%% key. It is the actor we want to increment for the current event,
+%% given that we are not starting a new epoch for the key.  Must work
+%% with non-epochal and epochal actors.  The return tuple is
+%% `{ActorId, Epoch, Counter}' where `ActorId' is the highest ID
+%% starting with `ActorBase' that has acted on this key, undefined if
+%% never acted before. `KeyEpoch' is the highest epoch for the
+%% `ActorBase'. `Counter' is the greatest event seen by the `VnodeId'.
+-spec highest_actor(binary(), riak_object:riak_object()) ->
+    {ActorId :: binary() | undefined,
+     KeyEpoch :: non_neg_integer(),
+     Counter :: non_neg_integer()}.
+highest_actor(ActorBase, Obj) ->
+    ActorSize = size(ActorBase),
+    Actors = riak_object:all_actors(Obj),
+
+    {Actor, Epoch} = lists:foldl(fun(Actor, {HighestActor, HighestEpoch}) ->
+                                         case Actor of
+                                             <<ActorBase:ActorSize/binary, Epoch:32/integer>>
+                                               when Epoch > HighestEpoch ->
+                                                 {Actor, Epoch};
+                                             %% Since an actor without
+                                             %% an epoch is lower than
+                                             %% an actor with one,
+                                             %% this means in the
+                                             %% unmatched case, `undefined'
+                                             %% through as the highest
+                                             %% actor, and the epoch
+                                             %% (of zero) passes
+                                             %% through too.
+                                             _ ->  {HighestActor, HighestEpoch}
+                                         end
+                                 end,
+                                 {undefined, 0},
+                                 Actors),
+    %% get the greatest event for the highest/latest actor
+    {Actor, Epoch, riak_object:actor_counter(Actor, Obj)}.
+
 -ifdef(TEST).
 
-%% Check assigning a vnodeid twice in the same second
-assign_vnodeid_restart_same_ts_test() ->
-    Now1 = {1314,224520,343446}, %% TS=(224520 * 100000) + 343446
-    Now2 = {1314,224520,343446}, %% as unsigned net-order int <<70,116,143,150>>
-    NodeId = <<1, 2, 3, 4>>,
-    {Vid1, Status1} = assign_vnodeid(Now1, NodeId, []),
-    ?assertEqual(<<1, 2, 3, 4, 70, 116, 143, 150>>, Vid1),
-    %% Simulate clear
-    Status2 = proplists:delete(vnodeid, Status1),
-    %% Reassign
-    {Vid2, _Status3} = assign_vnodeid(Now2, NodeId, Status2),
-    ?assertEqual(<<1, 2, 3, 4, 70, 116, 143, 151>>, Vid2).
+-define(MGR, riak_kv_vnode_status_mgr).
+-define(MAX_INT, 4294967295).
 
-%% Check assigning a vnodeid with a later date, but less than 11.57
-%% days later!
-assign_vnodeid_restart_later_ts_test() ->
-    Now1 = {1000,224520,343446}, %% <<70,116,143,150>>
-    Now2 = {1000,224520,343546}, %% <<70,116,143,250>>
-    NodeId = <<1, 2, 3, 4>>,
-    {Vid1, Status1} = assign_vnodeid(Now1, NodeId, []),
-    ?assertEqual(<<1, 2, 3, 4, 70,116,143,150>>, Vid1),
-    %% Simulate clear
-    Status2 = proplists:delete(vnodeid, Status1),
-    %% Reassign
-    {Vid2, _Status3} = assign_vnodeid(Now2, NodeId, Status2),
-    ?assertEqual(<<1, 2, 3, 4, 70,116,143,250>>, Vid2).
+%% @private test the vnode and vnode mgr interaction NOTE: sets up and
+%% tearsdown inside the test, the mgr needs the pid of the test
+%% process to send messages. @TODO(rdb) find a better way
+blocking_test_() ->
+    {setup, fun() -> (catch file:delete("undefined/kv_vnode/0")) end,
+     fun(_) -> file:delete("undefined/kv_vnode/0") end,
+     {spawn, [{"Blocking",
+               fun() ->
+                       {ok, Pid} = ?MGR:start_link(self(), 0, true),
+                       {ok, {VId, CounterState}} = get_vnodeid_and_counter(Pid, 100, true),
+                       #counter_state{cnt=Cnt, lease=Leased, lease_size=LS, leasing=L} = CounterState,
+                       ?assertEqual(0, Cnt),
+                       ?assertEqual(100, Leased),
+                       ?assertEqual(100, LS),
+                       ?assertEqual(false, L),
+                       State = #state{vnodeid=VId, status_mgr_pid=Pid, counter=CounterState},
+                       S2=#state{counter=#counter_state{leasing=L2, cnt=C2}} = update_counter(State),
+                       ?assertEqual(false, L2),
+                       ?assertEqual(1, C2),
+                       S3 = lists:foldl(fun(_, S) ->
+                                                update_counter(S)
+                                        end,
+                                        S2,
+                                        lists:seq(1, 98)),
+                       #state{counter=#counter_state{leasing=L3, cnt=C3}} = S3,
+                       ?assertEqual(true, L3),
+                       ?assertEqual(99, C3),
+                       S4 = update_counter(S3),
+                       #state{counter=#counter_state{lease=Leased2, leasing=L4, cnt=C4}} = S4,
+                       ?assertEqual(false, L4),
+                       ?assertEqual(100, C4),
+                       ?assertEqual(200, Leased2),
+                       {ok, cleared} = ?MGR:clear_vnodeid(Pid),
+                       ok = ?MGR:stop(Pid)
+               end}
+             ]
+     }
+    }.
 
-%% Check assigning a vnodeid with a earlier date - just in case of clock skew
-assign_vnodeid_restart_earlier_ts_test() ->
-    Now1 = {1000,224520,343546}, %% <<70,116,143,150>>
-    Now2 = {1000,224520,343446}, %% <<70,116,143,250>>
-    NodeId = <<1, 2, 3, 4>>,
-    {Vid1, Status1} = assign_vnodeid(Now1, NodeId, []),
-    ?assertEqual(<<1, 2, 3, 4, 70,116,143,250>>, Vid1),
-    %% Simulate clear
-    Status2 = proplists:delete(vnodeid, Status1),
-    %% Reassign
-    %% Should be greater than last offered - which is the 2mil timestamp
-    {Vid2, _Status3} = assign_vnodeid(Now2, NodeId, Status2),
-    ?assertEqual(<<1, 2, 3, 4, 70,116,143,251>>, Vid2).
-
-%% Test
-vnode_status_test_() ->
-    {setup,
-     fun() ->
-             filelib:ensure_dir("kv_vnode_status_test/.test"),
-             ?cmd("chmod u+rwx kv_vnode_status_test"),
-             ?cmd("rm -rf kv_vnode_status_test"),
-             application:set_env(riak_kv, vnode_status, "kv_vnode_status_test"),
-             ok
-     end,
+%% @private tests that the counter rolls over to 1 when a new vnode id
+%% is assigned
+rollover_test_() ->
+    {setup, fun() -> (catch file:delete("undefined/kv_vnode/0")) end,
      fun(_) ->
-             application:unset_env(riak_kv, vnode_status),
-             ?cmd("chmod u+rwx kv_vnode_status_test"),
-             ?cmd("rm -rf kv_vnode_status_test"),
-             ok
-     end,
-     [?_test(begin % initial create failure
-                 ?cmd("rm -rf kv_vnode_status_test || true"),
-                 ?cmd("mkdir kv_vnode_status_test"),
-                 ?cmd("chmod -w kv_vnode_status_test"),
-                 F = fun([]) ->
-                             {shouldfail, [badperm]}
-                     end,
-                 Index = 0,
-                 ?assertEqual({error, eacces},  update_vnode_status(F, Index))
-             end),
-      ?_test(begin % create successfully
-                 ?cmd("chmod +w kv_vnode_status_test"),
+             file:delete("undefined/kv_vnode/0") end,
+     {spawn, [{"Rollover",
+               fun() ->
+                       {ok, Pid} = ?MGR:start_link(self(), 0, true),
+                       {ok, {VId, CounterState}} = get_vnodeid_and_counter(Pid, ?MAX_INT, true),
+                       #counter_state{cnt=Cnt, lease=Leased, lease_size=LS, leasing=L} = CounterState,
+                       ?assertEqual(0, Cnt),
+                       ?assertEqual((?MAX_INT), Leased),
+                       ?assertEqual((?MAX_INT), LS),
+                       ?assertEqual(false, L),
+                       %% fiddle the counter to the max int size-2
+                       State = #state{vnodeid=VId, status_mgr_pid=Pid, counter=CounterState#counter_state{cnt=(?MAX_INT-2)}},
+                       S2=#state{counter=#counter_state{leasing=L2, cnt=C2}} = update_counter(State),
+                       ?assertEqual(true, L2),
+                       ?assertEqual((?MAX_INT-1), C2),
+                       %% Vnode ID should roll over, and counter reset
+                       #state{vnodeid=VId2, counter=#counter_state{leasing=L3, cnt=C3}} = update_counter(S2),
 
-                 F = fun([]) ->
-                             {created, [created]}
-                     end,
-                 Index = 0,
-                 ?assertEqual({ok, created}, update_vnode_status(F, Index))
-             end),
-      ?_test(begin % update successfully
-                 F = fun([created]) ->
-                             {updated, [updated]}
-                     end,
-                 Index = 0,
-                 ?assertEqual({ok, updated}, update_vnode_status(F, Index))
-             end),
-      ?_test(begin % update failure
-                 ?cmd("chmod 000 kv_vnode_status_test/0"),
-                 ?cmd("chmod 500 kv_vnode_status_test"),
-                 F = fun([updated]) ->
-                             {shouldfail, [updatedagain]}
-                     end,
-                 Index = 0,
-                 ?assertEqual({error, eacces},  update_vnode_status(F, Index))
-             end)
+                       ?assert(VId /= VId2),
+                       ?assertEqual(false, L3),
+                       ?assertEqual(1, C3),
 
-     ]}.
+                       {ok, cleared} = ?MGR:clear_vnodeid(Pid),
+                       ok = ?MGR:stop(Pid)
+               end}
+             ]}
+    }.
 
 dummy_backend(BackendMod) ->
     Ring = riak_core_ring:fresh(16,node()),

--- a/src/riak_kv_vnode_status_mgr.erl
+++ b/src/riak_kv_vnode_status_mgr.erl
@@ -1,0 +1,451 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_vnode_status_mgr: Manages persistence of vnode status data
+%% like vnodeid, vnode op counter etc
+%%
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_kv_vnode_status_mgr).
+
+-behaviour(gen_server).
+
+-ifdef(TEST).
+-ifdef(EQC).
+-include_lib("eqc/include/eqc.hrl").
+-endif.
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+%% API
+-export([start_link/3, get_vnodeid_and_counter/2, lease_counter/2, clear_vnodeid/1, status/1, stop/1]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(SERVER, ?MODULE).
+%% only 32 bits per counter, when you hit that, get a new vnode id
+-define(MAX_CNTR, 4294967295).
+%% version 2 includes epoch counter, version 1 does not
+-define(VNODE_STATUS_VERSION, 2).
+
+-record(state, {
+          %% vnode status directory
+          status_file :: undefined | file:filename(),
+          %% vnode index
+          index :: undefined | non_neg_integer(),
+          %% The vnode pid this mgr belongs to
+          vnode_pid :: undefined | pid(),
+          %% killswitch for counter
+          version = ?VNODE_STATUS_VERSION :: 1 | 2
+         }).
+
+-type status() :: orddict:orddict().
+-type init_args() :: {VnodePid :: pid(),
+                      LeaseSize :: non_neg_integer(),
+                      UseEpochCounter :: boolean()}.
+-type blocking_req() :: clear | {vnodeid, LeaseSize :: non_neg_integer()}.
+
+
+
+%% longer than the call default of 5 seconds, shorter than infinity.
+%% 20 seconds
+-define(FLUSH_TIMEOUT_MILLIS, 20000).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the server
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec start_link(pid(), non_neg_integer(), boolean()) -> {ok, pid()} | {error, term()}.
+start_link(VnodePid, Index, UseEpochCounter) ->
+    gen_server:start_link(?MODULE, {VnodePid, Index, UseEpochCounter}, []).
+
+%%--------------------------------------------------------------------
+%% @doc You can't ever have a `LeaseSize' greater than the maximum 32
+%% bit unsigned integer, since that would involve breaking the
+%% invariant of an vnodeid+cntr pair being used more than once to
+%% start a key epoch, the counter is encoded in a 32 bit binary, and
+%% going over 4billion+etc would wrap around and re-use integers.
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec get_vnodeid_and_counter(pid(), non_neg_integer()) ->
+                                     {ok, {VnodeId :: binary(),
+                                           Counter :: non_neg_integer(),
+                                           LeaseSize :: non_neg_integer()}}.
+get_vnodeid_and_counter(Pid, LeaseSize) when is_integer(LeaseSize),
+                                             LeaseSize > 0 ->
+    gen_server:call(Pid, {vnodeid, LeaseSize}, ?FLUSH_TIMEOUT_MILLIS).
+
+%%--------------------------------------------------------------------
+%% @doc Asynchronously lease increments for a counter. `Pid' is the
+%% server pid, and `LeaseSize' is the number of increments to lease. A
+%% `LeaseSize' of 10,000 means that a vnode can handle 10,000 new key
+%% epochs before asking for a new counter. The trade-off here is
+%% between the frequency of flushing and the speed with which a
+%% frequently crashing vnode burns through the 32bit integer space,
+%% thus requiring a new vnodeid. The calling vnode should handle the
+%% response message of `{counter_lease, {From :: pid(), VnodeId ::
+%% binary(), NewLease :: non_neg_integer()}}'
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec lease_counter(pid(), non_neg_integer()) -> ok.
+lease_counter(Pid, LeaseSize) when is_integer(LeaseSize),
+                                   LeaseSize > 0  ->
+    gen_server:cast(Pid, {lease, LeaseSize}).
+
+%%--------------------------------------------------------------------
+%% @doc Blocking call to remove the vnode id and counter and from
+%% disk. Used when a vnode has finished and will not act again.
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec clear_vnodeid(pid()) -> {ok, cleared}.
+clear_vnodeid(Pid) ->
+    gen_server:call(Pid, clear, ?FLUSH_TIMEOUT_MILLIS).
+
+status(Pid) ->
+    gen_server:call(Pid, status).
+
+stop(Pid) ->
+    gen_server:call(Pid, stop).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private @doc Initializes the server, Init Args must be `{VnodePid
+%% :: pid(), Index :: non_neg_integer(), UseEpochCounter ::
+%% boolean()}' where the first element is the pid of the vnode this
+%% manager works for, and the second is the vnode's index/partition
+%% number (used for locating the status file.) The third is a kill
+%% switch for the counter.
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec init(Args :: init_args()) -> {ok, #state{}}.
+init({VnodePid, Index, UseEpochCounter}) ->
+    Version = version(UseEpochCounter),
+    StatusFilename = vnode_status_filename(Index),
+    {ok, #state{status_file=StatusFilename,
+                index=Index,
+                vnode_pid=VnodePid,
+                version=Version
+               }
+    }.
+
+%% @private determine if we use a per epcoch counter/lease scheme or
+%% not
+-spec version(boolean()) -> 1 | 2.
+version(_UseEpochCounter=true) ->
+    ?VNODE_STATUS_VERSION;
+version(_UseEpochCounter=false) ->
+    1.
+
+%%--------------------------------------------------------------------
+%% @private handle calls
+%%--------------------------------------------------------------------
+-spec handle_call(blocking_req(), {pid(), term()}, #state{}) ->
+                         {reply, {ok, {VnodeId :: binary(),
+                                       Counter :: non_neg_integer(),
+                                       LeaseTo :: non_neg_integer()}},
+                          #state{}}.
+handle_call({vnodeid, LeaseSize}, _From, State) ->
+    #state{status_file=File, version=Version} = State,
+    {ok, Status} = read_vnode_status(File),
+    %% Note: this is subtle change to this function, now it will
+    %% _always_ trigger a store of the new status, since the lease
+    %% will always be moving upwards. A vnode that starts, and
+    %% crashes, and starts, and crashes over and over will burn
+    %% through a lot of counter (or vnode ids (if the leases are very
+    %% large.))
+    {Counter, LeaseTo, VnodeId, Status2} = get_counter_lease(LeaseSize, Status, Version),
+    ok = write_vnode_status(Status2, File, Version),
+    Res = {ok, {VnodeId, Counter, LeaseTo}},
+    {reply, Res, State};
+handle_call(clear, _From, State) ->
+    #state{status_file=File, version=Version} = State,
+    {ok, Status} = read_vnode_status(File),
+    Status2 = orddict:erase(counter, orddict:erase(vnodeid, Status)),
+    ok = write_vnode_status(Status2, File, Version),
+    {reply, {ok, cleared}, State};
+handle_call(status, _From, State) ->
+    #state{status_file=File} = State,
+    {ok, Status} = read_vnode_status(File),
+    {reply, {ok, Status}, State};
+handle_call(stop, _From, State) ->
+    {stop, normal, ok, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%%--------------------------------------------------------------------
+
+-spec handle_cast({lease, non_neg_integer()}, #state{}) ->
+                         {noreply, #state{}}.
+handle_cast({lease, LeaseSize}, State) ->
+    #state{status_file=File, vnode_pid=Pid} = State,
+    {ok, Status} = read_vnode_status(File),
+    {_Counter, LeaseTo, VnodeId, UpdStatus} = get_counter_lease(LeaseSize, Status, ?VNODE_STATUS_VERSION),
+    ok = write_vnode_status(UpdStatus, File, ?VNODE_STATUS_VERSION),
+    Pid ! {counter_lease, {self(), VnodeId, LeaseTo}},
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+%% @private monotonically advance the counter lease. Guarded at
+%% interface to server.
+-spec get_counter_lease(non_neg_integer(), status(), Version :: 1 | 2) ->
+                               {PreviousLease :: non_neg_integer(),
+                                NewLease :: non_neg_integer(),
+                                VnodeId :: binary(),
+                                Status :: status()}.
+get_counter_lease(_LeaseSize, Status, 1) ->
+    case get_status_item(vnodeid, Status, undefined) of
+        undefined ->
+            {VnodeId, Status2} = assign_vnodeid(erlang:now(),
+                                                riak_core_nodeid:get(),
+                                                Status),
+            {0, 0, VnodeId, Status2};
+        ID ->
+            {0, 0, ID, Status}
+    end;
+get_counter_lease(LeaseSize0, Status, ?VNODE_STATUS_VERSION) ->
+    PrevLease = get_status_item(counter, Status, undefined),
+    VnodeId0 = get_status_item(vnodeid, Status, undefined),
+    Version = get_status_item(version, Status, 1),
+
+    %% A lease of ?MAX_CNTR essentially means a new vnodeid every time
+    %% you start the vnode. This caps the lease size (silently.)
+    LeaseSize = min(LeaseSize0, ?MAX_CNTR),
+
+    case {Version, PrevLease, VnodeId0} of
+        {_, _, undefined} ->
+            new_id_and_counter(Status, LeaseSize);
+        {1, undefined, ID} ->
+            %% Upgrade, no counter existed, don't force a new vnodeid
+            %% Is there still some edge here, with UP->DOWN->UP grade?
+            %% We think not. Downgrade would keep the same vnode file,
+            %% and the pre-epochal vnodeid would be used. Upgrade
+            %% again picks up the same counter. Or, if the file is
+            %% re-written while downgraded, it can only be for a new
+            %% ID, so still safe.
+            {0, LeaseSize, ID, orddict:store(counter, LeaseSize, Status)};
+        {?VNODE_STATUS_VERSION, undefined, _ID} ->
+            %% Lost counter? Wha? New ID
+            new_id_and_counter(Status, LeaseSize);
+        {?VNODE_STATUS_VERSION, Leased, _ID} when Leased + LeaseSize > ?MAX_CNTR ->
+            %% Since `LeaseSize' must be > 0, there is no edge here
+            %% where last lease size was ?MAX_CNTR and new lease size
+            %% is 0.
+            new_id_and_counter(Status, LeaseSize);
+        {?VNODE_STATUS_VERSION, Leased, ID} ->
+            NewLease = Leased + LeaseSize,
+            {PrevLease, NewLease, ID, orddict:store(counter, NewLease, Status)}
+    end.
+
+%% @private generate a new ID and assign a new counter, and lease up
+%% to `LeaseSize'.
+-spec new_id_and_counter(status(), non_neg_integer()) ->
+                                {non_neg_integer(), non_neg_integer(), binary(), status()}.
+new_id_and_counter(Status, LeaseSize) ->
+    {VnodeId, Status2} = assign_vnodeid(erlang:now(),
+                                        riak_core_nodeid:get(),
+                                        Status),
+    {0, LeaseSize, VnodeId, orddict:store(counter, LeaseSize, Status2)}.
+
+
+%% @private Provide a `proplists:get_value/3' like function for status
+%% orddict.
+-spec get_status_item(term(), status(), term()) -> term().
+get_status_item(Item, Status, Default) ->
+    case orddict:find(Item, Status) of
+        {ok, Val} ->
+            Val;
+        error ->
+            Default
+    end.
+
+%% @private generate a file name for the vnode status, and ensure the
+%% path to exists.
+-spec vnode_status_filename(non_neg_integer()) -> file:filename().
+vnode_status_filename(Index) ->
+    P_DataDir = app_helper:get_env(riak_core, platform_data_dir),
+    VnodeStatusDir = app_helper:get_env(riak_kv, vnode_status,
+                                        filename:join(P_DataDir, "kv_vnode")),
+    Filename = filename:join(VnodeStatusDir, integer_to_list(Index)),
+    ok = filelib:ensure_dir(Filename),
+    Filename.
+
+%% @private Assign a unique vnodeid, making sure the timestamp is
+%% unique by incrementing into the future if necessary.
+-spec assign_vnodeid(erlang:timestamp(), binary(), status()) ->
+                            {binary(), status()}.
+assign_vnodeid(Now, NodeId, Status) ->
+    {_Mega, Sec, Micro} = Now,
+    NowEpoch = 1000000*Sec + Micro,
+    LastVnodeEpoch = get_status_item(last_epoch, Status, 0),
+    VnodeEpoch = erlang:max(NowEpoch, LastVnodeEpoch+1),
+    VnodeId = <<NodeId/binary, VnodeEpoch:32/integer>>,
+    UpdStatus = orddict:store(vnodeid, VnodeId,
+                              orddict:store(last_epoch, VnodeEpoch, Status)),
+    {VnodeId, UpdStatus}.
+
+%% @private read the vnode status from `File'. Returns `{ok,
+%% status()}' or `{error, Reason}'. If the file does not exist, an
+%% empty status is returned.
+-spec read_vnode_status(file:filename()) -> {ok, status()} |
+                                       {error, term()}.
+read_vnode_status(File) ->
+    case file:consult(File) of
+        {ok, [Status]} when is_list(Status) ->
+            {ok, orddict:from_list(Status)};
+        {error, enoent} ->
+            %% doesn't exist? same as empty
+            {ok, orddict:new()};
+        Er ->
+            Er
+    end.
+
+-ifdef(TEST).
+%% @private don't make testers suffer through the fsync time
+-spec write_vnode_status(status(), file:filename(), Version :: 1 | 2) -> ok.
+write_vnode_status(Status, File, Version) ->
+    VersionedStatus = orddict:store(version, Version, Status),
+    ok = file:write_file(File, io_lib:format("~p.", [orddict:to_list(VersionedStatus)])).
+-else.
+%% @private write the vnode status. This is why the file is guarded by
+%% the process. This file should have no concurrent access, and MUST
+%% not be written at any other place/time in the system.
+-spec write_vnode_status(status(), file:filename(), Version :: 1 | 2) -> ok.
+write_vnode_status(Status, File, Version) ->
+    VersionedStatus = orddict:store(version, Version, Status),
+    ok = riak_core_util:replace_file(File, io_lib:format("~p.", [orddict:to_list(VersionedStatus)])).
+-endif.
+
+-ifdef(TEST).
+
+%% Check assigning a vnodeid twice in the same second
+assign_vnodeid_restart_same_ts_test() ->
+    Now1 = {1314,224520,343446}, %% TS=(224520 * 100000) + 343446
+    Now2 = {1314,224520,343446}, %% as unsigned net-order int <<70,116,143,150>>
+    NodeId = <<1, 2, 3, 4>>,
+    {Vid1, Status1} = assign_vnodeid(Now1, NodeId, []),
+    ?assertEqual(<<1, 2, 3, 4, 70, 116, 143, 150>>, Vid1),
+    %% Simulate clear
+    Status2 = orddict:erase(vnodeid, Status1),
+    %% Reassign
+    {Vid2, _Status3} = assign_vnodeid(Now2, NodeId, Status2),
+    ?assertEqual(<<1, 2, 3, 4, 70, 116, 143, 151>>, Vid2).
+
+%% Check assigning a vnodeid with a later date, but less than 11.57
+%% days later!
+assign_vnodeid_restart_later_ts_test() ->
+    Now1 = {1000,224520,343446}, %% <<70,116,143,150>>
+    Now2 = {1000,224520,343546}, %% <<70,116,143,250>>
+    NodeId = <<1, 2, 3, 4>>,
+    {Vid1, Status1} = assign_vnodeid(Now1, NodeId, []),
+    ?assertEqual(<<1, 2, 3, 4, 70,116,143,150>>, Vid1),
+    %% Simulate clear
+    Status2 = orddict:erase(vnodeid, Status1),
+    %% Reassign
+    {Vid2, _Status3} = assign_vnodeid(Now2, NodeId, Status2),
+    ?assertEqual(<<1, 2, 3, 4, 70,116,143,250>>, Vid2).
+
+%% Check assigning a vnodeid with a earlier date - just in case of clock skew
+assign_vnodeid_restart_earlier_ts_test() ->
+    Now1 = {1000,224520,343546}, %% <<70,116,143,250>>
+    Now2 = {1000,224520,343446}, %% <<70,116,143,150>>
+    NodeId = <<1, 2, 3, 4>>,
+    {Vid1, Status1} = assign_vnodeid(Now1, NodeId, []),
+    ?assertEqual(<<1, 2, 3, 4, 70,116,143,250>>, Vid1),
+    %% Simulate clear
+    Status2 = orddict:erase(vnodeid, Status1),
+    %% Reassign
+    %% Should be greater than last offered - which is the 2mil timestamp
+    {Vid2, _Status3} = assign_vnodeid(Now2, NodeId, Status2),
+    ?assertEqual(<<1, 2, 3, 4, 70,116,143,251>>, Vid2).
+
+%% Test
+vnode_status_test_() ->
+    {setup,
+     fun() ->
+             filelib:ensure_dir("kv_vnode_status_test/.test"),
+             ?cmd("chmod u+rwx kv_vnode_status_test"),
+             ?cmd("rm -rf kv_vnode_status_test"),
+             application:set_env(riak_kv, vnode_status, "kv_vnode_status_test"),
+             ok
+     end,
+     fun(_) ->
+             application:unset_env(riak_kv, vnode_status),
+             ?cmd("chmod u+rwx kv_vnode_status_test"),
+             ?cmd("rm -rf kv_vnode_status_test"),
+             ok
+     end,
+     [?_test(begin % initial create failure
+                 ?cmd("rm -rf kv_vnode_status_test || true"),
+                 ?cmd("mkdir kv_vnode_status_test"),
+                 ?cmd("chmod -w kv_vnode_status_test"),
+                 Index = 0,
+                 File = vnode_status_filename(Index),
+                 try
+                     write_vnode_status(orddict:new(), File, ?VNODE_STATUS_VERSION)
+                 catch _Err:{badmatch, Reason} ->
+                         ?assertEqual({error, eacces}, Reason)
+                 end
+             end),
+      ?_test(begin % create successfully
+                 ?cmd("chmod +w kv_vnode_status_test"),
+                 Index = 0,
+                 File = vnode_status_filename(Index),
+                 ?assertEqual(ok, write_vnode_status([{created, true}], File, ?VNODE_STATUS_VERSION))
+             end),
+      ?_test(begin % update successfully
+                 Index = 0,
+                 File = vnode_status_filename(Index),
+                 {ok, [{created, true}, {version, 2}]} = read_vnode_status(File),
+                 ?assertEqual(ok, write_vnode_status([{updated, true}], File, ?VNODE_STATUS_VERSION))
+             end),
+      ?_test(begin % update failure
+                 ?cmd("chmod 000 kv_vnode_status_test/0"),
+                 ?cmd("chmod 500 kv_vnode_status_test"),
+                 Index = 0,
+                 File = vnode_status_filename(Index),
+                 ?assertEqual({error, eacces},  read_vnode_status(File))
+             end)
+
+     ]}.
+-endif.

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -81,7 +81,8 @@
 -define(EMPTY_VTAG_BIN, <<"e">>).
 
 -export([new/3, new/4, ensure_robject/1, ancestors/1, reconcile/2, equal/2]).
--export([increment_vclock/2, increment_vclock/3]).
+-export([increment_vclock/2, increment_vclock/3, prune_vclock/3, vclock_descends/2, all_actors/1]).
+-export([actor_counter/2]).
 -export([key/1, get_metadata/1, get_metadatas/1, get_values/1, get_value/1]).
 -export([hash/1, approximate_size/2]).
 -export([vclock_encoding_method/0, vclock/1, vclock_header/1, encode_vclock/1, decode_vclock/1]).
@@ -647,6 +648,29 @@ increment_vclock(Object=#r_object{bucket=B}, ClientId, Timestamp) ->
     %% a frontier object, then there must only ever be a single value
     %% when we increment, so add the dot here.
     assign_dot(Object#r_object{vclock=NewClock}, Dot, dvv_enabled(B)).
+
+%% @doc Prune vclock
+-spec prune_vclock(riak_object(), vclock:timestamp(), [proplists:property()]) ->
+                          riak_object().
+prune_vclock(Obj=#r_object{vclock=VC}, PruneTime, BucketProps) ->
+    VC2 = vclock:prune(VC, PruneTime, BucketProps),
+    Obj#r_object{vclock=VC2}.
+
+%% @doc Does the `riak_object' descend the provided `vclock'?
+-spec vclock_descends(riak_object(), vclock:vclock()) -> boolean().
+vclock_descends(#r_object{vclock=ObjVC}, VC) ->
+    vclock:descends(ObjVC, VC).
+
+%% @doc get the list of all actors that have touched this object.
+-spec all_actors(riak_object()) -> [binary()] | [].
+all_actors(#r_object{vclock=VC}) ->
+    vclock:all_nodes(VC).
+
+%%$ @doc get the counter for the given actor, 0 if not present
+-spec actor_counter(vclock:vclock_node(), riak_object()) ->
+                           non_neg_integer().
+actor_counter(Actor, #r_object{vclock=VC}) ->
+    vclock:get_counter(Actor, VC).
 
 %% @private assign the dot to the value only if DVV is enabled. Only
 %% call with a valid dot. Only assign dot when there is a single value

--- a/test/kv_vnode_status_mgr_eqc.erl
+++ b/test/kv_vnode_status_mgr_eqc.erl
@@ -1,0 +1,135 @@
+%%% @author Russell Brown <russelldb@basho.com>
+%%% @copyright (C) 2014, Russell Brown
+%%% @doc
+%%%
+%%% @end
+%%% Created : 14 Nov 2014 by Russell Brown <russelldb@basho.com>
+
+-module(kv_vnode_status_mgr_eqc).
+
+-ifdef(EQC).
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eqc/include/eqc_statem.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+-record(state,{}).
+
+-define(NUMTESTS, 1000).
+-define(QC_OUT(P),
+        eqc:on_output(fun(Str, Args) ->
+                              io:format(user, Str, Args) end, P)).
+
+-define(MAX_INT, ((1 bsl 32) -1)).
+
+%%====================================================================
+%% eunit test
+%%====================================================================
+
+eqc_test_() ->
+    {timeout, 40,
+     ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(20,
+                                                         ?QC_OUT(prop_monotonic())
+                                                        )
+                                       )
+                  )}.
+
+run() ->
+    run(?NUMTESTS).
+
+run(Count) ->
+    eqc:quickcheck(eqc:numtests(Count, prop_monotonic())).
+
+check() ->
+    eqc:check(prop_monotonic()).
+
+
+%% @doc Returns the state in which each test case starts. (Unless a different
+%%      initial state is supplied explicitly to, e.g. commands/2.)
+-spec initial_state() -> eqc_statem:symbolic_state().
+initial_state() ->
+    #state{}.
+
+%% ------ Grouped operator: lease_counter
+lease_counter_args(_S) ->
+    [
+
+     frequency([{5, ?SUCHTHAT(Lease, ?LET(I, largeint(), abs(I)), Lease > 0)},
+                {5, ?SUCHTHAT(Lease, ?LET(I, int(), abs(I)), Lease > 0)}])
+    ].
+
+lease_counter(Lease) ->
+    [{status, LastId, MoCnt, Pid}] = ets:lookup(vnode_status, status),
+    NewMoLease = MoCnt + Lease,
+    {NewMoId, NewCntrModel} = case {MoCnt == ?MAX_INT, NewMoLease >  ?MAX_INT} of
+                                  {true, _} ->
+                                      %% New Id
+                                      {LastId+1, min(Lease, ?MAX_INT)};
+                                  {false, true} ->
+                                      {LastId+1, min(?MAX_INT, Lease)};
+                                  {false, false} ->
+                                      {LastId, NewMoLease}
+                              end,
+    ok = riak_kv_vnode_status_mgr:lease_counter(Pid, Lease),
+    {VnodeId, NewCntr} = receive
+                             {counter_lease, {_, Id, NewLease}} ->
+                                 {Id, NewLease}
+                         after
+                             60000 -> %% one minute!
+                                 io:format("timeout!!!! ~p ~n", [erlang:is_process_alive(Pid)]),
+                                 timeout
+                         end,
+
+    true = ets:insert(vnode_status, {status, NewMoId, NewCntrModel, Pid}),
+    true = ets:insert(vnodeids, {VnodeId}),
+    {NewCntrModel, NewCntr}.
+
+%% @doc lease_counter_post - Postcondition for lease_counter
+-spec lease_counter_post(S :: eqc_statem:dynamic_state(),
+                         Args :: [term()], R :: term()) -> true | term().
+lease_counter_post(_S, _Args, {Cnt, Cnt}) ->
+    true;
+lease_counter_post(_S, _Args, {MoCnt, Cnt}) ->
+    {postcondition_failed, "Ets and Disk don't match", MoCnt, Cnt}.
+
+%% @doc weight/2 - Distribution of calls
+-spec weight(S :: eqc_statem:symbolic_state(), Command :: atom()) -> integer().
+weight(_S, lease_counter) -> 1;
+weight(_S, _Cmd) -> 1.
+
+%% @doc Default generated property
+-spec prop_monotonic() -> eqc:property().
+prop_monotonic() ->
+    ?FORALL(Cmds, non_empty(commands(?MODULE)),
+            begin
+                ets:new(vnode_status, [named_table, set]),
+                ets:new(vnodeids, [named_table, set]),
+                {ok, Pid} = riak_kv_vnode_status_mgr:start_link(self(), 1, true),
+                {ok, {ID, _Counter, _Lease}} = riak_kv_vnode_status_mgr:get_vnodeid_and_counter(Pid, 1),
+                true =  ets:insert(vnode_status, {status, 1, 1, Pid}),
+                true = ets:insert(vnodeids, {ID}),
+                {H, S, Res} = run_commands(?MODULE,Cmds),
+                [{status, Id, MoCntr, Pid}] = ets:lookup(vnode_status, status),
+                VnodeIds = ets:info(vnodeids, size),
+                {ok, Status} = riak_kv_vnode_status_mgr:status(Pid),
+                Cnt = proplists:get_value(counter, Status, 0),
+
+                ets:delete(vnode_status),
+                ets:delete(vnodeids),
+                riak_kv_vnode_status_mgr:clear_vnodeid(Pid),
+                ok = riak_kv_vnode_status_mgr:stop(Pid),
+
+                measure(vnodeid_changes, Id,
+                        aggregate(command_names(Cmds),
+                                  pretty_commands(?MODULE, Cmds, {H, S, Res},
+                                                  conjunction([{result, equals(Res, ok)},
+                                                               {values, equals(MoCntr, Cnt)},
+                                                               {ids, equals(Id, VnodeIds)}
+                                                              ])
+                                                 )
+                                 )
+                       )
+            end).
+
+-endif.


### PR DESCRIPTION
See http://github.com/riak_kv/issues/679 for a full history and
discussion. In summary: certain scenarios may lead to riak breaking a
strict invariant of version vectors, namely that each actor issue an
increasing, total order of events. When this invariant is broken some
new data item may be lost when some older item appears to be from a
later causal time. This fix adds per-key-epochs, so causal histories
are not re-used.
## Examples:

Tombstone->doomstone
- Key is deleted
- Tombstone is written to 2 primaries and a fallback
- fallback is unavailable
- tombstone read-repaired over 3 primaries and reaped
- new key written
- fallback hands off
- old tombstone subsumes new key, data lost

Dataloss
- A replica becomes unavailable in a put coordinating node due to corruption or user error.
- The incoming object may or may not contain a vector clock.
- We get a not_found in the local put. We have lost the information corresponding to this vnode id.
- The vector clock created could have a stale number for this vnode
  actor id. Either 1 if no vclock or < than the real one if more
  writes have happened since.
- The vector clock is subsumed by the other replicas when sent out, so
  this write will lose and will eventually be read repaired completely
  out of existence.

There are others, but these are the two that this commit addresses.
See the kv679\* tests in riak_test for more details.
## How it Does it:

When a coordinating vnode updates a key it has no local clock entry
for, it creates a new vnode id for that key only, using its base
vnodeid and a monotonic per vnode epoch counter, this ensures that any
version vector from the past/future would conflict with the new one,
not overwrite it. We use a counter lease scheme, and async leasing to
keep the counter update durable and quick. The actor is per-key, so no
 general actor explosion occurrs.

There is an off switch {riak_kv, [{use_epoch_counter, false}]}. The
default is `true`.
## Not done:

There is another flavour of the issue, see private issue tracker, that
is not yet addressed, but can be in future with some extra clock
metadata.
