### PR TITLE
Fix for reversed rows in make_tsqueryresp output.

### DIFF
--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -422,7 +422,7 @@ assemble_records(Rows, RecordSize) ->
     assemble_records_(Rows, RecordSize, []).
 %% should we protect against incomplete records?
 assemble_records_([], _, Acc) ->
-    Acc;
+    lists:reverse(Acc);
 assemble_records_(RR, RSize, Acc) ->
     Remaining = lists:nthtail(RSize, RR),
     assemble_records_(


### PR DESCRIPTION
The cell/row order is correct going into assemble_records, but the row order is reversed on the way out.
