### PR TITLE
Bugfix/fd/riak 1937

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -56,6 +56,7 @@ Callback info about the riak_kv_backend behaviour is not available
 Unknown functions:
   dtrace:init/0
   yz_kv:index/3
+  yz_kv:index_binary/5
   yz_kv:should_handoff/1
   yz_stat:search_stats/0
 Unknown types:


### PR DESCRIPTION
This PR assumes a modification to the yz_kv:index function, to support passing both the bucket and key, which it did not support, before.  Passing a bucket is needed for the write_once put path, where there is no (decoded) Riak Object.  We need to decode the object, when indexing (in order to get at the value), but we want to do so in such a 

Cf. https://github.com/basho/yokozuna/pull/529
