### PR TITLE
move ddl validation to riak_ql_parser, add more DDL validation checks

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_console: interface for Riak admin commands
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -520,7 +520,7 @@ decode_json_props(JsonProps) ->
 bucket_type_create(CreateTypeFn, Type, {struct, Fields}) ->
     case Fields of
         [{<<"props", _/binary>>, {struct, Props1}}] ->
-            case catch riak_kv_wm_utils:maybe_parse_table_def(Type, Props1) of
+            case catch riak_kv_ts_util:maybe_parse_table_def(Type, Props1) of
                 {ok, Props2} ->
                     Props3 = [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props2],
                     CreateTypeFn(Props3);
@@ -548,6 +548,9 @@ bucket_type_print_create_result(Type, ok) ->
         false ->
             ok
     end;
+bucket_type_print_create_result(Type, {error, {_LineNo, riak_ql_parser, Reason}}) ->
+    io:format("Error validating table definition for bucket type ~ts:\n~s\n", [Type, Reason]),
+    error;
 bucket_type_print_create_result(Type, {error, Reason}) ->
     io:format("Error creating bucket type ~ts:~n", [Type]),
     io:format(bucket_error_xlate(Reason)),

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -1,0 +1,92 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_ts_util: supporting functions for timeseries code paths
+%%
+%% Copyright (c) 2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Various functions related to timeseries.
+
+-module(riak_kv_ts_util).
+
+-export([maybe_parse_table_def/2]).
+
+-include_lib("riak_ql/include/riak_ql_ddl.hrl").
+
+%% Given bucket properties, transform the `<<"table_def">>' property if it
+%% exists to riak_ql DDL and store it under the `<<"ddl">>' key, table_def
+%% is removed.
+-spec maybe_parse_table_def(BucketType :: binary(),
+                            Props :: list(proplists:property())) ->
+        {ok, Props2 :: [proplists:property()]} | {error, any()}.
+maybe_parse_table_def(BucketType, Props) ->
+    case lists:keytake(<<"table_def">>, 1, Props) of
+        false ->
+            {ok, Props};
+        {value, {<<"table_def">>, TableDef}, PropsNoDef} ->
+            case riak_ql_parser:parse(riak_ql_lexer:get_tokens(binary_to_list(TableDef))) of
+                {ok, DDL} ->
+                    ok = assert_type_and_table_name_same(BucketType, DDL),
+                    ok = try_compile_ddl(DDL),
+                    ok = assert_write_once_not_false(PropsNoDef),
+                    apply_timeseries_bucket_props(DDL, PropsNoDef);
+                {error, _} = E ->
+                    E
+            end
+    end.
+
+%%
+-spec apply_timeseries_bucket_props(DDL::#ddl_v1{},
+                                    Props1::[proplists:property()]) ->
+        {ok, Props2::[proplists:property()]}.
+apply_timeseries_bucket_props(DDL, Props1) ->
+    Props2 = lists:keystore(
+        <<"write_once">>, 1, Props1, {<<"write_once">>, true}),
+    {ok, [{<<"ddl">>, DDL} | Props2]}.
+
+%% Time series must always use write_once so throw an error if the write_once
+%% property is ever set to false. This prevents a user thinking they have
+%% disabled write_once when it has been set to true internally.
+assert_write_once_not_false(Props) ->
+    case lists:keyfind(<<"write_once">>, 1, Props) of
+        {<<"write_once">>, false} ->
+            throw({error,
+                   {write_once,
+                    "Error, the time series bucket type could not be created. "
+                    "The write_once property must be true\n"}});
+        _ ->
+            ok
+    end.
+
+%% @doc Ensure table name in DDL and bucket type are the same.
+assert_type_and_table_name_same(BucketType, #ddl_v1{table = BucketType}) ->
+    ok;
+assert_type_and_table_name_same(BucketType1, #ddl_v1{table = BucketType2}) ->
+    throw({error,
+           {table_name,
+            "The bucket type and table name must be the same\n"
+            "    bucket type was: " ++ binary_to_list(BucketType1) ++ "\n"
+            "     table name was: " ++ binary_to_list(BucketType2) ++ "\n"}}).
+
+%% Attempt to compile the DDL but don't do anything with the output, this is
+%% catch failures as early as possible. Also the error messages are easy to
+%% return at this point.
+try_compile_ddl(DDL) ->
+    {_, AST} = riak_ql_ddl_compiler:compile(DDL),
+    {ok, _, _} = compile:forms(AST),
+    ok.

--- a/src/riak_kv_wm_props.erl
+++ b/src/riak_kv_wm_props.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_kv_wm_props: Webmachine resource for listing bucket properties.
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -281,7 +281,7 @@ get_bucket_props_json(Client, Bucket) ->
 %% @doc Modify the bucket properties according to the body of the
 %%      bucket-level PUT request.
 accept_bucket_body(RD, Ctx=#ctx{bucket_type=T, bucketprops=Props1}) ->
-    case catch riak_kv_wm_utils:maybe_parse_table_def(T, Props1) of
+    case catch riak_kv_ts_util:maybe_parse_table_def(T, Props1) of
         {ok, Props2} ->
             set_bucket(RD, Ctx#ctx{ bucketprops = Props2 });
         {error, Details} when is_list(Details) ->

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_kv_wm_utils: Common functions used by riak_kv_wm_* modules.
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -42,11 +42,8 @@
          ensure_bucket_type/3,
          bucket_type_exists/1,
          maybe_bucket_type/2,
-         method_to_perm/1,
-         maybe_parse_table_def/2
+         method_to_perm/1
         ]).
-
--include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 -include_lib("webmachine/include/webmachine.hrl").
 -include("riak_kv_wm_raw.hrl").
@@ -442,98 +439,3 @@ method_to_perm('GET') ->
     "riak_kv.get";
 method_to_perm('DELETE') ->
     "riak_kv.delete".
-
-%% Given bucket properties, transform the `<<"table_def">>' property if it
-%% exists to riak_ql DDL and store it under the `<<"ddl">>' key, table_def
-%% is removed.  
--spec maybe_parse_table_def(BucketType :: binary(),
-                            Props :: list(proplists:property())) -> 
-        {ok, Props2 :: [proplists:property()]} | {error, any()}.
-maybe_parse_table_def(BucketType, Props) ->
-    case lists:keytake(<<"table_def">>, 1, Props) of
-        false ->
-            {ok, Props};
-        {value, {<<"table_def">>, TableDef}, PropsNoDef} ->
-            case riak_ql_parser:parse(riak_ql_lexer:get_tokens(binary_to_list(TableDef))) of
-                {ok, DDL} ->
-                    ok = assert_type_and_table_name_same(BucketType, DDL),
-                    ok = try_compile_ddl(DDL),
-                    ok = assert_write_once_not_false(PropsNoDef),
-                    ok = assert_partition_key_length(DDL),
-                    ok = assert_primary_and_local_keys_match(DDL),
-                    apply_timeseries_bucket_props(DDL, PropsNoDef);
-                {error, _} = E ->
-                    E
-            end
-    end.
-
-%%
--spec apply_timeseries_bucket_props(DDL::#ddl_v1{},
-                                    Props1::[proplists:property()]) -> 
-        {ok, Props2::[proplists:property()]}.
-apply_timeseries_bucket_props(DDL, Props1) ->
-    Props2 = lists:keystore(
-        <<"write_once">>, 1, Props1, {<<"write_once">>, true}),
-    {ok, [{<<"ddl">>, DDL} | Props2]}.
-
-%% Time series must always use write_once so throw an error if the write_once
-%% property is ever set to false. This prevents a user thinking they have
-%% disabled write_once when it has been set to true internally.
-assert_write_once_not_false(Props) ->
-    case lists:keyfind(<<"write_once">>, 1, Props) of
-        {<<"write_once">>, false} ->
-            throw({error,
-                   {write_once,
-                    "Error, the time series bucket type could not be created. "
-                    "The write_once property must be true\n"}});
-        _ ->
-            ok
-    end.
-
-%%
-assert_type_and_table_name_same(BucketType, #ddl_v1{table = BucketType}) ->
-    ok;
-assert_type_and_table_name_same(BucketType1, #ddl_v1{table = BucketType2}) ->
-    throw({error,
-           {table_name,
-            "Error, the bucket type could not be the created. The bucket type and table name must be the same~n"
-            "    bucket type was: " ++ binary_to_list(BucketType1) ++ "\n"
-            "    table name was:  " ++ binary_to_list(BucketType2) ++ "\n"}}).
-
-%% @doc Verify that the primary key has three components
-%%      and the first element is a quantum
-assert_partition_key_length(#ddl_v1{partition_key = {key_v1, Key}}) when length(Key) == 3 ->
-    assert_third_param_is_quantum(lists:nth(3, Key));
-assert_partition_key_length(_DDL) ->
-    throw({error, {primary_key, "Primary key is too short"}}).
-
-%% @doc Verify that the first element of the primary key is a quantum
-assert_third_param_is_quantum(#hash_fn_v1{mod=riak_ql_quanta, fn=quantum}) ->
-    ok;
-assert_third_param_is_quantum(_KeyComponent) ->
-    throw({error, {primary_key, "Third element of primary key must be a quantum"}}).
-
-%% @doc Verify primary key and local partition have the same elements
-assert_primary_and_local_keys_match(#ddl_v1{partition_key = #key_v1{ast = Primary}, local_key = #key_v1{ast = Local}}) ->
-    PrimaryList = [query_field_name(F) || F <- Primary],
-    LocalList = [query_field_name(F) || F <- Local],
-    case PrimaryList == LocalList of
-        true -> ok;
-        _Else ->
-            throw({error, {primary_key, "Local key does not match primary key"}})
-    end.
-
-%% Pull the name out of the appropriate record
-query_field_name(#hash_fn_v1{args = Args}) ->
-    Param = lists:keyfind(param_v1, 1, Args),
-    query_field_name(Param);
-query_field_name(#param_v1{name = Field}) ->
-    Field.
-
-%% Attempt to compile the DDL but don't do anything with the output, this is
-%% catch failures as early as possible. Also the error messages are easy to
-%% return at this point.
-try_compile_ddl(DDL) ->
-    {_, AST} = riak_ql_ddl_compiler:compile(DDL),
-    {ok, _, _} = compile:forms(AST),
-    ok.

--- a/test/sql_compilation_end_to_end.erl
+++ b/test/sql_compilation_end_to_end.erl
@@ -1,10 +1,32 @@
+%% -------------------------------------------------------------------
+%%
+%% sql_compilation_end_to_end: basic timeseries DDL validation test
+%%
+%% Copyright (c) 2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc A basic test of timeseries that writes a single element to the back end
+%%      and checks it is correct
+
 -module(sql_compilation_end_to_end).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
-
-%% this is a basic test of timeseries that writes a single element to the back end
-%% and checks it is correct
 
 -define(VALID,   true).
 -define(INVALID, false).
@@ -45,38 +67,39 @@ make_sql(Query) ->
 get_standard_pk() -> #key_v1{ast = [
                 #param_v1{name = [<<"location">>]},
                 #param_v1{name = [<<"user">>]},
-				#hash_fn_v1{mod = riak_ql_quanta,
-					    fn = quantum,
-					    args = [
-						    #param_v1{name = [<<"time">>]},
-						    15,
-						    s
-						   ],
-					    type = timestamp}
-			       ]
-			}.
+                                #hash_fn_v1{mod = riak_ql_quanta,
+                                            fn = quantum,
+                                            args = [
+                                                    #param_v1{name = [<<"time">>]},
+                                                    15,
+                                                    s
+                                                   ],
+                                            type = timestamp}
+                               ]
+                        }.
 
 get_standard_lk() -> #key_v1{ast = [
                     #param_v1{name = [<<"location">>]},
                     #param_v1{name = [<<"user">>]},
-				    #param_v1{name = [<<"time">>]}
-				   ]}.
+                                    #param_v1{name = [<<"time">>]}
+                                   ]}.
 
 %%
 %% Passing Tests
 %%
 
 ?assert_test(plain_qry_test,
-              "CREATE TABLE GeoCheckin "
-              ++ "(geohash varchar not null, "
-              ++ "location varchar not null, "
-              ++ "user varchar not null, "
-              ++ "time timestamp not null, "
-              ++ "weather varchar not null, "
-              ++ "temperature varchar, "
-              ++ "PRIMARY KEY ((location, user, quantum(time, 15, 's')),"
-              ++ "location, user, time))",
-              "select weather from GeoCheckin where time > 3000 and time < 5000 and user = 'gordon' and location = 'Lithgae'",
+             "CREATE TABLE GeoCheckin ("
+             " geohash varchar not null,"
+             " location varchar not null,"
+             " user varchar not null,"
+             " time timestamp not null,"
+             " weather varchar not null,"
+             " temperature varchar,"
+             " PRIMARY KEY ((location, user, quantum(time, 15, 's')),"
+             " location, user, time))",
+             "select weather from GeoCheckin where time > 3000"
+             " and time < 5000 and user = 'gordon' and location = 'Lithgae'",
              [
               #riak_sql_v1{'SELECT'      = [[<<"weather">>]],
                            'FROM'        = <<"GeoCheckin">>,
@@ -94,7 +117,7 @@ get_standard_lk() -> #key_v1{ast = [
                                                        ]
                                             },
                                             {filter, []},
