### PR TITLE
Batching put support using w1c workers

### DIFF
--- a/src/riak_kv_w1c_worker.erl
+++ b/src/riak_kv_w1c_worker.erl
@@ -72,14 +72,14 @@ workers() ->
 start_link(Name) ->
     gen_server:start_link({local, Name}, ?MODULE, [], []).
 
-%% @spec put(RObj :: riak_object:riak_object(), riak_object:options()) ->
+%% @spec put(RObj :: riak_object:riak_object(), proplists:proplist()) ->
 %%        ok |
 %%       {error, timeout} |
 %%       {error, term()}
 put(RObj, Options) ->
     synchronize_put(async_put(RObj, Options), Options).
 
--spec async_put(RObj :: riak_object:riak_object(), riak_object:options()) ->
+-spec async_put(RObj :: riak_object:riak_object(), proplists:proplist()) ->
                        {ok, {reference(), pid()}} |
                        {error, term()}.
 async_put(RObj, Options) ->
@@ -131,7 +131,7 @@ async_put(RObj, Options) ->
             Error
     end.
 
--spec async_put_replies(ReqIdTuples :: list({reference(), pid()}), riak_object:options()) ->
+-spec async_put_replies(ReqIdTuples :: list({reference(), pid()}), proplists:proplist()) ->
                                        list(term()).
 async_put_replies(ReqIdTuples, Options) ->
     async_put_reply_loop(ReqIdTuples, [], os:timestamp(),

--- a/src/riak_kv_w1c_worker.erl
+++ b/src/riak_kv_w1c_worker.erl
@@ -389,13 +389,11 @@ async_put_reply_loop(ReqIds, Responses, Timeout) ->
         {'DOWN', ReqId, process, _Pid, _Reason} when is_reference(ReqId) ->
             async_put_reply_loop(lists:keydelete(ReqId, 1, ReqIds),
                                  [{error, riak_kv_w1c_server_crashed}|Responses],
-                                 StartTime,
                                  Timeout);
         {ReqId, Response} when is_reference(ReqId) ->
             erlang:demonitor(ReqId, [flush]),
             async_put_reply_loop(lists:keydelete(ReqId, 1, ReqIds),
                                  [Response|Responses],
-                                 StartTime,
                                  Timeout)
     after Timeout ->
             lists:foreach(fun({ReqId, Worker}) ->


### PR DESCRIPTION
Per discussions over the last couple of weeks, performance on large batch puts is dramatically better if those batches are parallelized in Riak. @jonmeredith pointed out that the obvious way to do so without introducing more infrastructure is to leverage the write-once workers already present on the coordinating node, hence this PR.

This changes **all** puts handled by the write-once logic, so it will need to be reviewed carefully.

Before this is approved I/we need to come up with a test to verify the behavior on worker failure and timeouts.
