### PR TITLE
Hard-code vclock_encoding_method/0 to return encode_raw

### DIFF
--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -1141,7 +1141,7 @@ update_last_modified(RObj, TS) ->
 %% Fetch the preferred vclock encoding method:
 -spec vclock_encoding_method() -> atom().
 vclock_encoding_method() ->
-    riak_core_capability:get({riak_kv, vclock_data_encoding}, encode_raw).
+    encode_raw.
 
 %% Encode a vclock in accordance with our capability setting:
 encode_vclock(VClock) ->


### PR DESCRIPTION
This takes the work of https://github.com/basho/riak_kv/pull/1186 and further optimizes it by removing the call to `riak_core_capability:get/2`. The only downside is now the vclock encoding cannot be changed.
