### PR TITLE
Review submitted PR [JIRA: RIAK-2303]

### DIFF
--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -484,9 +484,8 @@ assert_write_once_not_false(Props) ->
         {<<"write_once">>, false} ->
             throw({error,
                    {write_once,
-                    "Error, the bucket type could not be the created. "
-                    "The write_once property had a value of false but must be true "
-                    "or left blank\n"}});
+                    "Error, the time series bucket type could not be created. "
+                    "The write_once property must be true\n"}});
         _ ->
             ok
     end.

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -483,9 +483,10 @@ assert_write_once_not_false(Props) ->
     case lists:keyfind(<<"write_once">>, 1, Props) of
         {<<"write_once">>, false} ->
             throw({error,
-                "Error, the bucket type could not be the created. "
-                "The write_once property had a value of false but must be true "
-                "or left blank\n"});
+                   {write_once,
+                    "Error, the bucket type could not be the created. "
+                    "The write_once property had a value of false but must be true "
+                    "or left blank\n"}});
         _ ->
             ok
     end.
@@ -495,9 +496,10 @@ assert_type_and_table_name_same(BucketType, #ddl_v1{table = BucketType}) ->
     ok;
 assert_type_and_table_name_same(BucketType1, #ddl_v1{table = BucketType2}) ->
     throw({error,
-        "Error, the bucket type could not be the created. The bucket type and table name must be the same~n"
-        "    bucket type was: " ++ binary_to_list(BucketType1) ++ "\n"
-        "    table name was:  " ++ binary_to_list(BucketType2) ++ "\n"}).
+           {table_name,
+            "Error, the bucket type could not be the created. The bucket type and table name must be the same~n"
+            "    bucket type was: " ++ binary_to_list(BucketType1) ++ "\n"
+            "    table name was:  " ++ binary_to_list(BucketType2) ++ "\n"}}).
 
 %% @doc Verify that the primary key has three components
 %%      and the first element is a quantum


### PR DESCRIPTION
Formerly, these errors were represented on the console as a long stream of ASCII integers. Now:

```
$ ./riak-admin bucket-type create testone '{"props":{"table_def":"CREATE TABLE test1one (field1 varchar not null, field2 varchar not null, time timestamp not null, PRIMARY KEY((field1, field2, quantum(time, 15, s)), field1, field2, time))"}}'
Error creating bucket type testone:
Error, the bucket type could not be the created. The bucket type and table name must be the same
    bucket type was: testone
    table name was:  test1one

sturm:bin John$ ./riak-admin bucket-type create test1one '{"props":{"write_once":false, "table_def":"CREATE TABLE test1one (field1 varchar not null, field2 varchar not null, time timestamp not null, PRIMARY KEY((field1, field2, quantum(time, 15, s)), field1, field2, time))"}}'
Error creating bucket type test1one:
Error, the bucket type could not be the created. The write_once property had a value of false but must be true or left blank
```
