### PR TITLE
Perf/test release candidate

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,5 +36,6 @@
         {riak_dt,          ".*", {git, "git://github.com/basho/riak_dt.git",           {branch, "develop"}}},
         {msgpack,          ".*", {git, "git://github.com/msgpack/msgpack-erlang.git",  {tag, "0.3.5"}}},
         {riak_ql,          ".*", {git, "git@github.com:basho/riak_ql.git",             {branch, "develop"}}},
-        {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag,    "0.1.2"}}}
+        {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag,    "0.1.2"}}},
+        {eleveldb,         ".*", {git, "git://github.com/basho/eleveldb.git",          {branch, "perf/test_release_candidate"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -36,6 +36,5 @@
         {riak_dt,          ".*", {git, "git://github.com/basho/riak_dt.git",           {branch, "develop"}}},
         {msgpack,          ".*", {git, "git://github.com/msgpack/msgpack-erlang.git",  {tag, "0.3.5"}}},
         {riak_ql,          ".*", {git, "git@github.com:basho/riak_ql.git",             {branch, "develop"}}},
-        {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag,    "0.1.2"}}},
-        {eleveldb,         ".*", {git, "git://github.com/basho/eleveldb.git",          {branch, "perf/test_release_candidate"}}}
+        {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag,    "0.1.2"}}}
        ]}.

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -32,6 +32,7 @@
          get/3,
          put/5,
          async_put/5,
+         sync_put/5,
          delete/4,
          drop/1,
          fix_index/3,
@@ -215,6 +216,11 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, #state{ref=Ref,
 async_put(Context, Bucket, PrimaryKey, Val, #state{ref=Ref, write_opts=WriteOpts}=State) ->
     StorageKey = to_object_key(Bucket, PrimaryKey),
     eleveldb:async_put(Ref, Context, StorageKey, Val, WriteOpts),
+    {ok, State}.
+
+sync_put(Context, Bucket, PrimaryKey, Val, #state{ref=Ref, write_opts=WriteOpts}=State) ->
+    StorageKey = to_object_key(Bucket, PrimaryKey),
+    eleveldb:sync_put(Ref, Context, StorageKey, Val, WriteOpts),
     {ok, State}.
 
 indexes_fixed(#state{ref=Ref,read_opts=ReadOpts}) ->

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -220,8 +220,12 @@ async_put(Context, Bucket, PrimaryKey, Val, #state{ref=Ref, write_opts=WriteOpts
 
 sync_put(Context, Bucket, PrimaryKey, Val, #state{ref=Ref, write_opts=WriteOpts}=State) ->
     StorageKey = to_object_key(Bucket, PrimaryKey),
-    eleveldb:sync_put(Ref, Context, StorageKey, Val, WriteOpts),
-    {ok, State}.
+    case eleveldb:sync_put(Ref, Context, StorageKey, Val, WriteOpts) of
+	ok ->
+	    {ok, State};
+	{error, Reason}  ->
+	    {error, Reason, State}
+    end.
 
 indexes_fixed(#state{ref=Ref,read_opts=ReadOpts}) ->
     case eleveldb:get(Ref, to_md_key(?FIXED_INDEXES_KEY), ReadOpts) of


### PR DESCRIPTION
This is half of a last-minute performance optimization for TS 1.0 (the other half is in the corresponding branch of eleveldb, where the sync_put function is implemented).  There are two parts to this:

1) riak_kv_vnode:handle_command has been changed to default to Mod:sync_put instead of Mod:async_put for the TS W1C path.

riak_kv_eleveldb_backend:sync_put calls eleveldb:sync_put and checks for success or error status.  The call to eleveldb:sync_put causes leveldb writes to happen synchromously instead of asynchronously.

NB: this change is not compatible with backends other than eleveldb, since it requires Mod:sync_put to exist.  However backends other than eleveldb are not supported for TS

2) Because we are now using synchronous calls, we are bypassing the asynchronous reply loop, which is handled in riak_kv_vnode:handle_info({{w1c_async_put,...).  That function did three things: update_hashtree, ?INDEX_BIN, and update_vnode_stats.  The last of these (the vnode stats update) was found to consume 20% of the ts put path time, and the decision was made not to do this for TS1.0.  

The modifications to riak_kv_vnode:handle_command therefore replicate everything that was previously done in the asynchronous reply loop, with the exception of the call to update_vnode_stats.
