### PR TITLE
.hrl merge in riak_ql fixes, plus filters rewrite for eleveldb

### DIFF
--- a/include/riak_kv_qry_queue.hrl
+++ b/include/riak_kv_qry_queue.hrl
@@ -24,7 +24,7 @@
 -define(RIAK_KV_QRY_QUEUE_HRL, included).
 
 -include("riak_kv_index.hrl").
--include_lib("riak_ql/include/riak_ql_sql.hrl").
+-include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 -record(queue_query, {
           qry = #riak_sql_v1{}

--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -46,7 +46,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--include_lib("riak_ql/include/riak_ql_sql.hrl").
+-include_lib("riak_ql/include/riak_ql_ddl.hrl").
 -include("riak_kv_wm_raw.hrl").
 -include("riak_kv_index.hrl").
 -define(TIMEOUT, 30000).

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -55,7 +55,7 @@
                   ]}).
 
 -include("riak_kv_index.hrl").
--include_lib("riak_ql/include/riak_ql_sql.hrl").
+-include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/riak_kv_index_fsm.erl
+++ b/src/riak_kv_index_fsm.erl
@@ -42,7 +42,7 @@
 -behaviour(riak_core_coverage_fsm).
 
 -include_lib("riak_kv_vnode.hrl").
--include_lib("riak_ql/include/riak_ql_sql.hrl").
+-include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 -export([init/2,
          plan/2,

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -1,7 +1,6 @@
 -module(riak_kv_pb_timeseries).
 
 -include_lib("riak_pb/include/riak_kv_pb.hrl").
--include_lib("riak_ql/include/riak_ql_sql.hrl").
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 -behaviour(riak_api_pb_service).
 

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -33,14 +33,15 @@ compile(#ddl_v1{}, #riak_sql_v1{is_executable = true}) ->
     {error, 'query is already compiled'};
 compile(#ddl_v1{}, #riak_sql_v1{'SELECT' = []}) ->
     {error, 'full table scan not implmented'};
-compile(#ddl_v1{} = DDL, #riak_sql_v1{is_executable = false, type = sql} = Q) ->
+compile(#ddl_v1{} = DDL, #riak_sql_v1{is_executable = false, 
+				      type          = sql} = Q) ->
     comp2(DDL, Q).
 
 %% adding the local key here is a bodge
 %% should be a helper fun in the generated DDL module but I couldn't
 %% write that up in time
 comp2(#ddl_v1{} = DDL, #riak_sql_v1{is_executable = false,
-                   'WHERE'       = W} = Q) ->
+				    'WHERE'       = W} = Q) ->
     case compile_where(DDL, W) of
         {error, E} -> [{error, E}];
         NewW       -> expand_query(DDL, Q, NewW)
@@ -58,18 +59,19 @@ expand_query(#ddl_v1{local_key = LK, partition_key = PK}, Q, NewW) ->
 	
 
 expand_where(Where, #key_v1{ast = PAST}) ->
-    GetMaxMinFun = fun({startkey, [{_, H} | _T]}, {_S, E}) ->
+    GetMaxMinFun = fun({startkey, [{_, _, H} | _T]}, {_S, E}) ->
 			   {H, E};
-		      ({endkey, [{_, H} | _T]}, {S, _E}) ->
+		      ({endkey,   [{_, _, H} | _T]}, {S, _E}) ->
 			   {S, H};
 		      (_, {S, E})  ->
 			   {S, E}
 		   end,
     {Min, Max} = lists:foldl(GetMaxMinFun, {"", ""}, Where),
-    [{[QField], Q, U}] = [{X, Y, Z} || #hash_fn_v1{mod = riak_ql_quanta,
-						 fn   = quantum,
-						 args = [#param_v1{name = X}, Y, Z]} 
-					 <- PAST],
+    [{[QField], Q, U}] = [{X, Y, Z} 
+			  || #hash_fn_v1{mod = riak_ql_quanta,
+					 fn   = quantum,
+					 args = [#param_v1{name = X}, Y, Z]} 
+				 <- PAST],
     {NoSubQueries, Boundaries} = riak_ql_quanta:quanta(Min, Max, Q, U),
     case NoSubQueries of
 	1 -> [Where];
@@ -88,9 +90,10 @@ make_w2([Start | T1], [End | T2], QField, Where, Acc) ->
     Where3 = swap(Where2, QField, endkey, End),
     make_w2(T1, T2, QField, Where, [Where3 | Acc]).
 
+%% this rewrite is premised on the fact the the Query field is a timestamp
 swap(Where, QField, Key, Val) ->
     {Key, Fields} = lists:keyfind(Key, 1, Where),
-    NewFields = lists:keyreplace(QField, 1, Fields, {QField, Val}),
+    NewFields = lists:keyreplace(QField, 1, Fields, {QField, timestamp, Val}),
     _NewWhere = lists:keyreplace(Key, 1, Where, {Key, NewFields}).
 
 %% going forward the compilation and restructuring of the queries will be a big piece of work
@@ -102,24 +105,26 @@ compile_where(DDL, Where) ->
         {true, NewW} -> NewW
 end.
 
-check_if_timeseries(#ddl_v1{bucket = _B, partition_key = PK, local_key = LK},
+check_if_timeseries(#ddl_v1{bucket = B, partition_key = PK, local_key = LK},
               [{and_, _LHS, _RHS} = W]) ->
     try    #key_v1{ast = PAST} = PK,
            #key_v1{ast = LAST} = LK,
            LocalFields     = [X || #param_v1{name = X} <- LAST],
            PartitionFields = [X || #param_v1{name = X} <- PAST],
-           [QField] = [X || #hash_fn_v1{mod = riak_ql_quanta,
+           [QField] = [X || #hash_fn_v1{mod  = riak_ql_quanta,
 					fn   = quantum,
 					args = [#param_v1{name = X} | _Rest]} 
 				<- PAST],
-           StrippedW = strip(W, []),
-           {StartW, EndW, Filter} = break_out_timeseries(StrippedW, LocalFields, [QField]),
-           StartKey = rewrite(LK, StartW),
-           EndKey = rewrite(LK, EndW),
+	   StrippedW = strip(W, []),
+	   {StartW, EndW, Filter} = break_out_timeseries(StrippedW, LocalFields, [QField]),
+	   Mod = riak_ql_ddl:make_module_name(B),
+	   StartKey = rewrite(LK, StartW, Mod),
+           EndKey = rewrite(LK, EndW, Mod),
+	   RewrittenFilter = add_types_to_filter(Filter, Mod),
            {true, [
                    {startkey, StartKey},
                    {endkey,   EndKey},
-                   {filter,   Filter}
+                   {filter,   RewrittenFilter}
                   ]}
     catch  _:_ -> {error, {where_not_timeseries, W}}
     end;
@@ -146,19 +151,44 @@ take(Key, Ands, Acc) ->
 strip({and_, B, C}, Acc) -> strip(C, [B | Acc]);
 strip(A, Acc)            -> [A | Acc].
 
-rewrite(#key_v1{ast = AST}, W) ->
-    rew2(AST, W, []).
+add_types_to_filter(Filter, Mod) ->
+    add_types2(Filter, Mod, []).
 
-rew2([], [], Acc) ->
+add_types2([], _Mod, Acc) ->
+    make_ands(lists:reverse(Acc));
+add_types2([{Op, LHS, RHS} | T], Mod, Acc) when Op =:= and_ orelse
+						Op =:= or_  ->
+    NewAcc = {Op, add_types2([LHS], Mod, []), add_types2([RHS], Mod, [])},
+    add_types2(T, Mod, [NewAcc | Acc]);
+add_types2([{Op, Field, {_, Val}} | T], Mod, Acc) ->
+    NewAcc = {Op, {field, Field, Mod:get_field_type([Field])}, {const, Val}},
+    add_types2(T, Mod, [NewAcc | Acc]).	      
+
+%% I know, not tail recursive could stackbust
+%% but not really
+make_ands([]) ->
+    [];
+make_ands([H | []]) ->
+    H;
+make_ands([H | T]) ->
+    {and_, H, make_ands(T)}.
+
+rewrite(#key_v1{ast = AST}, W, Mod) ->
+    rew2(AST, W, Mod, []).
+
+rew2([], [], _Mod, Acc) ->
    lists:reverse(Acc);
 %% the rewrite should have consumed all the passed in values
-rew2([], _W, _Acc) ->
+rew2([], _W, _Mod, _Acc) ->
     {error, invalid_rewrite};
-rew2([#param_v1{name = [N]} | T], W, Acc) ->
-     case lists:keytake(N, 2, W) of
-         false                           -> {error, invalid_rewrite};
-         {value, {_, _, {_, Val}}, NewW} -> rew2(T, NewW, [{N, Val} | Acc])
-     end.
+rew2([#param_v1{name = [N]} | T], W, Mod, Acc) ->
+    Type = Mod:get_field_type([N]),
+    case lists:keytake(N, 2, W) of
+	false                           -> 
+	    {error, invalid_rewrite};
+	{value, {_, _, {_, Val}}, NewW} -> 
+	    rew2(T, NewW, Mod, [{N, Type, Val} | Acc])
+    end.
 
 -ifdef(TEST).
 -compile(export_all).
@@ -202,6 +232,18 @@ get_query(String) ->
     Lexed = riak_ql_lexer:get_tokens(String),
     {ok, _Q} = riak_ql_parser:parse(Lexed).
 
+get_long_ddl() ->
+    SQL = "CREATE TABLE GeoCheckin " ++
+        "(geohash varchar not null, " ++
+        "user varchar not null, " ++
+	"extra int not null, " ++
+	"more float not null, " ++
+        "time timestamp not null, " ++
+        "weather varchar not null, " ++
+        "temperature varchar, " ++
+        "PRIMARY KEY((quantum(time, 15, s)), time, user))",
+    get_ddl(SQL).
+
 get_standard_ddl() ->
     SQL = "CREATE TABLE GeoCheckin " ++
         "(geohash varchar not null, " ++
@@ -210,6 +252,9 @@ get_standard_ddl() ->
         "weather varchar not null, " ++
         "temperature varchar, " ++
         "PRIMARY KEY((quantum(time, 15, s)), time, user))",
+    get_ddl(SQL).
+
+get_ddl(SQL) ->
     Lexed = riak_ql_lexer:get_tokens(SQL),
     {ok, DDL} = riak_ql_parser:parse(Lexed),
     {module, _Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
@@ -239,64 +284,106 @@ get_standard_lk() ->
 %%
 
 %%
-%% rewrite passing tests
+%% tests for adding type information and rewriting filters
 %%
 
+simple_filter_typing_test() ->
+    #ddl_v1{bucket = B} = get_long_ddl(),
+    Mod = riak_ql_ddl:make_module_name(B),
+    Filter = [
+	      {or_, 
+	       {'=', <<"weather">>, {word, <<"yankee">>}},
+	       {and_, 
+		{'=', <<"geohash">>,     {word, <<"erko">>}},
+		{'=', <<"temperature">>, {word, <<"yelp">>}}
+	       }
+	      },
+	      {'=', <<"extra">>, {int, 1}}
+	     ],
+    Got = add_types_to_filter(Filter, Mod),
+    Expected = {and_, 
+	    {or_, 
+	     {'=', {field, <<"weather">>, binary}, {const, <<"yankee">>}},
+	     {and_, 
+	      {'=', {field, <<"geohash">>,     binary}, {const, <<"erko">>}},
+	      {'=', {field, <<"temperature">>, binary}, {const, <<"yelp">>}}
+	     }
+	    },
+	    {'=', {field, <<"extra">>, integer}, {const, 1}}
+	   },
+    ?assertEqual(Expected, Got).
+
+%%
+%% rewrite passing tests
+%%
+%% success here is because the where clause covers the entire local key
+%% we have enough info to build a range scan
+%%
 simple_rewrite_test() ->
+    #ddl_v1{bucket = B} = get_standard_ddl(),
+    Mod = riak_ql_ddl:make_module_name(B),
     LK  = #key_v1{ast = [
-                         #param_v1{name = ["bob"]},
-                         #param_v1{name = ["ripple"]}
+                         #param_v1{name = [<<"geohash">>]},
+                         #param_v1{name = [<<"time">>]}
                         ]},
     W   = [
-           {'=', "bob",    {word, "yardle"}},
-           {'>', "ripple", {int,  678}}
+           {'=', <<"geohash">>, {word, "yardle"}},
+           {'>', <<"time">>,    {int,   678}}
           ],
     Exp = [
-           {"bob",    "yardle"},
-           {"ripple", 678}
+           {<<"geohash">>,  binary,   "yardle"},
+           {<<"time">>,     timestamp, 678}
           ],
-    Got = rewrite(LK, W),
+    Got = rewrite(LK, W, Mod),
     ?assertEqual(Exp, Got).
 
 %%
 %% rewrite failing tests
 %%
-
+%% failure is because the where clause does NOT cover the
+%% local key - there is no enough info for a range scan
+%%
 simple_rewrite_fail_1_test() ->
+    #ddl_v1{bucket = B} = get_standard_ddl(),
+    Mod = riak_ql_ddl:make_module_name(B),
     LK  = #key_v1{ast = [
-                         #param_v1{name = ["bob"]},
-                         #param_v1{name = ["ripple"]}
+                         #param_v1{name = [<<"geohash">>]},
+                         #param_v1{name = [<<"user">>]}
                         ]},
     W   = [
-           {'=', "bob", {"word", "yardle"}}
+           {'=', <<"geohash">>, {"word", "yardle"}}
           ],
     Exp = {error, invalid_rewrite},
-    Got = rewrite(LK, W),
+    Got = rewrite(LK, W, Mod),
     ?assertEqual(Exp, Got).
 
 simple_rewrite_fail_2_test() ->
+    #ddl_v1{bucket = B} = get_standard_ddl(),
+    Mod = riak_ql_ddl:make_module_name(B),
     LK  = #key_v1{ast = [
-                         #param_v1{name = ["bob"]},
-                         #param_v1{name = ["archipelego"]}
+                         #param_v1{name = [<<"geohash">>]},
+                         #param_v1{name = [<<"user">>]}
                         ]},
     W   = [
-           {'=', "bob", {"word", "yardle"}}
+           {'=', <<"user">>, {"word", "yardle"}}
           ],
     Exp = {error, invalid_rewrite},
-    Got = rewrite(LK, W),
+    Got = rewrite(LK, W, Mod),
     ?assertEqual(Exp, Got).
 
 simple_rewrite_fail_3_test() ->
+    #ddl_v1{bucket = B} = get_standard_ddl(),
+    Mod = riak_ql_ddl:make_module_name(B),
     LK  = #key_v1{ast = [
-                         #param_v1{name = ["bob"]},
-                         #param_v1{name = ["ripple"]},
-                         #param_v1{name = ["kumquat"]}
+                         #param_v1{name = [<<"geohash">>]},
+                         #param_v1{name = [<<"user">>]},
+                         #param_v1{name = [<<"temperature">>]}
                       ]},
     W   = [
-           {'=', "bob", {"word", "yardle"}}
+           {'=', <<"geohash">>, {"word", "yardle"}}
           ],
     Exp = {error, invalid_rewrite},
-    Got = rewrite(LK, W),
+    Got = rewrite(LK, W, Mod),
     ?assertEqual(Exp, Got).
 
 %%
@@ -313,19 +400,122 @@ simplest_test() ->
                               type          = timeseries,
                               'WHERE'       = [
                                                {startkey, [
-                                                           {<<"time">>, 3000},
-                                                           {<<"user">>, <<"user_1">>}
+                                                           {<<"time">>, 
+							    timestamp, 
+							    3000},
+                                                           {<<"user">>, 
+							    binary,
+							    <<"user_1">>}
                                                            ]},
                                                {endkey,   [
-                                                           {<<"time">>, 5000},
-                                                           {<<"user">>, <<"user_1">>}
+                                                           {<<"time">>, 
+							    timestamp, 
+							    5000},
+                                                           {<<"user">>, 
+							    binary, 
+							    <<"user_1">>}
                                                           ]},
                                                {filter,   []}
                                               ],
                               partition_key = get_standard_pk(),
                               local_key     = get_standard_lk()
                      }],
-    %% simplify the test we overwrite a couple of fields
+    ?assertEqual(Expected, Got).
+
+simple_with_filter_test() ->
+    DDL = get_standard_ddl(),
+    Query = "select weather from GeoCheckin where time > 3000 and time < 5000 and user = \"user_1\" and weather = 'yankee'",
+    {ok, Q} = get_query(Query),
+    true = is_query_valid(DDL, Q),
+    Got = compile(DDL, Q),
+    Where = [
+	     {startkey, [
+			 {<<"time">>, timestamp, 3000},
+			 {<<"user">>, binary,    <<"user_1">>}
+			]},
+	     {endkey,   [
+			 {<<"time">>, timestamp, 5000},
+			 {<<"user">>, binary,    <<"user_1">>}
+			]},
+	     {filter,   {'=', {field, <<"weather">>, binary}, 
+			 {const, <<"yankee">>}}}
+	    ],
+    Expected = [Q#riak_sql_v1{is_executable = true,
+                              type          = timeseries,
+                              'WHERE'       = Where,
+                              partition_key = get_standard_pk(),
+                              local_key     = get_standard_lk()
+                     }],
+    ?assertEqual(Expected, Got).
+
+simple_with_2_field_filter_test() ->
+    DDL = get_standard_ddl(),
+    Query = "select weather from GeoCheckin where time > 3000 and time < 5000 and user = \"user_1\" and weather = 'yankee' and temperature = 'yelp'",
+    {ok, Q} = get_query(Query),
+    true = is_query_valid(DDL, Q),
+    Got = compile(DDL, Q),
+    Where = [
+	     {startkey, [
+			 {<<"time">>, timestamp, 3000},
+			 {<<"user">>, binary,    <<"user_1">>}
+			]},
+	     {endkey,   [
+			 {<<"time">>, timestamp, 5000},
+			 {<<"user">>, binary,    <<"user_1">>}
+			]},
+	     {filter,   {and_, 
+			 {'=', {field, <<"weather">>,     binary}, 
+			  {const, <<"yankee">>}},
+			 {'=', {field, <<"temperature">>, binary}, 
+			  {const, <<"yelp">>}}
+			}
+	     }
+	    ],
+    Expected = [Q#riak_sql_v1{is_executable = true,
+                              type          = timeseries,
+                              'WHERE'       = Where,
+                              partition_key = get_standard_pk(),
+                              local_key     = get_standard_lk()
+                     }],
+    ?assertEqual(Expected, Got).
+
+complex_with_4_field_filter_test() ->
+    DDL = get_long_ddl(),
+    Query = "select weather from GeoCheckin where time > 3000 and time < 5000 and user = \"user_1\" and extra = 1 and (weather = 'yankee' or (temperature = 'yelp' and geohash = 'erko'))",
+    {ok, Q} = get_query(Query),
+    true = is_query_valid(DDL, Q),
+    Got = compile(DDL, Q),
+    Where = [
+	     {startkey, [
+			 {<<"time">>, timestamp, 3000},
+			 {<<"user">>, binary,    <<"user_1">>}
+			]},
+	     {endkey,   [
+			 {<<"time">>, timestamp, 5000},
+			 {<<"user">>, binary,    <<"user_1">>}
+			]},
+	     {filter,   {and_, 
+			 {or_, 
+			  {'=', {field, <<"weather">>, binary}, 
+			   {const, <<"yankee">>}},
+			  {and_, 
+			   {'=', {field, <<"geohash">>,     binary}, 
+			    {const, <<"erko">>}},
+			   {'=', {field, <<"temperature">>, binary}, 
+			    {const, <<"yelp">>}}
+			  }
+			 },
+			 {'=', {field, <<"extra">>, integer}, 
+			  {const, 1}}
+			}
+	     }
+	    ],
+    Expected = [Q#riak_sql_v1{is_executable = true,
+                              type          = timeseries,
+                              'WHERE'       = Where,
+                              partition_key = get_standard_pk(),
+                              local_key     = get_standard_lk()
+                     }],
     ?assertEqual(Expected, Got).
 
 %% got for 3 queries to get partition ordering problems flushed out
@@ -338,18 +528,24 @@ simple_spanning_boundary_test() ->
     Got = compile(DDL, Q),
     %% now make the result - expecting 3 queries
     W1 = [
-	  {startkey, [{<<"time">>, 3000},  {<<"user">>, <<"user_1">>}]},
-	  {endkey,   [{<<"time">>, 15000}, {<<"user">>, <<"user_1">>}]},
+	  {startkey, [{<<"time">>, timestamp, 3000},  
+		      {<<"user">>, binary, <<"user_1">>}]},
+	  {endkey,   [{<<"time">>, timestamp, 15000}, 
+		      {<<"user">>, binary, <<"user_1">>}]},
 	  {filter, []}
 	 ],
     W2 = [
-	  {startkey, [{<<"time">>, 15000}, {<<"user">>, <<"user_1">>}]},
-	  {endkey,   [{<<"time">>, 30000}, {<<"user">>, <<"user_1">>}]},
+	  {startkey, [{<<"time">>, timestamp, 15000}, 
+		      {<<"user">>, binary, <<"user_1">>}]},
+	  {endkey,   [{<<"time">>, timestamp, 30000}, 
+		      {<<"user">>, binary, <<"user_1">>}]},
 	  {filter, []}
 	 ],
     W3 = [
-	  {startkey, [{<<"time">>, 30000}, {<<"user">>, <<"user_1">>}]},
-	  {endkey,   [{<<"time">>, 31000}, {<<"user">>, <<"user_1">>}]},
+	  {startkey, [{<<"time">>, timestamp, 30000}, 
+		      {<<"user">>, binary, <<"user_1">>}]},
+	  {endkey,   [{<<"time">>, timestamp, 31000}, 
+		      {<<"user">>, binary, <<"user_1">>}]},
 	  {filter, []}
 	 ],
     Expected = [

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -27,7 +27,6 @@
         ]).
 
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
--include_lib("riak_ql/include/riak_ql_sql.hrl").
 -include("riak_kv_index.hrl").
 
 compile(#ddl_v1{}, #riak_sql_v1{is_executable = true}) ->

--- a/src/riak_kv_qry_coverage_plan.erl
+++ b/src/riak_kv_qry_coverage_plan.erl
@@ -26,7 +26,7 @@
 	 create_plan/6
 	]).
 
--include_lib("riak_ql/include/riak_ql_sql.hrl").
+-include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 create_plan(_VNodeSelector, NVal, _PVC, _ReqId, _NodeCheckService, Request) ->
     BucketName = riak_kv_util:get_bucket_from_req(Request),

--- a/src/riak_kv_qry_queue.erl
+++ b/src/riak_kv_qry_queue.erl
@@ -56,7 +56,7 @@
 -endif.
 
 -include("riak_kv_qry_queue.hrl").
--include_lib("riak_ql/include/riak_ql_ddl.hrl").  %% for #ddl_v1{}
+-include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 -define(SERVER, ?MODULE).
 

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -56,8 +56,6 @@
 -endif.
 
 -include("riak_kv_qry_queue.hrl").
-%% TODO sort out inclusion policy
-%%-include_lib("riak_ql/include/riak_ql_sql.hrl").
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 -define(SERVER, ?MODULE).

--- a/src/riak_local_index.erl
+++ b/src/riak_local_index.erl
@@ -29,7 +29,7 @@
 	 get_query_from_req/1
 	]).
 
