### PR TITLE
bitcask dependency fix

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
 {deps, [
         {sidejob, ".*", {git, "git://github.com/basho/sidejob.git", {branch, "2.0"}}},
         {erlang_js, ".*", {git, "git://github.com/basho/erlang_js.git", {tag, "1.3.0"}}},
-        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {branch, "1.7"}}},
+        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {tag, "1.7.2"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", {tag, "0.78"}}},
         {sext, ".*", {git, "git://github.com/basho/sext.git", {tag, "1.1p3"}}},
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {branch, "2.0"}}},


### PR DESCRIPTION
Made bitcask dependency a tagged dependency on the same bit cask version that ships with Riak 2.0.6 (fe8cb6e8962ed8d29814d8f5de49147a439415d8).  This bitcask SHA corresponds with the bit cask 1.7.2 tag (June 25, 2015).

This fix addresses a build failure (make deps) because of some recent changes in the bit cask branch that is (recursively) pulling in an incompatible version of lager from that which is pulled in from riak_core.
