### PR TITLE
new API function riak_client:list_ts_keys/3

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,22 +1,4 @@
 riak_core_pb.erl
-riak_kv_pipe_index.erl:164: Function queue_existing_pipe/4 has no local return
-riak_kv_pipe_listkeys.erl:159: Function queue_existing_pipe/3 has no local return
-riak_kv_put_fsm.erl:822: The pattern <[COP = {'counter_op', _Amt} | T], Acc> can never match the type <[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()},...],[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()}]>
-riak_kv_put_fsm.erl:825: The pattern <[COP = {'crdt_op', _Op} | T], Acc> can never match the type <[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()},...],[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()}]>
-riak_kv_util.erl:304: The pattern 'error' can never match the type 'ok' | 'undefined'
-riak_kv_vnode.erl:908: Invalid type specification for function riak_kv_vnode:prepare_index_query/1. The success typing is ('undefined' | {_,_}) -> 'undefined' | {_,_}
-riak_kv_vnode.erl:909: The pattern Q = {'riak_kv_index_v3', _, _, _, _, _, _, _, _, RE, _} can never match the type 'undefined' | {_,_}
-riak_kv_vnode.erl:919: The pattern <{'riak_kv_index_v3', _, _, _, _, _, _, _, _, _, N}, DefaultSize> can never match the type <'undefined' | {_,_},'undefined' | pos_integer()>
-riak_kv_vnode.erl:940: The call riak_kv_vnode:prepare_index_query(Query::'undefined' | {_,_}) breaks the contract (#riak_kv_index_v3{}) -> #riak_kv_index_v3{}
-riak_kv_vnode.erl:1205: The call riak_kv_vnode:raw_put(HOTarget::atom(),Key::{binary() | {binary(),binary()},binary()},Obj::riak_object:riak_object()) will never return since it differs in the 1st argument from the success typing arguments: ({_,_},any(),any())
-riak_kv_vnode.erl:1327: Function raw_put/3 has no local return
-riak_kv_vnode.erl:1327: The pattern <{Idx, Node}, Key, Obj> can never match the type <atom(),{binary() | {binary(),binary()},binary()},riak_object:riak_object()>
-riak_kv_vnode.erl:1367: Function do_backend_delete/3 has no local return
-riak_kv_vnode.erl:2051: Function delete_from_hashtree/3 has no local return
-riak_kv_vnode.erl:2055: The call riak_kv_index_hashtree:async_delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ({binary(),binary()} | [{binary(),binary()}],pid()) -> 'ok'
-riak_kv_vnode.erl:2058: The call riak_kv_index_hashtree:delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ([{binary(),binary()}],pid()) -> 'ok'
-riak_kv_vnode.erl:2128: Function update_index_delete_stats/1 will never be called
-riak_kv_pb_timeseries.erl:169: Function put_data/3 has no local return
 # Callback info not available
 Callback info about the riak_core_vnode_worker behaviour is not available
 Callback info about the riak_core_coverage_fsm behaviour is not available

--- a/include/riak_kv_vnode.hrl
+++ b/include/riak_kv_vnode.hrl
@@ -40,7 +40,7 @@
 %% used to serve list_keys for timeseries
 -record(riak_kv_listkeys_ts_req_v1, {
           table :: binary(),
-          item_filter :: none | function(),
+          item_filter :: none | fun((list()) -> boolean()),
           ddl_mod :: module()}).
 
 -record(riak_kv_listbuckets_req_v1, {

--- a/include/riak_kv_vnode.hrl
+++ b/include/riak_kv_vnode.hrl
@@ -37,12 +37,11 @@
           bucket :: binary() | tuple(),
           item_filter :: function()}).
 
-%% Can #riak_kv_listkeys_req_v4{} accommodate a new field for
-%% us, rather than creating a new record?
+%% used to serve list_keys for timeseries
 -record(riak_kv_listkeys_ts_req_v1, {
           table :: binary(),
           item_filter :: none | function(),
-          ddl :: riak_ql_ddl:ddl()}).
+          ddl_mod :: module()}).
 
 -record(riak_kv_listbuckets_req_v1, {
           item_filter :: function()}).

