### PR TITLE
Removed riak_ql dep from riak_kv

### DIFF
--- a/src/riak_kv.app.src
+++ b/src/riak_kv.app.src
@@ -18,8 +18,7 @@
                   os_mon,
                   riak_pipe,
                   riak_dt,
-                  riak_pb,
-                  riak_ql
+                  riak_pb
                  ]},
   {registered, []},
   {mod, {riak_kv_app, []}},


### PR DESCRIPTION
This removes the riak_ql dependency from riak_kv, in favor of a modification to load riak_ql via reltool.config.
