### PR TITLE
Change time series key encoding to use sext format encoded tuples.

### DIFF
--- a/include/riak_kv_vnode.hrl
+++ b/include/riak_kv_vnode.hrl
@@ -37,12 +37,6 @@
           bucket :: binary() | tuple(),
           item_filter :: function()}).
 
-%% used to serve list_keys for timeseries
--record(riak_kv_listkeys_ts_req_v1, {
-          table :: binary(),
-          item_filter :: none | fun((list()) -> boolean()),
-          ddl_mod :: module()}).
-
 -record(riak_kv_listbuckets_req_v1, {
           item_filter :: function()}).
 

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -29,7 +29,7 @@
 -export([put/2,put/3,put/4,put/5,put/6]).
 -export([delete/3,delete/4,delete/5]).
 -export([delete_vclock/4,delete_vclock/5,delete_vclock/6]).
--export([list_keys/2,list_keys/3,list_keys/4,list_keys/5]).
+-export([list_keys/2,list_keys/3,list_keys/4]).
 -export([stream_list_keys/2,stream_list_keys/3,stream_list_keys/4]).
 -export([filter_buckets/2]).
 -export([filter_keys/3,filter_keys/4]).
@@ -628,7 +628,7 @@ split_cover(SubpartitionPlan) when is_list(SubpartitionPlan) ->
 %%      out of date if called immediately after a put or delete.
 %% @equiv list_keys(Bucket, default_timeout()*8)
 list_keys(Bucket, {?MODULE, [_Node, _ClientId]}=THIS) ->
-    list_keys(Bucket, none, ?DEFAULT_TIMEOUT*8, none, THIS).
+    list_keys(Bucket, none, ?DEFAULT_TIMEOUT*8, THIS).
 
 -spec list_keys(riak_object:bucket(), pos_integer() | none, riak_client()) ->
                        {ok, [tuple()]} | {error, term()}.
