### PR TITLE
Converting stop_fold exception breaks vnode worker

### DIFF
--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -704,12 +704,12 @@ fold_keys_fun(FoldKeysFun, {index, FilterBucket,
             fun(Bucket, Key, Acc) ->
                     case re:run(Key, TermRe) of
                         nomatch -> Acc;
-                        _ -> stoppable_fold(FoldKeysFun, Bucket, Key, Acc)
+                        _ -> FoldKeysFun(Bucket, Key, Acc)
                     end
             end;
         false ->
             fun(Bucket, Key, Acc) ->
-                    stoppable_fold(FoldKeysFun, Bucket, Key, Acc)
+                    FoldKeysFun(Bucket, Key, Acc)
             end
     end,
 
@@ -730,7 +730,7 @@ fold_keys_fun(FoldKeysFun, {index, FilterBucket, Q=?KV_INDEX_Q{return_terms=Term
     AccFun = case TermRe =:= undefined of
         true ->
             fun(Bucket, _Term, Val, Acc) ->
-                    stoppable_fold(FoldKeysFun, Bucket, Val, Acc)
+                    FoldKeysFun(Bucket, Val, Acc)
             end;
         false ->
             fun(Bucket, Term, Val, Acc) ->
@@ -738,7 +738,7 @@ fold_keys_fun(FoldKeysFun, {index, FilterBucket, Q=?KV_INDEX_Q{return_terms=Term
                         nomatch ->
                             Acc;
                         _ ->
-                            stoppable_fold(FoldKeysFun, Bucket, Val, Acc)
+                            FoldKeysFun(Bucket, Val, Acc)
                     end
             end
     end,
@@ -797,18 +797,6 @@ fold_keys_fun(FoldKeysFun, {index, Bucket, V1Q}) ->
     fold_keys_fun(FoldKeysFun, {index, Bucket, Q}).
 
 %% @private
-%% To stop a fold in progress when pagination limit is reached.
-stoppable_fold(Fun, Bucket, Item, Acc) ->
-    try
-        Fun(Bucket, Item, Acc)
-    catch
-        stop_fold ->
-            throw({break, Acc})
-    end.
-
-
-
-%% @private
 %% Return a function to fold over the objects on this backend
 fold_objects_fun(FoldObjectsFun, {index, FilterBucket, Q=?KV_INDEX_Q{}}) ->
     %% 2I query on $key or $bucket field with return_body
@@ -816,7 +804,7 @@ fold_objects_fun(FoldObjectsFun, {index, FilterBucket, Q=?KV_INDEX_Q{}}) ->
             ObjectKey = from_object_key(StorageKey),
             case riak_index:object_key_in_range(ObjectKey, FilterBucket, Q) of
                 {true, {Bucket, Key}} ->
-                    stoppable_fold(FoldObjectsFun, Bucket, {o, Key, Value}, Acc);
+                    FoldObjectsFun(Bucket, {o, Key, Value}, Acc);
                 {skip, _BK} ->
                     Acc;
                 _ ->

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -578,12 +578,8 @@ key_range_folder(Folder, Acc0, DataRef, {B, _K}=DataKey, {B, Q}) ->
             case riak_index:object_key_in_range(DataKey, B, Q) of
                 {true, DataKey} ->
                     %% add value to acc
-                    try
-                        Acc = Folder(Obj, Acc0),
-                        key_range_folder(Folder, Acc, DataRef, ets:next(DataRef, DataKey), {B, Q})
-                    catch stop_fold ->
-                            Acc0
-                    end;
+                    Acc = Folder(Obj, Acc0),
+                    key_range_folder(Folder, Acc, DataRef, ets:next(DataRef, DataKey), {B, Q});
                 {skip, DataKey} ->
                     key_range_folder(Folder, Acc0, DataRef, ets:next(DataRef, DataKey), {B, Q});
                 false -> Acc0
@@ -609,12 +605,8 @@ index_range_folder(Folder, Acc0, IndexRef, {B, I, V, _K}=IndexKey,
             %% Exclude start {val,key} from results
             index_range_folder(Folder, Acc0, IndexRef, ets:next(IndexRef, IndexKey), Query);
         {_, [Posting]} ->
-            try
-                Acc = Folder(Posting, Acc0),
-                index_range_folder(Folder, Acc, IndexRef, ets:next(IndexRef, IndexKey), Query)
-            catch stop_fold ->
-                    Acc0
-            end
+            Acc = Folder(Posting, Acc0),
+            index_range_folder(Folder, Acc, IndexRef, ets:next(IndexRef, IndexKey), Query)
     end;
 index_range_folder(_Folder, Acc, _IndexRef, _IndexKey, _Query) ->
     Acc.


### PR DESCRIPTION
This fixes a problem where, occasionally, paginated 2i queries would be missing values.  The fix is very short, but the explanation is very long:

2i queries eventually execute folds, which run in one of the the riak_kv vnode pool workers.  The request to run work in a pool worker has a fold function with an accumulator, and a finish function that runs on the result of the fold function ([riak_kv_worker:handle_work](https://github.com/basho/riak_kv/blob/ec9b41ece5e5fe2ce6d6b30cfe43c2cbc93db917/src/riak_kv_worker.erl#L44)). See how a stop_fold exception is handled by skipping the finish function.  In the case of paginated 2i queries, the fold sends back results to the index FSM using [riak_kv_vnode:result_fun_ack](https://github.com/basho/riak_kv/blob/ec9b41ece5e5fe2ce6d6b30cfe43c2cbc93db917/src/riak_kv_vnode.erl#L1714) (see [2i handler](https://github.com/basho/riak_kv/blob/ec9b41ece5e5fe2ce6d6b30cfe43c2cbc93db917/src/riak_kv_vnode.erl#L821)), which waits for an ack from the index FSM and may throw stop_fold if the FSM signals it does not need any more results.

Results are collected in batches before being sent in a [riak_kv_fold_buffer](https://github.com/basho/riak_kv/blob/ec9b41ece5e5fe2ce6d6b30cfe43c2cbc93db917/src/riak_kv_vnode.erl#L895), which is used as the accumulator in the fold.  Adding to this buffer and reaching the batch limit is what triggers the sending.  A [finish function](https://github.com/basho/riak_kv/blob/ec9b41ece5e5fe2ce6d6b30cfe43c2cbc93db917/src/riak_kv_vnode.erl#L1741-L1749) is provided so that any remaining items in the buffer by the end of the fold are also sent.  That's the key of the problem right there: the folder adds an item, the buffer gets full, the folder sends the batch to the FSM and receives a stop command, then throws stop_fold.  The intention is to stop the fold right there and not send any more items, so the finish function should be skipped. The stoppable_fold wrapper was catching that stop_fold and converting it to a {break, Acc} exception, where the accumulator was the value **before** the last items were sent, still containing most of those items.  The riak_kv_fold_worker never gets the exception, and simply processes that last buffer minus last item by calling the finish function on it, re-sending those items. An example:
- Last batch, after adding last item 9: [7,8,9]
- FSM receives [7,8,9]. Then, if it stays around long enough, it receives an extra [7,8] due to the finish function being called on the stale accumulator and ends up with [7,8,9,7,8].  **This is the bit that is timing sensitive and makes it non-deterministic**.
- The merge sort algorithm expects items in order. The result is undefined otherwise. So occasionally it will output items out of order. For example [7,8,7,9,8].  It also truncates to page size, so the [9,8] is dropped and the 7 dropped due to de-duplication.

/cc @jonmeredith @JeetKunDoug
The code around the fold functions is pretty hairy. Let me know if you need more clarification (you will).
