### PR TITLE
Converting stop_fold exception breaks vnode worker - BDP patch [JIRA: RIAK-2184]

### DIFF
--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -710,12 +710,12 @@ fold_keys_fun(FoldKeysFun, {index, FilterBucket,
             fun(Bucket, Key, Acc) ->
                     case re:run(Key, TermRe) of
                         nomatch -> Acc;
-                        _ -> stoppable_fold(FoldKeysFun, Bucket, Key, Acc)
+                        _ -> FoldKeysFun(Bucket, Key, Acc)
                     end
             end;
         false ->
             fun(Bucket, Key, Acc) ->
-                    stoppable_fold(FoldKeysFun, Bucket, Key, Acc)
+                    FoldKeysFun(Bucket, Key, Acc)
             end
     end,
 
@@ -736,7 +736,7 @@ fold_keys_fun(FoldKeysFun, {index, FilterBucket, Q=?KV_INDEX_Q{return_terms=Term
     AccFun = case TermRe =:= undefined of
         true ->
             fun(Bucket, _Term, Val, Acc) ->
-                    stoppable_fold(FoldKeysFun, Bucket, Val, Acc)
+                    FoldKeysFun(Bucket, Val, Acc)
             end;
         false ->
             fun(Bucket, Term, Val, Acc) ->
@@ -744,7 +744,7 @@ fold_keys_fun(FoldKeysFun, {index, FilterBucket, Q=?KV_INDEX_Q{return_terms=Term
                         nomatch ->
                             Acc;
                         _ ->
-                            stoppable_fold(FoldKeysFun, Bucket, Val, Acc)
+                            FoldKeysFun(Bucket, Val, Acc)
                     end
             end
     end,
@@ -803,18 +803,6 @@ fold_keys_fun(FoldKeysFun, {index, Bucket, V1Q}) ->
     fold_keys_fun(FoldKeysFun, {index, Bucket, Q}).
 
 %% @private
-%% To stop a fold in progress when pagination limit is reached.
-stoppable_fold(Fun, Bucket, Item, Acc) ->
-    try
-        Fun(Bucket, Item, Acc)
-    catch
-        stop_fold ->
-            throw({break, Acc})
-    end.
-
-
-
-%% @private
 %% Return a function to fold over the objects on this backend
 fold_objects_fun(FoldObjectsFun, {index, FilterBucket, Q=?KV_INDEX_Q{}}) ->
     %% 2I query on $key or $bucket field with return_body
@@ -822,7 +810,7 @@ fold_objects_fun(FoldObjectsFun, {index, FilterBucket, Q=?KV_INDEX_Q{}}) ->
             ObjectKey = from_object_key(StorageKey),
             case riak_index:object_key_in_range(ObjectKey, FilterBucket, Q) of
                 {true, {Bucket, Key}} ->
-                    stoppable_fold(FoldObjectsFun, Bucket, {o, Key, Value}, Acc);
+                    FoldObjectsFun(Bucket, {o, Key, Value}, Acc);
                 {skip, _BK} ->
                     Acc;
                 _ ->

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -578,12 +578,8 @@ key_range_folder(Folder, Acc0, DataRef, {B, _K}=DataKey, {B, Q}) ->
             case riak_index:object_key_in_range(DataKey, B, Q) of
                 {true, DataKey} ->
                     %% add value to acc
-                    try
-                        Acc = Folder(Obj, Acc0),
-                        key_range_folder(Folder, Acc, DataRef, ets:next(DataRef, DataKey), {B, Q})
-                    catch stop_fold ->
-                            Acc0
-                    end;
+                    Acc = Folder(Obj, Acc0),
+                    key_range_folder(Folder, Acc, DataRef, ets:next(DataRef, DataKey), {B, Q});
                 {skip, DataKey} ->
                     key_range_folder(Folder, Acc0, DataRef, ets:next(DataRef, DataKey), {B, Q});
                 false -> Acc0
@@ -609,12 +605,8 @@ index_range_folder(Folder, Acc0, IndexRef, {B, I, V, _K}=IndexKey,
             %% Exclude start {val,key} from results
             index_range_folder(Folder, Acc0, IndexRef, ets:next(IndexRef, IndexKey), Query);
         {_, [Posting]} ->
-            try
-                Acc = Folder(Posting, Acc0),
-                index_range_folder(Folder, Acc, IndexRef, ets:next(IndexRef, IndexKey), Query)
-            catch stop_fold ->
-                    Acc0
-            end
+            Acc = Folder(Posting, Acc0),
+            index_range_folder(Folder, Acc, IndexRef, ets:next(IndexRef, IndexKey), Query)
     end;
 index_range_folder(_Folder, Acc, _IndexRef, _IndexKey, _Query) ->
     Acc.


### PR DESCRIPTION
If the riak_kv_worker sees a stop_fold exception, it will stop and do no
further work. The code was blocking that exception and handling it in
the backend by return the value of the accumulator _before_ the
exception. This is wrong. The kv fold logic has already processed that
accumulator and sent the results back. This causes some extra values to
be appended to the results. In the case of paginated 2i queries that use
list:merge to do a merge sort of the results, the extra values made the
partial lists not be in sorted order, and list:merge in turn returns
results that are in the incorrect order. This causes some results to be
moved to the end and be left out of the final merged result.
