### PR TITLE
Correctly create the various start_include and end_include options

### DIFF
--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -33,7 +33,7 @@ compile(#ddl_v1{}, #riak_sql_v1{is_executable = true}) ->
     {error, 'query is already compiled'};
 compile(#ddl_v1{}, #riak_sql_v1{'SELECT' = []}) ->
     {error, 'full table scan not implmented'};
-compile(#ddl_v1{} = DDL, #riak_sql_v1{is_executable = false, 
+compile(#ddl_v1{} = DDL, #riak_sql_v1{is_executable = false,
 				      type          = sql} = Q) ->
     comp2(DDL, Q).
 
@@ -55,7 +55,7 @@ expand_query(#ddl_v1{local_key = LK, partition_key = PK}, Q, NewW) ->
 		   'WHERE'       = X,
 		   local_key     = LK,
 		   partition_key = PK} || X <- NewWs].
-	
+
 
 expand_where(Where, #key_v1{ast = PAST}) ->
     GetMaxMinFun = fun({startkey, [{_, _, H} | _T]}, {_S, E}) ->
@@ -66,10 +66,10 @@ expand_where(Where, #key_v1{ast = PAST}) ->
 			   {S, E}
 		   end,
     {Min, Max} = lists:foldl(GetMaxMinFun, {"", ""}, Where),
-    [{[QField], Q, U}] = [{X, Y, Z} 
+    [{[QField], Q, U}] = [{X, Y, Z}
 			  || #hash_fn_v1{mod = riak_ql_quanta,
 					 fn   = quantum,
-					 args = [#param_v1{name = X}, Y, Z]} 
+					 args = [#param_v1{name = X}, Y, Z]}
 				 <- PAST],
     {NoSubQueries, Boundaries} = riak_ql_quanta:quanta(Min, Max, Q, U),
     case NoSubQueries of
@@ -78,9 +78,18 @@ expand_where(Where, #key_v1{ast = PAST}) ->
     end.
 
 make_wheres(Where, QField, Min, Max, Boundaries) ->
+    {HeadOption, TailOption, NewWhere} = extract_options(Where),
     Starts = [Min | Boundaries],
     Ends   = Boundaries ++ [Max],
-    make_w2(Starts, Ends, QField, Where, []).
+    [HdW | Ws] = make_w2(Starts, Ends, QField, NewWhere, []),
+    %% add the head options to the head
+    %% reverse the list
+    %% add an 'end_include' to all values except the tail
+    %% add the tail options to the tail
+    %% reverse again
+    [TW | Rest] = lists:reverse([lists:flatten(HdW ++ [HeadOption]) | Ws]),
+    Rest2 = [X ++ [{end_inclusive, true}] || X <- Rest],
+    _Wheres = lists:reverse([lists:flatten(TW ++ [TailOption]) | Rest2]).
 
 make_w2([], [], _QField, _Where, Acc) ->
     lists:reverse(Acc);
@@ -88,6 +97,17 @@ make_w2([Start | T1], [End | T2], QField, Where, Acc) ->
     Where2 = swap(Where, QField, startkey, Start),
     Where3 = swap(Where2, QField, endkey, End),
     make_w2(T1, T2, QField, Where, [Where3 | Acc]).
+
+extract_options(Where) ->
+    {HeadOption, W1} = case lists:keytake(start_inclusive, 1, Where) of
+			     false                  -> {[], Where};
+			     {value, HdO, NewWhere} -> {HdO, NewWhere}
+			 end,
+    {TailOption, W2} = case lists:keytake(end_inclusive, 1, W1) of
+			   false                  -> {[], W1};
+			   {value, TO, NewWhere2} -> {TO, NewWhere2}
+		       end,
+    {HeadOption, TailOption, W2}.
 
 %% this rewrite is premised on the fact the the Query field is a timestamp
 swap(Where, QField, Key, Val) ->
@@ -112,22 +132,32 @@ check_if_timeseries(#ddl_v1{bucket = B, partition_key = PK, local_key = LK},
            PartitionFields = [X || #param_v1{name = X} <- PAST],
            [QField] = [X || #hash_fn_v1{mod  = riak_ql_quanta,
 					fn   = quantum,
-					args = [#param_v1{name = X} | _Rest]} 
+					args = [#param_v1{name = X} | _Rest]}
 				<- PAST],
 	   StrippedW = strip(W, []),
 	   {StartW, EndW, Filter} = break_out_timeseries(StrippedW, LocalFields, [QField]),
 	   Mod = riak_ql_ddl:make_module_name(B),
 	   StartKey = rewrite(LK, StartW, Mod),
            EndKey = rewrite(LK, EndW, Mod),
+	   %% defaults on startkey and endkey are different
+	   IncStart = case includes(StartW, '>', Mod) of
+			  true  -> [{start_inclusive, false}];
+			  false -> []
+		      end,
+	   IncEnd = case includes(EndW, '<', Mod) of
+			  true  -> [];
+			  false -> [{end_inclusive, true}]
+		      end,
 	   HasErrs = [X || {error, _} = X <- [StartKey, EndKey]],
 	   case HasErrs of
 	       [] ->
 		   RewrittenFilter = add_types_to_filter(Filter, Mod),
-		   {true, [
-			   {startkey, StartKey},
-			   {endkey,   EndKey},
-			   {filter,   RewrittenFilter}
-			  ]};
+		   {true, lists:flatten([
+					 {startkey, StartKey},
+					 {endkey,   EndKey},
+					 {filter,   RewrittenFilter}
+					] ++ IncStart ++IncEnd
+				       )};
 	       _ ->
 		   {error, {invalid_where_clause, W}}
 	   end
@@ -135,6 +165,22 @@ check_if_timeseries(#ddl_v1{bucket = B, partition_key = PK, local_key = LK},
     end;
 check_if_timeseries(_DLL, Where) ->
     {error, {where_not_supported, Where}}.
+
+%% this is pretty brutal - it is assuming this is a time series query
+%% if it isn't this clause is mince
+includes([], _Op, _Mod) ->
+    false;
+includes([{Op1, Field, _} | T], Op2, Mod) ->
+    Type = Mod:get_field_type([Field]),
+    case Type of
+	timestamp ->
+	    case Op1 of
+		Op2 -> true;
+		_   -> false
+	    end;
+	_ ->
+	    includes(T, Op2, Mod)
+    end.
 
 break_out_timeseries(Ands, LocalFields, QuantumFields) ->
     {NewAnds, [Ends, Starts]} = get_fields(QuantumFields, Ands, []),
@@ -167,7 +213,7 @@ add_types2([{Op, LHS, RHS} | T], Mod, Acc) when Op =:= and_ orelse
     add_types2(T, Mod, [NewAcc | Acc]);
 add_types2([{Op, Field, {_, Val}} | T], Mod, Acc) ->
     NewAcc = {Op, {field, Field, Mod:get_field_type([Field])}, {const, Val}},
-    add_types2(T, Mod, [NewAcc | Acc]).	      
+    add_types2(T, Mod, [NewAcc | Acc]).
 
 %% I know, not tail recursive could stackbust
 %% but not really
@@ -189,9 +235,9 @@ rew2([], _W, _Mod, _Acc) ->
 rew2([#param_v1{name = [N]} | T], W, Mod, Acc) ->
     Type = Mod:get_field_type([N]),
     case lists:keytake(N, 2, W) of
-	false                           -> 
+	false                           ->
 	    {error, invalid_rewrite};
-	{value, {_, _, {_, Val}}, NewW} -> 
+	{value, {_, _, {_, Val}}, NewW} ->
 	    rew2(T, NewW, Mod, [{N, Type, Val} | Acc])
     end.
 
@@ -296,9 +342,9 @@ simple_filter_typing_test() ->
     #ddl_v1{bucket = B} = get_long_ddl(),
     Mod = riak_ql_ddl:make_module_name(B),
     Filter = [
-	      {or_, 
+	      {or_,
 	       {'=', <<"weather">>, {word, <<"yankee">>}},
-	       {and_, 
+	       {and_,
 		{'=', <<"geohash">>,     {word, <<"erko">>}},
 		{'=', <<"temperature">>, {word, <<"yelp">>}}
 	       }
@@ -306,10 +352,10 @@ simple_filter_typing_test() ->
 	      {'=', <<"extra">>, {int, 1}}
 	     ],
     Got = add_types_to_filter(Filter, Mod),
-    Expected = {and_, 
-	    {or_, 
+    Expected = {and_,
+	    {or_,
 	     {'=', {field, <<"weather">>, binary}, {const, <<"yankee">>}},
-	     {and_, 
+	     {and_,
 	      {'=', {field, <<"geohash">>,     binary}, {const, <<"erko">>}},
 	      {'=', {field, <<"temperature">>, binary}, {const, <<"yelp">>}}
 	     }
@@ -401,35 +447,55 @@ simplest_test() ->
     {ok, Q} = get_query(Query),
     true = is_query_valid(DDL, Q),
     Got = compile(DDL, Q),
+    Where = [
+	     {startkey,        [
+				{<<"time">>, timestamp, 3000},
+				{<<"user">>, binary,    <<"user_1">>}
+			       ]},
+	     {endkey,          [
+				{<<"time">>, timestamp, 5000},
+				{<<"user">>, binary,    <<"user_1">>}
+			       ]},
+	     {filter,          []},
+	     {start_inclusive, false}
+	    ],
     Expected = [Q#riak_sql_v1{is_executable = true,
                               type          = timeseries,
-                              'WHERE'       = [
-                                               {startkey, [
-                                                           {<<"time">>, 
-							    timestamp, 
-							    3000},
-                                                           {<<"user">>, 
-							    binary,
-							    <<"user_1">>}
-                                                           ]},
-                                               {endkey,   [
-                                                           {<<"time">>, 
-							    timestamp, 
-							    5000},
-                                                           {<<"user">>, 
-							    binary, 
-							    <<"user_1">>}
-                                                          ]},
-                                               {filter,   []}
-                                              ],
+                              'WHERE'       = Where,
                               partition_key = get_standard_pk(),
                               local_key     = get_standard_lk()
                      }],
     ?assertEqual(Expected, Got).
 
-simple_with_filter_test() ->
+simple_with_filter_1_test() ->
     DDL = get_standard_ddl(),
     Query = "select weather from GeoCheckin where time > 3000 and time < 5000 and user = \"user_1\" and weather = 'yankee'",
+    {ok, Q} = get_query(Query),
+    true = is_query_valid(DDL, Q),
+    Got = compile(DDL, Q),
+    Where = [
+	     {startkey,        [
+				{<<"time">>, timestamp, 3000},
+				{<<"user">>, binary,    <<"user_1">>}
+			       ]},
+	     {endkey,          [
+				{<<"time">>, timestamp, 5000},
+				{<<"user">>, binary,    <<"user_1">>}
+			       ]},
+	     {filter,          {'=', {field, <<"weather">>, binary}, {const, <<"yankee">>}}},
+	     {start_inclusive, false}
+	    ],
+    Expected = [Q#riak_sql_v1{is_executable = true,
+                              type          = timeseries,
+                              'WHERE'       = Where,
+                              partition_key = get_standard_pk(),
+                              local_key     = get_standard_lk()
+                     }],
+    ?assertEqual(Expected, Got).
+
+simple_with_filter_2_test() ->
+    DDL = get_standard_ddl(),
+    Query = "select weather from GeoCheckin where time >= 3000 and time < 5000 and user = \"user_1\" and weather = 'yankee'",
     {ok, Q} = get_query(Query),
     true = is_query_valid(DDL, Q),
     Got = compile(DDL, Q),
@@ -442,8 +508,34 @@ simple_with_filter_test() ->
 			 {<<"time">>, timestamp, 5000},
 			 {<<"user">>, binary,    <<"user_1">>}
 			]},
-	     {filter,   {'=', {field, <<"weather">>, binary}, 
-			 {const, <<"yankee">>}}}
+	     {filter,   {'=', {field, <<"weather">>, binary}, {const, <<"yankee">>}}}
+	    ],
+    Expected = [Q#riak_sql_v1{is_executable = true,
+                              type          = timeseries,
+                              'WHERE'       = Where,
+                              partition_key = get_standard_pk(),
+                              local_key     = get_standard_lk()
+                     }],
+    ?assertEqual(Expected, Got).
+
+simple_with_filter_3_test() ->
+    DDL = get_standard_ddl(),
+    Query = "select weather from GeoCheckin where time > 3000 and time <= 5000 and user = \"user_1\" and weather = 'yankee'",
+    {ok, Q} = get_query(Query),
+    true = is_query_valid(DDL, Q),
+    Got = compile(DDL, Q),
+    Where = [
+	     {startkey,        [
+				{<<"time">>, timestamp, 3000},
+				{<<"user">>, binary,    <<"user_1">>}
+			       ]},
+	     {endkey,          [
+				{<<"time">>, timestamp, 5000},
+				{<<"user">>, binary,    <<"user_1">>}
+			       ]},
+	     {filter,          {'=', {field, <<"weather">>, binary}, {const, <<"yankee">>}}},
+	     {start_inclusive, false},
+	     {end_inclusive,   true}
 	    ],
     Expected = [Q#riak_sql_v1{is_executable = true,
                               type          = timeseries,
@@ -460,21 +552,22 @@ simple_with_2_field_filter_test() ->
     true = is_query_valid(DDL, Q),
     Got = compile(DDL, Q),
     Where = [
-	     {startkey, [
-			 {<<"time">>, timestamp, 3000},
-			 {<<"user">>, binary,    <<"user_1">>}
-			]},
-	     {endkey,   [
-			 {<<"time">>, timestamp, 5000},
-			 {<<"user">>, binary,    <<"user_1">>}
-			]},
-	     {filter,   {and_, 
-			 {'=', {field, <<"weather">>,     binary}, 
-			  {const, <<"yankee">>}},
-			 {'=', {field, <<"temperature">>, binary}, 
-			  {const, <<"yelp">>}}
-			}
-	     }
+	     {startkey,        [
+				{<<"time">>, timestamp, 3000},
+				{<<"user">>, binary,    <<"user_1">>}
+			       ]},
+	     {endkey,          [
+				{<<"time">>, timestamp, 5000},
+				{<<"user">>, binary,    <<"user_1">>}
+			       ]},
+	     {filter,          {and_,
+				{'=', {field, <<"weather">>,     binary},
+				 {const, <<"yankee">>}},
+				{'=', {field, <<"temperature">>, binary},
+				 {const, <<"yelp">>}}
+			       }
+	     },
+	     {start_inclusive, false}
 	    ],
     Expected = [Q#riak_sql_v1{is_executable = true,
                               type          = timeseries,
@@ -491,29 +584,30 @@ complex_with_4_field_filter_test() ->
     true = is_query_valid(DDL, Q),
     Got = compile(DDL, Q),
     Where = [
-	     {startkey, [
-			 {<<"time">>, timestamp, 3000},
-			 {<<"user">>, binary,    <<"user_1">>}
-			]},
-	     {endkey,   [
-			 {<<"time">>, timestamp, 5000},
-			 {<<"user">>, binary,    <<"user_1">>}
-			]},
-	     {filter,   {and_, 
-			 {or_, 
-			  {'=', {field, <<"weather">>, binary}, 
-			   {const, <<"yankee">>}},
-			  {and_, 
-			   {'=', {field, <<"geohash">>,     binary}, 
-			    {const, <<"erko">>}},
-			   {'=', {field, <<"temperature">>, binary}, 
-			    {const, <<"yelp">>}}
-			  }
-			 },
-			 {'=', {field, <<"extra">>, integer}, 
-			  {const, 1}}
-			}
-	     }
+	     {startkey,        [
+				{<<"time">>, timestamp, 3000},
+				{<<"user">>, binary,    <<"user_1">>}
+			       ]},
+	     {endkey,          [
+				{<<"time">>, timestamp, 5000},
+				{<<"user">>, binary,    <<"user_1">>}
+			       ]},
+	     {filter,          {and_,
+				{or_,
+				 {'=', {field, <<"weather">>, binary},
+				  {const, <<"yankee">>}},
+				 {and_,
+				  {'=', {field, <<"geohash">>,     binary},
+				   {const, <<"erko">>}},
+				  {'=', {field, <<"temperature">>, binary},
+				   {const, <<"yelp">>}}
+				 }
+				},
+				{'=', {field, <<"extra">>, integer},
+				 {const, 1}}
+			       }
+	     },
+	     {start_inclusive, false}
 	    ],
     Expected = [Q#riak_sql_v1{is_executable = true,
                               type          = timeseries,
@@ -526,32 +620,34 @@ complex_with_4_field_filter_test() ->
 %% got for 3 queries to get partition ordering problems flushed out
 simple_spanning_boundary_test() ->
     DDL = get_standard_ddl(),
-    Query = "select weather from GeoCheckin where time > 3000 and time < 31000 and user = \"user_1\"",
+    Query = "select weather from GeoCheckin where time >= 3000 and time < 31000 and user = \"user_1\"",
     {ok, Q} = get_query(Query),
     true = is_query_valid(DDL, Q),
     %% get basic query
     Got = compile(DDL, Q),
     %% now make the result - expecting 3 queries
     W1 = [
-	  {startkey, [{<<"time">>, timestamp, 3000},  
-		      {<<"user">>, binary, <<"user_1">>}]},
-	  {endkey,   [{<<"time">>, timestamp, 15000}, 
-		      {<<"user">>, binary, <<"user_1">>}]},
-	  {filter, []}
+	  {startkey,        [{<<"time">>, timestamp, 3000},
+			     {<<"user">>, binary, <<"user_1">>}]},
+	  {endkey,          [{<<"time">>, timestamp, 15000},
+			     {<<"user">>, binary, <<"user_1">>}]},
+	  {filter,          []},
+	  {end_inclusive,   true}
 	 ],
     W2 = [
-	  {startkey, [{<<"time">>, timestamp, 15000}, 
-		      {<<"user">>, binary, <<"user_1">>}]},
-	  {endkey,   [{<<"time">>, timestamp, 30000}, 
-		      {<<"user">>, binary, <<"user_1">>}]},
-	  {filter, []}
+	  {startkey,        [{<<"time">>, timestamp, 15000},
+			     {<<"user">>, binary, <<"user_1">>}]},
+	  {endkey,          [{<<"time">>, timestamp, 30000},
+			     {<<"user">>, binary, <<"user_1">>}]},
+	  {filter,          []},
+	  {end_inclusive,   true}
 	 ],
     W3 = [
-	  {startkey, [{<<"time">>, timestamp, 30000}, 
-		      {<<"user">>, binary, <<"user_1">>}]},
-	  {endkey,   [{<<"time">>, timestamp, 31000}, 
-		      {<<"user">>, binary, <<"user_1">>}]},
-	  {filter, []}
+	  {startkey,        [{<<"time">>, timestamp, 30000},
+			     {<<"user">>, binary, <<"user_1">>}]},
+	  {endkey,          [{<<"time">>, timestamp, 31000},
+			     {<<"user">>, binary, <<"user_1">>}]},
+	  {filter,          []}
 	 ],
     Expected = [
 		Q#riak_sql_v1{is_executable = true,

--- a/test/sql_compilation_end_to_end.erl
+++ b/test/sql_compilation_end_to_end.erl
@@ -25,6 +25,7 @@
                case riak_ql_ddl:is_query_valid(DDL, SQL) of
                    true ->
                        Got = riak_kv_qry_compiler:compile(DDL, SQL),
+		       gg:format("in ~p~n- Expected:~n- ~p~nGot:~n- ~p~n", [Name, Expected, Got]),
                        ?assertEqual(Expected, Got);
                    false ->
                        ?assertEqual(Expected, invalid_query)
@@ -94,7 +95,8 @@ get_standard_lk() -> #key_v1{ast = [
 							 <<"gordon">>}
                                                        ]
                                             },
-                                            {filter, []}
+                                            {filter, []},
+					    {start_inclusive,   false}
                                            ],
                            helper_mod    = riak_ql_ddl:make_module_name(<<"GeoCheckin">>),
                            partition_key = get_standard_pk(),
@@ -153,7 +155,9 @@ get_standard_lk() -> #key_v1{ast = [
 							 <<"gordon">>}
                                                        ]
                                             },
-                                            {filter, []}
+                                            {filter, []},
+					    {start_inclusive, false},
+					    {end_inclusive,   true}
 					   ],
                            helper_mod    = riak_ql_ddl:make_module_name(<<"GeoCheckin">>),
                            partition_key = get_standard_pk(),
@@ -181,8 +185,7 @@ get_standard_lk() -> #key_v1{ast = [
 							 <<"gordon">>}
                                                        ]
                                             },
-                                            {filter, []}
-					   ],
+                                            {filter, []}					   ],
                            helper_mod    = riak_ql_ddl:make_module_name(<<"GeoCheckin">>),
                            partition_key = get_standard_pk(),
 			   is_executable = true,

--- a/test/sql_compilation_end_to_end.erl
+++ b/test/sql_compilation_end_to_end.erl
@@ -25,7 +25,6 @@
                case riak_ql_ddl:is_query_valid(DDL, SQL) of
                    true ->
                        Got = riak_kv_qry_compiler:compile(DDL, SQL),
-		       gg:format("in ~p~n- Expected:~n- ~p~nGot:~n- ~p~n", [Name, Expected, Got]),
                        ?assertEqual(Expected, Got);
                    false ->
                        ?assertEqual(Expected, invalid_query)


### PR DESCRIPTION
This enables queries to correctly do '<' '<=' '>' and '>=' comparisons
on keys

Also is stripped through the query rewriter
