### PR TITLE
Fetch range scan query results; expose API #1179 [JIRA: RTS-312]

### DIFF
--- a/src/riak_kv_qry_queue.erl
+++ b/src/riak_kv_qry_queue.erl
@@ -87,6 +87,7 @@
 %% @doc Enqueue a prepared query for execution.  The query should be
 %%      compatible with the DDL supplied.
 put_on_queue(Qry, DDL) ->
+    %% worker needs DDL to perform column filtering
     gen_server:call(?MODULE, {put_on_queue, Qry, DDL}).
 
 -spec fetch(query_id()) -> {ok, list()} | {error, atom()}.


### PR DESCRIPTION
Starting from a merge of end-to-end/timeseries branch into gg/integration/timeseries, my own commits do the following:
- implement a `riak_kv_qry_queue:fetch/1` API function to complement `:put_on_queue/2`, which collects the range_scan execution results as received from eleveldb, and returns those as a list of lists, the latter containing `{Key::string(), Value::term()}` of the data SELECT'ed;
- the `:put_on_queue/2` function now takes DDL of the table against which to execute its query, as a second argument (patching up a 'fixup' in the prototype code);
- rename riak_kv_qry.erl to riak_kv_qry_worker.erl to better reflect its role and purpose;
- in riak_kv_qry.erl, add the user API functions `submit(Query::string()) -> {ok, query_id()}` and `fetch(query_id()) -> list()`;
- general cleanup.

At present, for this to work, you need to build it with eleveldb/gg/prototype/timeseries-range-scan-filter.

For an ad hoc example, see https://github.com/hmmr/bits/blob/master/src/ts_run2.erl.
