### PR TITLE
Small refactor for fast_path special buckets

### DIFF
--- a/src/riak_kv_bucket.erl
+++ b/src/riak_kv_bucket.erl
@@ -396,9 +396,9 @@ validate_update_default_props(New) ->
     %% Only called if not already a consistent, datatype, fast_path
     %% bucket. Check that none of those are being set to `true'/valid
     %% datatypes.
-    ensure_not_present(New, [], [], [{datatype, ""},
-                                     {consistent, false, ""},
-                                     {fast_path, false, ""}]).
+    ensure_not_present(New, [], [], [{datatype, "`datatype` must not be defined."},
+                                     {consistent, false, "Fast Path buckets must not be consistent=true"},
+                                     {fast_path, false, "Cannot set existing bucket type to `fast_path`"}]).
 
 %% @private validate that strongly-consistent types and buckets do not
 %% have their n_val changed, nor become eventually consistent

--- a/src/riak_kv_bucket.erl
+++ b/src/riak_kv_bucket.erl
@@ -115,7 +115,12 @@ validate_create_bucket_type(BucketProps) ->
         %% type is explicitly or implicitly not intended to be consistent
         Consistent when Consistent =:= false orelse
                         Consistent =:= undefined ->
-            {Unvalidated, Valid, Errors} = validate_create_dt_props(BucketProps);
+            {Unvalidated, Valid, Errors} = case get_boolean(fast_path, BucketProps) of
+                true ->
+                    validate_create_fp_props(BucketProps);
+                _ ->
+                    validate_create_dt_props(BucketProps)
+            end;
         %% type may be consistent (the value may not be valid)
         Consistent ->
             {Unvalidated, Valid, Errors} = validate_create_consistent_props(Consistent, BucketProps)
@@ -123,19 +128,50 @@ validate_create_bucket_type(BucketProps) ->
     validate(Unvalidated, Valid, Errors).
 
 %% @private update phase of bucket type. Merges properties from
-%% existing with valid new properties
+%% existing with valid new properties. Existing can be assumed valid,
+%% since they were validated by the `create' phase.
 -spec validate_update_bucket_type(props(), props()) -> {props(), errors()}.
 validate_update_bucket_type(Existing, New) ->
-    case proplists:get_value(consistent, Existing) of
-        %% type is explicitly or implicitly not already consistent
-        Consistent when Consistent =:= false orelse
-                        Consistent =:= undefined ->
-            {Unvalidated, Valid, Errors} = validate_update_dt_props(Existing, New);
-        _Consistent ->
-            {Unvalidated, Valid, Errors} = validate_update_consistent_props(Existing, New)
-    end,
+    Type = type(Existing),
+    {Unvalidated, Valid, Errors} = validate_update_type(Type, Existing, New),
     {Good, Bad} = validate(Unvalidated, Valid, Errors),
     {merge(Good, Existing), Bad}.
