### PR TITLE
Reset status and query state when the query is complete RTS-365

### DIFF
--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -232,7 +232,7 @@ handle_req({fetch, QId}, State = #state{qid    = QId,
 handle_req({fetch, QId}, State = #state{qid    = QId,
                                         status = finished,
                                         result = Result}) ->
-    {{ok, Result}, [], State#state{ status = void, qry = none, ddl = none }};
+    {{ok, Result}, [], State#state{ status = void, qry = none, ddl = undefined }};
 
 handle_req(_Request, State) ->
     {ok, ?NO_SIDEEFFECTS, State}.

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -232,7 +232,7 @@ handle_req({fetch, QId}, State = #state{qid    = QId,
 handle_req({fetch, QId}, State = #state{qid    = QId,
                                         status = finished,
                                         result = Result}) ->
-    {{ok, Result}, [], State};
+    {{ok, Result}, [], State#state{ status = void, qry = none, ddl = none }};
 
 handle_req(_Request, State) ->
     {ok, ?NO_SIDEEFFECTS, State}.


### PR DESCRIPTION
To test, assuming you have the GeoCheckin example TS bucket type created, open a socket run the following query:

```
{ok, P} = riakc_pb_socket:start_link("127.0.0.1", 10017).

riakc_ts:query(P, "SELECT * FROM GeoCheckin6 WHERE time > 0 AND time < 20 AND myfamily = 'till' AND myseries = 'moderfamily'").
```

Run it consecutively a bunch of times, it should not throw an error.
