### PR TITLE
Launch epmd at start of tests

### DIFF
--- a/src/riak_kv_test_util.erl
+++ b/src/riak_kv_test_util.erl
@@ -175,6 +175,9 @@ setup(TestName, SetupFun) ->
     Deps = dep_apps(TestName, SetupFun),
     do_dep_apps(load, Deps),
 
+    %% Start epmd
+    os:cmd("epmd -daemon"),
+
     %% Start erlang node
     {ok, Hostname} = inet:gethostname(),
     TestNode = list_to_atom(TestName ++ "@" ++ Hostname),


### PR DESCRIPTION
Addresses test failures seen in https://github.com/basho/riak_kv/issues/1112

See also #1119 
