### PR TITLE
Prevent duplication of bucket properties in state of get/put FSMs

### DIFF
--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -191,7 +191,7 @@ prepare(timeout, StateData=#state{bkey=BKey={Bucket,_Key},
     Props = 
         case is_tuple(Bucket) of
             false ->
-                lists:keymerge(1, lists:keysort(1, BucketProps), 
+                lists:ukeymerge(1, lists:keysort(1, BucketProps),
                                lists:keysort(1, DefaultProps));
             true ->
                 BucketProps

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -289,7 +289,7 @@ prepare(timeout, StateData0 = #state{from = From, robj = RObj,
     Props = 
         case is_tuple(Bucket) of
             false -> 
-                lists:keymerge(1, lists:keysort(1, BucketProps), 
+                lists:ukeymerge(1, lists:keysort(1, BucketProps),
                                lists:keysort(1, DefaultProps));
             true ->
                 BucketProps


### PR DESCRIPTION
When using non-typed buckets, the bucket properties from the bucket are merged with the default bucket properties. However, they were merged using lists:keymerge rather than lists:ukeymerge, which kept all of the duplicated propertied in the merged list. This PR changes riak_kv_get_fsm and riak_kv_put_fsm to use lists:ukeymerge instead, which takes the value from the custom properties list if it exists, and discards the matching key from the default list.
