### PR TITLE
Fix bad pattern match during handoff with write_once buckets

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1047,8 +1047,8 @@ handle_handoff_command(Req=?KV_PUT_REQ{}, Sender, State) ->
 
 handle_handoff_command(?KV_W1C_PUT_REQ{}=Request, Sender, State) ->
     NewState0 = case handle_command(Request, Sender, State) of
-        {noreply, NewState} -> lager:info("FDUSHIN> w1c handle_handoff_command noreply", []), NewState;
-        {reply, Reply, NewState} -> lager:info("FDUSHIN> w1c handle_handoff_command reply: ~p", [Reply]), NewState
+        {noreply, NewState} -> NewState;
+        {reply, _Reply, NewState} -> NewState
     end,
     {forward, NewState0};
 

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1046,8 +1046,11 @@ handle_handoff_command(Req=?KV_PUT_REQ{}, Sender, State) ->
     end;
 
 handle_handoff_command(?KV_W1C_PUT_REQ{}=Request, Sender, State) ->
-    {noreply, NewState} = handle_command(Request, Sender, State),
-    {forward, NewState};
+    NewState0 = case handle_command(Request, Sender, State) of
+        {noreply, NewState} -> lager:info("FDUSHIN> w1c handle_handoff_command noreply", []), NewState;
+        {reply, Reply, NewState} -> lager:info("FDUSHIN> w1c handle_handoff_command reply: ~p", [Reply]), NewState
+    end,
+    {forward, NewState0};
 
 %% Handle all unspecified cases locally without forwarding
 handle_handoff_command(Req, Sender, State) ->


### PR DESCRIPTION
This PR addresses a bug with write_once buckets that may arise during handoff.  If data is coming into a write_once bucket while handoff is taking place, the riak_core_vnode will crash with a bad_match.

C.f., https://github.com/basho/riak_kv/issues/1138

The fix is to pattern match cleanly against possible return values from handle_command with a KV_W1C_PUT_REQ as input.

A corresponding fix to the verify_handoff_write_once riak_test is on the bugfix/fd/RIAK-1850 branch in the riak_test repo, under PR https://github.com/basho/riak_test/pull/812