+
+%% @private pick the validation function depending on existing type.
+-spec validate_update_type(Type :: consistent | datatype | fast_path | default,
+                           Existing :: props(),
+                           New :: props()) ->
+                                  {Unvalidated :: props(),
+                                   Valid  :: props(),
+                                   Errors :: props()}.
+validate_update_type(consistent, Existing, New) ->
+    validate_update_consistent_props(Existing, New);
+validate_update_type(fast_path, _Existing, New) ->
+    NewFastPath = proplists:get_value(fast_path, New),
+    validate_update_fp_props(NewFastPath, New);
+validate_update_type(datatype, Existing, New) ->
+    validate_update_dt_props(Existing, New);
+validate_update_type(default, _Existing, New) ->
+    validate_update_default_props(New).
+
+%% @private figure out what `type' the existing bucket is.  NOTE: only
+%% call with validated props from existing buckets!!
+-spec type(props()) -> consistent | default | datatype | fast_path.
+type(Props) ->
+    type(proplists:get_value(consistent, Props, false),
+         proplists:get_value(fast_path, Props, false),
+         proplists:get_value(datatype, Props, false)).
+
+-spec type(boolean(), boolean(), atom()) ->
+                  consistent | default | datatype | fast_path.
+type(_Consistent=true, _FastPath, _DataType) ->
+    consistent;
+type(_Consistent, _FastPath=true, _DataType) ->
+    fast_path;
+type(_Consistent=false, _FastPath=false, _DataType=false) ->
+    default;
+type(_, _, _) ->
+    datatype.
 
 %% @private just delegates, but I added it to illustrate the many
 %% possible type of validation.
@@ -165,13 +201,17 @@ validate([{BoolProp, MaybeBool}|T], ValidProps, Errors) when is_atom(BoolProp), 
                                                              orelse BoolProp =:= basic_quorum
                                                              orelse BoolProp =:= last_write_wins
                                                              orelse BoolProp =:= notfound_ok
-                                                             orelse BoolProp =:= stat_tracked
-                                                             orelse BoolProp =:= fast_path ->
+                                                             orelse BoolProp =:= stat_tracked ->
     case coerce_bool(MaybeBool) of
         error ->
             validate(T, ValidProps, [{BoolProp, not_boolean}|Errors]);
         Bool ->
             validate(T, [{BoolProp, Bool}|ValidProps], Errors)
+    end;
+validate([{fast_path, Value}|T], ValidProps, Errors) ->
+    case Value of
+        false -> validate(T, [{fast_path, false} | ValidProps], Errors);
+        _ -> validate(T, ValidProps, [{fast_path, "cannot update fast_path property"}|Errors])
     end;
 validate([{consistent, Value}|T], ValidProps, Errors) ->
     case Value of
@@ -264,7 +304,13 @@ coerce_bool(_) ->
 %% value to true? Well, the user maybe type "fals" so lets be careful.
 -spec validate_create_consistent_props(any(), props()) -> {props(), props(), errors()}.
 validate_create_consistent_props(true, New) ->
-    {lists:keydelete(consistent, 1, New), [{consistent, true}], []};
+    % fast_path and consistent can't both be true
+    case get_boolean(fast_path, New) of
+        true ->
+            {lists:keydelete(consistent, 1, New), [], [{consistent, "Fast path buckets must be not be consistent=true"}]};
+        _ ->
+            {lists:keydelete(consistent, 1, New), [{consistent, true}], []}
+    end;
 validate_create_consistent_props(false, New) ->
     {lists:keydelete(consistent, 1, New), [{consistent, false}], []};
 validate_create_consistent_props(undefined, New) ->
@@ -325,6 +371,35 @@ validate_create_dt_props(Unvalidated0, Valid, Invalid) ->
             {Unvalidated, Valid, [{allow_mult, Err} | Invalid]}
     end.
 
+
+%% @private Riak fast_path support requires a bucket type where
+%% fast_path is set to true.  This function validates that when
+%% fast_path is set to true, other properties are consistent.
+%% See validate_create_fp_props/3 for an enumeration of these rules.
+-spec validate_create_fp_props(props()) -> {props(), props(), errors()}.
+validate_create_fp_props(New) ->
+    validate_create_fp_props(proplists:get_value(fast_path, New), New).
+
+%% @private validate the fast_path, if present
+-spec validate_create_fp_props(true, props()) -> {props(), props(), errors()}.
+validate_create_fp_props(true, New) ->
+    Unvalidated = lists:keydelete(fast_path, 1, New),
+    validate_fp_props(Unvalidated, [{fast_path, true}], []).
+
+%% @private checks that a bucket that is not a special immutable type
+%% is not attempting to become one.
+-spec validate_update_default_props(New :: props()) ->
+                                           {Unvalidated :: props(),
+                                            Valid :: props(),
+                                            Error :: props()}.
+validate_update_default_props(New) ->
+    %% Only called if not already a consistent, datatype, fast_path
+    %% bucket. Check that none of those are being set to `true'/valid
+    %% datatypes.
+    ensure_not_present(New, [], [], [{datatype, ""},
+                                     {consistent, false, ""},
+                                     {fast_path, false, ""}]).
+
 %% @private validate that strongly-consistent types and buckets do not
 %% have their n_val changed, nor become eventually consistent
 -spec validate_update_consistent_props(props(), props()) -> {props(), props(), errors()}.
@@ -353,18 +428,12 @@ validate_update_consistent_props(Existing, New) ->
             {Unvalidated, [], [{n_val, NErr}, {consistent, CErr}]}
     end.
 
