### PR TITLE
Configure timeouts and quanta spans for Time Series RTS-639 RTS-673

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -677,3 +677,19 @@ end
   fun(Value) when is_integer(Value) andalso Value >= 0 -> true;
      (_) -> false
   end}.
+
+%% @doc Timeout in milliseconds for Time Series queries, after which riak
+%% will return a timeout error.
+{mapping, "timeseries_query_timeout_ms", "riak_kv.timeseries_query_timeout_ms", [
+  {default, 10000},
+  {datatype, integer}
+]}.
+
+%% @doc Maximum number of quanta that a query can span. Larger quanta spans
+%% mean the time duration for a query can be bigger. This is constrained to
+%% prevent excessively long running queries that could affect the performance
+%% of the cluster.
+{mapping, "timeseries_query_max_quanta_span", "riak_kv.timeseries_query_max_quanta_span", [
+  {default, 5},
+  {datatype, integer}
+]}.

--- a/src/riak_kv.app.src
+++ b/src/riak_kv.app.src
@@ -78,6 +78,10 @@
          %% pipe ('true'), or serially via a helper process
          %% ('false' or undefined).  Set to 'false' or leave
          %% undefined during a rolling upgrade from 1.0.
-         {mapred_2i_pipe, true}
+         {mapred_2i_pipe, true},
+
+         {timeseries_query_timeout_ms, 10000},
+
+         {timeseries_query_max_quanta_span, 5}
         ]}
  ]}.

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -65,13 +65,15 @@ maybe_submit_to_queue(SQL, #ddl_v1{table = BucketType} = DDL) ->
 maybe_await_query_results({error,_} = Error) ->
     Error;
 maybe_await_query_results(_) ->
+    Timeout = app_helper:get_env(riak_kv, timeseries_query_timeout_ms),
+
     % we can't use a gen_server call here because the reply needs to be
     % from an fsm but one is not assigned if the query is queued.
     receive
         Result ->
             Result
     after
-        10000 ->
+        Timeout ->
             {error, qry_worker_timeout}
     end.
 


### PR DESCRIPTION
I have left the default configuration the same, performance testing should tell us what they "should" be.
