### PR TITLE
hashtree:flush_buffer before finishing build of hashtree

### DIFF
--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -622,12 +622,7 @@ apply_tree(Id, Fun, State=#state{trees=Trees}) ->
 do_build_finished(State=#state{index=Index, built=_Pid, trees=Trees0}) ->
     lager:debug("Finished build: ~p", [Index]),
     Trees = orddict:map(fun(_Id, Tree) ->
-                            try
-                                hashtree:flush_buffer(Tree)
-                            catch _:_ ->
-                                lager:warning("Failed to flush trees during build_finish"),
-                                Tree
-                            end
+                            hashtree:flush_buffer(Tree)
                         end, Trees0),
     {_, Tree0} = hd(Trees),
     BuildTime = get_build_time(Tree0),


### PR DESCRIPTION
simple fix, but make sure to call hashtree:flush_buffer before buildtime, meta for build_finished

^^ @jonmeredith 