-
-
 %% @private somewhat duplicates the create path, but easier to read
 %% this way, and chars are free
 -spec validate_update_dt_props(props(), props()) -> {props(), props(), errors()}.
 validate_update_dt_props(Existing, New0) ->
     New = lists:keydelete(datatype, 1, New0),
     case {proplists:get_value(datatype, Existing), proplists:get_value(datatype, New0)} of
-        {undefined, undefined} ->
-            {New, [], []};
-        {undefined, _Datatype} ->
-            {New, [], [{datatype, "Cannot add datatype to existing bucket"}]};
         {_Datatype, undefined} ->
             validate_update_dt_props(New, [] , []);
         {Datatype, Datatype} ->
@@ -386,6 +455,64 @@ validate_update_dt_props(New, Valid, Invalid) ->
             {Unvalidated, Valid, [{allow_mult, "Cannot change datatype bucket from allow_mult=true"} | Invalid]}
 end.
 
+%% @private
+%% precondition: Existing contains {fast_path, true}
+-spec validate_update_fp_props(boolean() | undefined, props()) ->
+                                      {props(), props(), errors()}.
+validate_update_fp_props(NewFP, New) ->
+    Unvalidated = lists:keydelete(fast_path, 1, New),
+    case NewFP of
+        Unchanged when Unchanged == true orelse Unchanged == undefined ->
+            validate_fp_props(Unvalidated, [{fast_path, true}], []);
+        _ ->
+            validate_fp_props(Unvalidated, [],
+                              [{fast_path, "Cannot modify fast_path property once set to true"}])
+    end.
+
+%% @private validate the boolean property, if `fast_path' was present.
+%% precondition: fast_path is not an entry in Unvalidated
+%%               fastpath is an entry in Valid
+%% The following rules apply when fastpath is true:
+%%   - datatype may not be defined
+%%   - consistent may not be true
+-spec validate_fp_props(props(), props(), errors()) -> {props(), props(), errors()}.
+validate_fp_props(Unvalidated, Valid, Errors) ->
+    ensure_not_present(Unvalidated, Valid, Errors,
+                       [{consistent, false, "Fast Path buckets must not be consistent=true"},
+                        {datatype, "Fast Path buckets must not have datatype defined"}
+                       ]).
+
+%% @private any property in `InvalidPropsSpec' present in
+%% `Unvalidated' will be added to `Errors'. Returned is the as yet
+%% unvalidated remainder properties from `Unvalidated', the properties
+%% from `InvalidPropsSpec' that were present and not invalid added to
+%% `Valid' and the accumulated errors added to `Errors'.
+-spec ensure_not_present(props(), props(), props(), [{atom(), term(), string()} |
+                                                     {atom(), term()}]) ->
+                                {props(), props(), props()}.
+ensure_not_present(Unvalidated, Valid, Errors, InvalidPropsSpec) ->
+    lists:foldl(fun({Key, Allowed, ErrorMessage}, {U, V, E}) ->
+                        case lists:keytake(Key, 1, U) of
+                            false ->
+                                {U, V, E};
+                            {value, {Key, Val}, U2} ->
+                                Val2 = coerce_bool(Val),
+                                if Val2 /= Allowed ->
+                                        {U2, V, [{Key, ErrorMessage} | E]};
+                                   true ->
+                                        {U2, [{Key, Allowed} | V], E}
+                                end
+                        end;
+                   ({Key, ErrorMessage}, {U, V, E}) ->
+                        case lists:keytake(Key, 1, U) of
+                            false -> {U, V, E};
+                            {value, {Key, _Val}, U2} ->
+                                {U2, V, [{Key, ErrorMessage} | E]}
+                        end
+                end,
+                {Unvalidated, Valid, Errors},
+                InvalidPropsSpec).
+
 %% @private just grab the allow_mult value if it exists
 -spec allow_mult(props()) -> boolean() | 'undefined' | 'error'.
 allow_mult(Props) ->
@@ -395,6 +522,17 @@ allow_mult(Props) ->
         MaybeBool ->
             coerce_bool(MaybeBool)
     end.
+
+%% @private coerce the value under key to be a boolean, if defined; undefined, otherwise.
+-spec get_boolean(PropName::atom(), props()) -> boolean() | 'undefined' | 'error'.
+get_boolean(Key, Props) ->
+    case proplists:get_value(Key, Props) of
+        undefined ->
+            undefined;
+        MaybeBool ->
+            coerce_bool(MaybeBool)
+    end.
+
 
 %%
 %% EUNIT tests...
