### PR TITLE
unbreak normal list_keys (regression caused by adding TS list_keys)

### DIFF
--- a/src/riak_kv_keys_fsm.erl
+++ b/src/riak_kv_keys_fsm.erl
@@ -88,6 +88,8 @@ req(Bucket, ItemFilter) ->
 %% the number of primary preflist vnodes the operation
 %% should cover, the service to use to check for available nodes,
 %% and the registered name to use to access the vnode master process.
+init(From, [Bucket, ItemFilter, Timeout]) ->
+    init(From, [Bucket, ItemFilter, Timeout, none]);
 init(From={_, _, ClientPid}, [Bucket, ItemFilter, Timeout, DDLMod]) ->
     riak_core_dtrace:put_tag(io_lib:format("~p", [Bucket])),
     ClientNode = atom_to_list(node(ClientPid)),


### PR DESCRIPTION
The commit that triggers the regression is 77cd66e3 (part of #1268).

With it, tests/verify_listkeys passes again.
