### PR TITLE
add a unit test for ranges spanning exact multiples of quanta

### DIFF
--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -863,6 +863,55 @@ simple_spanning_boundary_test() ->
            ],
     ?assertEqual(Expected, Got).
 
+
+%% check for spanning precision (same as above except selection range
+%% is exact multiple of quantum size)
+simple_spanning_boundary_precision_test() ->
+    DDL = get_standard_ddl(),
+    Query = "select weather from GeoCheckin where time >= 3000 and time < 30000 and user = 'user_1' and location = 'Scotland'",
+    {ok, Q} = get_query(Query),
+    true = is_query_valid(DDL, Q),
+    Got = compile(DDL, Q),
+    %% now make the result - expecting 2 queries
+    W1 = [
+        {startkey,        [
+            {<<"location">>, varchar, <<"Scotland">>},
+            {<<"user">>, varchar,    <<"user_1">>},
+            {<<"time">>, timestamp, 3000}
+        ]},
+        {endkey,          [
+            {<<"location">>, varchar, <<"Scotland">>},
+            {<<"user">>, varchar,    <<"user_1">>},
+            {<<"time">>, timestamp, 15000}
+        ]},
+      {filter,          []}
+     ],
+    W2 = [
+        {startkey,        [
+            {<<"location">>, varchar, <<"Scotland">>},
+            {<<"user">>, varchar,    <<"user_1">>},
+            {<<"time">>, timestamp, 15000}
+        ]},
+        {endkey,          [
+            {<<"location">>, varchar, <<"Scotland">>},
+            {<<"user">>, varchar,    <<"user_1">>},
+            {<<"time">>, timestamp, 30000}
+        ]},
+      {filter,          []}
+     ],
+    Expected =
+        [Q#riak_sql_v1{is_executable = true,
+                       type          = timeseries,
+                       'WHERE'       = W1,
+                       partition_key = get_standard_pk(),
+                       local_key     = get_standard_lk()},
+         Q#riak_sql_v1{is_executable = true,
+                       type          = timeseries,
+                       'WHERE'       = W2,
+                       partition_key = get_standard_pk(),
+                       local_key     = get_standard_lk()}],
+    ?assertEqual(Expected, Got).
+
 %%
 %% test failures
 %%


### PR DESCRIPTION
RTS-637.

This PR includes a eunit test for the case where a query has SELECT range spanning an exact multiple quanta. A fix for this case is in https://github.com/basho/riak_ql/pull/62.
