### PR TITLE
Ignore unknown encodings for RIAK-2221

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
 {deps, [
         {sidejob, ".*", {git, "git://github.com/basho/sidejob.git", {branch, "2.0"}}},
         {erlang_js, ".*", {git, "git://github.com/basho/erlang_js.git", {tag, "1.3.0"}}},
-        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {branch, "1.7"}}},
+        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {tag, "1.7.2"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", {tag, "0.78"}}},
         {sext, ".*", {git, "git://github.com/basho/sext.git", {tag, "1.1p3"}}},
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {branch, "2.0"}}},

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -24,6 +24,7 @@
 -define(MD_USERMETA, <<"X-Riak-Meta">>).
 -define(MD_INDEX,    <<"index">>).
 -define(MD_DELETED,  <<"X-Riak-Deleted">>).
+-define(MD_VAL_ENCODING, <<"X-Riak-Val-Encoding">>).
 
 %% Names of HTTP header fields
 -define(HEAD_CTYPE,           "Content-Type").

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -66,6 +66,7 @@
 -type index_value() :: integer() | binary().
 -type binary_version() :: v0 | v1.
 
+-define(VAL_ENCODING, <<"val-encoding">>).
 -define(MAX_KEY_SIZE, 65536).
 
 -define(LASTMOD_LEN, 29). %% static length of rfc1123_date() type. Hard-coded in Erlang.
@@ -871,7 +872,8 @@ binary_version(<<?MAGIC:8/integer, 1:8/integer, _/binary>>) -> v1.
     riak_object() | {error, 'bad_object_format'}.
 from_binary(_B,_K,<<131, _Rest/binary>>=ObjTerm) ->
     binary_to_term(ObjTerm);
-from_binary(B,K,<<?MAGIC:8/integer, 1:8/integer, Rest/binary>>=_ObjBin) ->
+
+from_binary(B,K,<<?MAGIC:8/integer, _BinType:8/integer, Rest/binary>>=_ObjBin) ->
     %% Version 1 of binary riak object
     case Rest of
         <<VclockLen:32/integer, VclockBin:VclockLen/binary, SibCount:32/integer, SibsBin/binary>> ->
