### PR TITLE
Handling undefined object size on kv stats during consistent put/get.

### DIFF
--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -298,11 +298,19 @@ do_update({Type, actor_count, Count}) ->
     exometer:update([?PFX, ?APP, Type, actor_count], Count);
 do_update(late_put_fsm_coordinator_ack) ->
     exometer:update([?PFX, ?APP, late_put_fsm_coordinator_ack], 1);
+do_update({consistent_get, _Bucket, Microsecs, undefined}) ->
+    P = ?PFX,
+    ok = exometer:update([P, ?APP, consistent, gets], 1),
+    ok = exometer:update([P, ?APP, consistent, gets, time], Microsecs);
 do_update({consistent_get, _Bucket, Microsecs, ObjSize}) ->
     P = ?PFX,
     ok = exometer:update([P, ?APP, consistent, gets], 1),
     ok = exometer:update([P, ?APP, consistent, gets, time], Microsecs),
     create_or_update([P, ?APP, consistent, gets, objsize], ObjSize, histogram);
+do_update({consistent_put, _Bucket, Microsecs, undefined}) ->
+    P = ?PFX,
+    ok = exometer:update([P, ?APP, consistent, puts], 1),
+    ok = exometer:update([P, ?APP, consistent, puts, time], Microsecs);
 do_update({consistent_put, _Bucket, Microsecs, ObjSize}) ->
     P = ?PFX,
     ok = exometer:update([P, ?APP, consistent, puts], 1),


### PR DESCRIPTION
To avoid stat's crash, riak_kv_stat should handle undefined object size during consistent put/get. 

riak_test: https://github.com/basho/riak_test/pull/788
original issue: #1086 
