### PR TITLE
Change the default value of `vclock_data_encoding` to `encode_raw`

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -187,7 +187,7 @@ start(_Type, _StartArgs) ->
 
             riak_core_capability:register({riak_kv, vclock_data_encoding},
                                           [encode_zlib, encode_raw],
-                                          encode_zlib),
+                                          encode_raw),
 
             riak_core_capability:register({riak_kv, crdt},
                                           [?TOP_LEVEL_TYPES, [pncounter], []],

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -1094,7 +1094,7 @@ update_last_modified(RObj, TS) ->
 %% Fetch the preferred vclock encoding method:
 -spec vclock_encoding_method() -> atom().
 vclock_encoding_method() ->
-    riak_core_capability:get({riak_kv, vclock_data_encoding}, encode_zlib).
+    riak_core_capability:get({riak_kv, vclock_data_encoding}, encode_raw).
 
 %% Encode a vclock in accordance with our capability setting:
 encode_vclock(VClock) ->


### PR DESCRIPTION
@engelsanchez discovered this one weird trick which seems to greatly improve Time Series write performance and slightly improves standard Riak write performance.
