### PR TITLE
RTS-348 Fix console/HTTP errors creating bucket types

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -936,11 +936,8 @@ bucket_type_and_table_name_must_match_test() ->
                        {table_def, TableDef}]),
     % if this error changes slightly it is not so important, as long as
     % the bucket type is not allowed to be created.
-    ?assertError(
-        {badmatch,
-            {error,
-                {bucket_type_and_table_name_different,
-                    <<"my_type">>,<<"times">>}}},
+    ?assertEqual(
+        error,
         bucket_type_create(
             fun(Props) -> put(Ref, Props) end,
             <<"my_type">>,
@@ -957,8 +954,8 @@ bucket_type_create_with_timeseries_table_error_when_write_once_set_to_false_test
     JSON = json_props([{bucket_type, my_type}, 
                        {table_def, TableDef},
                        {write_once, false}]),
-    ?assertError(
-        write_once_cannot_be_false,
+    ?assertEqual(
+        error,
         bucket_type_create(
             fun(Props) -> put(Ref, Props) end,
             <<"my_type">>,

--- a/src/riak_kv_wm_props.erl
+++ b/src/riak_kv_wm_props.erl
@@ -279,9 +279,10 @@ get_bucket_props_json(Client, Bucket) ->
 -spec accept_bucket_body(#wm_reqdata{}, context()) -> {true, #wm_reqdata{}, context()}.
 %% @doc Modify the bucket properties according to the body of the
 %%      bucket-level PUT request.
-accept_bucket_body(RD, Ctx=#ctx{bucket_type=T, bucket=B, client=C, bucketprops=Props}) ->
-    ErlProps = lists:map(fun riak_kv_wm_utils:erlify_bucket_prop/1, Props),
-    case C:set_bucket({T,B}, ErlProps) of
+accept_bucket_body(RD, Ctx=#ctx{bucket_type=T, bucket=B, client=C, bucketprops=Props1}) ->
+    {ok, Props2} = riak_kv_wm_utils:maybe_parse_table_def(T, Props1),
+    Props3 = lists:map(fun riak_kv_wm_utils:erlify_bucket_prop/1, Props2),
+    case C:set_bucket({T,B}, Props3) of
         ok ->
             {true, RD, Ctx};
         {error, Details} ->

--- a/src/riak_kv_wm_props.erl
+++ b/src/riak_kv_wm_props.erl
@@ -276,20 +276,33 @@ get_bucket_props_json(Client, Bucket) ->
     Props2 = lists:map(fun riak_kv_wm_utils:jsonify_bucket_prop/1, Props1),
     {?JSON_PROPS, {struct, Props2}}.
 
--spec accept_bucket_body(#wm_reqdata{}, context()) -> {true, #wm_reqdata{}, context()}.
+-spec accept_bucket_body(#wm_reqdata{}, context()) ->
+        {true, #wm_reqdata{}, context()}.
 %% @doc Modify the bucket properties according to the body of the
 %%      bucket-level PUT request.
-accept_bucket_body(RD, Ctx=#ctx{bucket_type=T, bucket=B, client=C, bucketprops=Props1}) ->
-    {ok, Props2} = riak_kv_wm_utils:maybe_parse_table_def(T, Props1),
-    Props3 = lists:map(fun riak_kv_wm_utils:erlify_bucket_prop/1, Props2),
-    case C:set_bucket({T,B}, Props3) of
+accept_bucket_body(RD, Ctx=#ctx{bucket_type=T, bucketprops=Props1}) ->
+    case catch riak_kv_wm_utils:maybe_parse_table_def(T, Props1) of
+        {ok, Props2} ->
+            set_bucket(RD, Ctx#ctx{ bucketprops = Props2 });
+        {error, Details} when is_list(Details) ->
+            error_response([{<<"error">>, list_to_binary(Details)}], RD, Ctx);
+        {error, Details} ->
+            error_response([{<<"error">>, Details}], RD, Ctx)
+    end.
+
+set_bucket(RD, Ctx=#ctx{bucket_type=T, bucket=B, client=C, bucketprops=Props1}) ->
+    Props2 = lists:map(fun riak_kv_wm_utils:erlify_bucket_prop/1, Props1),
+    case C:set_bucket({T,B}, Props2) of
         ok ->
             {true, RD, Ctx};
         {error, Details} ->
-            JSON = mochijson2:encode(Details),
-            RD2 = wrq:append_to_resp_body(JSON, RD),
-            {{halt, 400}, RD2, Ctx}
+            error_response(Details, RD, Ctx)
     end.
+
+error_response(Details, RD, Ctx) ->
+    JSON = mochijson2:encode(Details),
+    RD2 = wrq:append_to_resp_body(JSON, RD),
+    {{halt, 400}, RD2, Ctx}.
 
 -spec delete_resource(#wm_reqdata{}, context()) ->
     {boolean(), #wm_reqdata{}, context()}.

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -42,8 +42,11 @@
          ensure_bucket_type/3,
          bucket_type_exists/1,
          maybe_bucket_type/2,
-         method_to_perm/1
+         method_to_perm/1,
+         maybe_parse_table_def/2
         ]).
+
+-include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 -include_lib("webmachine/include/webmachine.hrl").
 -include("riak_kv_wm_raw.hrl").
@@ -439,3 +442,70 @@ method_to_perm('GET') ->
     "riak_kv.get";
 method_to_perm('DELETE') ->
     "riak_kv.delete".
+
+%%%
+%%%
+%%%
+
+%%
+-spec maybe_parse_table_def(BucketType :: binary(),
+                            Props :: list(proplists:property())) -> 
+        {ok, Props2 :: [proplists:property()]} | {error, any()}.
+maybe_parse_table_def(BucketType, Props) ->
+    case lists:keytake(<<"table_def">>, 1, Props) of
+        false ->
+            {ok, Props};
+        {value, {<<"table_def">>, TableDef}, PropsNoDef} ->
+            case riak_ql_parser:parse(riak_ql_lexer:get_tokens(binary_to_list(TableDef))) of
+                {ok, DDL} ->
+                    ok = assert_type_and_table_name_same(BucketType, DDL),
+                    ok = try_compile_ddl(DDL),
+                    ok = assert_write_once_not_false(PropsNoDef),
+                    apply_timeseries_bucket_props(DDL, PropsNoDef);
+                {error, _} = E ->
+                    E
+            end
+    end.
+
+%%
+-spec apply_timeseries_bucket_props(DDL::#ddl_v1{},
+                                    Props1::[proplists:property()]) -> 
+        {ok, Props2::[proplists:property()]}.
+apply_timeseries_bucket_props(DDL, Props1) ->
+    Props2 = lists:keystore(
+        <<"write_once">>, 1, Props1, {<<"write_once">>, true}),
+    {ok, [{<<"ddl">>, DDL} | Props2]}.
+
+%% Time series must always use write_once so throw an error if the write_once
+%% property is ever set to false. This prevents a user thinking they have
+%% disabled write_once when it has been set to true internally.
+assert_write_once_not_false(Props) ->
+    case lists:keyfind(<<"write_once">>, 1, Props) of
+        {<<"write_once">>, false} ->
+            io:format(
+                "Error, the bucket type could not be the created. "
+                "The write_once property had a value of false but must be true "
+                "or left blank~n"),
+            error(write_once_cannot_be_false);
+        _ ->
+            ok
+    end.
+
+%%
+assert_type_and_table_name_same(BucketType, #ddl_v1{ bucket = BucketType }) ->
+    ok;
+assert_type_and_table_name_same(BucketType, #ddl_v1{ bucket = TableName }) ->
+    io:format(
+        "Error, the bucket type could not be the created. The bucket type and table name must be the same~n"
+        "    bucket type was: ~s~n"
+        "    table name was:  ~s~n",
+        [BucketType, TableName]),
+    {error, {bucket_type_and_table_name_different, BucketType, TableName}}.
+
+%% Attempt to compile the DDL but don't do anything with the output, this is
+%% catch failures as early as possible. Also the error messages are easy to
+%% return at this point.
+try_compile_ddl(DDL) ->
+    {_, AST} = riak_ql_ddl_compiler:compile(DDL),
+    {ok, _, _} = compile:forms(AST),
+    ok.

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -443,11 +443,9 @@ method_to_perm('GET') ->
 method_to_perm('DELETE') ->
     "riak_kv.delete".
 
-%%%
-%%%
-%%%
-
-%%
+%% Given bucket properties, transform the `<<"table_def">>' property if it
+%% exists to riak_ql DDL and store it under the `<<"ddl">>' key, table_def
+%% is removed.  
 -spec maybe_parse_table_def(BucketType :: binary(),
                             Props :: list(proplists:property())) -> 
         {ok, Props2 :: [proplists:property()]} | {error, any()}.
@@ -482,11 +480,10 @@ apply_timeseries_bucket_props(DDL, Props1) ->
 assert_write_once_not_false(Props) ->
     case lists:keyfind(<<"write_once">>, 1, Props) of
         {<<"write_once">>, false} ->
-            io:format(
+            throw({error,
                 "Error, the bucket type could not be the created. "
                 "The write_once property had a value of false but must be true "
-                "or left blank~n"),
-            error(write_once_cannot_be_false);
+                "or left blank\n"});
         _ ->
             ok
     end.
@@ -494,13 +491,11 @@ assert_write_once_not_false(Props) ->
 %%
 assert_type_and_table_name_same(BucketType, #ddl_v1{ bucket = BucketType }) ->
     ok;
-assert_type_and_table_name_same(BucketType, #ddl_v1{ bucket = TableName }) ->
-    io:format(
+assert_type_and_table_name_same(BucketType1, #ddl_v1{ bucket = BucketType2 }) ->
+    throw({error, 
         "Error, the bucket type could not be the created. The bucket type and table name must be the same~n"
-        "    bucket type was: ~s~n"
-        "    table name was:  ~s~n",
-        [BucketType, TableName]),
-    {error, {bucket_type_and_table_name_different, BucketType, TableName}}.
+        "    bucket type was: " ++ binary_to_list(BucketType1) ++ "\n"
+        "    table name was:  " ++ binary_to_list(BucketType2) ++ "\n"}).
 
 %% Attempt to compile the DDL but don't do anything with the output, this is
 %% catch failures as early as possible. Also the error messages are easy to


### PR DESCRIPTION
Fixes a badarity error thrown when no bucket type properties are given via riak-admin.

Fixes list_to_existing_atom error thrown on the HTTP interface when a table_def is specified.

riak-admin and the HTTP bucket props interface share the `table_def` to `ddl` conversion code. Error messages should be prettier, no stack traces for anticipated problems i.e. write_once:false and BucketType =/= TableName.

There are commands on the JIRA for testing the HTTP interface.
