### PR TITLE
Do not crash riak node if vnode status file is unreadable.

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1985,14 +1985,8 @@ clear_vnodeid(Index) ->
 update_vnode_status(F, Index) ->
     VnodeFile = vnode_status_filename(Index),
     ok = filelib:ensure_dir(VnodeFile),
-    case read_vnode_status(VnodeFile) of
-        {ok, Status} ->
-            update_vnode_status2(F, Status, VnodeFile);
-        {error, enoent} ->
-            update_vnode_status2(F, [], VnodeFile);
-        ER ->
-            ER
-    end.
+    {ok, Status} = read_vnode_status(VnodeFile),
+    update_vnode_status2(F, Status, VnodeFile).
 
 update_vnode_status2(F, Status, VnodeFile) ->
     case F(Status) of
@@ -2014,11 +2008,22 @@ vnode_status_filename(Index) ->
     filename:join(VnodeStatusDir, integer_to_list(Index)).
 
 read_vnode_status(File) ->
-    case file:consult(File) of
-        {ok, [Status]} when is_list(Status) ->
-            {ok, proplists:delete(version, Status)};
-        ER ->
-            ER
+    try
+        case file:consult(File) of
+            {ok, [Status]} when is_list(Status) ->
+                {ok, proplists:delete(version, Status)};
+            {error, enoent} ->
+                %% doesn't exist? same as empty
+                {ok, []};
+            Er ->
+                %% "corruption" error, unreadable, log, and start anew
+                lager:error("Failed to consult vnode-status file ~p ~p", [File, Er]),
+                {ok, []}
+        end
+    catch C:T ->
+            %% consult threw
+            lager:error("Failed to consult vnode-status file ~p ~p ~p", [File, C, T]),
+            {ok, []}
     end.
 
 write_vnode_status(Status, File) ->
@@ -2415,7 +2420,7 @@ vnode_status_test_() ->
       ?_test(begin % update failure
                  ?cmd("chmod 000 kv_vnode_status_test/0"),
                  ?cmd("chmod 500 kv_vnode_status_test"),
-                 F = fun([updated]) ->
+                 F = fun([]) ->
                              {shouldfail, [updatedagain]}
                      end,
                  Index = 0,


### PR DESCRIPTION
If for any reason the vnode status file is unreadable with
file:consult/1 the vnode would start, fail to consult, crash until the
restart limit was hit and the node would fail to start/crash.

Squashed and rebased to include test fix.  

Confirmed that in the event of {error, eacces}, write will cause 
error to be returned and will not be swallowed.
