### PR TITLE
Add bucket property validation for last_write_wins xor dvv_enabled

### DIFF
--- a/src/riak_kv_bucket.erl
+++ b/src/riak_kv_bucket.erl
@@ -399,6 +399,7 @@ validate_post_merge(Props, Errors) ->
     validate_last_write_wins_implies_not_dvv_enabled({Props, Errors}).
 
 %% If `last_write_wins' is true, `dvv_enabled' must not also be true.
+-spec validate_last_write_wins_implies_not_dvv_enabled({props(), errors()}) -> {props(), errors()}.
 validate_last_write_wins_implies_not_dvv_enabled({Props, Errors}) ->
     case {last_write_wins(Props), dvv_enabled(Props)} of
         {true, true} ->


### PR DESCRIPTION
https://bashoeng.atlassian.net/browse/RIAK-1743 (#1069)

If `last_write_wins` is true then `dvv_enabled` cannot also be true. Add
bucket property validation to ensure that this is the case. The bucket
property validation applies to create and update on any buckets or
bucket types. Since this validation applies to a combination of two
separate properties in both the create and update scenarios, a new
`validate_post_merge` function was added, which allows for validation on
properties after they have been fully resolved and merged.