@@ -900,9 +902,17 @@ sib_of_binary(<<ValLen:32/integer, ValBin:ValLen/binary, MetaLen:32/integer, Met
     MDList0 = deleted_meta(Deleted, []),
     MDList1 = last_mod_meta({LMMega, LMSecs, LMMicro}, MDList0),
     MDList2 = vtag_meta(VTag, MDList1),
-    MDList = meta_of_binary(MetaRestBin, MDList2),
+    MDList3 = val_encoding_meta(ValBin, MDList2),
+    MDList = meta_of_binary(MetaRestBin, MDList3),
     MD = dict:from_list(MDList),
     {#r_content{metadata=MD, value=decode_maybe_binary(ValBin)}, Rest}.
+
+val_encoding_meta(<<0, _Rest/binary>>, MDList) ->
+    MDList;
+val_encoding_meta(<<1, _Rest/binary>>, MDList) ->
+    MDList;
+val_encoding_meta(<<Other:8, _Rest/binary>>, MDList) ->
+    [{?VAL_ENCODING, Other} | MDList].
 
 deleted_meta(<<1>>, MDList) ->
     [{?MD_DELETED, "true"} | MDList];
@@ -943,8 +953,8 @@ new_v1(Vclock, Siblings) ->
     SibsBin = bin_contents(Siblings),
     <<?MAGIC:8/integer, ?V1_VERS:8/integer, VclockLen:32/integer, VclockBin/binary, SibCount:32/integer, SibsBin/binary>>.
 
-bin_content(#r_content{metadata=Meta, value=Val}) ->
-    ValBin = encode_maybe_binary(Val),
+bin_content(#r_content{metadata=Meta0, value=Val}) ->
+    {ValBin, Meta} = encode_maybe_binary(Val, Meta0),
     ValLen = byte_size(ValBin),
     MetaBin = meta_bin(Meta),
     MetaLen = byte_size(MetaBin),
@@ -983,22 +993,30 @@ fold_meta_to_bin(?MD_DELETED, "true", Acc) ->
 fold_meta_to_bin(?MD_DELETED, _, {{Vt,_Del,Lm},RestBin}) ->
     {{Vt, <<0>>, Lm}, RestBin};
 fold_meta_to_bin(Key, Value, {{_Vt,_Del,_Lm}=Elems,RestBin}) ->
-    ValueBin = encode_maybe_binary(Value),
+    {ValueBin, _NewMeta} = encode_maybe_binary(Value, []),
     ValueLen = byte_size(ValueBin),
-    KeyBin = encode_maybe_binary(Key),
+    {KeyBin, _NewMeta} = encode_maybe_binary(Key, []),
     KeyLen = byte_size(KeyBin),
     MetaBin = <<KeyLen:32/integer, KeyBin/binary, ValueLen:32/integer, ValueBin/binary>>,
     {Elems, <<RestBin/binary, MetaBin/binary>>}.
 
-encode_maybe_binary(Bin) when is_binary(Bin) ->
-    <<1, Bin/binary>>;
-encode_maybe_binary(Bin) ->
-    <<0, (term_to_binary(Bin))/binary>>.
+encode_maybe_binary(Value, Meta) when is_binary(Value) ->
+    {TypeTag, NewMeta} = determine_binary_type(Meta),
+    {<<TypeTag, Value/binary>>, NewMeta};
+encode_maybe_binary(Value, Meta) ->
+    {<<0, (term_to_binary(Value))/binary>>, Meta}.
 
+determine_binary_type(Meta) ->
+    case dict:find(?VAL_ENCODING, Meta) of
+        error -> {1, Meta};
+        {ok, Val} -> {Val, dict:erase(?VAL_ENCODING, Meta)}
+    end.
 decode_maybe_binary(<<1, Bin/binary>>) ->
     Bin;
 decode_maybe_binary(<<0, Bin/binary>>) ->
-    binary_to_term(Bin).
+    binary_to_term(Bin);
+decode_maybe_binary(<<_Other:8, Bin/binary>>) ->
+    Bin.
 
 %% Update X-Riak-VTag and X-Riak-Last-Modified in the object's metadata, if
 %% necessary.
@@ -1084,7 +1102,7 @@ object_test() ->
     B = <<"buckets_are_binaries">>,
     K = <<"keys are binaries">>,
     V = <<"values are anything">>,
-    O = riak_object:new(B,K,V),
+    O = riak_object:new(B, K, V),
     B = riak_object:bucket(O),
     K = riak_object:key(O),
     V = riak_object:get_value(O),
@@ -1092,6 +1110,42 @@ object_test() ->
     1 = length(riak_object:get_values(O)),
     1 = length(riak_object:get_metadatas(O)),
     O.
+
+val_encoding_term_test() ->
+    B = <<"buckets are binaries">>,
+    K = <<"keys are binaries">>,
+    V = {a, tuple, is, a, valid, value},
+    Object = riak_object:new(B, K, V),
+    Binary = to_binary(v1, Object),
+    FirstBinaryByte = get_binary_type_tag_from_full_binary(Binary),
+    %% term_to_binary format is 0
+    ?assertEqual(0, FirstBinaryByte).
+
+val_encoding_bin_test() ->
+    B = <<"buckets are binaries">>,
+    K = <<"keys are binaries">>,
+    V = <<"Some Binary Data">>,
+    Object = riak_object:new(B, K, V),
+    Binary = to_binary(v1, Object),
+    FirstBinaryByte = get_binary_type_tag_from_full_binary(Binary),
+    %% arbitrary binary format is 1
+    ?assertEqual(1, FirstBinaryByte).
+
+val_encoding_with_metadata_test() ->
+    B = <<"buckets are binaries">>,
+    K = <<"keys are binaries">>,
+    V = <<"Some Binary Data">>,
+    Object = riak_object:new(B, K, V, dict:from_list([{?VAL_ENCODING, 2}])),
+    Binary = to_binary(v1, Object),
+    FirstBinaryByte = get_binary_type_tag_from_full_binary(Binary),
+    %% When specified in binary, use the val_encoding version
+    ?assertEqual(2, FirstBinaryByte).
+
+get_binary_type_tag_from_full_binary(Binary) ->
+    <<?MAGIC:8/integer, ?V1_VERS:8/integer, VclockLen:32/integer, _VclockBin:VclockLen/binary, _SibCount:32/integer, SibsBin/binary>> = Binary,
+    <<ValLen:32/integer, ValBin:ValLen/binary, MetaLen:32/integer, _MetaBin:MetaLen/binary>> = SibsBin,
+    <<FirstBinaryByte:8, _Rest/binary>> = ValBin,
+    FirstBinaryByte.
 
 update_test() ->
     O = object_test(),

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -872,7 +872,7 @@ binary_version(<<?MAGIC:8/integer, 1:8/integer, _/binary>>) -> v1.
 from_binary(_B,_K,<<131, _Rest/binary>>=ObjTerm) ->
     binary_to_term(ObjTerm);
 
-from_binary(B,K,<<?MAGIC:8/integer, _BinType:8/integer, Rest/binary>>=_ObjBin) ->
+from_binary(B,K,<<?MAGIC:8/integer, 1:8/integer, Rest/binary>>=_ObjBin) ->
     %% Version 1 of binary riak object
     case Rest of
         <<VclockLen:32/integer, VclockBin:VclockLen/binary, SibCount:32/integer, SibsBin/binary>> ->

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -1136,11 +1136,13 @@ val_encoding_with_metadata_test() ->
     B = <<"buckets are binaries">>,
     K = <<"keys are binaries">>,
     V = <<"Some Binary Data">>,
-    Object = riak_object:new(B, K, V, dict:from_list([{?MD_VAL_ENCODING, 2}])),
+    Object = riak_object:new(B, K, V, dict:from_list([{?MD_VAL_ENCODING, 2}, {<<"X-Foo_MetaData">>, "Foo"}])),
     Binary = to_binary(v1, Object),
     {FirstBinaryByte, Meta} = get_binary_type_tag_and_metadata_from_full_binary(Binary),
     %% When specified in metadata, use the val_encoding version
     ?assertEqual(2, FirstBinaryByte),
+    %% Make sure <<"X-Riak-Val-Encoding">> metadata was removed, as it's encoded in the binary itself
+    %% and would be superfluous
     ?assertNot(dict:is_key(?MD_VAL_ENCODING, Meta)).
 
 get_binary_type_tag_and_metadata_from_full_binary(Binary) ->

--- a/test/fsm_eqc_util.erl
+++ b/test/fsm_eqc_util.erl
@@ -65,11 +65,25 @@ increment(Actor, Count, Vclock) ->
       lists:duplicate(Count, Actor)).
 
 riak_object() ->
-    ?LET({{Bucket, Key}, Vclock, Value},
-         {bkey(), vclock(), binary()},
+    ?LET({{Bucket, Key}, Vclock, Value, Meta},
+        {bkey(), vclock(), object_value(), oneof([[], [{binary(), object_value()}]])},
+        %% TODO: The above oneof() should really be the below list(), but
+        %% because dicts don't serialize/deserialize deterministically,
+        %% riak_object_eqc:prop_roundtrip will fail if we put the list in now.
+        %% related to riak_object
+        %%{bkey(), vclock(), binary(), list({binary(), binary()})},
          riak_object:set_vclock(
-           riak_object:new(Bucket, Key, Value),
+           riak_object:new(Bucket, Key, Value, dict:from_list(Meta)),
            Vclock)).
+
+object_value() ->
+    oneof([binary(), erlang_term()]).
+
+erlang_term() ->
+    oneof([gen_atom(), nat(), binary(), {?LAZY(erlang_term()), ?LAZY(erlang_term())}]).
+
+gen_atom() -> % a,q seems to be the minimum provoking example for atoms
+    elements([a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z]).
 
 maybe_tombstone() ->
     weighted_default({2, notombstone}, {1, tombstone}).


### PR DESCRIPTION
In case of downgrade from a version of Riak that uses new binary types other than term-to-binary or "whatever the user gave us" binaries, make sure at minimum we don't crash when trying to read those keys back. Also, if a user provides an "X-Riak-Val-Encoding" metadata tag, store the binary with that value as its magic byte to provide round-trip support.
