### PR TITLE
Initial Implementation of data validation module

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -78,9 +78,11 @@ new(Node, ClientId) ->
 %%      R-value for the nodes have responded with a value or error.
 %% @equiv get(Bucket, Key, R, default_timeout())
 get(Bucket, Key, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    gg:format("in get (1)~n"),
     get(Bucket, Key, [], THIS).
 
 normal_get(Bucket, Key, Options, {?MODULE, [Node, _ClientId]}) ->
+    gg:format("in normal get~n"),
     Me = self(),
     ReqId = mk_reqid(),
     case node() of
@@ -95,6 +97,7 @@ normal_get(Bucket, Key, Options, {?MODULE, [Node, _ClientId]}) ->
     wait_for_reqid(ReqId, Timeout).
 
 consistent_get(Bucket, Key, Options, {?MODULE, [Node, _ClientId]}) ->
+    gg:format("in consistent get~n"),
     BKey = {Bucket, Key},
     Ensemble = ensemble(BKey),
     Timeout = recv_timeout(Options),
@@ -140,6 +143,7 @@ maybe_update_consistent_stat(Node, Stat, Bucket, StartTS, Result) ->
 %% @doc Fetch the object at Bucket/Key.  Return a value as soon as R-value for the nodes
 %%      have responded with a value or error.
 get(Bucket, Key, Options, {?MODULE, [Node, _ClientId]}=THIS) when is_list(Options) ->
+    gg:format("in get (2)~n"),
     case consistent_object(Node, Bucket) of
         true ->
             consistent_get(Bucket, Key, Options, THIS);
@@ -160,6 +164,7 @@ get(Bucket, Key, Options, {?MODULE, [Node, _ClientId]}=THIS) when is_list(Option
 %%      nodes have responded with a value or error.
 %% @equiv get(Bucket, Key, R, default_timeout())
 get(Bucket, Key, R, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    gg:format("in get (3)~n"),
     get(Bucket, Key, [{r, R}], THIS).
 
 %% @spec get(riak_object:bucket(), riak_object:key(), R :: integer(),
@@ -177,6 +182,7 @@ get(Bucket, Key, R, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) when
                                   is_binary(Key),
                                   (is_atom(R) or is_integer(R)),
                                   is_integer(Timeout) ->
+    gg:format("in get (4)~n"),
     get(Bucket, Key, [{r, R}, {timeout, Timeout}], THIS).
 
 
@@ -193,6 +199,7 @@ put(RObj, {?MODULE, [_Node, _ClientId]}=THIS) -> put(RObj, [], THIS).
 
 
 normal_put(RObj, Options, {?MODULE, [Node, ClientId]}) ->
+    gg:format("in normal put~n"),
     Me = self(),
     ReqId = mk_reqid(),
     case ClientId of
@@ -219,6 +226,7 @@ normal_put(RObj, Options, {?MODULE, [Node, ClientId]}) ->
     wait_for_reqid(ReqId, Timeout).
 
 consistent_put(RObj, Options, {?MODULE, [Node, _ClientId]}) ->
+    gg:format("in consistent_put~n"),
     Bucket = riak_object:bucket(RObj),
     BKey = {Bucket, riak_object:key(RObj)},
     Ensemble = ensemble(BKey),
@@ -273,6 +281,8 @@ consistent_put_type(RObj, Options) ->
 %%       {error, Err :: term(), details()}
 %% @doc Store RObj in the cluster.
 put(RObj, Options, {?MODULE, [Node, _ClientId]}=THIS) when is_list(Options) ->
+    gg:format("in put (3) RObj is ~p~n- Options is ~p~n- THIS is ~p~n", [riak_object_json:encode(RObj), Options, THIS]),
+    gg:format("Raw is ~p~n", [RObj]),
     case consistent_object(Node, riak_object:bucket(RObj)) of
         true ->
             consistent_put(RObj, Options, THIS);
@@ -314,6 +324,7 @@ put(RObj, W, DW, {?MODULE, [_Node, _ClientId]}=THIS) -> put(RObj, [{w, W}, {dw, 
 %%      at least DW nodes have stored it in their storage backend, or
 %%      TimeoutMillisecs passes.
 put(RObj, W, DW, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    gg:format("in put/5~n"),
     put(RObj,  [{w, W}, {dw, DW}, {timeout, Timeout}], THIS).
 
 %% @spec put(RObj::riak_object:riak_object(), W :: integer(), RW :: integer(),
@@ -327,6 +338,7 @@ put(RObj, W, DW, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
 %%      at least DW nodes have stored it in their storage backend, or
 %%      TimeoutMillisecs passes.
 put(RObj, W, DW, Timeout, Options, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    gg:format("in put/6~n"),
     put(RObj, [{w, W}, {dw, DW}, {timeout, Timeout} | Options], THIS).
 
 %% @spec delete(riak_object:bucket(), riak_object:key(), riak_client()) ->

--- a/src/riak_kv_ddl.hrl
+++ b/src/riak_kv_ddl.hrl
@@ -1,0 +1,38 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_ddl: defines records used in the data description language
+%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% TODO these types will be improved as the timeseries work progresses
+-type riak_field() :: any().
+-type field_type() :: binary | int | float | timeseries | boolean | any.
+%% TODO fix up type definitions etc, etc
+%% -type colocation() :: any().
+
+-record(riak_field, {
+	  name = throw("field 'name' in #riak_field{} is required") :: binary(),
+	  type = throw("field 'type' in #riak_field{} is required"):: field_type()
+	 }).
+
+-record(ddl, {
+	  bucket     = throw("field 'bucket' in #ddl{} is required") :: binary(),
+	  fields     = []                                            :: [riak_field()],
+	  colocation = throw("field 'bucket' in #ddl{} is required") :: colocation()
+	 }).

--- a/src/riak_kv_ddl_compiler.erl
+++ b/src/riak_kv_ddl_compiler.erl
@@ -1,0 +1,586 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_ddl_compiler: compile the record description in the DDL
+%% into code to verify that data conforms to a schema at the boundary
+%%
+%%
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% TODO
+%% * are we usings lists to describe fields or what?
+%% * turning bucket names into verification modules is a potential
+%%   memory leak on the atom table - not much we can do about that...
+%% * do we care about the name of the validation module?
+
+%% @doc
+-module(riak_kv_ddl_compiler).
+
+-include("riak_kv_index.hrl").
+-include("riak_kv_ddl.hrl").
+
+-export([
+	 make_validation/1,
+	 make_validation/2
+	]).
+
+-define(NODEBUGOUTPUT, false).
+-define(DEBUGOUTPUT,   true).
+-define(MAKEIGNORE,    true).
+-define(MAKE,          false).
+
+make_validation(#ddl{} = DDL) ->
+    make_validation(DDL, ?NODEBUGOUTPUT, "/tmp").
+
+make_validation(#ddl{} = DDL, OutputDir) ->
+    make_validation(DDL, ?DEBUGOUTPUT, OutputDir).
+
+make_validation(#ddl{} = DDL, HasDebugOutput, OutputDir) ->
+    {Module, AST} = compile(DDL, HasDebugOutput, OutputDir),
+    {ok, Module, Bin} = compile:forms(AST),
+    SpoofBeam = "/tmp/" ++ atom_to_list(Module) ++ ".beam",
+    {module, Module} = code:load_binary(Module, SpoofBeam, Bin).
+
+compile(#ddl{} = DDL, HasDebugOutput, OutputDir) ->
+    #ddl{bucket = Bucket,
+	 fields = Fields} = DDL,
+    {ModName, Attrs, N} = make_attrs(Bucket, 1),
+    {Funs, N2} = recurse_over_fns(Fields, N, 1, []),
+    AST = Attrs ++ Funs ++ [{eof, N2}],
+    if HasDebugOutput ->
+	    ASTFileName = filename:join([OutputDir, ModName]) ++ ".ast",
+	    write_file(ASTFileName, io_lib:format("~p", [AST]));
+       el/=se ->
+	    ok
+    end,
+    case erl_lint:module(AST) of
+ 	{ok, []} ->
+     	    if
+     		HasDebugOutput ->
+		    write_src(AST, DDL, ModName, OutputDir);
+     		el/=se ->
+		    ok
+     	    end,
+     	    _Module = {ModName, AST};
+     	Other  -> exit(Other)
+    end.
+
+write_src(AST, DDL, ModName, OutputDir) ->
+    Syntax = erl_syntax:form_list(AST),
+    Header = io_lib:format("%%% Generated Module, do NOT edit~n~n" ++
+			       "Validates the DDL~n~p~n",
+			   [DDL]),
+    Header2 = re:replace(Header, "\\n", "\\\n%%% ", [global, {return, list}]),
+    Src = erl_prettypr:format(Syntax),
+    Contents  = [Header2 ++ "\n" ++ Src],
+    SrcFileName = filename:join([OutputDir, ModName]) ++ ".erl",
+    write_file(SrcFileName, Contents).
+
+write_file(FileName, Contents) ->
+    ok = filelib:ensure_dir(FileName),
+    {ok, Fd} = file:open(FileName, [write]),
+    io:fwrite(Fd, "~s~n", [Contents]),
+    file:close(Fd).
+
+recurse_over_fns(Fields, N, M, Acc) ->
+    {Funs, N2, Maps, M2} = make_funs(Fields, N, M),
+    Maps2 = lists:flatten([Y || {_X, Y} <- Maps]),
+    case Maps2 of
+	[] -> {lists:flatten(lists:reverse([Funs | Acc])), N2 + 1};
+	_  -> recurse_over_fns(Maps2, N2, M2, [Funs | Acc])
+    end.
+
+make_attrs(Bucket, N) when is_binary(Bucket)    ->
+    ModName = make_module_name(Bucket),
+    {ModAttr, N1} = make_module_attr(ModName, N),
+    {ExpAttr, N2} = make_export_attr(N1),
+    {ModName, [ModAttr, ExpAttr], N2}.
+
+make_funs(Fields, N, M) ->
+    %% we will reverse the field list at the start
+    %% becuz we can reverse an AST but keeping fields in order
+    %% makes it nicer for the next person to look at this
+    %% I <3 Me <- so helpful, such love
+    Fields2 = lists:reverse(Fields),
+    {Guards, Maps, Fields3, N2} = make_guards(Fields2, N + 1),
+    Success = case Maps of
+		  [] -> make_atom(true, N2);
+		  _  -> make_map_call(Maps, N2, M + 1)
+	      end,
+    {ClauseS, _N3} = make_success_clause(Fields3, Guards, Success, N2),
+    {ClauseF, _N4} = make_fail_clause(N2),
+    FunName = get_fn_name(M),
+    Fun = make_fun2(FunName, [ClauseS, ClauseF], N2),
+    {[Fun], N2, Maps, M + 1}.
+
+make_map_call(Fields, N, M) ->
+    Tuple = make_tuple([make_var(X, N) || {{_, _, X}, _} <- Fields], N),
+    Name = get_fn_name(M),
+    Nm = make_atom(Name, N),
+    make_call(Nm, Tuple, N).
+
+make_guards(Fields, N) ->
+    {_G1, _Maps, _F2, _N2} = make_g2(Fields, N, 1, [], [], []).
+
+make_g2([], N, _M, [], Acc2, Acc3) ->
+    {[], Acc2, Acc3, N};
+make_g2([], N, _M, Acc1, Acc2, Acc3) ->
+    {[[Acc1]], Acc2, Acc3, N};
+make_g2([#riak_field{name = Name, type = any} | T], N, M, Acc1, Acc2, Acc3) ->
+    {Nm, M2} = make_name(Name, ?MAKEIGNORE, N, M),
+    make_g2(T, N, M2, Acc1, Acc2, [Nm | Acc3]);
+make_g2([#riak_field{name = Name, type = {map, L}} | T], N, M, Acc1, Acc2, Acc3)
+  when is_list(L) ->
+    {Nm, M2} = make_name(Name, ?MAKE, N, M),
+    make_g2(T, N, M2, Acc1, [{Nm, L} | Acc2], [Nm | Acc3]);
+make_g2([#riak_field{name = Name, type = Type} | T], N, M, Acc1, Acc2, Acc3)
+  when Type =:= binary    orelse
+       Type =:= integer   orelse
+       Type =:= float     orelse
+       Type =:= boolean   orelse
+       Type =:= set       orelse
+       Type =:= timestamp ->
+    {Nm, M2} = make_name(Name, ?MAKE, N, M),
+    Call = make_guard(Nm, Type, N),
+    Acc1a = case Acc1 of
+		[] -> Call;
+		_  -> make_op('andalso', Call, Acc1, N)
+	    end,
+    make_g2(T, N, M2, Acc1a, Acc2, [Nm | Acc3]).
+
+make_op(Op, LHS, RHS, N) -> {op, N, Op, LHS, RHS}.
+
+make_guard(Nm, binary,    N) -> {call, N, make_atom(is_binary,  N), [Nm]};
+make_guard(Nm, integer,   N) -> {call, N, make_atom(is_integer, N), [Nm]};
+make_guard(Nm, float,     N) -> {call, N, make_atom(is_float,   N), [Nm]};
+make_guard(Nm, boolean,   N) -> {call, N, make_atom(is_boolean, N), [Nm]};
+make_guard(Nm, set,       N) -> {call, N, make_atom(is_list,    N), [Nm]};
+make_guard(Nm, timestamp, N) -> LHS = {call, N, make_atom(is_integer, N), [Nm]},
+				RHS = make_op('>', Nm, make_integer(0, N), N),
+				make_op('andalso', LHS, RHS, N).
+
+make_integer(I, N) when is_integer(I) -> {integer, N, I}.
+
+make_atom(A, N) -> {atom, N, A}.
+
+make_call(FnName, Vars, N) when is_list(Vars) ->
+    {call, N, FnName, Vars};
+make_call(FnName, Var, N) ->
+    {call, N, FnName, [Var]}.
+
+make_name(Name, HasPrefix, N, M) ->
+    Prefix = if
+		 HasPrefix -> "_";
+		 el/=se    -> ""
+	     end,
+    Nm = list_to_atom(Prefix ++ "Var" ++ integer_to_list(M) ++ "_" ++ Name),
+    {make_var(Nm, N), M + 1}.
+
+make_var(Name, N) -> {var, N, Name}.
+
+make_success_clause(Fields, Guards, Success, N) ->
+    Tuple = make_tuple(Fields, N),
+    Clause = make_clause(Tuple, Guards, Success, N),
+    {Clause, N + 1}.
+
+make_fail_clause(N) ->
+    Var = make_var('_', N),
+    False = make_atom(false, N),
+    Clause = make_clause(Var, [], False, N),
+    {Clause, N + 1}.
+
+get_fn_name(1) ->
+    validate;
+get_fn_name(N) when is_integer(N) ->
+    list_to_atom("validate" ++ integer_to_list(N)).
+
+make_fun2(FunName, Clause, N) -> {function, N, FunName, 1, Clause}.
+
+make_clause(Tuple, Guards, Body, N) -> {clause, N, [Tuple], Guards, [Body]}.
+
+make_tuple(Fields, N) -> {tuple, N, Fields}.
+
+make_module_name(Bucket) ->
+    Nonce = binary_to_list(base64:encode(crypto:hash(md4, Bucket))),
+    Nonce2 = remove_hooky_chars(Nonce),
+    ModName = "riak_ddl_validation_" ++ Nonce2,
+    list_to_atom(ModName).
+
+remove_hooky_chars(Nonce) ->
+    re:replace(Nonce, "[/|\+|\.|=]", "", [global, {return, list}]).
+
+make_module_attr(ModName, N) ->
+    {{attribute, N, module, ModName}, N + 1}.
+
+make_export_attr(N) ->
+    {{attribute, N, export, [{validate, 1}]}, N + 1}.
+
+-ifdef(TEST).
+-compile(export_all).
+
+-define(VALID,   true).
+-define(INVALID, false).
+
+-include_lib("eunit/include/eunit.hrl").
+
+make_ddl(Bucket, Fields) ->
+    #ddl{bucket     = term_to_binary(Bucket),
+	 fields     = Fields,
+	 colocation = []}.
+
+simplest_valid_test() ->
+    DDL = make_ddl(<<"simplest_valid_test">>,
+		   [
+		    #riak_field{name = "yando", type = binary}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({<<"ewrewr">>}),
+    ?_assertEqual(Result, ?VALID).
+
+simple_valid_binary_test() ->
+    DDL = make_ddl(<<"simple_valid_binary_test">>,
+		   [
+		    #riak_field{name = "yando", type = binary},
+		    #riak_field{name = "erko",  type = binary}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({<<"ewrewr">>, <<"werewr">>}),
+    ?_assertEqual(Result, ?VALID).
+
+simple_valid_integer_test() ->
+    DDL = make_ddl("simple_valid_integer_test",
+		   [
+		    #riak_field{name = "yando", type = integer},
+		    #riak_field{name = "erko",  type = integer},
+		    #riak_field{name = "erkle", type = integer}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({999, -9999, 0}),
+    ?_assertEqual(Result, ?VALID).
+
+simple_valid_float_test() ->
+    DDL = make_ddl("simple_valid_float_test",
+		   [
+		    #riak_field{name = "yando", type = float},
+		    #riak_field{name = "erko",  type = float},
+		    #riak_field{name = "erkle", type = float}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({432.22, -23423.22, -0.0}),
+    ?_assertEqual(Result, ?VALID).
+
+simple_valid_boolean_test() ->
+    DDL = make_ddl("simple_valid_boolean_test",
+		   [
+		    #riak_field{name = "yando", type = boolean},
+		    #riak_field{name = "erko",  type = boolean}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({true, false}),
+    ?_assertEqual(Result, ?VALID).
+
+simple_valid_timestamp_test() ->
+    DDL = make_ddl("simple_valid_timestamp_test",
+		   [
+		    #riak_field{name = "yando", type = timestamp},
+		    #riak_field{name = "erko",  type = timestamp},
+		    #riak_field{name = "erkle", type = timestamp}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({234324, 23424, 34636}),
+    ?_assertEqual(Result, ?VALID).
+
+simple_valid_map_1_test() ->
+    Map = {map, [
+		 #riak_field{name = "yarple", type = binary}
+		]},
+    DDL = make_ddl("simple_valid_map_1_test",
+		   [
+		    #riak_field{name = "yando", type = binary},
+		    #riak_field{name = "erko",  type = Map},
+		    #riak_field{name = "erkle", type = float}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({<<"ewrewr">>, {<<"erko">>}, 4.4}),
+    ?_assertEqual(Result, ?VALID).
+
+simple_valid_map_2_test() ->
+    Map = {map, [
+		 #riak_field{name = "yarple",  type = binary}
+		 #riak_field{name = "yoplait", type = integer}
+		]},
+    DDL = make_ddl("simple_valid_map_2_test",
+		   [
+		    #riak_field{name = "yando", type = binary},
+		    #riak_field{name = "erko",  type = Map},
+		    #riak_field{name = "erkle", type = float}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({<<"ewrewr">>, {<<"erko">>, -999}, 4.4}),
+    ?_assertEqual(Result, ?VALID).
+
+complex_valid_map_1_test() ->
+    Map2 = {map, [
+		  #riak_field{name = "dingle", type = binary},
+		  #riak_field{name = "zoomer", type = integer}
+		 ]},
+    Map1 = {map, [
+		 #riak_field{name = "yarple",  type = binary},
+		 #riak_field{name = "yoplait", type = Map2},
+		 #riak_field{name = "yowl",    type = integer}
+		]},
+    DDL = make_ddl("simple_valid_map_2_test",
+		   [
+		    #riak_field{name = "yando", type = binary},
+		    #riak_field{name = "erko",  type = Map1},
+		    #riak_field{name = "erkle", type = float}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({<<"ewrewr">>,
+			      {<<"erko">>, {<<"yerk">>, 33}},
+			      4.4}),
+    ?_assertEqual(Result, ?VALID).
+
+simple_valid_any_test() ->
+    DDL = make_ddl("simple_valid_any_test",
+		   [
+		    #riak_field{name = "yando", type = binary},
+		    #riak_field{name = "erko",  type = any},
+		    #riak_field{name = "erkle", type = float}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({<<"ewrewr">>, [a, b, d], 4.4}),
+    ?_assertEqual(Result, ?VALID).
+
+simple_valid_set_test() ->
+    DDL = make_ddl("simple_valid_any_test",
+		   [
+		    #riak_field{name = "yando", type = binary},
+		    #riak_field{name = "erko",  type = set},
+		    #riak_field{name = "erkle", type = float}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({<<"ewrewr">>, [a, b, d], 4.4}),
+    ?_assertEqual(Result, ?VALID).
+
+simple_valid_mixed_test() ->
+    DDL = make_ddl("simple_valid_mixed_test",
+		   [
+		    #riak_field{name = "yando", type = binary},
+		    #riak_field{name = "erko",  type = integer},
+		    #riak_field{name = "erkle", type = float},
+		    #riak_field{name = "banjo", type = timestamp}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({<<"ewrewr">>, 99, 4.4, 5555}),
+    ?_assertEqual(Result, ?VALID).
+
+%% invalid tests
+simple_invalid_binary_test() ->
+    DDL = make_ddl("simple_invalid_binary_test",
+		   [
+		    #riak_field{name = "yando", type = binary},
+		    #riak_field{name = "erko",  type = binary}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({<<"ewrewr">>, 55}),
+    ?_assertEqual(Result, ?INVALID).
+
+simple_invalid_integer_test() ->
+    DDL = make_ddl("simple_invalid_integer_test",
+		   [
+		    #riak_field{name = "yando", type = integer},
+		    #riak_field{name = "erko",  type = integer},
+		    #riak_field{name = "erkle", type = integer}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({999, -9999, 0,0}),
+    ?_assertEqual(Result, ?INVALID).
+
+simple_invalid_float_test() ->
+    DDL = make_ddl("simple_invalid_float_test",
+		   [
+		    #riak_field{name = "yando", type = float},
+		    #riak_field{name = "erko",  type = float},
+		    #riak_field{name = "erkle", type = float}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({432.22, -23423.22, [a, b, d]}),
+    ?_assertEqual(Result, ?INVALID).
+
+simple_invalid_boolean_test() ->
+    DDL = make_ddl("simple_invalid_boolean_test",
+		   [
+		    #riak_field{name = "yando", type = boolean},
+		    #riak_field{name = "erko",  type = boolean},
+		    #riak_field{name = "erkle", type = boolean}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({true, false, [a, b, d]}),
+    ?_assertEqual(Result, ?INVALID).
+
+simple_invalid_set_test() ->
+    DDL = make_ddl("simple_valid_any_test",
+		   [
+		    #riak_field{name = "yando", type = binary},
+		    #riak_field{name = "erko",  type = set},
+		    #riak_field{name = "erkle", type = float}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({<<"ewrewr">>, 444.44, 4.4}),
+    ?_assertEqual(Result, ?VALID).
+
+simple_invalid_timestamp_1_test() ->
+    DDL = make_ddl("simple_invalid_timestamp_1_test",
+		   [
+		    #riak_field{name = "yando", type = timestamp},
+		    #riak_field{name = "erko",  type = timestamp},
+		    #riak_field{name = "erkle", type = timestamp}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({234.324, 23424, 34636}),
+    ?_assertEqual(Result, ?INVALID).
+
+simple_invalid_timestamp_2_test() ->
+    DDL = make_ddl("simple_invalid_timestamp_2_test",
+		   [
+		    #riak_field{name = "yando", type = timestamp},
+		    #riak_field{name = "erko",  type = timestamp},
+		    #riak_field{name = "erkle", type = timestamp}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({234324, -23424, 34636}),
+    ?_assertEqual(Result, ?INVALID).
+
+simple_invalid_timestamp_3_test() ->
+    DDL = make_ddl("simple_invalid_timestamp_3_test",
+		   [
+		    #riak_field{name = "yando", type = timestamp},
+		    #riak_field{name = "erko",  type = timestamp},
+		    #riak_field{name = "erkle", type = timestamp}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({234324, 0, 34636}),
+    ?_assertEqual(Result, ?INVALID).
+
+simple_invalid_map_1_test() ->
+    Map = {map, [
+		 #riak_field{name = "yarple", type = binary}
+		]},
+    DDL = make_ddl("simple_invalid_map_test",
+		   [
+		    #riak_field{name = "yando", type = binary},
+		    #riak_field{name = "erko",  type = Map},
+		    #riak_field{name = "erkle", type = float}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({<<"ewrewr">>, {99}, 4.4}),
+    ?_assertEqual(Result, ?VALID).
+
+simple_invalid_map_2_test() ->
+    Map = {map, [
+		 #riak_field{name = "yarple", type = binary},
+		 #riak_field{name = "yip",    type = binary}
+		]},
+    DDL = make_ddl("simple_invalid_map_test",
+		   [
+		    #riak_field{name = "yando", type = binary},
+		    #riak_field{name = "erko",  type = Map},
+		    #riak_field{name = "erkle", type = float}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({<<"ewrewr">>, {<<"erer">>}, 4.4}),
+    ?_assertEqual(Result, ?VALID).
+
+simple_invalid_map_3_test() ->
+    Map = {map, [
+		 #riak_field{name = "yarple", type = binary},
+		 #riak_field{name = "yip",    type = binary}
+		]},
+    DDL = make_ddl("simple_invalid_map_test",
+		   [
+		    #riak_field{name = "yando", type = binary},
+		    #riak_field{name = "erko",  type = Map},
+		    #riak_field{name = "erkle", type = float}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({<<"ewrewr">>, {<<"bingo">>, <<"bango">>, <<"erk">>}, 4.4}),
+    ?_assertEqual(Result, ?VALID).
+
+simple_invalid_map_4_test() ->
+    Map = {map, [
+		 #riak_field{name = "yarple", type = binary}
+		]},
+    DDL = make_ddl("simple_invalid_map_test",
+		   [
+		    #riak_field{name = "yando", type = binary},
+		    #riak_field{name = "erko",  type = Map},
+		    #riak_field{name = "erkle", type = float}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({<<"ewrewr">>, [99], 4.4}),
+    ?_assertEqual(Result, ?VALID).
+
+complex_invalid_map_1_test() ->
+    Map2 = {map, [
+		  #riak_field{name = "dingle", type = binary},
+		  #riak_field{name = "zoomer", type = integer}
+		 ]},
+    Map1 = {map, [
+		 #riak_field{name = "yarple",  type = binary},
+		 #riak_field{name = "yoplait", type = Map2},
+		 #riak_field{name = "yowl",    type = integer}
+		]},
+    DDL = make_ddl("simple_valid_map_2_test",
+		   [
+		    #riak_field{name = "yando", type = binary},
+		    #riak_field{name = "erko",  type = Map1},
+		    #riak_field{name = "erkle", type = float}
+		   ]),
+    {module, Module} = make_validation(DDL, "/tmp"),
+    Result = Module:validate({<<"ewrewr">>,
+			      [<<"erko">>,
+			       [<<"yerk">>, 33.0]
+			      ],
+			      4.4}),
+    ?_assertEqual(Result, ?VALID).
+
+%%% test the size of the tuples
+too_small_tuple_test() ->
+    DDL = make_ddl("simple_too_small_tuple_test",
+		   [
+		    #riak_field{name = "yando", type = float},
+		    #riak_field{name = "erko",  type = float},
+		    #riak_field{name = "erkle", type = float}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({432.22, -23423.22}),
+    ?_assertEqual(Result, ?INVALID).
+
+too_big_tuple_test() ->
+    DDL = make_ddl("simple_too_big_tuple_test",
+		   [
+		    #riak_field{name = "yando", type = float},
+		    #riak_field{name = "erko",  type = float},
+		    #riak_field{name = "erkle", type = float}
+		   ]),
+    {module, Module} = make_validation(DDL),
+    Result = Module:validate({432.22, -23423.22, 44.44, 65.43}),
+    ?_assertEqual(Result, ?INVALID).
+
+-endif.

--- a/src/riak_kv_index.hrl
+++ b/src/riak_kv_index.hrl
@@ -1,0 +1,69 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_index: central module for indexing.
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% Index query records
+-record(riak_kv_index_v2, {
+          start_key= <<>> :: binary(),
+          filter_field :: binary() | undefined,
+          start_term :: binary() | undefined, %% Note, in a $key query, start_key==start_term
+          end_term :: binary() | undefined, %% Note, in an eq query, start==end
+          return_terms=true :: boolean(), %% Note, should be false for an equals query
+          start_inclusive=true :: boolean(),
+          end_inclusive=true :: boolean(),
+          return_body=false ::boolean() %% Note, only for riak cs bucket folds
+         }).
+
+-record(riak_kv_index_v3, {
+          start_key= <<>> :: binary(),
+          filter_field :: binary() | undefined,
+          start_term :: integer() | binary() | undefined, %% Note, in a $key query, start_key==start_term
+          end_term :: integer() | binary() | undefined, %% Note, in an eq query, start==end
+          return_terms=true :: boolean(), %% Note, should be false for an equals query
+          start_inclusive=true :: boolean(),
+          end_inclusive=true :: boolean(),
+          return_body=false ::boolean(), %% Note, only for riak cs bucket folds
+          term_regex :: binary() | undefined,
+          max_results :: integer() | undefined
+         }).
+
+%% TODO these types will be improved over the duration of the time series project
+-type selection()  :: term().
+-type filter()     :: term().
+-type operator()   :: term().
+-type sorter()     :: term().
+-type combinator() :: term().
+-type colocation() :: any().
+-type limit()      :: any().
+
+-record(riak_kv_li_index_v1, {
+	  key         = throw("field 'key' in #riak_kv_li_index{} is required")        :: binary(),
+	  colocation  = throw("field 'colocation' in #riak_kv_li_index{} is required") :: colocation(),
+	  selections  = []                                      :: [selection()],
+	  filters     = []                                      :: [filter()],
+	  operators   = []                                      :: [operator()],
+	  sorters     = []                                      :: [sorter()],
+	  combinators = []                                      :: [combinator()],
+	  limit                                                 :: limit()
+	 }).
+
+-define(KV_INDEX_Q, #riak_kv_index_v3).
+-define(KV_LI_INDEX_Q, #riak_kv_li_index_v1).

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -10,7 +10,7 @@
 %% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 %% KIND, either express or implied.  See the License for the
 %% specific language governing permissions and limitations
-%% under the License.    
+%% under the License.
 
 %% Constants used by the raw_http resources
 
@@ -23,6 +23,7 @@
 -define(MD_LASTMOD,  <<"X-Riak-Last-Modified">>).
 -define(MD_USERMETA, <<"X-Riak-Meta">>).
 -define(MD_INDEX,    <<"index">>).
+-define(MD_LI_IDX,   <<"composite-indices">>).
 -define(MD_DELETED,  <<"X-Riak-Deleted">>).
 
 %% Names of HTTP header fields


### PR DESCRIPTION
This commit introduces:
- the first cut of the intermediate output of the
  DDL language as a set of records
- a library module that works on examples of those records to generate
  validation functions in Erlang and load them into the VM
- a comprehensive test suite

The types supported for this are:
- integer
- float
- binary
- timeseries
- booleans
- maps
- sets
- any (the values in this field)

Maps, and sets are expositional - work needs to be done to make them
correspond to typed CRDTs - as do other specific CRDT types

The validation generator contains a debug setting which will dump the
corresponding Erlang source and AST to a file
