### PR TITLE
Unregister per-vnode stats when cleanly shutting down.

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1075,7 +1075,7 @@ delete(State=#state{idx=Index,mod=Mod, modstate=ModState}) ->
     end,
     {ok, State#state{modstate=UpdModState,vnodeid=undefined,hashtrees=undefined}}.
 
-terminate(_Reason, #state{mod=Mod, modstate=ModState,hashtrees=Trees}) ->
+terminate(_Reason, #state{idx=Idx, mod=Mod, modstate=ModState,hashtrees=Trees}) ->
     Mod:stop(ModState),
 
     %% Explicitly stop the hashtree rather than relying on the process monitor
@@ -1084,6 +1084,7 @@ terminate(_Reason, #state{mod=Mod, modstate=ModState,hashtrees=Trees}) ->
     %% riak_core can complete their shutdown before the hashtree is written
     %% to disk causing the hashtree to be closed dirty.
     riak_kv_index_hashtree:sync_stop(Trees),
+    riak_kv_stat:unregister_vnode_stats(Idx),
     ok.
 
 handle_info({set_concurrency_limit, Lock, Limit}, State) ->


### PR DESCRIPTION
This removes the stats on a happy path terminate, however if the vnode crashes the terminate callback will not be executed.

The vnode manager currently monitors vnodes for exits and cleans up per-vnode msgq stats, but we need to extend the vnode manager to clean up non-core stats as well.

RIAK-2312
