### PR TITLE
fix client to leveldb double reversal of TS records

### DIFF
--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -162,7 +162,7 @@ handle_info({{SubQId, QId}, {results, Chunk}},
                    lager:debug("Got chunk on QId ~p (~p); SubQQ: ~p", [QId, SubQId, SubQs]),
                    NSubQ = lists:delete(SubQId, SubQs),
                    State#state{status   = accumulating_chunks,
-                               result   = [{SubQId, Decoded} | IndexedChunks],
+                               result   = lists:append(IndexedChunks, [{SubQId, Decoded}]),
                                sub_qrys = NSubQ};
                false ->
                    %% discard;


### PR DESCRIPTION
RTS-421.

Because the data were coming in reverse order (note the way new
elements are prepended in riak_pb_ts_codec:row_for/2), the records
were sent to leveldb in reverse order.  However, another reversal was
done on fetch, the cumulative effect being the eventually correct
order as presented to the client.

As leveldb has optimisations in place relying on the TS data in the
un-reversed order, the double reversal is a bug.  This commit is a
fix.

~~Comes in conjunction with https://github.com/basho/riak_pb/pull/140.~~
