### PR TITLE
Error messages for invalid where messages

### DIFF
--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -127,6 +127,9 @@ process(SQL = #riak_sql_v1{'FROM' = Bucket}, State) ->
                 {error, Reason} ->
                     {reply, make_rpberrresp(?E_FETCH, Reason), State}
             end;
+        {error, {E, Reason}} when is_atom(E), is_binary(Reason) ->
+            ErrorMessage = lists:flatten(io_lib:format("~p: ~s", [E, Reason])),
+            {reply, make_rpberrresp(?E_SUBMIT, ErrorMessage), State};
         {error, Reason} ->
             {reply, make_rpberrresp(?E_SUBMIT, Reason), State}
     end.

--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -32,3 +32,8 @@
     E_TSMSG_NO_LOWER_BOUND,
     <<"Where clause has no lower bound.">>
 ).
+
+-define(
+    E_MISSING_PARAM_IN_WHERE_CLAUSE(ParamName),
+    iolist_to_binary(["Missing parameter ", ParamName, " in where clase."])
+).

--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -25,10 +25,10 @@
 
 -define(
     E_TSMSG_NO_UPPER_BOUND,
-    "Where clause has no upper bound."
+    <<"Where clause has no upper bound.">>
 ).
 
 -define(
     E_TSMSG_NO_LOWER_BOUND,
-    "Where clause has no lower bound."
+    <<"Where clause has no lower bound.">>
 ).

--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -1,0 +1,34 @@
+%%% -------------------------------------------------------------------
+%%%
+%%% riak_kv_ts_error_msgs
+%%%
+%%% Time Series messages that are returned as a response to requests
+%%% that have experienced an error.
+%%%
+%%% Copyright (c) 2015 Basho Technologies, Inc.  All Rights Reserved.
+%%%
+%%% This file is provided to you under the Apache License,
+%%% Version 2.0 (the "License"); you may not use this file
+%%% except in compliance with the License.  You may obtain
+%%% a copy of the License at
+%%%
+%%%   http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing,
+%%% software distributed under the License is distributed on an
+%%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%%% KIND, either express or implied.  See the License for the
+%%% specific language governing permissions and limitations
+%%% under the License.
+%%%
+%%% -------------------------------------------------------------------
+
+-define(
+    E_TSMSG_NO_UPPER_BOUND,
+    "Where clause has no upper bound."
+).
+
+-define(
+    E_TSMSG_NO_LOWER_BOUND,
+    "Where clause has no lower bound."
+).

--- a/test/sql_compilation_end_to_end.erl
+++ b/test/sql_compilation_end_to_end.erl
@@ -113,14 +113,7 @@ get_standard_lk() -> #key_v1{ast = [
               ++ "temperature varchar, "
               ++ "PRIMARY KEY ((quantum(time, 15, s)), time, user))",
 	     "select weather from GeoCheckin where time > 3000 and time < 5000",
-	     [{error,
-	       {invalid_where_clause,
-		{and_, 
-		 {'<', <<"time">>, {int, 5000}}, 
-		 {'>', <<"time">>, {int, 3000}}
-		}
-		}
-	      }]).
+	     {error, {missing_param, <<"Missing parameter user in where clase.">>}}).
 
 ?assert_test(spanning_qry_test, 
 	      "CREATE TABLE GeoCheckin " ++


### PR DESCRIPTION
Better error messages for select statement where clauses that do not properly cover the primary key.  For example if the where clause does not have a greater than and less than clauses over the time then these messages are returned:

```
Where clause has no upper bound.
```

or:

```
Where clause has no lower bound.
```

If the where clause is missing a primary key field then this message is returned when the missing field is `user`:

```
Missing parameter user in where clase.
```