--- a/include/riak_kv_vnode.hrl
+++ b/include/riak_kv_vnode.hrl
@@ -37,6 +37,13 @@
           bucket :: binary() | tuple(),
           item_filter :: function()}).
 
+%% Can #riak_kv_listkeys_req_v4{} accommodate a new field for
+%% us, rather than creating a new record?
+-record(riak_kv_listkeys_ts_req_v1, {
+          table :: binary(),
+          item_filter :: none | function(),
+          ddl :: riak_ql_ddl:ddl()}).
+
 -record(riak_kv_listbuckets_req_v1, {
           item_filter :: function()}).
 

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -29,7 +29,7 @@
 -export([put/2,put/3,put/4,put/5,put/6]).
 -export([delete/3,delete/4,delete/5]).
 -export([delete_vclock/4,delete_vclock/5,delete_vclock/6]).
--export([list_keys/2,list_keys/3,list_keys/4,list_ts_keys/5]).
+-export([list_keys/2,list_keys/3,list_keys/4,list_keys/5]).
 -export([stream_list_keys/2,stream_list_keys/3,stream_list_keys/4]).
 -export([filter_buckets/2]).
 -export([filter_keys/3,filter_keys/4]).
@@ -621,52 +621,38 @@ split_cover(SubpartitionPlan) when is_list(SubpartitionPlan) ->
               SubpartitionPlan).
 
 
