### PR TITLE
Bugfix for allow_mult=true leaking into the default/legacy bucket type

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -103,7 +103,8 @@ start(_Type, _StartArgs) ->
        {rw, quorum},
        {basic_quorum, false},
        {notfound_ok, true},
-       {write_once, false}
+       {write_once, false},
+       {allow_mult, false}
    ]),
 
     %% Check the storage backend


### PR DESCRIPTION
See basho/riak#727 (RIAK-1662) (RIAK-1681 (#727 (RIAK-1662)))
