### PR TITLE
single-key reads

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -38,7 +38,7 @@
                    {riak_kv_pb_counter, 50, 53}, %% counter requests
                    {riak_kv_pb_coverage, 70, 71}, %% coverage requests
                    {riak_kv_pb_crdt, 80, 83}, %% CRDT requests
-                   {riak_kv_pb_timeseries, 90, 95} %% time series requests
+                   {riak_kv_pb_timeseries, 90, 97} %% time series requests
                   ]).
 -define(MAX_FLUSH_PUT_FSM_RETRIES, 10).
 


### PR DESCRIPTION
RTS-202. To be merged after https://github.com/basho/riak_pb/pull/143.

An implementation of single-key reads of TS data, building upon "single-key
delete" commit where groundwork for it was done (a44d3d33c, see changes in
riak_kv_get_fsm.erl).

This commit connects the pb messages #tsgetreq/-resp to the call to
`riak_client:get/4`, with duplicating Table for its Bucket arg, and correctly
unpacking the returned TS data.
