### PR TITLE
Upgrade bitcask version to 1.7.3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -27,7 +27,7 @@
 {deps, [
         {sidejob, ".*", {git, "git://github.com/basho/sidejob.git", {tag, "2.0.0"}}},
         {erlang_js, ".*", {git, "git://github.com/basho/erlang_js.git", {tag, "1.3.0"}}},
-        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {tag, "1.7.2"}}},
+        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {tag, "1.7.3"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", {tag, "0.78"}}},
         {sext, ".*", {git, "git://github.com/basho/sext.git", {tag, "1.1p3"}}},
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {branch, "2.1"}}},


### PR DESCRIPTION
This is required to update lager version to 2.2.0.
