### PR TITLE
single-key deletes for TS data

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_client: object used for access into the riak system
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -53,6 +53,12 @@
 %% @type default_timeout() = 60000
 -define(DEFAULT_TIMEOUT, 60000).
 -define(DEFAULT_ERRTOL, 0.00003).
+
+%% keys going via get path can eventually also be of TS kind (i.e., {PK, LK})
+-define(IS_KEY(K),
+        (is_binary(K)
+         orelse (is_tuple(K) andalso size(K) == 2
+                 andalso is_binary(element(1, K)) andalso is_binary(element(2, K))))).
 
 %% TODO: This type needs to be better specified and validated against
 %%       any dependents on riak_kv.
@@ -177,7 +183,7 @@ get(Bucket, Key, R, {?MODULE, [_Node, _ClientId]}=THIS) ->
 %%      nodes have responded with a value or error, or TimeoutMillisecs passes.
 get(Bucket, Key, R, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) when
                                   (is_binary(Bucket) orelse is_tuple(Bucket)),
-                                  is_binary(Key),
+                                  ?IS_KEY(Key),
                                   (is_atom(R) or is_integer(R)),
                                   is_integer(Timeout) ->
     get(Bucket, Key, [{r, R}, {timeout, Timeout}], THIS).
@@ -412,6 +418,7 @@ consistent_delete(Bucket, Key, Options, _Timeout, {?MODULE, [Node, _ClientId]}) 
         {ok, Obj} when element(1, Obj) =:= r_object ->
             ok
     end.
+
 
 %% @spec delete_vclock(riak_object:bucket(), riak_object:key(), vclock:vclock(), riak_client()) ->
 %%        ok |

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_app: application startup for Riak
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -38,7 +38,7 @@
                    {riak_kv_pb_counter, 50, 53}, %% counter requests
                    {riak_kv_pb_coverage, 70, 71}, %% coverage requests
                    {riak_kv_pb_crdt, 80, 83}, %% CRDT requests
-                   {riak_kv_pb_timeseries, 90, 93} %% time series requests
+                   {riak_kv_pb_timeseries, 90, 95} %% time series requests
                   ]).
 -define(MAX_FLUSH_PUT_FSM_RETRIES, 10).
 

--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -102,11 +102,11 @@ delete(ReqId,Bucket,Key,Options,Timeout,Client,ClientId,VClock) ->
             end
     end.
 
-new_tombstone_object(Table, {PK, LK}) ->
+new_tombstone_object(Bucket, {PK, LK}) ->
     %% TS objects have this peculiar way to use the two keys: time
     %% quanta-based partition key, for calculating coverage; and local
     %% key for actual lookups:
-    RO = new_tombstone_object(Table, PK),
+    RO = new_tombstone_object(Bucket, PK),
     MD1 = riak_object:get_update_metadata(RO),
     MD2  = dict:store(?MD_TS_LOCAL_KEY, LK, MD1),
     riak_object:update_metadata(RO, MD2);

--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_delete: two-step object deletion
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -60,7 +60,8 @@ delete(ReqId,Bucket,Key,Options,Timeout,Client,ClientId,undefined) ->
         {R, PR, PassThruOpts} ->
             RealStartTime = riak_core_util:moment(),
             {ok, C} = riak:local_client(),
-            case C:get(Bucket,Key,[{r,R},{pr,PR},{timeout,Timeout}]++PassThruOpts) of
+            case C:get(Bucket, Key,
+                       [{r,R}, {pr,PR}, {timeout,Timeout}] ++ PassThruOpts) of
                 {ok, OrigObj} ->
                     RemainingTime = Timeout - (riak_core_util:moment() - RealStartTime),
                     delete(ReqId,Bucket,Key,Options,RemainingTime,Client,ClientId,riak_object:vclock(OrigObj));
@@ -80,9 +81,9 @@ delete(ReqId,Bucket,Key,Options,Timeout,Client,ClientId,VClock) ->
             ?DTRACE(?C_DELETE_INIT2, [-1], []),
             Client ! {ReqId, {error, Reason}};
         {W, PW, DW, PassThruOptions} ->
