### PR TITLE
Adjust the timestamps provided for quanta calculation based on where clause

### DIFF
--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -77,7 +77,19 @@ expand_where(Where, #key_v1{ast = PAST}) ->
                      fn   = quantum,
                      args = [#param_v1{name = X}, Y, Z]}
                  <- PAST],
-    {NoSubQueries, Boundaries} = riak_ql_quanta:quanta(Min, Max, Q, U),
+    EffMin = case proplists:get_value(start_inclusive, Where, true) of
+                 true ->
+                     Min;
+                 _ ->
+                     Min + 1
+             end,
+    EffMax = case proplists:get_value(end_inclusive, Where, false) of
+                 true ->
+                     Max + 1;
+                 _ ->
+                     Max
+             end,
+    {NoSubQueries, Boundaries} = riak_ql_quanta:quanta(EffMin, EffMax, Q, U),
     MaxSubQueries =
         app_helper:get_env(riak_kv, timeseries_query_max_quanta_span),
     if


### PR DESCRIPTION
The quanta calculations are based on a default inclusive start range, exclusive
end range.  Now that the quanta calculations are correct in riak_ql commit
12118e the values being passed in need to be adjusted.

Found by ts_B_random_query_pass_eqc with counterexample {1,1,{1,d},1}.

Really needs to have some kind of local tests added that check for subqueries around quanta boundaries.
