### PR TITLE
RIAK-1802

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -210,7 +210,7 @@ start(_Type, _StartArgs) ->
                 {bucket_validator, riak_kv_bucket},
                 {stat_mod, riak_kv_stat},
                 {permissions, [get, put, delete, list_keys, list_buckets,
-                               mapreduce, index]}
+                               mapreduce, index, get_preflist]}
             ]
             ++ [{health_check, {?MODULE, check_kv_health, []}} || HealthCheckOn]),
 

--- a/src/riak_kv_pb_bucket_key_apl.erl
+++ b/src/riak_kv_pb_bucket_key_apl.erl
@@ -52,10 +52,10 @@ init() ->
 
 %% @doc decode/2 callback. Decodes an incoming message.
 decode(Code, Bin) when Code == 33 ->
-    Msg = #rpbgetbucketkeypreflistreq{type =T, bucket =B, key =Key} =
+    Msg = #rpbgetbucketkeypreflistreq{type =T, bucket =B, key =_Key} =
         riak_pb_codec:decode(Code, Bin),
     Bucket = riak_kv_pb_bucket:bucket_type(T, B),
-    {ok, Msg, {"riak_kv.get_preflist", {Bucket, Key}}}.
+    {ok, Msg, {"riak_kv.get_preflist", Bucket}}.
 
 %% @doc encode/1 callback. Encodes an outgoing response message.
 encode(Message) ->

--- a/src/riak_kv_wm_preflist.erl
+++ b/src/riak_kv_wm_preflist.erl
@@ -88,7 +88,7 @@ forbidden(RD, Ctx) ->
             {true, RD, Ctx};
         false ->
             Res = riak_core_security:check_permission({"riak_kv.get_preflist",
-                                                       Ctx#ctx.bucket_type},
+                                                       {Ctx#ctx.bucket_type, Ctx#ctx.bucket}},
                                                       Ctx#ctx.security),
             case Res of
                 {false, Error, _} ->


### PR DESCRIPTION
Address permissions issues around `riak_kv.get_preflist`
- Could not grant this permission as it was not part of the `permissions` list.
- When permission fails, error message would not get printed due to `badarg`. PBC `decode` function did not return the correct value.

See basho/riak_core#706 (RIAK-1602) (RIAK-1802)
