### PR TITLE
Change the flat_format string in decoder_parse_error_resp/1

### DIFF
--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -302,7 +302,7 @@ decode_query(#tsinterpolation{ base = BaseQuery }) ->
     riak_ql_parser:parse(Lexed).
 
 decoder_parse_error_resp({Token, riak_ql_parser, _}) ->
-    flat_format("Unexpected token '~s'", [Token]);
+    flat_format("Unexpected token '~p'", [Token]);
 decoder_parse_error_resp(Error) ->
     Error.
 


### PR DESCRIPTION
If the token is not a string, this error message blows up.
