### PR TITLE
handle backend and qry worker timeouts

### DIFF
--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -68,7 +68,7 @@ maybe_await_query_results(_) ->
     % we can't use a gen_server call here because the reply needs to be
     % from an fsm but one is not assigned if the query is queued.
     receive
-        {ok, _} = Result ->
+        Result ->
             Result
     after
         10000 ->

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -72,7 +72,7 @@ maybe_await_query_results(_) ->
             Result
     after
         10000 ->
-            {error, timeout}
+            {error, qry_worker_timeout}
     end.
 
 %% Format the multiple syntax errors into a multiline error


### PR DESCRIPTION
RTS-653
1. The riak_kv_qry_worker gen_server previously did not handle the timeout messages from the backend process. Under load, these messages would crash the query worker, with messages in the logs such as this:
   `{{function_clause,[{riak_kv_qry_worker,handle_info,[{{1, 'riak@10.0.24.42',#Ref<0.0.30.90883>}},{error,timeout}}`
   
   This condition is fixed in https://github.com/basho/riak_kv/commit/85d000bf40, whereby all backend error messages will be passed through to riak_kv_pb_timeseries and eventuate in corresponding `#rpberrorresp`.
2. The timeout messages will now result in a special error code 1013 and message "backend timeout" (the generic code 1001 did not distinguish between timeouts and other error conditions such as malformed requests).
3. If the backend process fails to send us any messages in 10 sec, the error code will be the same (1013) but the message now will be "no response from backend".