@@ -428,19 +566,19 @@ coerce_bool_test_ () ->
 -define(TEST_TIME_SECS, 10).
 
 immutable_test_() ->
-    {timeout, ?TEST_TIME_SECS+5, [?_assert(test_immutable() =:= true)]}.
+   {timeout, ?TEST_TIME_SECS+5, [?_assert(test_immutable() =:= true)]}.
 
 valid_test_() ->
-    {timeout, ?TEST_TIME_SECS+5, [?_assert(test_create() =:= true)]}.
+   {timeout, ?TEST_TIME_SECS+5, [?_assert(test_create() =:= true)]}.
 
 merges_props_test_() ->
     {timeout, ?TEST_TIME_SECS+5, [?_assert(test_merges() =:= true)]}.
 
 test_immutable() ->
-    test_immutable(?TEST_TIME_SECS).
+   test_immutable(?TEST_TIME_SECS).
 
 test_immutable(TestTimeSecs) ->
-        eqc:quickcheck(eqc:testing_time(TestTimeSecs, ?QC_OUT(prop_immutable()))).
+       eqc:quickcheck(eqc:testing_time(TestTimeSecs, ?QC_OUT(prop_immutable()))).
 
 test_create() ->
     test_create(?TEST_TIME_SECS).
@@ -461,6 +599,7 @@ test_merges(TestTimeSecs) ->
 %%     allow_mult must remain true
 %%   * the consistent property cannot change and neither can the n_val if
 %%     the type is consistent
+%%   * the fast_path property cannot change
 prop_immutable() ->
     ?FORALL(Args, gen_args(no_default_buckets),
             begin
@@ -499,24 +638,29 @@ prop_create_valid() ->
                        io:format("Existing ~p~n", [Existing]),
                        io:format("New ~p~n", [New]),
                        io:format("Result ~p~n", [Result]),
-                       io:format("{has_datatype, valid_datatype, allow_mult, has_consistent, valid_consistent}~n"),
-                       io:format("{~p,~p,~p,~p,~p}~n~n",
-                                 [has_datatype(New), valid_datatype(New), allow_mult(New), has_consistent(New), valid_consistent(New)])
+                       io:format("{has_datatype, valid_datatype, allow_mult, has_fp, valid_fp, has_consistent, valid_consistent}~n"),
+                       io:format("{~p,~p,~p,~p,~p,~p,~p}~n~n",
+                                 [has_datatype(New), valid_datatype(New), allow_mult(New),
+                                     has_fp(New), valid_fp(New),
+                                     has_consistent(New), valid_consistent(New)])
                    end,
-                   collect(with_title("{has_datatype, valid_datatype, allow_mult, has_consistent, valid_consistent}"),
-                           {has_datatype(New), valid_datatype(New), allow_mult(New), has_consistent(New), valid_consistent(New)},
+                   collect(with_title("{has_datatype, valid_datatype, allow_mult, has_fp, valid_fp, has_consistent, valid_consistent}"),
+                           {has_datatype(New), valid_datatype(New), allow_mult(New), has_fp(New), valid_fp(New),
+                           has_consistent(New), valid_consistent(New)},
                            only_create_if_valid(Result, New)))
             end).
 
 %% As of 2.0pre? validate/4 must merge the new and existing props,
 %% verify that.
 prop_merges() ->
