### PR TITLE
fixes for RTS-257

### DIFF
--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -243,9 +243,10 @@ put_data(Data, Table, Mod) ->
 
               %% Bucket needs to be in duplicate, see riak_kv_qry_coverage_plan:create_plan
               RObj0 = riak_object:new({Table, Table}, PK, Obj),
-              MD_ = riak_object:get_update_metadata(RObj0),
-              MD  = dict:store(?MD_TS_LOCAL_KEY, LK, MD_),
-              RObj = riak_object:update_metadata(RObj0, MD),
+              MD = riak_object:get_update_metadata(RObj0),
+              MD1 = dict:store(?MD_TS_LOCAL_KEY, LK, MD),
+	      MD2 = dict:store(?MD_DDL_VERSION, ?DDL_VERSION, MD1),
+              RObj = riak_object:update_metadata(RObj0, MD2),
 
               case riak_client:put(RObj, {riak_client, [node(), undefined]}) of
                   {error, _Why} ->

--- a/src/riak_kv_w1c_worker.erl
+++ b/src/riak_kv_w1c_worker.erl
@@ -109,10 +109,10 @@ put(RObj, Options) ->
             RObj2 = riak_object:set_vclock(RObj, vclock:fresh(<<0:8>>, 1)),
             RObj3 = riak_object:update_last_modified(RObj2),
             RObj4 = riak_object:apply_updates(RObj3),
-	    MD  = riak_object:get_metadata(RObj4),
-	    MD1 = dict:erase(?MD_TS_LOCAL_KEY, MD),
+            MD  = riak_object:get_metadata(RObj4),
+            MD1 = dict:erase(?MD_TS_LOCAL_KEY, MD),
             RObj5 = riak_object:update_metadata(RObj4, MD1),
-	    EncodedVal = EncodeFn(RObj5),
+            EncodedVal = EncodeFn(RObj5),
 
             gen_server:cast(
                 Worker,

--- a/src/riak_kv_w1c_worker.erl
+++ b/src/riak_kv_w1c_worker.erl
@@ -30,6 +30,7 @@
     code_change/3]).
 
 -include_lib("riak_kv_vnode.hrl").
+-include("riak_kv_wm_raw.hrl").
 
 -record(rec, {
     w, pw, n_val,
@@ -83,7 +84,7 @@ put(RObj, Options) ->
             Key = LocalKey,
             EncodeFn =
                 fun(XRObj) ->
-                    riak_object:to_binary(v1, XRObj, msgpack)
+                  riak_object:to_binary(v1, XRObj, msgpack)
                 end;
         error ->
             Key = riak_object:key(RObj),
@@ -108,7 +109,10 @@ put(RObj, Options) ->
             RObj2 = riak_object:set_vclock(RObj, vclock:fresh(<<0:8>>, 1)),
             RObj3 = riak_object:update_last_modified(RObj2),
             RObj4 = riak_object:apply_updates(RObj3),
-            EncodedVal = EncodeFn(RObj4),
+	    MD  = riak_object:get_metadata(RObj4),
+	    MD1 = dict:erase(?MD_TS_LOCAL_KEY, MD),
+            RObj5 = riak_object:update_metadata(RObj4, MD1),
+	    EncodedVal = EncodeFn(RObj5),
 
             gen_server:cast(
                 Worker,

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -23,9 +23,13 @@
 -define(MD_LASTMOD,  <<"X-Riak-Last-Modified">>).
 -define(MD_USERMETA, <<"X-Riak-Meta">>).
 -define(MD_INDEX,    <<"index">>).
--define(MD_LI_IDX,   <<"timeseries-local-key">>). % FIXME leaving this in for the bits repo, should be removed
 -define(MD_TS_LOCAL_KEY, <<"timeseries-local-key">>).
+-define(MD_DDL_VERSION,  <<"ddl">>).
 -define(MD_DELETED,  <<"X-Riak-Deleted">>).
+
+%% for the first DDL version we just brute force it to 1
+-define(DDL_VERSION, 1).
+
 
 %% Names of HTTP header fields
 -define(HEAD_CTYPE,           "Content-Type").


### PR DESCRIPTION
This commit writes the DDL version to the object meta data and also remove the time series local index which has been passed along with the object.