-                        {start_inclusive,   false}
+                                            {start_inclusive,   false}
                                            ],
                            helper_mod    = riak_ql_ddl:make_module_name(<<"GeoCheckin">>),
                            partition_key = get_standard_pk(),
@@ -104,74 +127,74 @@ get_standard_lk() -> #key_v1{ast = [
              ]).
 
 ?assert_test(badarith_regression_test,
-             "CREATE TABLE GeoCheckin "
-             ++ "(geohash varchar not null, "
-             ++ "user varchar not null, "
-             ++ "time timestamp not null, "
-             ++ "weather varchar not null, "
-             ++ "temperature varchar, "
-             ++ "PRIMARY KEY ((quantum(time, 15, s)), time, user))",
+             "CREATE TABLE GeoCheckin ("
+             " geohash varchar not null,"
+             " user varchar not null,"
+             " time timestamp not null,"
+             " weather varchar not null,"
+             " temperature varchar,"
+             " PRIMARY KEY ((user, geohash, quantum(time, 15, s)), user, geohash, time))",
              "select weather from GeoCheckin where time > 3000 and time < 5000",
              {error, {missing_param, <<"Missing parameter user in where clause.">>}}).
 
 ?assert_test(spanning_qry_test,
-    "CREATE TABLE GeoCheckin "
-    ++ "(geohash varchar not null, "
-        ++ "location varchar not null, "
-        ++ "user varchar not null, "
-        ++ "time timestamp not null, "
-        ++ "weather varchar not null, "
-        ++ "temperature varchar, "
-        ++ "PRIMARY KEY ((location, user, quantum(time, 15, 's')),"
-        ++ "location, user, time))",
-        "select weather from GeoCheckin where time > 3000 and "
-        ++ "time < 18000 and user = 'gordon' and location = 'Lithgae'",
+             "CREATE TABLE GeoCheckin ("
+             " geohash varchar not null, "
+             " location varchar not null, "
+             " user varchar not null, "
+             " time timestamp not null, "
+             " weather varchar not null, "
+             " temperature varchar, "
+             "PRIMARY KEY ((location, user, quantum(time, 15, 's')),"
+             " location, user, time))",
+             "select weather from GeoCheckin where time > 3000 and "
+             " time < 18000 and user = 'gordon' and location = 'Lithgae'",
 
           [
-          #riak_sql_v1{'SELECT'      = [[<<"weather">>]],
-               'FROM'        = <<"GeoCheckin">>,
-               'WHERE'       = [
-                                    {startkey, [
-                                        {<<"location">>, varchar, <<"Lithgae">>},
-                                        {<<"user">>, varchar, <<"gordon">>},
-                                        {<<"time">>, timestamp, 3000}
-                                    ]
-                                    },
-                                    {endkey,   [
-                                        {<<"location">>, varchar, <<"Lithgae">>},
-                                        {<<"user">>, varchar, <<"gordon">>},
-                                        {<<"time">>, timestamp, 15000}
-                                        ]
-                                    },
-                                    {filter, []},
-                                    {start_inclusive,   false}
-                                ],
-                helper_mod    = riak_ql_ddl:make_module_name(<<"GeoCheckin">>),
-                partition_key = get_standard_pk(),
-                is_executable = true,
-                type          = timeseries,
-                local_key     = get_standard_lk()},
+           #riak_sql_v1{'SELECT'      = [[<<"weather">>]],
+                        'FROM'        = <<"GeoCheckin">>,
+                        'WHERE'       = [
+                                         {startkey, [
+                                                     {<<"location">>, varchar, <<"Lithgae">>},
+                                                     {<<"user">>, varchar, <<"gordon">>},
+                                                     {<<"time">>, timestamp, 3000}
+                                                    ]
+                                         },
+                                         {endkey,   [
+                                                     {<<"location">>, varchar, <<"Lithgae">>},
+                                                     {<<"user">>, varchar, <<"gordon">>},
+                                                     {<<"time">>, timestamp, 15000}
+                                                    ]
+                                         },
+                                         {filter, []},
+                                         {start_inclusive,   false}
+                                        ],
+                        helper_mod    = riak_ql_ddl:make_module_name(<<"GeoCheckin">>),
+                        partition_key = get_standard_pk(),
+                        is_executable = true,
+                        type          = timeseries,
+                        local_key     = get_standard_lk()},
 