-            Obj0 = riak_object:new(Bucket, Key, <<>>, dict:store(?MD_DELETED,
-                                                                 "true", dict:new())),
-            Tombstone = riak_object:set_vclock(Obj0, VClock),
+            Tombstone =
+                riak_object:set_vclock(
+                  new_tombstone_object(Bucket, Key), VClock),
             {ok,C} = riak:local_client(ClientId),
             Reply = C:put(Tombstone, [{w,W},{pw,PW},{dw, DW},{timeout,Timeout}]++PassThruOptions),
             Client ! {ReqId, Reply},
@@ -100,6 +101,20 @@ delete(ReqId,Bucket,Key,Options,Timeout,Client,ClientId,VClock) ->
                     nop
             end
     end.
+
+new_tombstone_object(Table, {PK, LK}) ->
+    %% TS objects have this peculiar way to use the two keys: time
+    %% quanta-based partition key, for calculating coverage; and local
+    %% key for actual lookups:
+    RO = new_tombstone_object(Table, PK),
+    MD1 = riak_object:get_update_metadata(RO),
+    MD2  = dict:store(?MD_TS_LOCAL_KEY, LK, MD1),
+    riak_object:update_metadata(RO, MD2);
+new_tombstone_object(Bucket, Key) ->
+    riak_object:new(
+      Bucket, Key, <<>>,
+      dict:store(?MD_DELETED, "true", dict:new())).
+
 
 get_r_options(Bucket, Options) ->
     BucketProps = riak_core_bucket:get_bucket(Bucket),

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_get_fsm: coordination of Riak GET requests
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -107,7 +107,7 @@ start_link(ReqId,Bucket,Key,R,Timeout,From) ->
 start_link(From, Bucket, Key, GetOptions) ->
     case whereis(riak_kv_get_fsm_sj) of
         undefined ->
-            %% Overload protection disabled 
+            %% Overload protection disabled
             Args = [From, Bucket, Key, GetOptions, true],
             gen_fsm:start_link(?MODULE, Args, []);
         _ ->
@@ -157,11 +157,11 @@ init([From, Bucket, Key, Options0, Monitor]) ->
                        startnow = StartNow},
     (Monitor =:= true) andalso riak_kv_get_put_monitor:get_fsm_spawned(self()),
     Trace = app_helper:get_env(riak_kv, fsm_trace_enabled),
-    case Trace of 
+    case Trace of
         true ->
             riak_core_dtrace:put_tag([Bucket, $,, Key]),
             ?DTRACE(?C_GET_FSM_INIT, [], ["init"]);
-        _ -> 
+        _ ->
             ok
     end,
     {ok, prepare, StateData, 0};
@@ -184,14 +184,14 @@ prepare(timeout, StateData=#state{bkey = {Bucket, Key},
                                   options=Options,
                                   trace=Trace}) ->
     ?DTRACE(Trace, ?C_GET_FSM_PREPARE, [], ["prepare"]),