@@ -636,23 +636,14 @@ list_keys(Bucket, {?MODULE, [_Node, _ClientId]}=THIS) ->
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
 list_keys(Bucket, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
-    list_keys(Bucket, none, Timeout, none, THIS).
+    list_keys(Bucket, none, Timeout, THIS).
 
 -spec list_keys(riak_object:bucket(), function() | none, pos_integer() | none, riak_client()) ->
                        {ok, [tuple()]} | {error, term()}.
 %% @doc List the keys known to be present in Bucket.
 %%      Key lists are updated asynchronously, so this may be slightly
 %%      out of date if called immediately after a put or delete.
-list_keys(Bucket, Filter, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
-    list_keys(Bucket, Filter, Timeout, none, THIS).
-
--spec list_keys(riak_object:bucket(), function() | none, pos_integer() | none, DDLMod::module() | none,
-                riak_client()) ->
-                       {ok, [tuple()]} | {error, term()}.
-%% @doc Lists all keys in Bucket. When DDLMod is not 'none' and
-%%      Filter is not 'none', Filter function is applied to the
-%%      recovered compound key.
-list_keys(Bucket, Filter, Timeout0, Mod, {?MODULE, [Node, _ClientId]}) ->
+list_keys(Bucket, Filter, Timeout0, {?MODULE, [Node, _ClientId]}) ->
     Timeout =
         case Timeout0 of
             T when is_integer(T) -> T;
@@ -660,7 +651,7 @@ list_keys(Bucket, Filter, Timeout0, Mod, {?MODULE, [Node, _ClientId]}) ->
         end,
     Me = self(),
     ReqId = mk_reqid(),
-    riak_kv_keys_fsm_sup:start_keys_fsm(Node, [{raw, ReqId, Me}, [Bucket, Filter, Timeout, Mod]]),
+    riak_kv_keys_fsm_sup:start_keys_fsm(Node, [{raw, ReqId, Me}, [Bucket, Filter, Timeout]]),
     wait_for_listkeys(ReqId).
 
 stream_list_keys(Bucket, {?MODULE, [_Node, _ClientId]}=THIS) ->

--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -106,10 +106,10 @@ new_tombstone_object(Bucket, {PK, LK}) ->
     %% TS objects have this peculiar way to use the two keys: time
     %% quanta-based partition key, for calculating coverage; and local
     %% key for actual lookups:
-    RO = new_tombstone_object(Bucket, PK),
-    MD1 = riak_object:get_update_metadata(RO),
-    MD2  = dict:store(?MD_TS_LOCAL_KEY, LK, MD1),
-    riak_object:update_metadata(RO, MD2);
+    riak_object:newts(
+      Bucket, PK, <<>>,
+      dict:from_list([{?MD_DELETED, "true"},
+                      {?MD_TS_LOCAL_KEY, LK}]));
 new_tombstone_object(Bucket, Key) ->
     riak_object:new(
       Bucket, Key, <<>>,

--- a/src/riak_kv_delete.erl
+++ b/src/riak_kv_delete.erl
@@ -93,7 +93,7 @@ delete(ReqId,Bucket,Key,Options,Timeout,Client,ClientId,VClock) ->
                     ?DTRACE(?C_DELETE_INIT2, [1], [<<"reap">>]),
                     {ok, C2} = riak:local_client(),
                     AsyncTimeout = 60*1000,     % Avoid client-specified value
-                    Res = C2:get(Bucket, Key, all, AsyncTimeout),
+                    Res = C2:get(Bucket, Key, [{r, all}, {timeout, AsyncTimeout}]),
                     ?DTRACE(?C_DELETE_REAPER_GET_DONE, [1], [<<"reap">>]),
                     Res;
                 _ ->

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -895,12 +895,15 @@ fold_objects_fun(FoldObjectsFun, undefined) ->
 %% that represents the starting key for the scope. For example, since
 %% we store objects under {o, Bucket, Key}, the first key for the
 %% bucket "foo" would be `sext:encode({o, <<"foo">>, <<>>}).`
+%%
+%% For starting ranges, use key undefined.  Keys are either binaries
+%% for tuples for time series.  Either of sort *after* a bare atom.
 to_first_key(undefined) ->
     %% Start at the first object in LevelDB...
-    to_object_key({<<>>, <<>>}, <<>>);
+    to_object_key({<<>>, <<>>}, undefined); 
 to_first_key({bucket, Bucket}) ->
     %% Start at the first object for a given bucket...
-    to_object_key(Bucket, <<>>);
+    to_object_key(Bucket, undefined);
 to_first_key({index, incorrect_format, ForUpgrade}) when is_boolean(ForUpgrade) ->
     %% Start at first index entry
     to_index_key(<<>>, <<>>, <<>>, <<>>);

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -49,6 +49,7 @@
 
 -export([data_size/1]).
 
+-compile([export_all]).
 -compile({inline, [
                    to_object_key/2, from_object_key/1,
                    to_index_key/4, from_index_key/1
@@ -464,19 +465,18 @@ range_scan(FoldIndexFun, Buffer, Opts, #state{fold_opts=_FoldOpts,
         end,
     StartK2 = [{Field, Val} || {Field, _Type, Val} <- StartK],
     StartK3 = riak_ql_ddl:make_key(Mod, LK, StartK2),
-    StartKey = eleveldb_ts:encode_key(StartK3),
-    StartKey2 = to_object_key(Bucket, StartKey),
+    StartK4 = list_to_tuple([Val || {_Type, Val} <- StartK3]), %% TODO: Avoid adding/removing type info
+    StartKey = to_object_key(Bucket, StartK4),
     EndK2 = [{Field, Val} || {Field, _Type, Val} <- EndK],
     EndK3 = riak_ql_ddl:make_key(Mod, LK, EndK2),
-    EndKey = eleveldb_ts:encode_key(EndK3),
-    EndKey2 = to_object_key(Bucket, EndKey),
-    FoldFun =
-        fun({K, V}, Acc) ->
-		    [{K, V} | Acc]
-	    end,
+    EndK4 = list_to_tuple([Val || {_Type, Val} <- EndK3]),
+    EndKey = to_object_key(Bucket, EndK4),
+    FoldFun = fun({K, V}, Acc) ->
+		     [{K, V} | Acc]
+	     end,
     Options = [
-               {start_key,    StartKey2},
-               {end_key,      EndKey2},
+               {start_key,    StartKey},
+               {end_key,      EndKey},
                {fold_method,  streaming},
                {encoding,     msgpack} |
                AdditionalOptions2
@@ -929,10 +929,59 @@ to_legacy_first_key({index, Bucket, {range, Field, StartTerm, _EndTerm}}) ->
 to_legacy_first_key(Other) ->
     to_first_key(Other).
 
-to_object_key(Bucket, Key) ->
+orig_to_object_key(Bucket, Key) ->
     sext:encode({o, Bucket, Key}).
 
-from_object_key(LKey) ->
+%%
+%% Encode the Riak Object key for storing into leveldb.
+%% Originally this was just sext:encode({o, Bucket, Key}) but has been
+%% unrolled to save re-encoding things that don't change - like the tuple
+%% sizes and atoms. The binaries are still encoded with the sext library,
+%% for an extra boost, could copy sext:encode_bin_elems to this module
+%% and use.
+%%
+%% Timeseries objects provide their keys as tuples which are sext-encoded,
+%% however, on decode they are left as sext-encoded binaries so that the
+%% rest of Riak is not affected. They can be sext-decoded, but *cannot* just
+%% be round-tripped (as that would then be a binary-wrapping a sext-encoded
+%% TS key - for an extra 9 bytes used).
+%%
+to_object_key({BucketType, BucketName}, {Family, Series, Timestamp}) ->
+    EncodedBucketType = sext:encode(BucketType),
+    EncodedBucketName = sext:encode(BucketName),
+    EncodedFamily = sext:encode(Family),
+    EncodedSeries = sext:encode(Series),
+    EncodedTimestamp = sext:encode(Timestamp),
+    <<16,0,0,0,3, %% 3-tuple - outer
+      12,183,128,8, %% o-atom
+      16,0,0,0,2, %% 2-tuple for bucket type/name
+      EncodedBucketType/binary,
+      EncodedBucketName/binary,
+      16,0,0,0,3, %% 3-tuple - for time series key
+      EncodedFamily/binary,
+      EncodedSeries/binary,
+      EncodedTimestamp/binary>>;
+to_object_key({BucketType, BucketName}, Key) -> %% Riak 2.0 keys
+    %% sext:encode({o, Bucket, Key}).
+    EncodedBucketType = sext:encode(BucketType),
+    EncodedBucketName = sext:encode(BucketName),
+    EncodedKey = sext:encode(Key),
+    <<16,0,0,0,3, %% 3-tuple - outer
+      12,183,128,8, %% o-atom
+      16,0,0,0,2, %% 2-tuple for bucket type/name
+      EncodedBucketType/binary,
+      EncodedBucketName/binary,
+      EncodedKey/binary>>;
+to_object_key(Bucket, Key) -> %% Riak 1.0 keys
+    %% sext:encode({o, Bucket, Key}).
+    EncodedBucket = sext:encode(Bucket),
+    EncodedKey = sext:encode(Key),
+    <<16,0,0,0,3, %% 3-tuple
+      12,183,128,8, %% o-atom
+      EncodedBucket/binary,
+      EncodedKey/binary>>.
+
+orig_from_object_key(LKey) ->
     case (catch sext:decode(LKey)) of
         {'EXIT', _} ->
             lager:warning("Corrupted object key, discarding"),
@@ -942,6 +991,27 @@ from_object_key(LKey) ->
         _ ->
             undefined
     end.
+
+%%
+%% Custom sext-decoder making use of the knowledge that all of our object
+%% keys are encoded as 3-tuples with the first element an 'o' atom.
+%% Deliberately returning the un-decoded key part if a time series key
+%% so that the key in the riak object structure will be a binary on decode.
+%% All support tooling/usual methods for visiting objects should still work.
+%%
+from_object_key(<<16,0,0,0,3, %% 3-tuple - outer
+                  12,183,128,8, %% o-atom
+                  Rest/binary>>) ->
+    {Bucket, Rest1} = sext:decode_next(Rest), % grabs the two-tuple of bucket type/name
+    case Rest1 of
+        <<16,0,0,0,3,_TSKeyElements/binary>> = TSKey ->
+            {Bucket, TSKey}; % small risk not checking for junk at the end of the TSKeyElements
+        _ ->
+            {Key, <<>>} = sext:decode_next(Rest1),
+            {Bucket, Key}
+    end;
+from_object_key(_) -> %% If it did not start with the magic {o, ...} ignore
+    ignore.
 
 to_index_key(Bucket, Key, Field, Term) ->
     sext:encode({i, Bucket, Field, Term, Key}).

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -53,6 +53,9 @@
                    to_object_key/2, from_object_key/1,
                    to_index_key/4, from_index_key/1
                   ]}).
+%% Remove a few releases after 2.1 series, keeping
+%% around for debugging/comparison.
+-export([orig_to_object_key/2, orig_from_object_key/1]).
 
 -include("riak_kv_index.hrl").
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
@@ -467,11 +470,11 @@ range_scan(FoldIndexFun, Buffer, Opts, #state{fold_opts=_FoldOpts,
         end,
     StartK2 = [{Field, Val} || {Field, _Type, Val} <- StartK],
     StartK3 = riak_ql_ddl:make_key(Mod, LK, StartK2),
-    StartK4 = list_to_tuple([Val || {_Type, Val} <- StartK3]), %% TODO: Avoid adding/removing type info
+    StartK4 = riak_kv_ts_util:encode_typeval_key(StartK3), %% TODO: Avoid adding/removing type info
     StartKey = to_object_key(Bucket, StartK4),
     EndK2 = [{Field, Val} || {Field, _Type, Val} <- EndK],
     EndK3 = riak_ql_ddl:make_key(Mod, LK, EndK2),
-    EndK4 = list_to_tuple([Val || {_Type, Val} <- EndK3]),
+    EndK4 = riak_kv_ts_util:encode_typeval_key(EndK3),
     EndKey = to_object_key(Bucket, EndK4),
     FoldFun = fun({K, V}, Acc) ->
 		     [{K, V} | Acc]
@@ -1218,5 +1221,4 @@ prop_object_encoder_roundtrips() ->
             end).
 
 -endif. % EQC
-
 -endif.

--- a/src/riak_kv_keys_fsm.erl
+++ b/src/riak_kv_keys_fsm.erl
@@ -62,8 +62,8 @@ use_ack_backpressure() ->
     riak_core_capability:get({riak_kv, listkeys_backpressure}, false) == true.
 
 %% @doc Construct the correct listkeys command record.
--spec req(binary(), term(), none|module()) -> term().
-req(Bucket, ItemFilter, none) ->
+-spec req(binary(), term()) -> term().
+req(Bucket, ItemFilter) ->
     case use_ack_backpressure() of
         true ->
             ?KV_LISTKEYS_REQ{bucket=Bucket,
@@ -71,26 +71,14 @@ req(Bucket, ItemFilter, none) ->
         false ->
             #riak_kv_listkeys_req_v3{bucket=Bucket,
                                      item_filter=ItemFilter}
-    end;
-%% @doc Construct listkeys request record for TS buckets, where keys
-%% are meaningless hashes (Local Keys) and should be converted to
-%% Compound Keys using the table's DDL.
-req(Bucket, ItemFilter, Mod) ->
-    #riak_kv_listkeys_ts_req_v1{table = Bucket,
-                                item_filter = ItemFilter,
-                                ddl_mod = Mod}.
-%% @doc Exported for use in riak_kv_pipe:process/3
-req(Bucket, ItemFilter) ->
-    req(Bucket, ItemFilter, none).
+    end.
 
 
 %% @doc Return a tuple containing the ModFun to call per vnode,
 %% the number of primary preflist vnodes the operation
 %% should cover, the service to use to check for available nodes,
 %% and the registered name to use to access the vnode master process.
-init(From, [Bucket, ItemFilter, Timeout]) ->
-    init(From, [Bucket, ItemFilter, Timeout, none]);
-init(From={_, _, ClientPid}, [Bucket, ItemFilter, Timeout, DDLMod]) ->
+init(From={_, _, ClientPid}, [Bucket, ItemFilter, Timeout]) ->
     riak_core_dtrace:put_tag(io_lib:format("~p", [Bucket])),
     ClientNode = atom_to_list(node(ClientPid)),
     PidStr = pid_to_list(ClientPid),
@@ -105,7 +93,7 @@ init(From={_, _, ClientPid}, [Bucket, ItemFilter, Timeout, DDLMod]) ->
     BucketProps = riak_core_bucket:get_bucket(Bucket),
     NVal = proplists:get_value(n_val, BucketProps),
     %% Construct the key listing request
-    Req = req(Bucket, ItemFilter, DDLMod),
+    Req = req(Bucket, ItemFilter),
     {Req, all, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout,
      #state{from=From}}.
 

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -250,7 +250,7 @@ process(#tslistkeysreq{table = Table, timeout = Timeout}, State) ->
         _DDL ->
             Filter = none,
             Result = riak_client:list_keys(
-                       {Table, Table}, Filter, Timeout,
+                       table_to_bucket(Table), Filter, Timeout,
                        {riak_client, [node(), undefined]}),
             case Result of
                 {ok, CompoundKeys} ->

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -250,12 +250,12 @@ process(#tslistkeysreq{table = Table, timeout = Timeout}, State) ->
         _DDL ->
             Filter = none,
             Result = riak_client:list_keys(
-                       Table, Filter, Timeout, Mod,
+                       {Table, Table}, Filter, Timeout,
                        {riak_client, [node(), undefined]}),
             case Result of
                 {ok, CompoundKeys} ->
                     Keys = riak_pb_ts_codec:encode_rows_non_strict(
-                             [tuple_to_list(A) || A <- CompoundKeys]),
+                             [tuple_to_list(sext:decode(A)) || A <- CompoundKeys]),
                     {reply, #tslistkeysresp{keys = Keys, done = true}, State};
                 {error, Reason} ->
                     {reply, make_rpberrresp(

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -384,7 +384,7 @@ to_string(X) ->
 % functions supporting INSERT
 
 row_to_key(Row, DDL, Mod) ->
-    list_to_tuple([V || {_T, V} <- riak_ql_ddl:get_partition_key(DDL, Row, Mod)]).
+    riak_kv_ts_util:encode_typeval_key(riak_ql_ddl:get_partition_key(DDL, Row, Mod)).
 
 -spec partition_data(Data :: list(term()),
                      Bucket :: {binary(), binary()},
@@ -411,7 +411,7 @@ add_preflists(PartitionedData, NVal, UpNodes) ->
 
 build_object(Bucket, Mod, DDL, Row, PK) ->
     Obj = Mod:add_column_info(Row),
-    LK  = list_to_tuple([V || {_T,V} <- riak_ql_ddl:get_local_key(DDL, Row, Mod)]),
+    LK  = riak_kv_ts_util:encode_typeval_key(riak_ql_ddl:get_local_key(DDL, Row, Mod)),
 
     RObj = riak_object:newts(Bucket, PK, Obj,
                              dict:from_list([{?MD_DDL_VERSION, ?DDL_VERSION}])),
@@ -484,8 +484,8 @@ make_ts_keys(CompoundKey, DDL = #ddl_v1{local_key = #key_v1{ast = LKParams},
                    || {K, _} <- VoidRecord, lists:member(K, KeyFields)]),
 
             %% 2. make the PK and LK
-            PK  = list_to_tuple([V || {_T, V} <- riak_ql_ddl:get_partition_key(DDL, BareValues, Mod)]),
-            LK  = list_to_tuple([V || {_T, V} <- riak_ql_ddl:get_local_key(DDL, BareValues, Mod)]),
+            PK  = riak_kv_ts_util:encode_typeval_key(riak_ql_ddl:get_partition_key(DDL, BareValues, Mod)),
+            LK  = riak_kv_ts_util:encode_typeval_key(riak_ql_ddl:get_local_key(DDL, BareValues, Mod)),
             {ok, {PK, LK}};
        {G, N} ->
             {error, {bad_key_length, G, N}}

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -193,8 +193,8 @@ process(#tsdelreq{table = Table, key = PbCompoundKey,
                   vclock = PbVClock, timeout = Timeout},
         State) ->
     Options =
-        if Timeout == undefined -> [];
-           true -> [{timeout, Timeout}]
+        if Timeout == undefined -> [{dw, all}];
+           true -> [{timeout, Timeout}, {dw, all}]
         end,
     VClock =
         case PbVClock of

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -192,6 +192,13 @@ process(#tsgetreq{table = Table, key = PbCompoundKey,
 process(#tsdelreq{table = Table, key = PbCompoundKey,
                   vclock = PbVClock, timeout = Timeout},
         State) ->
+    %% Pass the {dw,all} option in to the delete FSM
+    %% to make sure all tombstones are written by the
+    %% async put before the reaping get runs otherwise
+    %% if the default {dw,quorum} is used there is the
+    %% possibility that the last tombstone put overlaps
+    %% inside the KV vnode with the reaping get and
+    %% prevents the tombstone removal.
     Options =
         if Timeout == undefined -> [{dw, all}];
            true -> [{timeout, Timeout}, {dw, all}]

--- a/src/riak_kv_qry_coverage_plan.erl
+++ b/src/riak_kv_qry_coverage_plan.erl
@@ -50,11 +50,11 @@ make_key(#riak_sql_v1{helper_mod    = Mod,
     {startkey, StartKey} = proplists:lookup(startkey, Where),
     StartKey2 = [{Field, Val} || {Field, _Type, Val} <- StartKey],
     Key = riak_ql_ddl:make_key(Mod, PartitionKey, StartKey2),
-    eleveldb_ts:encode_key(Key).
+    list_to_tuple([V || {_T,V} <- Key]).
 
 %%
 hash_for_nodes(NVal,
-               {_BucketType, _BucketName}=Bucket, Key) when is_binary(Key) ->
+               {_BucketType, _BucketName}=Bucket, Key) ->
     DocIdx = riak_core_util:chash_key({Bucket, Key}),
     % Fallbacks cannot be used for query results because they may have partial
     % or empty results and the riak_kv_qry_worker currently uses the first

--- a/src/riak_kv_qry_coverage_plan.erl
+++ b/src/riak_kv_qry_coverage_plan.erl
@@ -50,7 +50,7 @@ make_key(#riak_sql_v1{helper_mod    = Mod,
     {startkey, StartKey} = proplists:lookup(startkey, Where),
     StartKey2 = [{Field, Val} || {Field, _Type, Val} <- StartKey],
     Key = riak_ql_ddl:make_key(Mod, PartitionKey, StartKey2),
-    list_to_tuple([V || {_T,V} <- Key]).
+    riak_kv_ts_util:encode_typeval_key(Key).
 
 %%
 hash_for_nodes(NVal,

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -24,7 +24,8 @@
 
 -module(riak_kv_ts_util).
 
--export([maybe_parse_table_def/2]).
+-export([maybe_parse_table_def/2,
+         encode_typeval_key/1]).
 
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
@@ -90,3 +91,12 @@ try_compile_ddl(DDL) ->
     {_, AST} = riak_ql_ddl_compiler:compile(DDL),
     {ok, _, _} = compile:forms(AST),
     ok.
+
+
+%%
+%% Encode a time series key returned by riak_ql_ddl:get_partition_key/3,
+%% riak_ql_ddl:get_local_key/3,
+%%
+-spec encode_typeval_key(list({term(), term()})) -> tuple().
+encode_typeval_key(TypeVals) ->
+    list_to_tuple([Val || {_Type, Val} <- TypeVals]).

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -3058,22 +3058,4 @@ flush_msgs() ->
             ok
     end.
 
-strip_nonlk_fields_test() ->
-    ?assertEqual(
-       [1, 3],
-       strip_nonlk_fields(
-         [<<"a">>, <<"b">>],
-         [{<<"a">>, 1}, {<<"x">>, 2}, {<<"b">>, 3}])),
-    ?assertEqual(
-       [1, 2],
-       strip_nonlk_fields(
-         [<<"a">>, <<"b">>],
-         [{<<"a">>, 1}, {<<"b">>, 2}, {<<"x">>, 3}])),
-    ?assertEqual(
-       [1, 2],
-       strip_nonlk_fields(
-         [<<"b">>, <<"a">>],
-         [{<<"a">>, 1}, {<<"b">>, 2}, {<<"x">>, 3}])),
-    ok.
-
 -endif.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1878,28 +1878,12 @@ fold_fun(keys, BufferMod, none, undefined) ->
     fun(_, Key, Buffer) ->
             BufferMod:add(Key, Buffer)
     end;
-fold_fun({keys, RecoverTsFun}, BufferMod, none, undefined) ->
-    fun(_, Key, Buffer) ->
-            CompoundKey = RecoverTsFun(Key),
-            BufferMod:add(CompoundKey, Buffer)
-    end;
 fold_fun(keys, BufferMod, none, {Bucket, Index, N, NumPartitions}) ->
     fun(_, Key, Buffer) ->
             Hash = riak_core_util:chash_key({Bucket, Key}),
             case riak_core_ring:future_index(Hash, Index, N, NumPartitions, NumPartitions) of
                 Index ->
                     BufferMod:add(Key, Buffer);
-                _ ->
-                    Buffer
-            end
-    end;
-fold_fun({keys, RecoverTsFun}, BufferMod, none, {Bucket, Index, N, NumPartitions}) ->
-    fun(_, Key, Buffer) ->
-            Hash = riak_core_util:chash_key({Bucket, Key}),
-            case riak_core_ring:future_index(Hash, Index, N, NumPartitions, NumPartitions) of
-                Index ->
-                    CompoundKey = RecoverTsFun(Key),
-                    BufferMod:add(CompoundKey, Buffer);
                 _ ->
                     Buffer
             end
@@ -1913,16 +1897,6 @@ fold_fun(keys, BufferMod, Filter, undefined) ->
                     Buffer
             end
     end;
-fold_fun({keys, RecoverTsFun}, BufferMod, Filter, undefined) ->
-    fun(_, Key, Buffer) ->
-            CompoundKey = RecoverTsFun(Key),
-            case Filter(CompoundKey) of
-                true ->
-                    BufferMod:add(CompoundKey, Buffer);
-                false ->
-                    Buffer
-            end
-    end;
 fold_fun(keys, BufferMod, Filter, {Bucket, Index, N, NumPartitions}) ->
     fun(_, Key, Buffer) ->
             Hash = riak_core_util:chash_key({Bucket, Key}),
@@ -1931,22 +1905,6 @@ fold_fun(keys, BufferMod, Filter, {Bucket, Index, N, NumPartitions}) ->
                     case Filter(Key) of
                         true ->
                             BufferMod:add(Key, Buffer);
-                        false ->
-                            Buffer
-                    end;
-                _ ->
-                    Buffer
-            end
-    end;
-fold_fun({keys, RecoverTsFun}, BufferMod, Filter, {Bucket, Index, N, NumPartitions}) ->
-    fun(_, Key, Buffer) ->
-            Hash = riak_core_util:chash_key({Bucket, Key}),
-            case riak_core_ring:future_index(Hash, Index, N, NumPartitions, NumPartitions) of
-                Index ->
-                    CompoundKey = RecoverTsFun(Key),
-                    case Filter(CompoundKey) of
-                        true ->
-                            BufferMod:add(CompoundKey, Buffer);
                         false ->
                             Buffer
                     end;

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -82,7 +82,7 @@
 -define(EMPTY_VTAG_BIN, <<"e">>).
 -define(MSGPACK_ENCODING_FLAG, 2). %% Flag to indicate msgpack encoding
 
--export([new/3, new/4, ensure_robject/1, ancestors/1, reconcile/2, equal/2]).
+-export([new/3, new/4, newts/4, ensure_robject/1, ancestors/1, reconcile/2, equal/2]).
 -export([increment_vclock/2, increment_vclock/3, prune_vclock/3, vclock_descends/2, all_actors/1]).
 -export([actor_counter/2]).
 -export([key/1, get_metadata/1, get_metadatas/1, get_values/1, get_value/1]).
@@ -126,6 +126,9 @@ new({T, B}, K, V, MD) when is_binary(T), is_binary(B), is_binary(K) ->
 new(B, K, V, MD) when is_binary(B), is_binary(K) ->
     new_int(B, K, V, MD).
 
+newts(B, K, V, MD) ->
+    new_int2(B, K, V, MD).
+
 %% internal version after all validation has been done
 new_int(B, K, V, MD) ->
     case size(K) > ?MAX_KEY_SIZE of
@@ -134,15 +137,16 @@ new_int(B, K, V, MD) ->
         false ->
             case MD of
                 no_initial_metadata ->
-                    Contents = [#r_content{metadata=dict:new(), value=V}],
-                    #r_object{bucket=B,key=K,
-                              contents=Contents,vclock=vclock:fresh()};
+                    new_int2(B, K, V, dict:new());
                 _ ->
-                    Contents = [#r_content{metadata=MD, value=V}],
-                    #r_object{bucket=B,key=K,updatemetadata=MD,
-                              contents=Contents,vclock=vclock:fresh()}
+                    new_int2(B, K, V, MD)
             end
     end.
+
+new_int2(B, K, V, MD) ->
+    Contents = [#r_content{metadata=MD, value=V}],
+    #r_object{bucket=B,key=K,updatemetadata=MD,
+              contents=Contents,vclock=vclock:fresh()}.
 
 is_robject(#r_object{}) ->
     true;

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -61,7 +61,7 @@
           key :: key(),
           contents :: [#r_content{}],
           vclock = vclock:fresh() :: vclock:vclock(),
-          updatemetadata=dict:store(clean, true, dict:new()) :: riak_object_dict(),
+          updatemetadata=dict:from_list([{clean, true}]) :: riak_object_dict(),
           updatevalue :: term()
          }).
 -opaque riak_object() :: #r_object{}.
@@ -129,6 +129,8 @@ new(B, K, V, MD) when is_binary(B), is_binary(K) ->
 newts(B, K, V, MD) ->
     new_int2(B, K, V, MD).
 
+
+
 %% internal version after all validation has been done
 new_int(B, K, V, MD) ->
     case size(K) > ?MAX_KEY_SIZE of
@@ -137,7 +139,9 @@ new_int(B, K, V, MD) ->
         false ->
             case MD of
                 no_initial_metadata ->
-                    new_int2(B, K, V, dict:new());
+                    Contents = [#r_content{metadata=dict:new(), value=V}],
+                    #r_object{bucket=B,key=K,
+                              contents=Contents,vclock=vclock:fresh()};
                 _ ->
                     new_int2(B, K, V, MD)
             end


### PR DESCRIPTION
The previous encoding from leveldb_ts:encode_key stored the length first as a variable int, then the binary which meant that all 1-byte strings appeared before all 2-byte strings ( "A", "B", "AA", "AB", "BA" ) rather than in lexicographical order ("A", "AA", "AB", "B", "BA") which could cause future problems for ranges of family keys.

Instead of using the custom encoding in eleveldb_ts:encode_keys, the time series keys become plain tuples that are sext-encoded as part of the object.  On encode this is transparent, however on decode the riak_kv_eleveldb:from_object_key has been modified to keep the key portion as a binary regardless of whether it is a standard object or a time series object.  The key tuple can be recovered at any time useing `sext:decode` and means that any Riak code or support scripts still see decoded keys as binaries.

The time series list keys code has been modified to use the normal list keys code path and just decode the keys at the end (I think this would have been possible with the old encoding if we had written a DDL-aware decoder, but there is no type information information included in the format).

A consequence of the list keys change is that deleted objects will be included in key listing until their tombstones are removed from the underlying eleveldb database.

There are still some eunit failures that need to be resolved.  Opening to give a chance for reviewers to comment while they are fixed up.