--include_lib("riak_ql/include/riak_ql_sql.hrl").
+-include_lib("riak_ql/include/riak_ql_ddl.hrl").
 -include("riak_kv_index.hrl").
 -include("riak_kv_vnode.hrl").
 

--- a/test/sql_compilation_end_to_end.erl
+++ b/test/sql_compilation_end_to_end.erl
@@ -1,6 +1,7 @@
 -module(sql_compilation_end_to_end).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 %% this is a basic test of timeseries that writes a single element to the back end
 %% and checks it is correct
@@ -76,13 +77,21 @@ get_standard_lk() -> #key_v1{ast = [
                            'FROM'        = <<"GeoCheckin">>,
                            'WHERE'       = [
                                             {startkey, [
-                                                        {<<"time">>,  3000},
-                                                        {<<"user">>, <<"gordon">>}
+                                                        {<<"time">>,  
+							 timestamp, 
+							 3000},
+                                                        {<<"user">>, 
+							 binary,
+							 <<"gordon">>}
                                                        ]
                                             },
                                             {endkey,   [
-                                                        {<<"time">>, 5000},
-                                                        {<<"user">>, <<"gordon">>}
+                                                        {<<"time">>, 
+							 timestamp, 
+							 5000},
+                                                        {<<"user">>, 
+							 binary,
+							 <<"gordon">>}
                                                        ]
                                             },
                                             {filter, []}
@@ -108,14 +117,22 @@ get_standard_lk() -> #key_v1{ast = [
 	      #riak_sql_v1{'SELECT'      = [[<<"weather">>]],
 			   'FROM'        = <<"GeoCheckin">>,
 			   'WHERE'       = [
-	                                            {startkey, [
-                                                        {<<"time">>,  3000},
-                                                        {<<"user">>, <<"gordon">>}
+					    {startkey, [
+                                                        {<<"time">>, 
+							 timestamp,
+							 3000},
+                                                        {<<"user">>,
+							 binary,
+							 <<"gordon">>}
                                                        ]
                                             },
                                             {endkey,   [
-                                                        {<<"time">>, 15000},
-                                                        {<<"user">>, <<"gordon">>}
+                                                        {<<"time">>, 
+							 timestamp,
+							 15000},
+                                                        {<<"user">>, 
+							 binary,
+							 <<"gordon">>}
                                                        ]
                                             },
                                             {filter, []}
@@ -129,13 +146,21 @@ get_standard_lk() -> #key_v1{ast = [
 			   'FROM'        = <<"GeoCheckin">>,
 			   'WHERE'       = [
                                             {startkey, [
-                                                        {<<"time">>,  15000},
-                                                        {<<"user">>, <<"gordon">>}
+                                                        {<<"time">>,  
+							 timestamp,
+							 15000},
+                                                        {<<"user">>, 
+							 binary,
+							 <<"gordon">>}
                                                        ]
                                             },
                                             {endkey,   [
-                                                        {<<"time">>, 18000},
-                                                        {<<"user">>, <<"gordon">>}
+                                                        {<<"time">>, 
+							 timestamp,
+							 18000},
+                                                        {<<"user">>,
+							 binary,
+							 <<"gordon">>}
                                                        ]
                                             },
                                             {filter, []}

--- a/test/sql_compilation_end_to_end.erl
+++ b/test/sql_compilation_end_to_end.erl
@@ -1,7 +1,6 @@
 -module(sql_compilation_end_to_end).
 
 -include_lib("eunit/include/eunit.hrl").
--include_lib("riak_ql/include/riak_ql_sql.hrl").
 
 %% this is a basic test of timeseries that writes a single element to the back end
 %% and checks it is correct


### PR DESCRIPTION
There were dependency problems caused by having two .hrl files in riak_ql which meant that spurious dialyzer warnings were being created. They have been merged, this PR includes the riak_kv side of the house.

In addition the post-query-rewrite filters have to be rewritten in a way that they are consumable at the leveldb end. That change is incorporated here. 