-    {ok, DefaultProps} = application:get_env(riak_core, 
+    {ok, DefaultProps} = application:get_env(riak_core,
                                              default_bucket_props),
     BucketProps = riak_core_bucket:get_bucket(Bucket),
     %% typed buckets never fall back to defaults
-    Props = 
+    Props =
         case is_tuple(Bucket) of
             false ->
-                lists:keymerge(1, lists:keysort(1, BucketProps), 
+                lists:keymerge(1, lists:keysort(1, BucketProps),
                                lists:keysort(1, DefaultProps));
             true ->
                 BucketProps
@@ -216,7 +216,7 @@ prepare(timeout, StateData=#state{bkey = {Bucket, Key},
             {stop, normal, StateData2};
         _ ->
             StatTracked = get_option(stat_tracked, BucketProps, false),
-            Preflist2 = 
+            Preflist2 =
                 case get_option(sloppy_quorum, Options) of
                     false ->
                         riak_core_apl:get_primary_apl(DocIdx, N, riak_kv);
@@ -347,7 +347,7 @@ waiting_vnode_r({r, VnodeResult, Idx, _ReqId}, StateData = #state{get_core = Get
             {next_state, waiting_vnode_r,  StateData#state{get_core = UpdGetCore}}
     end;
 waiting_vnode_r(request_timeout, StateData = #state{trace=Trace}) ->
-    ?DTRACE(Trace, ?C_GET_FSM_WAITING_R_TIMEOUT, [-2], 
+    ?DTRACE(Trace, ?C_GET_FSM_WAITING_R_TIMEOUT, [-2],
             ["waiting_vnode_r", "timeout"]),
     S2 = client_reply({error,timeout}, StateData),
     update_stats(timeout, S2),
@@ -362,7 +362,7 @@ waiting_read_repair({r, VnodeResult, Idx, _ReqId},
             IdxStr = integer_to_list(Idx),
             ?DTRACE(?C_GET_FSM_WAITING_RR, [ShortCode],
                     ["waiting_read_repair", IdxStr]);
-        _ -> 
+        _ ->
             ok
     end,
     UpdGetCore = riak_kv_get_core:add_result(Idx, VnodeResult, GetCore),
@@ -445,7 +445,7 @@ maybe_delete(StateData=#state{n = N, preflist2=Sent, trace=Trace,
             ?DTRACE(Trace, ?C_GET_FSM_MAYBE_DELETE, [1],
                     ["maybe_delete", "triggered"]),
             riak_kv_vnode:del(IdealNodes, BKey, ReqId);
-        _ -> 
+        _ ->
             ?DTRACE(Trace, ?C_GET_FSM_MAYBE_DELETE, [0],
                     ["maybe_delete", "nop"]),
             nop
@@ -545,7 +545,7 @@ schedule_timeout(Timeout) ->
     erlang:send_after(Timeout, self(), request_timeout).
 
 client_reply(Reply, StateData = #state{from = {raw, ReqId, Pid},
-                                       options = Options, 
+                                       options = Options,
                                        timing = Timing,
                                        trace = Trace}) ->
     NewTiming = riak_kv_fsm_timing:add_timing(reply, Timing),
@@ -556,22 +556,22 @@ client_reply(Reply, StateData = #state{from = {raw, ReqId, Pid},
                   {ReqId, Reply};
               Details ->
                   {OkError, ObjReason} = Reply,
-                  Info = client_info(Details, 
-                                     StateData#state{timing = NewTiming}, 
+                  Info = client_info(Details,
+                                     StateData#state{timing = NewTiming},
                                      []),
                   {ReqId, {OkError, ObjReason, Info}}
           end,
     Pid ! Msg,
 
-    %% calculate timings here, since the trace macro needs total 
-    %% response time. Stuff the result in state so we don't 
+    %% calculate timings here, since the trace macro needs total
+    %% response time. Stuff the result in state so we don't
     %% need to calculate it again
-    {ResponseUSecs, Stages} = 
+    {ResponseUSecs, Stages} =
         riak_kv_fsm_timing:calc_timing(NewTiming),
     case Trace of
         true ->
             ShortCode = riak_kv_get_core:result_shortcode(Reply),
-            ?DTRACE(?C_GET_FSM_CLIENT_REPLY, 
+            ?DTRACE(?C_GET_FSM_CLIENT_REPLY,
                     [ShortCode, ResponseUSecs], ["client_reply"]);
         _ ->
             ok
@@ -588,14 +588,14 @@ update_stats({ok, Obj}, #state{options=Options,
     ObjFmt = riak_core_capability:get({riak_kv, object_format}, v0),
     ObjSize = riak_object:approximate_size(ObjFmt, Obj),
     Bucket = riak_object:bucket(Obj),
-    ok = riak_kv_stat:update({get_fsm, Bucket, ResponseUSecs, Stages, 
+    ok = riak_kv_stat:update({get_fsm, Bucket, ResponseUSecs, Stages,
                               NumSiblings, ObjSize, StatTracked, CRDTMod});
-update_stats(_, #state{ bkey = {Bucket, _}, 
+update_stats(_, #state{ bkey = {Bucket, _},
                         options = Options,
-                        tracked_bucket = StatTracked, 
+                        tracked_bucket = StatTracked,
                         calculated_timings={ResponseUSecs, Stages}}) ->
     CRDTMod = get_option(crdt_op, Options),
-    ok = riak_kv_stat:update({get_fsm, Bucket, ResponseUSecs, Stages, 
+    ok = riak_kv_stat:update({get_fsm, Bucket, ResponseUSecs, Stages,
                               undefined, undefined, StatTracked, CRDTMod}).
 
 client_info(true, StateData, Acc) ->

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -19,7 +19,7 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
-%% @doc Callbacks for TS protobuf messages [codes 90..93]
+%% @doc Callbacks for TS protobuf messages [codes 90..95]
 
 -module(riak_kv_pb_timeseries).
 
@@ -46,6 +46,9 @@
 %% bucket tuple. This function is a convenient mechanism for doing so
 %% and making that transition more obvious.
 -export([table_to_bucket/1]).
+%% more utility functions for where TS and non-TS keys are dealt with
+%% equally.
+-export([pk/1, lk/1]).
 
 -record(state, {}).
 
@@ -59,6 +62,7 @@
 -define(E_NOT_TS_TYPE, 6).
 -define(E_MISSING_TYPE, 7).
 -define(E_MISSING_TS_MODULE, 8).
+-define(E_DELETE,   9).
 
 -define(FETCH_RETRIES, 10).  %% TODO make it configurable in tsqueryreq
 
@@ -69,7 +73,7 @@ init() ->
 
 
 -spec decode(integer(), binary()) ->
-    {ok, #ddl_v1{} | #riak_sql_v1{} | #tsputreq{},
+    {ok, #ddl_v1{} | #riak_sql_v1{} | #tsputreq{} | #tsdelreq{},
         {PermSpec::string(), Table::binary()}} |
     {error,_}.
 decode(Code, Bin) ->
@@ -84,7 +88,9 @@ decode(Code, Bin) ->
                     {error, decoder_parse_error_resp(Error)}
             end;
         #tsputreq{table = Table} ->
-            {ok, Msg, {"riak_kv.ts_put", Table}}
+            {ok, Msg, {"riak_kv.ts_put", Table}};
+        #tsdelreq{table = Table} ->
+            {ok, Msg, {"riak_kv.ts_del", Table}}
     end.
 
 
@@ -95,11 +101,7 @@ encode(Message) ->
 
 -spec process(atom() | #ddl_v1{} | #riak_sql_v1{} | #tsputreq{}, #state{}) ->
                      {reply, #tsqueryresp{} | #rpberrorresp{}, #state{}}.
-%% @ignore CREATE TABLE
 process(#ddl_v1{}, State) ->
-    %% {module, Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
-    %% and what do we do with this DDL?
-    %% isn't bucket creation (primarily) effected via bucket activation (via riak-admin)?
     {reply, make_rpberrresp(?E_NOCREATE,
                             "CREATE TABLE not supported via client interface;"
                             " use riak-admin command instead"),
@@ -137,7 +139,53 @@ process(#tsputreq{table = Table, columns = _Columns, rows = Rows}, State) ->
             {reply, missing_helper_module(Table, BucketProps), State}
     end;
 
-%% @ignore SELECT
+process(#tsdelreq{table = Table, key = PbCompoundKey,
+                  vclock = PbVClock, timeout = Timeout},
+        State) ->
+    Options =
+        if Timeout == undefined -> [];
+           true -> [{timeout, Timeout}]
+        end,
+    VClock =
+        case PbVClock of
+            undefined ->
+                %% this will trigger a get in riak_kv_delete:delete to
+                %% retrieve the actual vclock
+                undefined;
+            PbVClock ->
+                %% else, clients may have it already (e.g., from an
+                %% earlier riak_object:get), which will short-circuit
+                %% to avoid a separate get
+                riak_object:decode_vclock(PbVClock)
+        end,
+
+    CompoundKey = riak_pb_ts_codec:decode_cells(PbCompoundKey),
+
+    Mod = riak_ql_ddl:make_module_name(Table),
+    try Mod:get_ddl() of
+        DDL ->
+            PKLK = make_ts_keys(CompoundKey, DDL),
+            %% = {PK, LK} = Key to pass to riak_client:delete
+            Result =
+                riak_client:delete_vclock(
+                  {Table, Table}, PKLK, VClock, Options,
+                  {riak_client, [node(), undefined]}),
+            case Result of
+                ok ->
+                    {reply, tsdelresp, State};
+                {error, notfound} ->
+                    {reply, tsdelresp, State};
+                {error, Reason} ->
+                    {reply, make_rpberrresp(
+                              ?E_DELETE, io_lib:format("Failed to delete record: ~p", [Reason])),
+                     State}
+            end
+    catch error:{undef, _} ->
+            Props = riak_core_bucket:get_bucket(Table),
+            {reply, missing_helper_module(Table, Props), State}
+    end;
+
+
 process(SQL = #riak_sql_v1{'FROM' = Table}, State) ->
     Mod = riak_ql_ddl:make_module_name(Table),
     case (catch Mod:get_ddl()) of
@@ -267,6 +315,28 @@ put_data(Data, Table, Mod) ->
       0, Data).
 
 
+make_ts_keys(CompoundKey, DDL = #ddl_v1{local_key = #key_v1{ast = LKParams},
+                                        fields = Fields}) ->
+
+    %% 1. use elements in Key to form a complete data record:
+    KeyFields = [F || #param_v1{name = [F]} <- LKParams],
+    KeyAssigned = lists:zip(KeyFields, CompoundKey),
+    VoidRecord = [{F, void} || #riak_field_v1{name = F} <- Fields],
+    %% (void values will not be looked at in riak_ql_ddl:make_key;
+    %% only LK-constituent fields matter)
+    BareValues =
+        list_to_tuple(
+          [proplists:get_value(K, KeyAssigned)
+           || {K, _} <- VoidRecord, lists:member(K, KeyFields)]),
+
+    %% 2. make the PK and LK
+    PK = eleveldb_ts:encode_key(
+           riak_ql_ddl:get_partition_key(DDL, BareValues)),
+    LK = eleveldb_ts:encode_key(
+           riak_ql_ddl:get_local_key(DDL, BareValues)),
+    {PK, LK}.
+
+
 %% ---------------------------------------------------
 % functions supporting SELECT
 
@@ -328,6 +398,21 @@ assemble_records_(RR, RSize, Acc) ->
 %% Utility API to limit some of the confusion over tables vs buckets
 table_to_bucket(Table) ->
     {Table, Table}.
+
+%% Useful key extractors for functions (e.g., in get or delete code
+%% paths) which are agnostic to whether they are dealing with TS or
+%% non-TS data
+pk({PK, _LK}) ->
+    PK;
+pk(NonTSKey) ->
+    NonTSKey.
+
+lk({_PK, LK}) ->
+    LK;
+lk(NonTSKey) ->
+    NonTSKey.
+
+
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -243,9 +243,9 @@ make_rpberrresp(Code, Message) ->
 
 
 -spec decode_query_permissions(#ddl_v1{} | #riak_sql_v1{}) -> {string(), binary()}.
-decode_query_permissions(#ddl_v1{table=NewBucketType}) ->
+decode_query_permissions(#ddl_v1{table = NewBucketType}) ->
     {"riak_kv.ts_create_table", NewBucketType};
-decode_query_permissions(#riak_sql_v1{'FROM'=Table}) ->
+decode_query_permissions(#riak_sql_v1{'FROM' = Table}) ->
     {"riak_kv.ts_query", Table}.
 
 %%
@@ -281,6 +281,7 @@ missing_table_module_response(BucketType) ->
 
 to_string(X) ->
     io_lib:format("~p", [X]).
+
 
 %% ---------------------------------------------------
 % functions supporting INSERT
@@ -344,7 +345,7 @@ make_ts_keys(CompoundKey, DDL = #ddl_v1{local_key = #key_v1{ast = LKParams},
                                  {ok, [{Key::binary(), riak_pb_ts_codec:ldbvalue()}]} |
                                  {error, atom()}.
 fetch_with_patience(QId, 0) ->
-    lager:info("Query results on qid ~p not available after ~b secs\n", [QId, ?FETCH_RETRIES]),
+    lager:info("Query results on qid ~p not available after ~b secs", [QId, ?FETCH_RETRIES]),
     {ok, []};
 fetch_with_patience(QId, N) ->
     case riak_kv_qry_queue:fetch(QId) of

--- a/src/riak_kv_pipe_listkeys.erl
+++ b/src/riak_kv_pipe_listkeys.erl
@@ -140,7 +140,7 @@ done(_State) ->
 
 %% Convenience
 
--type bucket_or_filter() :: binary() | {binary(), list()}.
+-type bucket_or_filter() :: binary() | {binary(), binary()} | {binary(), list()}.
 
 %% @doc List the keys from a bucket, and send them as inputs to the
 %%      given pipe.  This starts a new pipe with one fitting

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -50,7 +50,7 @@ submit(SQLString, DDL) when is_list(SQLString) ->
 submit(SQL, DDL) ->
     maybe_submit_to_queue(SQL, DDL).
 
-maybe_submit_to_queue(SQL, #ddl_v1{ table = BucketType } = DDL) ->
+maybe_submit_to_queue(SQL, #ddl_v1{table = BucketType} = DDL) ->
     Mod = riak_ql_ddl:make_module_name(BucketType),
     case riak_ql_ddl:is_query_valid(Mod, DDL, SQL) of
         true ->

--- a/src/riak_kv_qry_coverage_plan.erl
+++ b/src/riak_kv_qry_coverage_plan.erl
@@ -3,7 +3,7 @@
 %% riak_kv_qry_coverage: generate the coverage for a hashed query
 %%
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -23,8 +23,8 @@
 -module(riak_kv_qry_coverage_plan).
 
 -export([
-	 create_plan/6
-	]).
+         create_plan/6
+        ]).
 
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -264,8 +264,13 @@ decode_results(KVList, SelectSpec) ->
 extract_riak_object(SelectSpec, V) when is_binary(V) ->
     % don't care about bkey
     RObj = riak_object:from_binary(<<>>, <<>>, V),
-    FullRecord = riak_object:get_value(RObj),
-    filter_columns(lists:flatten(SelectSpec), FullRecord).
+    case riak_object:get_value(RObj) of
+        <<>> ->
+            %% record was deleted
+            [];
+        FullRecord ->
+            filter_columns(lists:flatten(SelectSpec), FullRecord)
+    end.
 
 %% Pull out the values we're interested in based on the select,
 %% statement, e.g. select user, geoloc returns only user and geoloc columns.

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -489,9 +489,9 @@ assert_write_once_not_false(Props) ->
     end.
 
 %%
-assert_type_and_table_name_same(BucketType, #ddl_v1{ table = BucketType }) ->
+assert_type_and_table_name_same(BucketType, #ddl_v1{table = BucketType}) ->
     ok;
-assert_type_and_table_name_same(BucketType1, #ddl_v1{ table = BucketType2 }) ->
+assert_type_and_table_name_same(BucketType1, #ddl_v1{table = BucketType2}) ->
     throw({error,
         "Error, the bucket type could not be the created. The bucket type and table name must be the same~n"
         "    bucket type was: " ++ binary_to_list(BucketType1) ++ "\n"


### PR DESCRIPTION
[RTS-201](https://bashoeng.atlassian.net/browse/RTS-201): Single key deletes for TS, via standard delete path. A new `tsdelreq` pb message is allocated, see the riak_pb PR below.

Depends on  https://github.com/basho/riak_pb/pull/136. There is a simple (not comprehensive) check of `riakc_ts:delete/4` (which function appears in https://github.com/basho/riak-erlang-client/pull/240) in https://github.com/basho/riak_test/pull/889.
