### PR TITLE
check compound key element count in riak_kv_pb_timeseries:make_ts_key/2

### DIFF
--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -53,19 +53,18 @@
 
 -record(state, {}).
 
-%% these error codes are obviously local to this module,
-%% until a central place for error numbers is defined
--define(E_SUBMIT,   1).
--define(E_FETCH,    2).
--define(E_IRREG,    3).
--define(E_PUT,      4).
--define(E_NOCREATE, 5).
--define(E_NOT_TS_TYPE, 6).
--define(E_MISSING_TYPE, 7).
--define(E_MISSING_TS_MODULE, 8).
--define(E_DELETE,   9).
--define(E_GET,     10).
--define(E_BAD_KEY_LENGTH, 11).
+%% per RIAK-1437, error codes assigned to TS are in the 1000-1500 range
+-define(E_SUBMIT,            1001).
+-define(E_FETCH,             1002).
+-define(E_IRREG,             1003).
+-define(E_PUT,               1004).
+-define(E_NOCREATE,          1005).
+-define(E_NOT_TS_TYPE,       1006).
+-define(E_MISSING_TYPE,      1007).
+-define(E_MISSING_TS_MODULE, 1008).
+-define(E_DELETE,            1009).
+-define(E_GET,               1010).
+-define(E_BAD_KEY_LENGTH,    1011).
 
 -define(FETCH_RETRIES, 10).  %% TODO make it configurable in tsqueryreq
 

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -24,6 +24,7 @@
 -module(riak_kv_pb_timeseries).
 
 -include_lib("riak_pb/include/riak_kv_pb.hrl").
+-include_lib("riak_pb/include/riak_ts_pb.hrl").
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 -include("riak_kv_wm_raw.hrl").
@@ -398,8 +399,8 @@ make_ts_keys(CompoundKey, DDL = #ddl_v1{local_key = #key_v1{ast = LKParams},
             LK = eleveldb_ts:encode_key(
                    riak_ql_ddl:get_local_key(DDL, BareValues)),
             {ok, {PK, LK}};
-       {Need, Got} ->
-            {error, {bad_key_length, Need, Got}}
+       {Got, Need} ->
+            {error, {bad_key_length, Got, Need}}
     end.
 
 

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -24,7 +24,6 @@
 -module(riak_kv_pb_timeseries).
 
 -include_lib("riak_pb/include/riak_kv_pb.hrl").
--include_lib("riak_pb/include/riak_ts_pb.hrl").
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 -include("riak_kv_wm_raw.hrl").


### PR DESCRIPTION
Instead of a badarg trace from lists:zip, get and delete will now return
# rpberrresp{11, "Need, Got"} unless cmpound key has the right number of

elements.

This should fix https://github.com/basho/riak_kv/issues/1257.

**Update:** Include a commit that moves all error codes to 1000 and above. See https://bashoeng.atlassian.net/browse/RIAK-1437 for details.
