### PR TITLE
fix for bug

### DIFF
--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -666,16 +666,14 @@ simple_spanning_boundary_test() ->
 			     {<<"user">>, binary, <<"user_1">>}]},
 	  {endkey,          [{<<"time">>, timestamp, 15000},
 			     {<<"user">>, binary, <<"user_1">>}]},
-	  {filter,          []},
-	  {end_inclusive,   true}
+	  {filter,          []}
 	 ],
     W2 = [
 	  {startkey,        [{<<"time">>, timestamp, 15000},
 			     {<<"user">>, binary, <<"user_1">>}]},
 	  {endkey,          [{<<"time">>, timestamp, 30000},
 			     {<<"user">>, binary, <<"user_1">>}]},
-	  {filter,          []},
-	  {end_inclusive,   true}
+	  {filter,          []}
 	 ],
     W3 = [
 	  {startkey,        [{<<"time">>, timestamp, 30000},

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -95,13 +95,10 @@ make_wheres(Where, QField, Min, Max, Boundaries) ->
     Ends   = Boundaries ++ [Max],
     [HdW | Ws] = make_w2(Starts, Ends, QField, NewWhere, []),
     %% add the head options to the head
-    %% reverse the list
-    %% add an 'end_include' to all values except the tail
     %% add the tail options to the tail
     %% reverse again
     [TW | Rest] = lists:reverse([lists:flatten(HdW ++ [HeadOption]) | Ws]),
-    Rest2 = [X ++ [{end_inclusive, true}] || X <- Rest],
-    _Wheres = lists:reverse([lists:flatten(TW ++ [TailOption]) | Rest2]).
+    _Wheres = lists:reverse([lists:flatten(TW ++ [TailOption]) | Rest]).
 
 make_w2([], [], _QField, _Where, Acc) ->
     lists:reverse(Acc);

--- a/test/sql_compilation_end_to_end.erl
+++ b/test/sql_compilation_end_to_end.erl
@@ -77,19 +77,19 @@ get_standard_lk() -> #key_v1{ast = [
                            'FROM'        = <<"GeoCheckin">>,
                            'WHERE'       = [
                                             {startkey, [
-                                                        {<<"time">>,  
-							 timestamp, 
+                                                        {<<"time">>,
+							 timestamp,
 							 3000},
-                                                        {<<"user">>, 
+                                                        {<<"user">>,
 							 binary,
 							 <<"gordon">>}
                                                        ]
                                             },
                                             {endkey,   [
-                                                        {<<"time">>, 
-							 timestamp, 
+                                                        {<<"time">>,
+							 timestamp,
 							 5000},
-                                                        {<<"user">>, 
+                                                        {<<"user">>,
 							 binary,
 							 <<"gordon">>}
                                                        ]
@@ -115,14 +115,14 @@ get_standard_lk() -> #key_v1{ast = [
 	     "select weather from GeoCheckin where time > 3000 and time < 5000",
 	     {error, {missing_param, <<"Missing parameter user in where clause.">>}}).
 
-?assert_test(spanning_qry_test, 
+?assert_test(spanning_qry_test,
 	      "CREATE TABLE GeoCheckin " ++
-		  "(geohash varchar not null, " ++ 
+		  "(geohash varchar not null, " ++
 		  "user varchar not null, " ++
-		  "time timestamp not null, " ++ 
-		  "weather varchar not null, " ++ 
-		  "temperature varchar, " ++ 
-		  "PRIMARY KEY((quantum(time, 15, s)), time, user))", 
+		  "time timestamp not null, " ++
+		  "weather varchar not null, " ++
+		  "temperature varchar, " ++
+		  "PRIMARY KEY((quantum(time, 15, s)), time, user))",
 	      "select weather from GeoCheckin where time > 3000 and time < 18000 "
 	      "and user = gordon",
 	      [
@@ -130,7 +130,7 @@ get_standard_lk() -> #key_v1{ast = [
 			   'FROM'        = <<"GeoCheckin">>,
 			   'WHERE'       = [
 					    {startkey, [
-                                                        {<<"time">>, 
+                                                        {<<"time">>,
 							 timestamp,
 							 3000},
                                                         {<<"user">>,
@@ -139,17 +139,16 @@ get_standard_lk() -> #key_v1{ast = [
                                                        ]
                                             },
                                             {endkey,   [
-                                                        {<<"time">>, 
+                                                        {<<"time">>,
 							 timestamp,
 							 15000},
-                                                        {<<"user">>, 
+                                                        {<<"user">>,
 							 binary,
 							 <<"gordon">>}
                                                        ]
                                             },
                                             {filter, []},
-					    {start_inclusive, false},
-					    {end_inclusive,   true}
+					    {start_inclusive, false}
 					   ],
                            helper_mod    = riak_ql_ddl:make_module_name(<<"GeoCheckin">>),
                            partition_key = get_standard_pk(),
@@ -160,16 +159,16 @@ get_standard_lk() -> #key_v1{ast = [
 			   'FROM'        = <<"GeoCheckin">>,
 			   'WHERE'       = [
                                             {startkey, [
-                                                        {<<"time">>,  
+                                                        {<<"time">>,
 							 timestamp,
 							 15000},
-                                                        {<<"user">>, 
+                                                        {<<"user">>,
 							 binary,
 							 <<"gordon">>}
                                                        ]
                                             },
                                             {endkey,   [
-                                                        {<<"time">>, 
+                                                        {<<"time">>,
 							 timestamp,
 							 18000},
                                                         {<<"user">>,


### PR DESCRIPTION
Previously the last key of a sub-query would be included and the first key of the next one would be too and they would be the same.

Now the sub-query goes up to the first record in the next quanta - but that record is then discarded from the range scan
