### PR TITLE
Two fixes for put/2 interactions with its worker process

### DIFF
--- a/src/riak_kv_w1c_worker.erl
+++ b/src/riak_kv_w1c_worker.erl
@@ -116,7 +116,10 @@ put(RObj, Options) ->
             after Timeout ->
                 gen_server:cast(Worker, {cancel, ReqId}),
                 receive
+                    {'DOWN', ReqId, process, _Pid, _Reason} ->
+                        {error, riak_kv_w1c_server_crashed};
                     {ReqId, Response} ->
+                        erlang:demonitor(ReqId, [flush]),
                         Response
                 end
             end;


### PR DESCRIPTION
- If a DOWN message arrives after the timeout, the calling process could
  hang forever
- If the timeout cancel succeeds and a response is returned, the monitor
  is` not removed (h/t @jonmeredith)
