### PR TITLE
Cleanup verify_membackend for RIAK-2061

### DIFF
--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -86,6 +86,7 @@
                 time_ref :: ets:tid(),
                 max_memory :: undefined | integer(),
                 used_memory=0 :: integer(),
+                put_obj_size=0 :: integer(),
                 ttl :: integer()}).
 
 -type state() :: #state{}.
@@ -241,7 +242,8 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, State=#state{data_ref=DataRef,
             UsedMemory + Size - Freed
     end,
     UsedMemory2 = UsedMemory1 - OldSize,
-    {ok, State#state{used_memory=UsedMemory2}}.
+    {ok, State#state{used_memory=UsedMemory2,
+                     put_obj_size=Size}}.
 
 %% @doc Delete an object from the memory backend
 -spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
@@ -388,18 +390,24 @@ is_empty(#state{data_ref=DataRef}) ->
 -spec status(state()) -> [{atom(), term()}].
 status(#state{data_ref=DataRef,
               index_ref=IndexRef,
-              time_ref=TimeRef}) ->
+              time_ref=TimeRef,
+              used_memory=Memory,
+              put_obj_size=PutObjSize}) ->
     DataStatus = ets:info(DataRef),
     IndexStatus = ets:info(IndexRef),
     case TimeRef of
         undefined ->
             [{data_table_status, DataStatus},
-             {index_table_status, IndexStatus}];
+             {index_table_status, IndexStatus},
+             {used_memory, Memory},
+             {put_obj_size, PutObjSize}];
         _ ->
             TimeStatus = ets:info(TimeRef),
             [{data_table_status, DataStatus},
              {index_table_status, IndexStatus},
-             {time_table_status, TimeStatus}]
+             {time_table_status, TimeStatus},
+             {used_memory, Memory},
+             {put_obj_size, PutObjSize}]
     end.
 
 %% @doc Get the size of the memory backend. Returns a dynamic size
@@ -717,9 +725,12 @@ ttl_test_() ->
     Key = <<"Key">>,
     Value = <<"Value">>,
 
+
+    %% Put an object, but ignore its put_obj_size
+    {ok, State1} = put(Bucket, Key, [], Value, State),
+    State2 = State1#state{put_obj_size=0},
     [
-     %% Put an object
-     ?_assertEqual({ok, State}, put(Bucket, Key, [], Value, State)),
+     ?_assertEqual(State, State2),
      %% Wait 1 second to access it
      ?_assertEqual(ok, timer:sleep(1000)),
      ?_assertEqual({ok, Value, State}, get(Bucket, Key, State)),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -50,7 +50,8 @@
          request_hashtree_pid/1,
          request_hashtree_pid/2,
          reformat_object/2,
-         stop_fold/1]).
+         stop_fold/1,
+         get_modstate/1]).
 
 %% riak_core_vnode API
 -export([init/1,
@@ -183,6 +184,12 @@ maybe_create_hashtrees(true, State=#state{idx=Index,
         _ ->
             State
     end.
+
+%% @doc Reveal the underlying module state for testing
+-spec(get_modstate(state()) -> {atom(), state()}).
+get_modstate(_State=#state{mod=Mod,
+                           modstate=ModState}) ->
+    {Mod, ModState}.
 
 %% API
 start_vnode(I) ->


### PR DESCRIPTION
- Add `put_obj_size` in the `riak_kv_memory_backend` state
- Return `used_memory` and `put_obj_size` in
  `riak_kv_memory_backend:status`
- `put_obj_size` is simply the size of the object last put
- Add `riak_kv_vnode:get_modstate/1` to expose the underlying module
  state for testing

For complete details see https://github.com/basho/riak_test/pull/821
