### PR TITLE
Make DDL distribution more robust

### DIFF
--- a/src/riak_kv_compile_tab.erl
+++ b/src/riak_kv_compile_tab.erl
@@ -20,12 +20,11 @@
 %%
 %% -------------------------------------------------------------------
 
-%% TODO use dets
-
 -module(riak_kv_compile_tab).
 
 -export([is_compiling/1]).
 -export([get_state/1]).
+-export([get_ddl/1]).
 -export([new/1]).
 -export([insert/4]).
 -export([update_state/2]).
@@ -74,6 +73,17 @@ get_state(BucketType) when is_binary(BucketType) ->
     case dets:lookup(?TABLE, BucketType) of
         [{_,_,_,State}] ->
             State;
+        [] ->
+            notfound
+    end.
+
+%%
+-spec get_ddl(BucketType :: binary()) ->
+        term() | notfound.
+get_ddl(BucketType) when is_binary(BucketType) ->
+    case dets:lookup(?TABLE, BucketType) of
+        [{_,DDL,_,_}] ->
+            DDL;
         [] ->
             notfound
     end.

--- a/src/riak_kv_metadata_store_listener.erl
+++ b/src/riak_kv_metadata_store_listener.erl
@@ -55,8 +55,9 @@ handle_event({metadata_stored, BucketType}, State) ->
 handle_event(_Event, State) ->
     {ok, State}.
 
-handle_call({is_type_compiled, BucketType}, State) ->
-    IsCompiled = (riak_kv_compile_tab:get_state(BucketType) == compiled),
+handle_call({is_type_compiled, [BucketType, DDL]}, State) ->
+    IsCompiled = (riak_kv_compile_tab:get_state(BucketType) == compiled andalso
+                  riak_kv_compile_tab:get_ddl(BucketType) == DDL),
     {ok, IsCompiled, State};
 handle_call(_Request, State) ->
     Reply = ok,

--- a/src/riak_kv_ts_newtype.erl
+++ b/src/riak_kv_ts_newtype.erl
@@ -101,21 +101,27 @@ terminate(_Reason, _State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-%%% 
+%%%
 %%% Internal.
 %%%
 
 %%
+%% We rely on the claimant to not give us new DDLs after the bucket
+%% type is activated, at least until we have a system in place for
+%% managing DDL versioning
 do_new_type(BucketType) ->
-    DDL = retrieve_ddl(BucketType),
-    case riak_kv_compile_tab:get_state(BucketType) =/= compiled 
-            andalso is_record(DDL, ddl_v1) of
-        false ->
-            ok;
-        true ->
-            ok = maybe_stop_current_compilation(BucketType),
-            ok = start_compilation(BucketType, DDL)
-    end.
+    maybe_compile_ddl(BucketType, retrieve_ddl_from_metadata(BucketType),
+                      riak_kv_compile_tab:get_ddl(BucketType)).
+
+maybe_compile_ddl(_BucketType, NewDDL, NewDDL) ->
+    %% Do nothing; we're seeing a CMD update but the DDL hasn't changed
+    ok;
+maybe_compile_ddl(BucketType, NewDDL, _OldDDL) when is_record(NewDDL, ddl_v1) ->
+    ok = maybe_stop_current_compilation(BucketType),
+    ok = start_compilation(BucketType, NewDDL);
+maybe_compile_ddl(_BucketType, _NewDDL, _OldDDL) ->
+    %% We don't know what to do with this new DDL, so stop
+    ok.
 
 %%
 maybe_stop_current_compilation(BucketType) ->
@@ -181,7 +187,7 @@ ddl_ebin_directory() ->
 %% Would be nice to have a function in riak_core_bucket_type or
 %% similar to get either the prefix or the actual metadata instead
 %% of including a riak_core header file for this prefix
-retrieve_ddl(BucketType) ->
+retrieve_ddl_from_metadata(BucketType) ->
     retrieve_ddl_2(riak_core_metadata:get(?BUCKET_TYPE_PREFIX, BucketType)).
 
 %%


### PR DESCRIPTION
- Do not allow DDL to be updated post-activation
- Include a DDL comparison as part of the claimant-driven activation process so that if messages are delayed the claimant doesn't accidentally validate a node who has compiled an earlier version of the DDL but has yet to receive the later version

Requires basho/riak_core#790