-          #riak_sql_v1{'SELECT'      = [[<<"weather">>]],
-               'FROM'        = <<"GeoCheckin">>,
-               'WHERE'       = [
-                                    {startkey, [
-                                        {<<"location">>, varchar, <<"Lithgae">>},
-                                        {<<"user">>, varchar, <<"gordon">>},
-                                        {<<"time">>, timestamp, 15000}
-                                    ]
-                                    },
-                                    {endkey,   [
-                                        {<<"location">>, varchar, <<"Lithgae">>},
-                                        {<<"user">>, varchar, <<"gordon">>},
-                                        {<<"time">>, timestamp, 18000}
-                                    ]
-                                    },
-                                    {filter, []}
-                                ],
-                                helper_mod    = riak_ql_ddl:make_module_name(<<"GeoCheckin">>),
-                                partition_key = get_standard_pk(),
-                                is_executable = true,
-                                type          = timeseries,
-                                local_key     = get_standard_lk()}
+           #riak_sql_v1{'SELECT'      = [[<<"weather">>]],
+                        'FROM'        = <<"GeoCheckin">>,
+                        'WHERE'       = [
+                                         {startkey, [
+                                                     {<<"location">>, varchar, <<"Lithgae">>},
+                                                     {<<"user">>, varchar, <<"gordon">>},
+                                                     {<<"time">>, timestamp, 15000}
+                                                    ]
+                                         },
+                                         {endkey,   [
+                                                     {<<"location">>, varchar, <<"Lithgae">>},
+                                                     {<<"user">>, varchar, <<"gordon">>},
+                                                     {<<"time">>, timestamp, 18000}
+                                                    ]
+                                         },
+                                         {filter, []}
+                                        ],
+                        helper_mod    = riak_ql_ddl:make_module_name(<<"GeoCheckin">>),
+                        partition_key = get_standard_pk(),
+                        is_executable = true,
+                        type          = timeseries,
+                        local_key     = get_standard_lk()}
           ]).


### PR DESCRIPTION
RTS-616, RTS-620, RTS-623 (items D, H, J in RTS-610).

Depends on https://github.com/basho/riak_ql/pull/50, where checks are now being done.

Corresponding r_t modules are added in https://github.com/basho/riak_test/pull/943.
