### PR TITLE
Queries must use full ranges and other error messages RTS-578

### DIFF
--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -29,7 +29,6 @@
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 -include("riak_kv_index.hrl").
 -include("riak_kv_ts_error_msgs.hrl").
--include_lib("eunit/include/eunit.hrl").
 
 -define(MAXSUBQ, 5).
 
@@ -339,6 +338,7 @@ rew2([#param_v1{name = [N]} | T], W, Mod, Acc) ->
 
 -ifdef(TEST).
 -compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
 
 %%
 %% Helper Fns for unit tests

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -940,7 +940,19 @@ duplicate_upper_bound_filter_not_allowed_test() ->
         compile(DDL, Q)
     ).
 
-% FIXME getting an invalid rewrite error on this
+% FIXME or operators
+% or_test_test() ->
+%     DDL = get_standard_ddl(),
+%     {ok, Q} = get_query(
+%         "SELECT weather FROM GeoCheckin "
+%         "WHERE time > 3000 AND time < 5000 "
+%         "AND user = \"user_1\" AND location = \"derby\" OR location = \"rottingham\""),
+%     ?assertEqual(
+%         {error, {upper_bound_specified_more_than_once, ?E_TSMSG_DUPLICATE_UPPER_BOUND}},
+%         compile(DDL, Q)
+%     ).
+
+% TODO support filters on the primary key, this is not currently supported
 % filter_on_quanta_field_test() ->
 %     DDL = get_standard_ddl(),
 %     {ok, Q} = get_query(

--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -37,3 +37,18 @@
     E_MISSING_PARAM_IN_WHERE_CLAUSE(ParamName),
     iolist_to_binary(["Missing parameter ", ParamName, " in where clause."])
 ).
+
+-define(
+    E_WHERE_CLAUSE_NOT_A_RANGE(ParamName, InvalidOperator),
+    iolist_to_binary([
+        "The where clause is not a complete time range e.g. ",
+        "\n\n    ", ParamName, ", > 1000 and ", ParamName, " < 2000.\n\n",
+        "Operator ", atom_to_list(InvalidOperator), " was used but only '>', '>=', '<' and '<=' are allowed."
+    ])).
+
+-define(
+    E_WHERE_CLAUSE_NOT_A_RANGE(ParamNameA, InvalidOperatorA, ParamNameB, InvalidOperatorB),
+    iolist_to_binary([
+        ?E_WHERE_CLAUSE_NOT_A_RANGE(ParamNameA, InvalidOperatorA), "\n",
+        ?E_WHERE_CLAUSE_NOT_A_RANGE(ParamNameB, InvalidOperatorB)
+    ])).

--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -54,6 +54,11 @@
 ).
 
 -define(
+    E_TIME_BOUNDS_MUST_USE_AND,
+    <<"The time bounds used OR but must use AND.">>
+).
+
+-define(
     E_TSMSG_LOWER_BOUND_MUST_BE_LESS_THAN_UPPER_BOUND,
     <<"The lower time bound is greater than the upper time bound.">>
 ).

--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -52,3 +52,14 @@
     E_MISSING_PARAM_IN_WHERE_CLAUSE(ParamName),
     iolist_to_binary(["Missing parameter ", ParamName, " in where clause."])
 ).
+
+-define(
+    E_TSMSG_LOWER_BOUND_MUST_BE_LESS_THAN_UPPER_BOUND,
+    <<"The lower time bound is greater than the upper time bound.">>
+).
+
+-define(
+    E_TSMSG_LOWER_AND_UPPER_BOUNDS_ARE_EQUAL_WHEN_NO_EQUALS_OPERATOR,
+    <<"The upper and lower boundaries are equal but the query uses the greater and less than operators.  ",
+      "Change the bounds time or use the greater/less than or equals to on either side.">>
+).

--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -34,21 +34,21 @@
 ).
 
 -define(
-    E_MISSING_PARAM_IN_WHERE_CLAUSE(ParamName),
-    iolist_to_binary(["Missing parameter ", ParamName, " in where clause."])
+    E_TSMSG_NO_BOUNDS_SPECIFIED,
+    <<"Neither upper or lower time bounds were specified in the query.">>
 ).
 
 -define(
-    E_WHERE_CLAUSE_NOT_A_RANGE(ParamName, InvalidOperator),
-    iolist_to_binary([
-        "The where clause is not a complete time range e.g. ",
-        "\n\n    ", ParamName, ", > 1000 and ", ParamName, " < 2000.\n\n",
-        "Operator ", atom_to_list(InvalidOperator), " was used but only '>', '>=', '<' and '<=' are allowed."
-    ])).
+    E_TSMSG_DUPLICATE_LOWER_BOUND,
+    <<"The lower time bound is specified more than once in the query.">>
+).
 
 -define(
-    E_WHERE_CLAUSE_NOT_A_RANGE(ParamNameA, InvalidOperatorA, ParamNameB, InvalidOperatorB),
-    iolist_to_binary([
-        ?E_WHERE_CLAUSE_NOT_A_RANGE(ParamNameA, InvalidOperatorA), "\n",
-        ?E_WHERE_CLAUSE_NOT_A_RANGE(ParamNameB, InvalidOperatorB)
-    ])).
+    E_TSMSG_DUPLICATE_UPPER_BOUND,
+    <<"The upper time bound is specified more than once in the query.">>
+).
+
+-define(
+    E_MISSING_PARAM_IN_WHERE_CLAUSE(ParamName),
+    iolist_to_binary(["Missing parameter ", ParamName, " in where clause."])
+).

--- a/test/sql_compilation_end_to_end.erl
+++ b/test/sql_compilation_end_to_end.erl
@@ -110,7 +110,7 @@ get_standard_lk() -> #key_v1{ast = [
              ++ "time timestamp not null, "
              ++ "weather varchar not null, "
              ++ "temperature varchar, "
-             ++ "PRIMARY KEY ((quantum(time, 15, s)), time, user))",
+             ++ "PRIMARY KEY ((time, user, quantum(time, 15, 's')), time, user, time))",
              "select weather from GeoCheckin where time > 3000 and time < 5000",
              {error, {missing_param, <<"Missing parameter user in where clause.">>}}).
 


### PR DESCRIPTION
Queries must specify a full range for the quantum: `time > 1000 AND time <= 2000`.

Queries not using the greater/less than [or equals to] will return an error message.

Queries using a valid range but add an additional filter return an error:  `time > 1000 AND time <= 2000 AND time != 1101`. No technical reason, it is just not implemented yet. I have left a commented test which I used to investigate whether this was already supported.

Allow multiple timestamps for the partition and local key, prior to this change the quantum was not extracted from the key correctly.

Check that the query range can actually match something: `time > 100 AND time < 50` returns an error. As does `time > 100 AND time < 100`.
