### PR TITLE
Do not include fallbacks in the coverage plan to prevent missing data RTS-698

### DIFF
--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -470,9 +470,11 @@ range_scan(FoldIndexFun, Buffer, Opts, #state{fold_opts=_FoldOpts,
     EndK3 = riak_ql_ddl:make_key(Mod, LK, EndK2),
     EndKey = eleveldb_ts:encode_key(EndK3),
     EndKey2 = to_object_key(Bucket, EndKey),
-    FoldFun = fun({K, V}, Acc) ->
-		     [{K, V} | Acc]
-	     end,
+    FoldFun =
+        fun({K, V}, Acc) ->
+            timer:sleep(40),
+		    [{K, V} | Acc]
+	    end,
     Options = [
                {start_key,    StartKey2},
                {end_key,      EndKey2},

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -472,7 +472,6 @@ range_scan(FoldIndexFun, Buffer, Opts, #state{fold_opts=_FoldOpts,
     EndKey2 = to_object_key(Bucket, EndKey),
     FoldFun =
         fun({K, V}, Acc) ->
-            timer:sleep(40),
 		    [{K, V} | Acc]
 	    end,
     Options = [

--- a/src/riak_kv_qry_coverage_plan.erl
+++ b/src/riak_kv_qry_coverage_plan.erl
@@ -56,9 +56,9 @@ make_key(#riak_sql_v1{helper_mod    = Mod,
 hash_for_nodes(NVal,
                {_BucketType, _BucketName}=Bucket, Key) when is_binary(Key) ->
     DocIdx = riak_core_util:chash_key({Bucket, Key}),
-    % RTS-698 For each sub-query, the query worker takes the first response from
-    % any vnode. If nodes are down and fallbacks are included in the query plan
-    % then it will return with a subset of results, or possibly an empty list.
+    % Fallbacks cannot be used for query results because they may have partial
+    % or empty results and the riak_kv_qry_worker currently uses the first
+    % result from a sub query, the primary must be used to get correct results
     Perfs = riak_core_apl:get_primary_apl(DocIdx, NVal, riak_kv),
     {VNodes, _} = lists:unzip(Perfs),
     VNodes.

--- a/src/riak_kv_qry_coverage_plan.erl
+++ b/src/riak_kv_qry_coverage_plan.erl
@@ -52,7 +52,9 @@ make_key(#riak_sql_v1{helper_mod    = Mod,
 hash_for_nodes(NVal,
                {_BucketType, _BucketName}=Bucket, Key) when is_binary(Key) ->
     DocIdx = riak_core_util:chash_key({Bucket, Key}),
-    UpNodes = riak_core_node_watcher:nodes(riak_kv),
-    Perfs = riak_core_apl:get_apl_ann(DocIdx, NVal, UpNodes),
+    % RTS-698 For each sub-query, the query worker takes the first response from
+    % any vnode. If nodes are down and fallbacks are included in the query plan
+    % then it will return with a subset of results, or possibly an empty list.
+    Perfs = riak_core_apl:get_primary_apl(DocIdx, NVal, riak_kv),
     {VNodes, _} = lists:unzip(Perfs),
     VNodes.

--- a/src/riak_kv_qry_coverage_plan.erl
+++ b/src/riak_kv_qry_coverage_plan.erl
@@ -33,9 +33,13 @@ create_plan(NVal, _PVC, _ReqId, _NodeCheckService, Request) ->
     Query = riak_local_index:get_query_from_req(Request),
     Key2 = make_key(Query),
     Bucket = riak_kv_util:get_bucket_from_req(Request),
-    VNodes = hash_for_nodes(NVal, Bucket, Key2),
-    NoFilters = [],
-    _CoveragePlan = {VNodes, NoFilters}.
+    case hash_for_nodes(NVal, Bucket, Key2) of
+        [] ->
+            {error, no_primaries_available};
+        VNodes when is_list(VNodes) ->
+            NoFilters = [],
+            {VNodes, NoFilters}
+    end.
 
 %% This is fugly because the physical format of the startkey
 %% which is neede by eleveldb is being used by the query

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -153,7 +153,7 @@ handle_info({{SubQId, QId}, {results, Chunk}},
                                sub_qrys = NSubQ};
                false ->
                    %% discard;
-                   %% Don't touch state as it may backend_timeouthave already 'finished'.
+                   %% Don't touch state as it may have already 'finished'.
                    State
            end,
     {noreply, NewS};

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -153,19 +153,19 @@ handle_info({{SubQId, QId}, {results, Chunk}},
                                sub_qrys = NSubQ};
                false ->
                    %% discard;
-                   %% Don't touch state as it may have already 'finished'.
+                   %% Don't touch state as it may backend_timeouthave already 'finished'.
                    State
            end,
     {noreply, NewS};
 
-handle_info({{SubQId, QId}, {error, timeout}},
+handle_info({{SubQId, QId}, {error, Reason} = Error},
             State = #state{receiver_pid = ReceiverPid,
                            qid    = QId,
                            result = IndexedChunks}) ->
-    lager:warning("Backend timed out while collecting on QId ~p (~p);"
+    lager:warning("Error ~p while collecting on QId ~p (~p);"
                   " dropping ~b chunks of data accumulated so far",
-                  [QId, SubQId, length(IndexedChunks)]),
-    ReceiverPid ! {error, backend_timeout},
+                  [Reason, QId, SubQId, length(IndexedChunks)]),
+    ReceiverPid ! Error,
     pop_next_query(),
     {noreply, new_state(State#state.name)};
 


### PR DESCRIPTION
Do not include fallbacks in the coverage plan to prevent missing data otherwise a race condition can occur where the fallbacks return a result first which might be partial or empty. The riak_kv_qry_worker accepts the first sub-query result so the correct result from the primary could be discarded.

I tested manually using a modified eleveldb backend that does a `timer:sleep` when it folds results, so vnodes with less or zero results will return more quickly.  The diff is here:

``` diff
diff --git a/src/riak_kv_eleveldb_backend.erl b/src/riak_kv_eleveldb_backend.erl
index f1fe366..ab31afb 100644
--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -470,9 +470,11 @@ range_scan(FoldIndexFun, Buffer, Opts, #state{fold_opts=_FoldOpts,
     EndK3 = riak_ql_ddl:make_key(Mod, LK, EndK2),
     EndKey = eleveldb_ts:encode_key(EndK3),
     EndKey2 = to_object_key(Bucket, EndKey),
-    FoldFun = fun({K, V}, Acc) ->
-                    [{K, V} | Acc]
-            end,
+    FoldFun =
+        fun({K, V}, Acc) ->
+            timer:sleep(40),
+                   [{K, V} | Acc]
+           end,
     Options = [
                {start_key,    StartKey2},
                {end_key,      EndKey2},
```

With the diff in place the error can be provoked with the following riak test:

``` erlang
-module(ts_C_select_pass_2).

-behavior(riak_test).

-include_lib("eunit/include/eunit.hrl").

-export([confirm/0]).

confirm() ->
    DDL  = ts_util:get_ddl(),
    Data = ts_util:get_valid_select_data_spanning_quanta(),
    Qry  = ts_util:get_valid_qry_spanning_quanta(),
    Expected = {
        ts_util:get_cols(),
        ts_util:exclusive_result_from_data(Data, 2, 9)},
    {[_Node, N2, N3], Conn} = ClusterConn = ts_util:cluster_and_connect(multiple),
    ?assertEqual(
        Expected,
        ts_util:ts_query(ClusterConn, normal, DDL, Data, Qry)),
    % Stop Node 2 after bucket type has been activated
    rt:stop(N2),
    rt:stop(N3),
    ?assertEqual(
        Expected,
        ts_util:single_query(Conn, Qry)),
    pass.
```
