### PR TITLE
Fix bug introduced by BDP/2i merge: create_plan/{5,6}

### DIFF
--- a/src/riak_kv_qry_coverage_plan.erl
+++ b/src/riak_kv_qry_coverage_plan.erl
@@ -23,13 +23,13 @@
 -module(riak_kv_qry_coverage_plan).
 
 -export([
-         create_plan/6
+         create_plan/5
         ]).
 
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 %%
-create_plan(_VNodeSelector, NVal, _PVC, _ReqId, _NodeCheckService, Request) ->
+create_plan(NVal, _PVC, _ReqId, _NodeCheckService, Request) ->
     Query = riak_local_index:get_query_from_req(Request),
     Key2 = make_key(Query),
     Bucket = riak_kv_util:get_bucket_from_req(Request),


### PR DESCRIPTION
When merging the BDP/2i code I simplified the call to the colocated `create_plan` from 6-arity to 5, but neglected to make the corresponding change in riak_kv.
