### PR TITLE
add #tscolumndescriptions to #tsgetresp

### DIFF
--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -317,7 +317,7 @@ get_long_ddl() ->
     SQL = "CREATE TABLE GeoCheckin " ++
         "(geohash varchar not null, " ++
         "user varchar not null, " ++
-	"extra int not null, " ++
+	"extra integer not null, " ++
 	"more float not null, " ++
         "time timestamp not null, " ++
         "weather varchar not null, " ++

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -254,7 +254,7 @@ handle_side_effects([{run_sub_query, {qry, Q}, {qid, QId}} | T]) ->
     {ok, _PID} = riak_kv_index_fsm_sup:start_index_fsm(node(), [{raw, QId, Me}, [Bucket, none, Q, Timeout, all, undefined, CoverageFn]]),
     handle_side_effects(T);
 handle_side_effects([H | T]) ->
-    io:format("in riak_kv_qry:handle_side_effects not handling ~p~n", [H]),
+    lager:warning("in riak_kv_qry:handle_side_effects not handling ~p", [H]),
     handle_side_effects(T).
 
 decode_results(KVList, SelectSpec) ->


### PR DESCRIPTION
RTS-480

**Note:** Because currently the get path is broken in e2e/ts due to riak_pb_ts_codec conversion issues, this PR (and the related ones mentioned below) will be finalized as soon as https://github.com/basho/riak_pb/pull/145 is in.

Depends on https://github.com/basho/riak_pb/pull/146. A corresponding PR for riak-erlang-client is https://github.com/basho/riak-erlang-client/pull/242, r_t module including a check for this new feature is https://github.com/basho/riak_test/pull/911.
