### PR TITLE
1.4: Launch epmd at start of riak_kv tests

### DIFF
--- a/src/riak_kv_test_util.erl
+++ b/src/riak_kv_test_util.erl
@@ -156,6 +156,9 @@ setup(TestName, SetupFun) ->
     Deps = dep_apps(TestName, SetupFun),
     do_dep_apps(load, Deps),
 
+    %% Start epmd
+    os:cmd("epmd -daemon"),
+
     %% Start erlang node
     {ok, Hostname} = inet:gethostname(),
     TestNode = list_to_atom(TestName ++ "@" ++ Hostname),


### PR DESCRIPTION
See #1119