-%% @spec list_keys(riak_object:bucket(), riak_client()) ->
-%%       {ok, [Key :: riak_object:key()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec list_keys(riak_object:bucket(), riak_client()) ->
+                       {ok, [tuple()]} | {error, term()}.
 %% @doc List the keys known to be present in Bucket.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
 %% @equiv list_keys(Bucket, default_timeout()*8)
 list_keys(Bucket, {?MODULE, [_Node, _ClientId]}=THIS) ->
-    list_keys(Bucket, ?DEFAULT_TIMEOUT*8, THIS).
+    list_keys(Bucket, none, ?DEFAULT_TIMEOUT*8, none, THIS).
 
-%% @spec list_keys(riak_object:bucket(), TimeoutMillisecs :: integer(), riak_client()) ->
-%%       {ok, [Key :: riak_object:key()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec list_keys(riak_object:bucket(), pos_integer() | none, riak_client()) ->
+                       {ok, [tuple()]} | {error, term()}.
 %% @doc List the keys known to be present in Bucket.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
 list_keys(Bucket, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
-    list_keys(Bucket, none, Timeout, THIS).
+    list_keys(Bucket, none, Timeout, none, THIS).
 
-%% @spec list_keys(riak_object:bucket(), Filter :: term(),
-%% TimeoutMillisecs :: integer(), riak_client()) ->
-%%       {ok, [Key :: riak_object:key()]} |
-%%       {error, timeout} |
-%%       {error, Err :: term()}
+-spec list_keys(riak_object:bucket(), function() | none, pos_integer() | none, riak_client()) ->
+                       {ok, [tuple()]} | {error, term()}.
 %% @doc List the keys known to be present in Bucket.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
-list_keys(Bucket, Filter, Timeout0, {?MODULE, [Node, _ClientId]}) ->
-    Timeout =
-        case Timeout0 of
-            T when is_integer(T) -> T;
-            _ -> ?DEFAULT_TIMEOUT*8
-        end,
-    Me = self(),
-    ReqId = mk_reqid(),
-    riak_kv_keys_fsm_sup:start_keys_fsm(Node, [{raw, ReqId, Me}, [Bucket, Filter, Timeout]]),
-    wait_for_listkeys(ReqId).
+list_keys(Bucket, Filter, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    list_keys(Bucket, Filter, Timeout, none, THIS).
 
--spec list_ts_keys(Table::binary(), function() | none, pos_integer() | undefined, riak_ql_ddl:ddl(),
-                   riak_client()) ->
-                          {ok, [tuple()]} | {error, term()}.
-%% @doc Lists all keys in a timeseries Table. When it is not 'none',
-%%      Filter function is applied to the recovered compound key.
-list_ts_keys(Table, Filter, Timeout0, DDL, {?MODULE, [Node, _ClientId]}) ->
+-spec list_keys(riak_object:bucket(), function() | none, pos_integer() | none, DDLMod::module() | none,
+                riak_client()) ->
+                       {ok, [tuple()]} | {error, term()}.
+%% @doc Lists all keys in Bucket. When DDLMod is not 'none' and
+%%      Filter is not 'none', Filter function is applied to the
+%%      recovered compound key.
+list_keys(Bucket, Filter, Timeout0, Mod, {?MODULE, [Node, _ClientId]}) ->
     Timeout =
         case Timeout0 of
             T when is_integer(T) -> T;
@@ -674,7 +660,7 @@ list_ts_keys(Table, Filter, Timeout0, DDL, {?MODULE, [Node, _ClientId]}) ->
         end,
     Me = self(),
     ReqId = mk_reqid(),
-    riak_kv_keys_fsm_sup:start_keys_fsm(Node, [{raw, ReqId, Me}, [Table, Filter, Timeout, DDL]]),
+    riak_kv_keys_fsm_sup:start_keys_fsm(Node, [{raw, ReqId, Me}, [Bucket, Filter, Timeout, Mod]]),
     wait_for_listkeys(ReqId).
 
 stream_list_keys(Bucket, {?MODULE, [_Node, _ClientId]}=THIS) ->

--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -66,12 +66,12 @@
 %%                          | {field_parsing_failed, {Field :: binary(), Value :: binary()}}.
 
 %% @type bucketname()      = binary().
-%% @type index_field()     = binary().
-%% @type index_value()     = binary() | integer().
-%% @type query_element()   = {eq,    index_field(), index_value()} |
-%%                           {range, index_field(), index_value(), index_value()}
-
--type query_def() :: {ok, term()} | {error, term()} | {term(), {error, term()}}.
+-type index_field() :: binary().
+-type index_value() :: binary() | integer().
+-type query_def() :: ?KV_INDEX_Q{} |
+                     #riak_kv_index_v2{} |
+                     {eq, index_field(), index_value()} |
+                     {range, index_field(), index_value(), index_value()}.
 -export_type([query_def/0]).
 
 -type last_result() :: {value(), key()} | key().

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -38,7 +38,7 @@
                    {riak_kv_pb_counter, 50, 53}, %% counter requests
                    {riak_kv_pb_coverage, 70, 71}, %% coverage requests
                    {riak_kv_pb_crdt, 80, 83}, %% CRDT requests
-                   {riak_kv_pb_timeseries, 90, 97} %% time series requests
+                   {riak_kv_pb_timeseries, 90, 99} %% time series requests
                   ]).
 -define(MAX_FLUSH_PUT_FSM_RETRIES, 10).
 

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -121,13 +121,13 @@ async_insert(Items, _Opts, Tree) when Tree =:= undefined; Items =:= [] ->
 async_insert(Items=[_|_], Opts, Tree) ->
     gen_server:cast(Tree, {insert, Items, Opts}).
 
--spec delete([{binary(), binary()}], pid()) -> ok.
+-spec delete([{object, {binary(), binary()}}], pid()) -> ok.
 delete(Items, Tree) when Tree =:= undefined; Items =:= [] ->
     ok;
 delete(Items=[{_Id, _Key}|_], Tree) ->
     catch gen_server:call(Tree, {delete, Items}, infinity).
 
--spec async_delete({binary(), binary()}|[{binary(), binary()}], pid()) -> ok.
+-spec async_delete([{object, {binary(), binary()}}], pid()) -> ok.
 async_delete(Items, Tree) when Tree =:= undefined; Items =:= [] ->
     ok;
 async_delete(Items=[{_Id, _Key}|_], Tree) ->

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -245,10 +245,10 @@ process(#tslistkeysreq{table = Table, timeout = Timeout}, State) ->
         {_, {undef, _}} ->
             Props = riak_core_bucket:get_bucket(Table),
             {reply, missing_helper_module(Table, Props), State};
-        DDL ->
+        _DDL ->
             Filter = none,
-            Result = riak_client:list_ts_keys(
-                       Table, Filter, Timeout, DDL,
+            Result = riak_client:list_keys(
+                       Table, Filter, Timeout, Mod,
                        {riak_client, [node(), undefined]}),
             case Result of
                 {ok, CompoundKeys} ->

--- a/src/riak_kv_pipe_index.erl
+++ b/src/riak_kv_pipe_index.erl
@@ -142,7 +142,7 @@ done(_State) ->
 
 %% Convenience
 
--type bucket_or_filter() :: binary() | {binary(), list()}.
+-type bucket_or_filter() :: binary() | {binary(), list()} | {binary(), list()}.
 
 %% @doc Query and index, and send the results as inputs to the
 %%      given pipe.  This starts a new pipe with one fitting

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1915,8 +1915,8 @@ fold_fun(keys, BufferMod, none, undefined) ->
     end;
 fold_fun({keys, RecoverTsFun}, BufferMod, none, undefined) ->
     fun(_, Key, Buffer) ->
-            CompounfKey = RecoverTsFun(Key),
-            BufferMod:add(CompounfKey, Buffer)
+            CompoundKey = RecoverTsFun(Key),
+            BufferMod:add(CompoundKey, Buffer)
     end;
 fold_fun(keys, BufferMod, none, {Bucket, Index, N, NumPartitions}) ->
     fun(_, Key, Buffer) ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -144,7 +144,7 @@
                 key_buf_size :: pos_integer(),
                 async_folding :: boolean(),
                 in_handoff = false :: boolean(),
-                handoff_target :: node(),
+                handoff_target :: {integer(), node()},
                 handoffs_rejected = 0 :: integer(),
                 forward :: node() | [{integer(), node()}],
                 hashtrees :: pid(),

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -770,7 +770,7 @@ diff_specs_core(AllIndexSet, OldIndexSet) ->
 
 %% @doc Get a list of {Index, Value} tuples from the
 %% metadata of an object.
--spec index_data(riak_object()) -> [{binary(), index_value()}].
+-spec index_data(undefined | riak_object()) -> [{binary(), index_value()}].
 index_data(undefined) ->
     [];
 index_data(Obj) ->


### PR DESCRIPTION
RTS-203.

Depends on:
- https://github.com/basho/riak_pipe/pull/102 (for a dialyzer fix);
- https://github.com/basho/riak_ql/pull/40 (for type `ddl()`, now used in specs);
- https://github.com/basho/riak_pb/pull/162 (for new pb messages `tslistkeys{req,resp}`).

Required for https://github.com/basho/riak_test/pull/929.

An implementation of `list_keys` for TS data is cumbersome and tricky because it involves the reading and decoding (against its table's DDL) of each TS object, in order to reconstruct the original Local Key from the encoded binary. The challenge is to engineer this code path as far as possible from a dumb query("select \* ...") followed by stripping the unneeded values, and utilize the streaming mechanisms available for normal `riak_client:list_keys`.

In this PR this is done by passing the DDL structure all the way to `riak_kv_vnode:handle_coverage/4`, via `riak_kv_keys_fsm`, where the conversion of the key (as binary) to Local Key (now a list) is done in function `recover_ts_key/3`.

As a bonus, a separate commit fixes most of outstanding dialyzer issues in riak_kv (courtesy of Paul Oliver https://github.com/puzza007).
