### PR TITLE
Add checks for bad elements in DDL primary key

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -522,7 +522,6 @@ bucket_type_create(CreateTypeFn, Type, {struct, Fields}) ->
         [{<<"props", _/binary>>, {struct, Props1}}] ->
             case catch riak_kv_wm_utils:maybe_parse_table_def(Type, Props1) of
                 {ok, Props2} ->
-                    lager:info("OK Return"),
                     Props3 = [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props2],
                     CreateTypeFn(Props3);
                 {error, ErrorMessage} when is_list(ErrorMessage) ->

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -522,15 +522,13 @@ bucket_type_create(CreateTypeFn, Type, {struct, Fields}) ->
         [{<<"props", _/binary>>, {struct, Props1}}] ->
             case catch riak_kv_wm_utils:maybe_parse_table_def(Type, Props1) of
                 {ok, Props2} ->
+                    lager:info("OK Return"),
                     Props3 = [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props2],
                     CreateTypeFn(Props3);
                 {error, ErrorMessage} when is_list(ErrorMessage) ->
-                    io:format(ErrorMessage),
-                    error;
+                    bucket_type_print_create_result(Type, {error, ErrorMessage});
                 {error, Error} ->
-                    io:format("~p~n", [Error]),
-                    error
-
+                    bucket_type_print_create_result(Type, {error, Error})
             end;
         _ ->
             io:format("Cannot create bucket type ~ts: no props field found in json~n", [Type]),
@@ -893,10 +891,12 @@ bucket_type_create_no_timeseries_test() ->
 bucket_type_create_with_timeseries_table_test() ->
     Ref = make_ref(),
     TableDef =