-    ?FORALL({Bucket, Existing0, New}, {gen_bucket(update, any),
+    ?FORALL({Bucket, Existing0, New0}, {gen_bucket(update, any),
                                       gen_existing(), gen_new(update)},
             begin
-                %% ensure default buckets are not marked consistent since that is invalid
+                %Existing0 = lists:keydelete(fast_path, 1, Existing00),
+                New = lists:keydelete(fast_path, 1, New0),
+                %% ensure default buckets are not marked consistent or fast_path since that is invalid
                 Existing = case default_bucket(Bucket) of
-                               true -> lists:keydelete(consistent, 1, Existing0);
+                               true -> lists:keydelete(fast_path, 1, lists:keydelete(consistent, 1, Existing0));
                                false -> Existing0
                            end,
                 Result={Good, _Bad} = validate(update, Bucket, Existing, New),
@@ -526,64 +670,70 @@ prop_merges() ->
                 AllowMult = allow_mult(New),
                 HasDatatype = has_datatype(Existing),
                 NValChanged = n_val_changed(Existing, New),
+                ExistingFastPath = is_fp(Existing),
+                NewFastPath = is_fp(New),
                 IsConsistent = is_consistent(Existing),
                 NewConsistent = proplists:get_value(consistent, New),
                 Expected = case {DefaultBucket, HasAllowMult, AllowMult, HasDatatype,
-                                 NValChanged, IsConsistent, NewConsistent} of
+                                 NValChanged, IsConsistent, NewConsistent, ExistingFastPath, NewFastPath} of
                                %% default bucket, attempted to change consistent to invalid value
                                %% allow_mult may be invalid too
-                               {true,_, Mult, _, _, false, notvalid} ->
+                               {true,_, Mult, _, _, false, notvalid, _, _} ->
                                    maybe_bad_mult(Mult, merge(lists:keydelete(consistent, 1, New), Existing));
                                %% default bucket, attempted to change consistent to true
                                %% allow_mult may be invalid too
-                               {true, _, Mult, _, _, false, true} ->
+                               {true, _, Mult, _, _, false, true, _, _} ->
                                    maybe_bad_mult(Mult, merge(lists:keydelete(consistent, 1, New), Existing));
                                %% all valid for default type buckets
-                               {true, _, Mult,  _, _, _, _} when Mult /= error ->
+                               {true, _, Mult,  _, _, _, _, _, _} when Mult /= error ->
                                    merge(New, Existing);
                                %% default bucket: allow mult is invalid
-                               {true, true, _, _, _, _, _} ->
+                               {true, true, _, _, _, _, _, _, _} ->
                                    maybe_bad_mult(error, merge(New, Existing));
 
+                               % non-default existing fast_path
+                               {false, _, _, _, _, _, _, true, _} ->
+                                   [];
+
                                %% typed bucket, allow mult changed but not consistent or data type
-                               {false, true, Mult,  false, _, false, _} when Mult /= error ->
+                               {false, true, Mult,  false, _, false, _, _, _} when Mult /= error ->
                                    %% the n_val is the only valid change we generate in this case. can't change
                                    %% data type or consistent peroperty
                                    NVal = proplists:get_value(n_val, New, proplists:get_value(n_val, Existing)),
                                    merge([proplists:lookup(allow_mult, New), {n_val, NVal}], Existing);
                                %% typed bucket, allow_mult change is invalid. n_val has changed. not a datatype or
                                %% consistent
-                               {false, true, error, false, true, false, _} ->
+                               {false, true, error, false, true, false, _, _, _} ->
                                    merge([proplists:lookup(n_val, New)], Existing);
                                %% typed bucket, allow_mult change is invalid and n_val hasn't changed
-                               {false, true, error, false, false, false, _} ->
+                               {false, true, error, false, false, false, _, _, _} ->
                                    Existing;
                                %% typed bucket, strongly-consistent, both n_val and consistent value are invalid changes
-                               {false, _, Mult,_,true,true,false} ->
+                               {false, _, Mult,_,true,true,false, _, _} ->
                                    maybe_bad_mult(Mult,
                                                   merge(lists:keydelete(consistent, 1, lists:keydelete(n_val, 1, New)), Existing));
                                %% typed bucket, strongly-consistent, both n_val and consistent value are invalid changes
-                               {false, _, Mult,_,true,true,notvalid} ->
+                               {false, _, Mult,_,true,true,notvalid, _, _} ->
                                    maybe_bad_mult(Mult,
                                                   merge(lists:keydelete(consistent, 1, lists:keydelete(n_val, 1, New)), Existing));
                                %% typed bucket, strongly-consistent, n_val change is invalid
-                               {false, _, Mult,_,true,true,_} ->
+                               {false, _, Mult,_,true,true,_, _, _} ->
                                    maybe_bad_mult(Mult, merge(lists:keydelete(n_val, 1, New), Existing));
                                %% typed bucket, strongly-consistent, consistent value change is invalid
-                               {false, _, Mult, _, _, true, false} ->
+                               {false, _, Mult, _, _, true, false, _, _} ->
                                    maybe_bad_mult(Mult, merge(lists:keydelete(consistent, 1, New), Existing));
                                %% typed bucket, strongly-consistent, consistent value change is invalid
-                               {false, _, Mult, _, _, true, notvalid} ->
+                               {false, _, Mult, _, _, true, notvalid, _, _} ->
                                    maybe_bad_mult(Mult, merge(lists:keydelete(consistent, 1, New), Existing));
                                %% typed bucket, strongly-consistent, all good (except maybe allow_mult)
-                               {false, _, Mult, _, _, true, _} ->
+                               {false, _, Mult, _, _, true, _, _, _} ->
                                    maybe_bad_mult(Mult, merge(New, Existing));
                                %% typed bucket, strongly-consistent, all good (except maybe allow_mult)
-                               {false, true, _Mult, true,_, _, _} ->
+                               {false, true, _Mult, true,_, _, _, _, _} ->
                                    NVal = proplists:get_value(n_val, New, proplists:get_value(n_val, Existing)),
                                    merge([{n_val, NVal}], Existing);
                                %% typed bucket, bucket not strongly consistent or a data type, all valid
-                               {false,_,_,_,_,false,_} ->
+                               {false,_,_,_,_,false,_, _, _} ->
                                    merge(New, Existing)
                            end,
 
@@ -625,8 +775,7 @@ gen_bucket() ->
 gen_existing() ->
     Defaults0 = riak_core_bucket_type:defaults(),
     Defaults = lists:keydelete(allow_mult, 1, Defaults0),
-    ?LET({MultDT, Consistent}, {gen_valid_mult_dt(), gen_maybe_consistent()},
-         Defaults ++ MultDT ++ Consistent).
+    ?LET(Special, oneof([gen_valid_mult_dt(), gen_valid_fp(), gen_valid_consistent(), []]), Defaults ++ Special).
 
 gen_maybe_consistent() ->
     oneof([[], gen_valid_consistent()]).
@@ -646,17 +795,26 @@ gen_valid_mult_dt(true) ->
     ?LET(Datatype, gen_datatype(), [{allow_mult, true}, {datatype, Datatype}]).
 
 gen_new(update) ->
-    ?LET({Mult, Datatype, Consistent, NVal},
+    ?LET({Mult, Datatype, FastPath, Consistent, NVal},
          {gen_allow_mult(), oneof([[], gen_datatype_property()]),
+          oneof([[], gen_valid_fp()]),
           oneof([[], gen_maybe_bad_consistent()]), oneof([[], [{n_val, choose(1, 10)}]])},
-         Mult ++ Datatype ++ Consistent ++ NVal);
+         Mult ++ Datatype ++ FastPath ++ Consistent ++ NVal);
 gen_new(create) ->
     Defaults0 = riak_core_bucket_type:defaults(),
     Defaults = lists:keydelete(allow_mult, 1, Defaults0),
-    ?LET({Mult, DatatypeOrConsistent}, {gen_allow_mult(), frequency([{5, gen_datatype_property()},
-                                                                     {5, gen_maybe_bad_consistent()},
-                                                                     {5, []}])},
-         Defaults ++ Mult ++ DatatypeOrConsistent).
+    ?LET(
+        {Mult, DatatypeOrConsistent, FastPath},
+        {
+            gen_allow_mult(),
+            frequency(
+                [{5, gen_datatype_property()},
+                 {5, gen_maybe_bad_consistent()},
+                 {5, []}]
+            ),
+            gen_fp()
+        },
+        Defaults ++ Mult ++ DatatypeOrConsistent ++ FastPath).
 
 gen_allow_mult() ->
     ?LET(Mult, frequency([{9, bool()}, {1, binary()}]), [{allow_mult, Mult}]).
@@ -666,25 +824,45 @@ gen_datatype_property() ->
 
 gen_datatype() ->
     ?LET(Datamod, oneof(?V2_TOP_LEVEL_TYPES), riak_kv_crdt:from_mod(Datamod)).
+
+%gen_maybe_bad_fp() ->
+%    oneof([gen_valid_fp(), {fast_path, rubbish}]).
+
+gen_fp() ->
+    ?LET(FastPath, frequency([{9, bool()}, {1, binary()}]), [{fast_path, FastPath}]).
+
+gen_valid_fp() ->
+    ?LET(FastPath, bool(), [{fast_path, FastPath}]).
+
 %% helpers
 
+gen_string_bool() ->
+    oneof(["true", "false"]).
+
+-spec immutable(Phase :: create | update,
+                New :: props(),
+                Existing :: props(),
+                Result :: {props(), errors()}) -> boolean().
 immutable(create, _,  _, _) ->
     true;
 immutable(_, _New, undefined, _) ->
     true;
 immutable(update, New, Existing, {_Good, Bad}) ->
-    case proplists:get_value(consistent, Existing) of
-        Consistent when Consistent =:= false orelse
-                        Consistent =:= undefined ->
-            %% not an existing consistent type (or bucket) so validate it
-            %% as a datatype (immutable_dt also covers the case where it was
-            %% not a datatype, yes i know this is kind of wierd when you read the
-            %% test, sorry...)
+    case type(Existing)  of
+        datatype ->
             NewDT = proplists:get_value(datatype, New),
             NewAM = proplists:get_value(allow_mult, New),
             ExistingDT = proplists:get_value(datatype, Existing),
             immutable_dt(NewDT, NewAM, ExistingDT, Bad);
-        true ->
+        fast_path ->
+            OldFP = proplists:get_value(fast_path, Existing),
+            NewFP = proplists:get_value(fast_path, New),
+            immutable_fast_path(OldFP, NewFP, New, Bad);
+        default ->
+            %% doesn't mean valid props, just that there is no
+            %% immutability constraint.
+            true;
+        consistent ->
             %% existing type (or bucket) is consistent
             immutable_consistent(New, Existing, Bad)
     end.
@@ -721,14 +899,31 @@ immutable_consistent(_Consistent, OldN, NewN, Bad) when OldN =:= NewN orelse
 immutable_consistent(_Consistent, _OldN, _NewN, Bad) ->
     has_consistent(Bad) andalso has_n_val(Bad).
 
+%% @private only called when the existing bucket type is immutable All
+%% that has to be true is that the bucket type is still fast_path
+immutable_fast_path(true, New, NewProps, Bad) when New == true orelse New == undefined ->
+    not has_fast_path(Bad) andalso undefined_props([datatype, {consistent, true}], NewProps, Bad);
+immutable_fast_path(true, _New, NewProps, Bad) ->
+    has_fast_path(Bad) andalso undefined_props([datatype, {consistent, true}], NewProps, Bad);
+immutable_fast_path(_Existing, true, _NewProps, Bad) ->
+    has_fast_path(Bad).
+
+%% @private every prop in Names that is present in Props, must be in
+%% Errors.
+undefined_props(Names, Props, Errors) ->
+    lists:all(fun({Name, Value}) ->
+                      (Value /= proplists:get_value(Name, Props)) orelse
+                          lists:keymember(Name, 1, Errors);
+                 (Name) ->
+                      (not lists:keymember(Name, 1, Props)) orelse
+                          lists:keymember(Name, 1, Errors)
+              end,
+              Names).
 
 %% If data type and allow mult and are in New they must match what is in existing
 %% or be in Bad
-immutable_dt(undefined, undefined, _Meh1, _Bad) ->
+immutable_dt(_NewDT=undefined, _NewAllowMult=undefined, _ExistingDT, _Bad) ->
     %% datatype and allow_mult are not being modified, so its valid
-    true;
-immutable_dt(undefined, _, undefined, _Bad) ->
-    %% data type not in new or existing, so its valid
     true;
 immutable_dt(_Datatype, undefined, _Datatype, _Bad) ->
     %% data types from new and existing match and allow mult not modified, valid
@@ -751,7 +946,7 @@ immutable_dt(_Datatype, false, undefined, Bad) ->
 immutable_dt(_Datatype, false, _Datatype, Bad) ->
     %% attempt to set allow_mult to false when data type set is invalid, datatype not modified
     has_allow_mult(Bad);
-immutable_dt(undefined, false, _Meh, Bad) ->
+immutable_dt(undefined, false, _Datatype, Bad) ->
     %% data type not modified but exists and allow_mult set to false is invalid
     has_allow_mult(Bad);
 immutable_dt(_Datatype, false, _Datatype2, Bad) ->
@@ -770,16 +965,25 @@ immutable_dt(_, _, _, Bad) ->
 only_create_if_valid({Good, Bad}, New) ->
     DT = proplists:get_value(datatype, New),
     AM = proplists:get_value(allow_mult, New),
+    FP = get_boolean(fast_path, New),
     CS = proplists:get_value(consistent, New),
-    case {DT, AM, CS} of
+    case {DT, AM, FP, CS} of
+        %% fast_path true entails data type undefined and consistent false or undefined
+        {_DataType, _AllowMult, true, _Consistent} ->
+            not has_datatype(Good)
+                andalso not is_consistent(Good)
+                % NB. (!P v Q) iff P => Q
+                andalso (not has_datatype(New) or has_datatype(Bad))
+                andalso (not is_consistent(New) or has_consistent(Bad))
+            ;
         %% if consistent or datatype properties are not defined then properties should be
         %% valid since no other properties generated can be in valid
-        {undefined, _AllowMult, Consistent} when Consistent =:= false orelse
+        {undefined, _AllowMult, _FastPath, Consistent} when Consistent =:= false orelse
                                                  Consistent =:= undefined ->
             true;
         %% if datatype is defined, its not a consistent type and allow_mult=true
         %% then the datatype must be valid
-        {Datatype, true, Consistent} when Consistent =:= false orelse
+        {Datatype, true, _FastPath,  Consistent} when Consistent =:= false orelse
                                           Consistent =:= undefined ->
             case lists:member(riak_kv_crdt:to_mod(Datatype), ?V2_TOP_LEVEL_TYPES) of
                 true ->
@@ -790,7 +994,7 @@ only_create_if_valid({Good, Bad}, New) ->
         %% if the datatype is defined, the type is not consistent and allow_mult is false
         %% then allow_mult should be in the Bad list and the datatype may be depending on if it
         %% is valid
-        {Datatype, _, Consistent} when Consistent =:= false orelse
+        {Datatype, _, _FastPath,  Consistent} when Consistent =:= false orelse
                                        Consistent =:= undefined->
             case lists:member(riak_kv_crdt:to_mod(Datatype), ?V2_TOP_LEVEL_TYPES) of
                 true ->
@@ -800,10 +1004,10 @@ only_create_if_valid({Good, Bad}, New) ->
             end;
         %% the type is consistent, whether it has a datatype or allow_mult set is irrelevant (for now
         %% at least)
-        {_, _, true} ->
+        {_, _, _, true} ->
             has_consistent(Good);
         %% the type was not inconsistent (explicitly or implicitly) but the value is invalid
-        {_, _, _Consistent} ->
+        {_, _, _, _Consistent} ->
             has_consistent(Bad)
     end.
 
@@ -816,6 +1020,22 @@ has_allow_mult(Props) ->
 valid_datatype(Props) ->
     Datatype = proplists:get_value(datatype, Props),
     lists:member(riak_kv_crdt:to_mod(Datatype), ?V2_TOP_LEVEL_TYPES).
+
+has_fp(Props) ->
+    proplists:get_value(fast_path, Props) /= undefined.
+
+valid_fp(Props) ->
+    case proplists:get_value(fast_path, Props) of
+        true ->
+            true;
+        false ->
+            true;
+        _ ->
+            false
+    end.
+
+is_fp(Props) ->
+    proplists:get_value(fast_path, Props) =:= true.
 
 has_consistent(Props) ->
     proplists:get_value(consistent, Props) /= undefined.
@@ -841,6 +1061,9 @@ n_val_changed(Existing, New) ->
     NewN = proplists:get_value(n_val, New),
     proplists:get_value(n_val, Existing) =/= NewN andalso
         NewN =/= undefined.
+
+has_fast_path(Bad) ->
+    proplists:get_value(fast_path, Bad) /= undefined.
 
 default_bucket({<<"default">>, _}) ->
     true;


### PR DESCRIPTION
This file needs a full refactor for a more extensible, readable, hell
_sane_ scheme. Suggesting erlog and prolog defined rules for validation
but really anything will do.

The main work here is to try and simplify enough that the tests still
pass and we can introduce validation for `fast_path` buckets. Please
review as such.
