### PR TITLE
riak_kv_vnode:hashtree_pid should return {error, wrong_node} appropriately

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -637,7 +637,12 @@ handle_command({hashtree_pid, Node}, _, State=#state{hashtrees=HT}) ->
             case HT of
                 undefined ->
                     State2 = maybe_create_hashtrees(State),
-                    {reply, {ok, State2#state.hashtrees}, State2};
+                    case State2#state.hashtrees of
+                        undefined ->
+                            {reply, {error, wrong_node}, State2};
+                        _ ->
+                            {reply, {ok, State2#state.hashtrees}, State2}
+                    end;
                 _ ->
                     {reply, {ok, HT}, State}
             end;


### PR DESCRIPTION
riak_kv_vnode:hashtree_pid should be returning {error, wrong_node} when it's no longer the primary (but at some point was). It used to return {ok, undefined} in this case.

Related to deadlock issues in riak_repl:

https://github.com/basho/riak_repl/pull/671
https://github.com/basho/riak_test/pull/789