-        <<"CREATE TABLE my_type ",
-          "(time TIMESTAMP NOT NULL, ",
-	  "user varchar not null, ",
-          " PRIMARY KEY ((quantum(time, 15, m)), time, user))">>,
+        <<"CREATE TABLE my_type (",
+          "series varchar   not null, ",
+          "user   varchar   not null, ",
+          "time   timestamp not null, ",
+          "PRIMARY KEY ((series, user, quantum(time, 15, m)), "
+          "series, user, time))">>,
     JSON = json_props([{bucket_type, my_type}, 
                        {table_def, TableDef}]),
     bucket_type_create(
@@ -912,9 +912,12 @@ bucket_type_create_with_timeseries_table_test() ->
 bucket_type_create_with_timeseries_table_is_write_once_test() ->
     Ref = make_ref(),
     TableDef =
-        <<"CREATE TABLE my_type ",
-          "(time TIMESTAMP NOT NULL, ",
-          " PRIMARY KEY (time))">>,
+        <<"CREATE TABLE my_type (",
+        "series varchar   not null, ",
+        "user   varchar   not null, ",
+        "time   timestamp not null, ",
+        "PRIMARY KEY ((series, user, quantum(time, 15, m)), "
+        "series, user, time))">>,
     JSON = json_props([{bucket_type, my_type}, 
                        {table_def, TableDef}]),
     bucket_type_create(
@@ -930,10 +933,12 @@ bucket_type_create_with_timeseries_table_is_write_once_test() ->
 bucket_type_and_table_name_must_match_test() ->
     Ref = make_ref(),
     TableDef =
-        <<"CREATE TABLE times ",
-          "(time TIMESTAMP NOT NULL, ",
-	  "user varchar not null, ",
-          " PRIMARY KEY (time, user))">>,
+        <<"CREATE TABLE times (",
+        "series varchar   not null, ",
+        "user   varchar   not null, ",
+        "time   timestamp not null, ",
+        "PRIMARY KEY ((series, user, quantum(time, 15, m)), "
+        "series, user, time))">>,
     JSON = json_props([{bucket_type, my_type}, 
                        {table_def, TableDef}]),
     % if this error changes slightly it is not so important, as long as
@@ -950,12 +955,75 @@ bucket_type_and_table_name_must_match_test() ->
 bucket_type_create_with_timeseries_table_error_when_write_once_set_to_false_test() ->
     Ref = make_ref(),
     TableDef =
-        <<"CREATE TABLE my_type ",
-          "(time TIMESTAMP NOT NULL, ",
-          " PRIMARY KEY (time))">>,
+        <<"CREATE TABLE my_type (",
+        "series varchar   not null, ",
+        "user   varchar   not null, ",
+        "time   timestamp not null, ",
+        "PRIMARY KEY ((series, user, quantum(time, 15, m)), "
+        "series, user, time))">>,
     JSON = json_props([{bucket_type, my_type}, 
                        {table_def, TableDef},
                        {write_once, false}]),
+    ?assertEqual(
+        error,
+        bucket_type_create(
+            fun(Props) -> put(Ref, Props) end,
+            <<"my_type">>,
+            mochijson2:decode(JSON)
+        )
+    ).
+
+bucket_type_create_with_timeseries_table_error_with_short_primary_key_test() ->
+    Ref = make_ref(),
+    TableDef =
+        <<"CREATE TABLE my_type (",
+        "user   varchar   not null, ",
+        "time   timestamp not null, ",
+        "PRIMARY KEY ((user, quantum(time, 15, m)), "
+        "user, time))">>,
+    JSON = json_props([{bucket_type, my_type},
+                       {table_def, TableDef}]),
+    ?assertEqual(
+        error,
+        bucket_type_create(
+            fun(Props) -> put(Ref, Props) end,
+            <<"my_type">>,
+            mochijson2:decode(JSON)
+        )
+    ).
+
+bucket_type_create_with_timeseries_table_error_with_misplaced_quantum_test() ->
+    Ref = make_ref(),
+    TableDef =
+        <<"CREATE TABLE my_type (",
+        "time   timestamp not null, ",
+        "series varchar   not null, ",
+        "user   varchar   not null, ",
+        "PRIMARY KEY ((quantum(time, 15, m), series, user), "
+        "time, series, user, ))">>,
+    JSON = json_props([{bucket_type, my_type},
+                       {table_def, TableDef}]),
+    ?assertEqual(
+        error,
+        bucket_type_create(
+            fun(Props) -> put(Ref, Props) end,
+            <<"my_type">>,
+            mochijson2:decode(JSON)
+        )
+    ).
+
+bucket_type_and_table_error_local_key_test() ->
+    Ref = make_ref(),
+    TableDef =
+        <<"CREATE TABLE my_type (",
+        "series varchar   not null, ",
+        "user   varchar   not null, ",
+        "time   timestamp not null, ",
+        "other  varchar   not null, ",
+        "PRIMARY KEY ((series, user, quantum(time, 15, m)), "
+        "series, user, time, other))">>,
+    JSON = json_props([{bucket_type, my_type},
+        {table_def, TableDef}]),
     ?assertEqual(
         error,
         bucket_type_create(

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -459,6 +459,8 @@ maybe_parse_table_def(BucketType, Props) ->
                     ok = assert_type_and_table_name_same(BucketType, DDL),
                     ok = try_compile_ddl(DDL),
                     ok = assert_write_once_not_false(PropsNoDef),
+                    ok = assert_partition_key_length(DDL),
+                    ok = assert_primary_and_local_keys_match(DDL),
                     apply_timeseries_bucket_props(DDL, PropsNoDef);
                 {error, _} = E ->
                     E
@@ -496,6 +498,36 @@ assert_type_and_table_name_same(BucketType1, #ddl_v1{table = BucketType2}) ->
         "Error, the bucket type could not be the created. The bucket type and table name must be the same~n"
         "    bucket type was: " ++ binary_to_list(BucketType1) ++ "\n"
         "    table name was:  " ++ binary_to_list(BucketType2) ++ "\n"}).
+
+%% @doc Verify that the primary key has three components
+%%      and the first element is a quantum
+assert_partition_key_length(#ddl_v1{partition_key = {key_v1, Key}}) when length(Key) == 3 ->
+    assert_third_param_is_quantum(lists:nth(3, Key));
+assert_partition_key_length(_DDL) ->
+    throw({error, {primary_key, "Primary key is too short"}}).
+
+%% @doc Verify that the first element of the primary key is a quantum
+assert_third_param_is_quantum(#hash_fn_v1{mod=riak_ql_quanta, fn=quantum}) ->
+    ok;
+assert_third_param_is_quantum(_KeyComponent) ->
+    throw({error, {primary_key, "Third element of primary key must be a quantum"}}).
+
+%% @doc Verify primary key and local partition have the same elements
+assert_primary_and_local_keys_match(#ddl_v1{partition_key = #key_v1{ast = Primary}, local_key = #key_v1{ast = Local}}) ->
+    PrimaryList = lists:sort([query_field_name(F) || F <- Primary]),
+    LocalList = lists:sort([query_field_name(F) || F <- Local]),
+    case PrimaryList == LocalList of
+        true -> ok;
+        _Else ->
+            throw({error, {primary_key, "Local key does not match primary key"}})
+    end.
+
+%% Pull the name out of the appropriate record
+query_field_name(#hash_fn_v1{args = Args}) ->
+    Param = lists:keyfind(param_v1, 1, Args),
+    query_field_name(Param);
+query_field_name(#param_v1{name = Field}) ->
+    Field.
 
 %% Attempt to compile the DDL but don't do anything with the output, this is
 %% catch failures as early as possible. Also the error messages are easy to

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -514,8 +514,8 @@ assert_third_param_is_quantum(_KeyComponent) ->
 
 %% @doc Verify primary key and local partition have the same elements
 assert_primary_and_local_keys_match(#ddl_v1{partition_key = #key_v1{ast = Primary}, local_key = #key_v1{ast = Local}}) ->
-    PrimaryList = lists:sort([query_field_name(F) || F <- Primary]),
-    LocalList = lists:sort([query_field_name(F) || F <- Local]),
+    PrimaryList = [query_field_name(F) || F <- Primary],
+    LocalList = [query_field_name(F) || F <- Local],
     case PrimaryList == LocalList of
         true -> ok;
         _Else ->


### PR DESCRIPTION
- Make sure that the primary key has 3 elements
- Ensure that quantum is the last element
- Verify that the local key matches the same space as the primary key, i.e, same elements
- Properly report the errors back to `riak-admin`
