### PR TITLE
Back port fix for hashtree_pid not returning {error, wrong_node}

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -580,7 +580,12 @@ handle_command({hashtree_pid, Node}, _, State=#state{hashtrees=HT}) ->
             case HT of
                 undefined ->
                     State2 = maybe_create_hashtrees(State),
-                    {reply, {ok, State2#state.hashtrees}, State2};
+                    case State2#state.hashtrees of
+                        undefined ->
+                            {reply, {error, wrong_node}, State2};
+                        _ ->
+                            {reply, {ok, State2#state.hashtrees}, State2}
+                    end;
                 _ ->
                     {reply, {ok, HT}, State}
             end;


### PR DESCRIPTION
if it is no longer primary for that node from 2.1 branch. 
- See https://github.com/basho/riak_kv/pull/1106
