### PR TITLE
Window aggregate functions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -34,7 +34,7 @@
         {riak_pipe,        ".*", {git, "git://github.com/basho/riak_pipe.git",         {branch, "end-to-end/timeseries"}}},
         {riak_api,         ".*", {git, "git://github.com/basho/riak_api.git",          {branch, "end-to-end/timeseries"}}},
         {riak_dt,          ".*", {git, "git://github.com/basho/riak_dt.git",           {branch, "develop"}}},
-        {msgpack,          ".*", {git, "git://github.com/msgpack/msgpack-erlang.git",  {tag, "0.3.5"}}},
-        {riak_ql,          ".*", {git, "git@github.com:basho/riak_ql.git",             {branch, "develop"}}},
+        {msgpack,          ".*", {git, "git://github.com/msgpack/msgpack-erlang.git",  {tag,    "0.3.5"}}},
+        {riak_ql,          ".*", {git, "git@github.com:basho/riak_ql.git",             {branch, "ts1.1/timeseries"}}},
         {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag,    "0.1.2"}}}
        ]}.

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -557,7 +557,12 @@ get_column_names([{C1, _} | MoreRecords]) ->
 
 -spec get_column_types(list(binary()), module()) -> list(riak_pb_ts_codec:tscolumntype()).
 get_column_types(ColumnNames, Mod) ->
-    [Mod:get_field_type([ColumnName]) || ColumnName <- ColumnNames].
+    [get_column_types2(Mod, N) || N <- ColumnNames].
+
+get_column_types2(_, <<"aggregate">>) ->
+    sint64; % FIXME hack until we get return types in
+get_column_types2(Mod, ColumnName) ->
+    Mod:get_field_type([ColumnName]).
 
 -spec make_tscolumndescription_list(list(binary()), list(riak_pb_ts_codec:tscolumntype())) ->
                                            list(#tscolumndescription{}).

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -53,15 +53,14 @@ maybe_submit_to_queue(SQL, #ddl_v1{table = BucketType} = DDL) ->
             case riak_kv_qry_compiler:compile(DDL, SQL) of
                 {error,_} = Error ->
                     Error;
-                Queries when is_list(Queries) ->
+                {ok, InitialState, Queries} ->
                     maybe_await_query_results(
-                        riak_kv_qry_queue:put_on_queue(self(), Queries, DDL))
+                        riak_kv_qry_queue:put_on_queue(self(), InitialState, Queries, DDL))
             end;
         {false, Errors} ->
             {error, {invalid_query, format_query_syntax_errors(Errors)}}
     end.
 
-%%
 maybe_await_query_results({error,_} = Error) ->
     Error;
 maybe_await_query_results(_) ->

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -35,19 +35,19 @@
 -include("riak_kv_ts_error_msgs.hrl").
 
 -spec compile(#ddl_v1{}, #riak_sql_v1{}) ->
-    [#riak_sql_v1{}] | {error, any()}.
+    {ok, InitialState::[any()], SubQueries::[#riak_sql_v1{}]} | {error, any()}.
 compile(#ddl_v1{}, #riak_sql_v1{is_executable = true}) ->
     {error, 'query is already compiled'};
 compile(#ddl_v1{}, #riak_sql_v1{'SELECT' = []}) ->
     {error, 'full table scan not implmented'};
 compile(#ddl_v1{} = DDL, #riak_sql_v1{is_executable = false,
                                       type          = sql} = Q) ->
-    comp2(DDL, Q).
+    compile2(DDL, Q).
 
 %% adding the local key here is a bodge
 %% should be a helper fun in the generated DDL module but I couldn't
 %% write that up in time
-comp2(#ddl_v1{} = DDL, #riak_sql_v1{is_executable = false,
+compile2(#ddl_v1{} = DDL, #riak_sql_v1{is_executable = false,
                     'WHERE'       = W} = Q) ->
     case compile_where(DDL, W) of
         {error, E} -> {error, E};
@@ -56,45 +56,113 @@ comp2(#ddl_v1{} = DDL, #riak_sql_v1{is_executable = false,
 
 %% now break out the query on quantum boundaries
 expand_query(#ddl_v1{local_key = LK, partition_key = PK} = DDL, 
-             #riak_sql_v1{ 'SELECT' = SelectSpec1 } = Q, Where1) ->
+             #riak_sql_v1{ 'SELECT' = SelectSpec1 } = Q1, Where1) ->
     case expand_where(Where1, PK) of
         {error, E} ->
             {error, E};
         Where2 ->
-            SelectSpec2 = [compile_select(DDL, S) || S <- SelectSpec1],
-            [Q#riak_sql_v1{
-                   is_executable = true,
-                   type          = timeseries,
-                   'SELECT'      = SelectSpec2,
-                   'WHERE'       = X,
-                   local_key     = LK,
-                   partition_key = PK} || X <- Where2]
+            {ResultType, InitialState, SelectSpec2} = compile_select(DDL, SelectSpec1),
+            Q2 = Q1#riak_sql_v1{ is_executable = true,
+                                 type          = timeseries,
+                                 'SELECT'      = SelectSpec2,
+                                 local_key     = LK,
+                                 partition_key = PK,
+                                 result_type   = ResultType },
+            SubQueries = [Q2#riak_sql_v1{ 'WHERE' = X } || X <- Where2],
+            {ok, InitialState, SubQueries}
     end.
+-include_lib("eunit/include/eunit.hrl").
 
 %% Run the selection spec for all selection columns that was created by
 -spec run_select(SelectionSpec::[compiled_select()], Row::riak_object:value()) ->
         riak_object:value().
 run_select(SelectSpec, Row) ->
-    lists:flatten([Fn(Row) || Fn <- SelectSpec]).
+    % the second argument is the state, if we're return roq query results then
+    % there is no long running state
+    run_select2(SelectSpec, Row, undefined, []).
+
+
+run_select(SelectSpec, Row, InitialState) ->
+    % the second argument is the state, if we're return roq query results then
+    % there is no long running state
+    run_select2(SelectSpec, Row, InitialState, []).
+
+%% @priv
+run_select2([], _, _, Acc) ->
+    lists:flatten(lists:reverse(Acc));
+run_select2([Fn | SelectTail], Row, [ColState1 | ColStateTail], Acc1) ->
+    ColState2 = Fn(Row, ColState1),
+    Acc2 = [ColState2 | Acc1],
+    run_select2(SelectTail, Row, ColStateTail, Acc2);
+run_select2([Fn | SelectTail], Row, RowState, Acc1) ->
+    Value = Fn(Row, RowState),
+    Acc2 = [Value | Acc1],
+    run_select2(SelectTail, Row, RowState, Acc2).
+
+%%
+compile_select(DDL, SelectSpec1) ->
+    % compile each select column and put all the results types into a set, if
+    % any of the results are aggregate then aggregate is the result type for the
+    % whole query
+    CompileColFn = 
+        fun(ColX, {TypeSetX, InitColStatesX, SelectSpecX}) ->
+            {ColResultType, ColStateX, X} = compile_select_col(DDL, ColX),
+            {sets:add_element(ColResultType, TypeSetX), % result types
+             [ColStateX | InitColStatesX], % initial states if aggregates
+             [X | SelectSpecX]} % compiled select fun
+        end,
+    {TypeSet, InitialState, SelectSpec2} =
+        lists:foldr(CompileColFn, {sets:new(), [], []}, SelectSpec1),
+    case sets:is_element(aggregate, TypeSet) of
+        true  -> {aggregate, InitialState, SelectSpec2};
+        false -> {rows, [], SelectSpec2}
+    end.
 
 %% Compile a single selection column into a fun that can extract the cell 
 %% from the row.
--spec compile_select(DDL::#ddl_v1{}, ColumnName::[binary()]) ->
+-spec compile_select_col(DDL::#ddl_v1{}, ColumnSpec::{identifier,[binary()]}) ->
         compiled_select().
-compile_select(_, [<<"*">>]) ->
+compile_select_col(DDL, {funcall, {FnName, [Arg1]}} = Select) ->
+    Initial_state = riak_ql_window_agg_fns:start_state(FnName),
+    Compiled_arg1 = compile_select_col_stateless(DDL, Arg1),
+    case riak_ql_window_agg_fns:start_state(FnName) of
+        stateless ->
+            {rows, undefined, compile_select_col_stateless(DDL, Select)};
+        Initial_state ->
+            Fn =
+                fun(Row, State) ->
+                    riak_ql_window_agg_fns:FnName(Compiled_arg1(Row), State)
+                end,
+            {aggregate, Initial_state, Fn}
+    end;
+compile_select_col(DDL, Select) ->
+    Fn = compile_select_col_stateless(DDL, Select),
+    % to support aggregates that have a running state all top level funs must be
+    % arity two, when we know the function is stateless wrap it in a two arity
+    % fun and ignore the state arg
+    {rows, undefined, fun(Row, _) -> Fn(Row) end}.
+
+%%
+compile_select_col_stateless(_, {identifier, [<<"*">>]}) ->
     fun(Row) ->
         Row
     end;
-compile_select(#ddl_v1{ fields = Fields }, ColumnName) ->
-    Index = field_index_of(Fields, ColumnName),
+compile_select_col_stateless(#ddl_v1{ fields = Fields }, {identifier, ColumnName}) ->
+    Index = column_index_of(Fields, to_column_name_binary(ColumnName)),
     fun(Row) ->
         lists:nth(Index, Row)
     end.
 
+%%
+to_column_name_binary([Name]) when is_binary(Name) ->
+    Name;
+to_column_name_binary(Name) when is_binary(Name) ->
+    Name.
+
 %% Return the index of a field in the table definition.
-field_index_of(Fields, [ColumnName]) ->
+column_index_of(Fields, ColumnName) ->
     #riak_field_v1{ position = Position } =
-        lists:keyfind(ColumnName, 2, Fields),
+        lists:keyfind(ColumnName, #riak_field_v1.name, Fields),
     Position.
 
 expand_where(Where, #key_v1{ast = PAST}) ->
@@ -630,11 +698,11 @@ simplest_test() ->
     PK = get_standard_pk(),
     LK = get_standard_lk(),
     ?assertMatch(
-        [#riak_sql_v1{ is_executable = true,
-                       type          = timeseries,
-                       'WHERE'       = Where2,
-                       partition_key = PK,
-                       local_key     = LK }],
+        {ok, _, [#riak_sql_v1{ is_executable = true,
+                                type          = timeseries,
+                                'WHERE'       = Where2,
+                                partition_key = PK,
+                                local_key     = LK }]},
         compile(DDL, Q)
     ).
 
@@ -658,11 +726,11 @@ simple_with_filter_1_test() ->
     PK = get_standard_pk(),
     LK = get_standard_lk(),
     ?assertMatch(
-        [#riak_sql_v1{ is_executable = true,
-                       type          = timeseries,
-                       'WHERE'       = Where,
-                       partition_key = PK,
-                       local_key     = LK }],
+        {ok, _, [#riak_sql_v1{ is_executable = true,
+                               type          = timeseries,
+                               'WHERE'       = Where,
+                               partition_key = PK,
+                               local_key     = LK }]},
         compile(DDL, Q)
     ).
 
@@ -685,11 +753,11 @@ simple_with_filter_2_test() ->
     PK = get_standard_pk(),
     LK = get_standard_lk(),
     ?assertMatch(
-        [#riak_sql_v1{ is_executable = true,
-                       type          = timeseries,
-                       'WHERE'       = Where,
-                       partition_key = PK,
-                       local_key     = LK }],
+        {ok, _, [#riak_sql_v1{ is_executable = true,
+                               type          = timeseries,
+                               'WHERE'       = Where,
+                               partition_key = PK,
+                               local_key     = LK }]},
         compile(DDL, Q)
     ).
 
@@ -714,11 +782,11 @@ simple_with_filter_3_test() ->
         {end_inclusive,   true}
     ],
     ?assertMatch(
-        [#riak_sql_v1{ is_executable = true,
-                       type          = timeseries,
-                       'WHERE'       = Where,
-                       partition_key = PK,
-                       local_key     = LK }],
+        {ok, _, [#riak_sql_v1{ is_executable = true,
+                               type          = timeseries,
+                               'WHERE'       = Where,
+                               partition_key = PK,
+                               local_key     = LK }]},
         compile(DDL, Q)
     ).
 
@@ -748,11 +816,11 @@ simple_with_2_field_filter_test() ->
         {start_inclusive, false}
     ],
     ?assertMatch(
-        [#riak_sql_v1{ is_executable = true,
-                       type          = timeseries,
-                       'WHERE'       = Where,
-                       partition_key = PK,
-                       local_key     = LK }],
+        {ok, _, [#riak_sql_v1{ is_executable = true,
+                               type          = timeseries,
+                               'WHERE'       = Where,
+                               partition_key = PK,
+                               local_key     = LK }]},
         compile(DDL, Q)
     ).
 
@@ -781,11 +849,11 @@ complex_with_4_field_filter_test() ->
     PK = get_standard_pk(),
     LK = get_standard_lk(),
     ?assertMatch(
-        [#riak_sql_v1{ is_executable = true,
-                       type          = timeseries,
-                       'WHERE'       = Where2,
-                       partition_key = PK,
-                       local_key     = LK }],
+        {ok, _, [#riak_sql_v1{ is_executable = true,
+                               type          = timeseries,
+                               'WHERE'       = Where2,
+                               partition_key = PK,
+                               local_key     = LK }]},
         compile(DDL, Q)
     ).
 
@@ -813,12 +881,12 @@ complex_with_boolean_rewrite_filter_test() ->
         {start_inclusive, false}
     ],
     ?assertMatch(
-        [#riak_sql_v1{is_executable  = true,
-                       type          = timeseries,
-                       'WHERE'       = Where,
-                       partition_key = PK,
-                       local_key     = LK
-                     }], 
+        {ok, _, [#riak_sql_v1{ is_executable  = true,
+                               type          = timeseries,
+                               'WHERE'       = Where,
+                               partition_key = PK,
+                               local_key     = LK
+                             }]}, 
         compile(DDL, Q)
     ).
 
@@ -835,23 +903,20 @@ simple_spanning_boundary_test() ->
                                [{3000, 15000}, {15000, 30000}, {30000, 31000}]),
     PK = get_standard_pk(),
     LK = get_standard_lk(),
-    ?assertMatch([
-            #riak_sql_v1{is_executable = true,
-                      type          = timeseries,
-                      'WHERE'       = Where1,
-                      partition_key = PK,
-                      local_key     = LK},
-            #riak_sql_v1{is_executable = true,
-                      type          = timeseries,
-                      'WHERE'       = Where2,
-                      partition_key = PK,
-                      local_key     = LK},
-            #riak_sql_v1{is_executable = true,
-                      type          = timeseries,
-                      'WHERE'       = Where3,
-                      partition_key = PK,
-                      local_key     = LK}
-       ],
+    ?assertMatch({ok, _, [
+                #riak_sql_v1{
+                          'WHERE'       = Where1,
+                          partition_key = PK,
+                          local_key     = LK},
+                #riak_sql_v1{
+                          'WHERE'       = Where2,
+                          partition_key = PK,
+                          local_key     = LK},
+                #riak_sql_v1{
+                          'WHERE'       = Where3,
+                          partition_key = PK,
+                          local_key     = LK}
+           ]},
        compile(DDL, Q)
     ).
 
@@ -864,8 +929,8 @@ boundary_quanta_test() ->
     {ok, Q} = get_query(Query),
     true = is_query_valid(DDL, Q),
     %% get basic query
-    Got = compile(DDL, Q),
-    ?assertEqual(2, length(Got)).
+    Actual = compile(DDL, Q),
+    ?assertEqual(2, length(element(3, Actual))).
 
 test_data_where_clause(Family, Series, StartEndTimes) ->
     Fn =
@@ -899,17 +964,13 @@ simple_spanning_boundary_precision_test() ->
     PK = get_standard_pk(),
     LK = get_standard_lk(),
     ?assertMatch(
-        [#riak_sql_v1{ is_executable = true,
-                       type          = timeseries,
-                       'WHERE'       = Where1,
-                       partition_key = PK,
-                       local_key     = LK},
-         #riak_sql_v1{ is_executable = true,
-                       type          = timeseries,
-                       'WHERE'       = Where2,
-                       partition_key = PK,
-                       local_key     = LK
-                       }],
+        {ok, _, [#riak_sql_v1{ 'WHERE'       = Where1,
+                               partition_key = PK,
+                               local_key     = LK},
+                 #riak_sql_v1{ 'WHERE'       = Where2,
+                               partition_key = PK,
+                               local_key     = LK
+                               }]},
         compile(DDL, Q)
     ).
 
@@ -923,10 +984,12 @@ simplest_compile_once_only_fail_test() ->
     {ok, Q} = get_query(Query),
     true = is_query_valid(DDL, Q),
     %% now try and compile twice
-    [Q2] = compile(DDL, Q),
+    {ok, _, [Q2]} = compile(DDL, Q),
     Got = compile(DDL, Q2),
-    Expected = {error, 'query is already compiled'},
-    ?assertEqual(Expected, Got).
+    ?assertEqual(
+        {error, 'query is already compiled'},
+        Got
+    ).
 
 end_key_not_a_range_test() ->
     DDL = get_standard_ddl(),
@@ -963,21 +1026,21 @@ key_is_all_timestamps_test() ->
         "WHERE time_c > 2999 AND time_c < 5000 "
         "AND time_a = 10 AND time_b = 15"),
     ?assertMatch(
-        [#riak_sql_v1{
-            'WHERE' = [
-                {startkey, [
-                    {<<"time_a">>, timestamp, 10},
-                    {<<"time_b">>, timestamp, 15},
-                    {<<"time_c">>, timestamp, 2999}
-                ]},
-                {endkey, [
-                    {<<"time_a">>, timestamp, 10},
-                    {<<"time_b">>, timestamp, 15},
-                    {<<"time_c">>, timestamp, 5000}
-                ]},
-                {filter, []},
-                {start_inclusive, false}]
-        }],
+        {ok, _, [#riak_sql_v1{
+                    'WHERE' = [
+                        {startkey, [
+                            {<<"time_a">>, timestamp, 10},
+                            {<<"time_b">>, timestamp, 15},
+                            {<<"time_c">>, timestamp, 2999}
+                        ]},
+                        {endkey, [
+                            {<<"time_a">>, timestamp, 10},
+                            {<<"time_b">>, timestamp, 15},
+                            {<<"time_c">>, timestamp, 5000}
+                        ]},
+                        {filter, []},
+                        {start_inclusive, false}]
+                }]},
         compile(DDL, Q)
     ).
 
@@ -1085,14 +1148,16 @@ no_where_clause_test() ->
 
 -define(ROW, [<<"geodude">>, <<"derby">>, <<"ralph">>, 10, <<"hot">>, 12.2]).
 
-testing_compile_select(DDL, QueryString) ->
-    [#riak_sql_v1{ 'SELECT' = SelectSpec } | _] =
+% this helper function is only for tests testing queries with the
+% query_result_type of 'rows' and _not_ 'aggregate'
+testing_compile_row_select(DDL, QueryString) ->
+    {ok, _, [#riak_sql_v1{ 'SELECT' = SelectSpec } | _]} =
         compile(DDL, element(2, get_query(QueryString))),
     SelectSpec.
 
 run_select_all_test() ->
     DDL = get_standard_ddl(),
-    SelectSpec = testing_compile_select(DDL,
+    SelectSpec = testing_compile_row_select(DDL,
         "SELECT * FROM GeoCheckin "
         "WHERE time > 1 AND time < 6 AND user = '2' AND location = '4'"),
     ?assertEqual(
@@ -1102,7 +1167,7 @@ run_select_all_test() ->
 
 run_select_first_test() ->
     DDL = get_standard_ddl(),
-    SelectSpec = testing_compile_select(DDL,
+    SelectSpec = testing_compile_row_select(DDL,
         "SELECT geohash FROM GeoCheckin "
         "WHERE time > 1 AND time < 6 AND user = '2' AND location = '4'"),
     ?assertEqual(
@@ -1112,7 +1177,7 @@ run_select_first_test() ->
 
 run_select_last_test() ->
     DDL = get_standard_ddl(),
-    SelectSpec = testing_compile_select(DDL,
+    SelectSpec = testing_compile_row_select(DDL,
         "SELECT temperature FROM GeoCheckin "
         "WHERE time > 1 AND time < 6 AND user = '2' AND location = '4'"),
     ?assertEqual(
@@ -1122,7 +1187,7 @@ run_select_last_test() ->
 
 run_select_all_individually_test() ->
     DDL = get_standard_ddl(),
-    SelectSpec = testing_compile_select(DDL,
+    SelectSpec = testing_compile_row_select(DDL,
         "SELECT geohash, location, user, time, weather, temperature FROM GeoCheckin "
         "WHERE time > 1 AND time < 6 AND user = '2' AND location = '4'"),
     ?assertEqual(
@@ -1132,12 +1197,33 @@ run_select_all_individually_test() ->
 
 run_select_some_test() ->
     DDL = get_standard_ddl(),
-    SelectSpec = testing_compile_select(DDL,
+    SelectSpec = testing_compile_row_select(DDL,
         "SELECT  location, weather FROM GeoCheckin "
         "WHERE time > 1 AND time < 6 AND user = '2' AND location = '4'"),
     ?assertEqual(
         [<<"derby">>, <<"hot">>],
         run_select(SelectSpec, ?ROW)
+    ).
+
+select_count_aggregation_test() ->
+    DDL = get_standard_ddl(),
+    SelectSpec = testing_compile_row_select(DDL,
+        "SELECT count(location) FROM GeoCheckin "
+        "WHERE time > 1 AND time < 6 AND user = '2' AND location = '4'"),
+    ?assertEqual(
+        [1],
+        run_select(SelectSpec, ?ROW, [0])
+    ).
+
+
+select_count_aggregation_2_test() ->
+    DDL = get_standard_ddl(),
+    SelectSpec = testing_compile_row_select(DDL,
+        "SELECT count(location), count(location) FROM GeoCheckin "
+        "WHERE time > 1 AND time < 6 AND user = '2' AND location = '4'"),
+    ?assertEqual(
+        [1, 10],
+        run_select(SelectSpec, ?ROW, [0, 9])
     ).
 
 % FIXME or operators

--- a/src/riak_kv_qry_queue.erl
+++ b/src/riak_kv_qry_queue.erl
@@ -29,7 +29,7 @@
 %% User API
 -export([
          blocking_pop/0,
-         put_on_queue/3
+         put_on_queue/4
         ]).
 
 %% OTP API
@@ -67,13 +67,13 @@
 %%% API
 %%%===================================================================
 
--spec put_on_queue(pid(), [qry()], #ddl_v1{}) ->
+-spec put_on_queue(pid(), [qry()], any(), #ddl_v1{}) ->
         {ok, query_id()} | {error, term()}.
 %% @doc Enqueue a prepared query for execution.  The query should be
 %%      compatible with the DDL supplied.
-put_on_queue(ReceivePid, Qry, DDL) when is_pid(ReceivePid) ->
+put_on_queue(ReceivePid, InitialState, Qry, DDL) when is_pid(ReceivePid) ->
     %% worker needs DDL to perform column filtering
-    gen_server:call(?SERVER, {push_query, ReceivePid, Qry, DDL}).
+    gen_server:call(?SERVER, {push_query, ReceivePid, InitialState, Qry, DDL}).
 
 %% Pop a query from the queue, this function will not return until a queue is
 %% read to be executed.
@@ -103,9 +103,9 @@ init([MaxQueryLength]) ->
 %% @private
 handle_call(blocking_pop, From, State) ->
     do_blocking_pop(From, State);
-handle_call({push_query, ReceivePid, Qry, DDL}, _, State) ->
+handle_call({push_query, ReceivePid, InitialState, Qry, DDL}, _, State) ->
     QId = {node(), make_ref()},
-    QueryItem = {query, ReceivePid, QId, Qry, DDL},
+    QueryItem = {query, ReceivePid, QId, InitialState, Qry, DDL},
     do_push_query(QueryItem, State).
 
 -spec handle_cast(term(), #state{}) -> {noreply, #state{}}.

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -43,12 +43,6 @@
          code_change/3
         ]).
 
--ifdef(TEST).
--export([
-         runner_TEST/1
-        ]).
--endif.
-
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 -define(NO_SIDEEFFECTS, []).
@@ -56,14 +50,14 @@
 -define(NO_PG_SORT, undefined).
 
 -record(state, {
-          name                 :: atom(),
-          ddl                  :: undefined | #ddl_v1{},
-          qry      = none      :: none | #riak_sql_v1{},
-          qid      = undefined :: undefined | {node(), non_neg_integer()},
-          sub_qrys  = []       :: [integer()],
-          status    = void     :: void | accumulating_chunks,
-          receiver_pid         :: pid(),
-          result    = []       :: [{non_neg_integer(), list()}] | [{binary(), term()}]
+          name                                :: atom(),
+          qry           = none                :: none | #riak_sql_v1{},
+          qid           = undefined           :: undefined | {node(), non_neg_integer()},
+          sub_qrys      = []                  :: [integer()],
+          status        = void                :: void | accumulating_chunks,
+          receiver_pid                        :: pid(),
+          result        = []                  :: [{non_neg_integer(), list()}] | [{binary(), term()}],
+          run_sub_qs_fn = fun run_sub_qs_fn/1 :: fun()
          }).
 
 %%%===================================================================
@@ -83,18 +77,8 @@ init([RegisteredName]) ->
     pop_next_query(),
     {ok, new_state(RegisteredName)}.
 
--spec handle_call(term(), {pid(), term()}, #state{}) ->
-                         {reply, Reply::ok | {error, atom()} | list(), #state{}}.
-%% @private
-handle_call(Request, _, State) ->
-    case handle_req(Request, State) of
-        {{error, _} = Error, _SEs, NewState} ->
-            {reply, Error, NewState};
-        {Reply, SEs, NewState} ->
-            ok = handle_side_effects(SEs),
-            {reply, Reply, NewState}
-    end.
-
+handle_call(_, _, State) ->
+    {reply, {error, not_handled}, State}.
 
 -spec handle_cast(term(), #state{}) -> {noreply, #state{}}.
 %% @private
@@ -105,59 +89,13 @@ handle_cast(Msg, State) ->
 %% @private
 -spec handle_info(term(), #state{}) -> {noreply, #state{}}.
 handle_info(pop_next_query, State1) ->
-    {query, ReceivePid, QId, Qry, DDL} = riak_kv_qry_queue:blocking_pop(),
-    Request = {execute, {QId, Qry, DDL}},
-    case handle_req(Request, State1) of
-        {{error, _} = Error, _, State2} ->
-            ReceivePid ! Error,
-            {noreply, new_state(State2#state.name)};
-        {ok, SEs, State2} ->
-            ok = handle_side_effects(SEs),
-            {noreply, State2#state{ receiver_pid = ReceivePid }}
-    end;
-
-handle_info({{SubQId, QId}, done},
-            State = #state{qid       = QId,
-                           receiver_pid = ReceiverPid,
-                           result    = IndexedChunks,
-                           sub_qrys  = SubQQ}) ->
-    lager:debug("Received done on QId ~p (~p); SubQQ: ~p", [QId, SubQId, SubQQ]),
-    case SubQQ of
-        [] ->
-            lager:debug("Done collecting on QId ~p (~p): ~p", [QId, SubQId, IndexedChunks]),
-            %% sort by index, to reassemble according to coverage plan
-            {_, R2} = lists:unzip(lists:sort(IndexedChunks)),
-            Results = lists:append(R2),
-            % send the results to the waiting client process
-            ReceiverPid ! {ok, Results},
-            pop_next_query(),
-            %% drop indexes, serialize
-            {noreply, new_state(State#state.name)};
-        _MoreSubQueriesNotDone ->
-            {noreply, State}
-    end;
-
-handle_info({{SubQId, QId}, {results, Chunk}},
-            State = #state{qid      = QId,
-                           qry      = Qry,
-                           result   = IndexedChunks,
-                           sub_qrys = SubQs}) ->
-    #riak_sql_v1{'SELECT' = SelectSpec} = Qry,
-    NewS = case lists:member(SubQId, SubQs) of
-               true ->
-                   Decoded = decode_results(lists:flatten(Chunk), SelectSpec),
-                   lager:debug("Got chunk on QId ~p (~p); SubQQ: ~p", [QId, SubQId, SubQs]),
-                   NSubQ = lists:delete(SubQId, SubQs),
-                   State#state{status   = accumulating_chunks,
-                               result   = [{SubQId, Decoded} | IndexedChunks],
-                               sub_qrys = NSubQ};
-               false ->
-                   %% discard;
-                   %% Don't touch state as it may have already 'finished'.
-                   State
-           end,
-    {noreply, NewS};
-
+    QueryWork = riak_kv_qry_queue:blocking_pop(),
+    {ok, State2} = execute_query(QueryWork, State1),
+    {noreply, State2};
+handle_info({{_, QId}, done}, #state{ qid = QId } = State) ->
+    {noreply, subqueries_done(QId, State)};
+handle_info({{SubQId, QId}, {results, Chunk}}, #state{ qid = QId } = State) ->
+    {noreply, add_subquery_result(SubQId, Chunk, State)};
 handle_info({{SubQId, QId}, {error, Reason} = Error},
             State = #state{receiver_pid = ReceiverPid,
                            qid    = QId,
@@ -193,45 +131,22 @@ code_change(_OldVsn, State, _Extra) ->
 new_state(RegisteredName) ->
     #state{name = RegisteredName}.
 
--spec handle_req({atom(), term()}, #state{}) ->
-                        {ok | {ok | error, term()},
-                         list(), #state{}}.
-handle_req({execute, {QId, [Qry|_] = SubQueries, DDL}}, State = #state{status = void}) ->
-    %% TODO make this run with multiple sub-queries
-    %% limit sub-queries and throw error
-    Indices = lists:seq(1, length(SubQueries)),
-    ZQueries = lists:zip(Indices, SubQueries),
-    SEs = [{run_sub_query, {qry, Q}, {qid, {I, QId}}} || {I, Q} <- ZQueries],
-    {ok, SEs, State#state{qid = QId, qry = Qry, ddl = DDL, sub_qrys = Indices}};
-
-handle_req({execute, {QId, _, _}}, State = #state{status = Status})
-  when Status =/= void ->
-    lager:error("Qry queue manager should have cleared the status before assigning new query ~p", [QId]),
-    {{error, mismanagement}, [], State};
-
-handle_req(_Request, State) ->
-    {ok, ?NO_SIDEEFFECTS, State}.
-
-handle_side_effects([]) ->
-    ok;
-handle_side_effects([{run_sub_query, {qry, Q}, {qid, QId}} | T]) ->
+run_sub_qs_fn([]) -> ok;
+run_sub_qs_fn([{{qry, Q}, {qid, QId}} | T]) ->
     Table = Q#riak_sql_v1.'FROM',
     Bucket = riak_kv_pb_timeseries:table_to_bucket(Table),
     %% fix these up too
     Timeout = {timeout, 10000},
     Me = self(),
     CoverageFn = {colocated, riak_kv_qry_coverage_plan},
-    {ok, _PID} = riak_kv_index_fsm_sup:start_index_fsm(node(), [{raw, QId, Me}, [Bucket, none, Q, Timeout, all, undefined, CoverageFn]]),
-    handle_side_effects(T);
-handle_side_effects([H | T]) ->
-    lager:warning("in riak_kv_qry:handle_side_effects not handling ~p", [H]),
-    handle_side_effects(T).
+    Opts = [Bucket, none, Q, Timeout, all, undefined, CoverageFn],
+    {ok, _PID} = riak_kv_index_fsm_sup:start_index_fsm(node(), [{raw, QId, Me}, Opts]),
+    run_sub_qs_fn(T).
 
-decode_results(KVList, SelectSpec) ->
-    lists:append(
-      [extract_riak_object(SelectSpec, V) || {_, V} <- KVList]).
+decode_results(KVList) ->
+    [extract_riak_object(V) || {_, V} <- KVList].
 
-extract_riak_object(SelectSpec, V) when is_binary(V) ->
+extract_riak_object(V) when is_binary(V) ->
     % don't care about bkey
     RObj = riak_object:from_binary(<<>>, <<>>, V),
     case riak_object:get_value(RObj) of
@@ -239,12 +154,82 @@ extract_riak_object(SelectSpec, V) when is_binary(V) ->
             %% record was deleted
             [];
         FullRecord ->
-            riak_kv_qry_compiler:run_select(SelectSpec, FullRecord)
+            FullRecord
     end.
 
 %% Send a message to this process to get the next query.
 pop_next_query() ->
     self() ! pop_next_query.
+
+%%
+execute_query({query, ReceiverPid, QId, InitialState, [Qry|_] = SubQueries, _},
+              #state{ run_sub_qs_fn = RunSubQs } = State) ->
+    Indices = lists:seq(1, length(SubQueries)),
+    ZQueries = lists:zip(Indices, SubQueries),
+    SubQs = [{{qry, Q}, {qid, {I, QId}}} || {I, Q} <- ZQueries],
+    ok = RunSubQs(SubQs),
+    {ok, State#state{qid          = QId,
+                     receiver_pid = ReceiverPid,
+                     qry          = Qry,
+                     sub_qrys     = Indices,
+                     result = InitialState }}.
+
+%%
+add_subquery_result(SubQId, Chunk,
+                    #state{qry      = Qry,
+                           result   = QueryResult1,
+                           sub_qrys = SubQs} = State) ->
+    #riak_sql_v1{'SELECT' = SelectSpec, result_type = ResultType } = Qry,
+    case lists:member(SubQId, SubQs) of
+        true ->
+            DecodedChunk = decode_results(lists:flatten(Chunk)),
+            case ResultType of
+                rows ->
+                    IndexedChunks = [riak_kv_qry_compiler:run_select(SelectSpec, Row) || Row <- DecodedChunk],
+                    QueryResult2 = [{SubQId, IndexedChunks} | QueryResult1];
+                aggregate ->
+                    QueryResult2 = 
+                      lists:foldl(
+                          fun(E, Acc) ->
+                              riak_kv_qry_compiler:run_select(SelectSpec, E, Acc)
+                          end, QueryResult1, DecodedChunk)
+            end,
+            NSubQ = lists:delete(SubQId, SubQs),
+            State#state{status   = accumulating_chunks,
+                        result   = QueryResult2,
+                        sub_qrys = NSubQ};
+        false ->
+            %% discard; Don't touch state as it may have already 'finished'.
+            State
+    end.
+
+subqueries_done(QId,
+                #state{qid          = QId,
+                       receiver_pid = ReceiverPid,
+                       result       = QueryResult1,
+                       sub_qrys     = SubQQ,
+                       qry = #riak_sql_v1{ result_type = ResultType }} = State) ->
+    case SubQQ of
+        [] ->
+            QueryResult2 = prepare_final_results(ResultType, QueryResult1),
+            %   send the results to the waiting client process
+            ReceiverPid ! {ok, QueryResult2},
+            pop_next_query(),
+            %% drop indexes, serialize
+            new_state(State#state.name);
+        _ ->
+            % more sub queries are left to run
+            State
+    end.
+
+%%
+prepare_final_results(rows, IndexedChunks) ->
+    %% sort by index, to reassemble according to coverage plan
+    {_, [R2]} = lists:unzip(lists:sort(IndexedChunks)),
+    lists:append(R2);
+prepare_final_results(aggregate, Aggregate) ->
+    [{<<"aggregate">>, A} || A <- Aggregate].
+
 
 %%%===================================================================
 %%% Unit tests
@@ -253,77 +238,5 @@ pop_next_query() ->
 -compile(export_all).
 -include_lib("eunit/include/eunit.hrl").
 
-%%
-%% Test runner
-%%
-
--define(NO_OUTPUTS, []).
-
-runner_TEST(Tests) -> io:format("running tests ~p~n", [Tests]),
-                      test_r2(Tests, #state{}, 1, [], [], []).
-
-test_r2([], _State, _LineNo, SideEffects, Replies, Errs) ->
-    {lists:reverse(SideEffects), lists:reverse(Replies), lists:reverse(Errs)};
-test_r2([H | T], State, LineNo, SideEffects, Replies, Errs) ->
-    io:format("Before ~p~n- SideEffects is ~p~n- Replies is ~p~n- Errors is ~p~n", [H, SideEffects, Replies, Errs]),
-    {NewSt, NewSEs, NewRs, NewE} = run(H, State, LineNo, SideEffects, Replies, Errs),
-    io:format("After ~p~n- NewSEs is ~p~n- NewRs is ~p~n- NewE is ~p~n", [H, NewSEs, NewRs, NewE]),
-    test_r2(T, NewSt, LineNo + 1, NewSEs, NewRs, NewE).
-
-run({run, {init, Arg}}, _State, _LNo, SideEffects, Replies, Errs) ->
-    {ok, NewState} = init(Arg),
-    {NewState, SideEffects, Replies, Errs};
-run({clear, side_effects}, State, _LNo, _SideEffects, Replies, Errs) ->
-    {State, [], Replies, Errs};
-run({clear, replies}, State, _LNo, SideEffects, _Replies, Errs) ->
-    {State, SideEffects, [], Errs};
-run({dump, state}, State, LNo, SideEffects, Replies, Errs) ->
-    io:format("On Line No ~p State is~n- ~p~n", [LNo, State]),
-    {State, SideEffects, Replies, Errs};
-run({dump, Replies}, State, LNo, SideEffects, Replies, Errs) ->
-    io:format("On Line No ~p Replies is~n- ~p~n", [LNo, Replies]),
-    {State, SideEffects, Replies, Errs};
-run({dump, errors}, State, LNo, SideEffects, Replies, Errs) ->
-    io:format("On Line No ~p Errs is~n- ~p~n", [LNo, Errs]),
-    {State, SideEffects, Replies, Errs};
-run({msg, Msg}, State, _LNo, SideEffects, Replies, Errs) ->
-    {Reply, SEs, NewState} = handle_req(Msg, State),
-    NewSEs = case SEs of
-                 [] -> SideEffects;
-                 _  -> lists:flatten(SEs, SideEffects)
-             end,
-    {NewState, NewSEs, [Reply | Replies], Errs};
-run({side_effect, G}, State, LNo, SEs, Replies, Errs) ->
-    {NewSE, NewErrs}
-        = case SEs of
-              []      -> Err = {error, {line_no, LNo}, {side_effect, {expected, []}, {got, G}}},
-                         {[], [Err | Errs]};
-              [G | T] -> {T, Errs};
-              [E | T] -> Err = {error, {line_no, LNo}, {side_effect, {expected, E}, {got, G}}},
-                         {T, [Err | Errs]}
-          end,
-    {State, NewSE, Replies, NewErrs};
-run({reply, G}, State, LNo, SideEffects, Replies, Errs) ->
-    {NewRs, NewErrs}
-        = case Replies of
-              []      -> Err = {error, {line_no, LNo}, {reply, {expected, []}, {got, G}}},
-                         {[], [Err | Errs]};
-              [G | T] -> {T, Errs};
-              [E | T] -> Err = {error, {line_no, LNo}, {reply, {expected, E}, {got, G}}},
-                         {T, [Err | Errs]}
-          end,
-    {State, SideEffects, NewRs, NewErrs};
-run(H, State, LNo, SideEffects, Replies, Errs) ->
-    Err = {error, {line_no, LNo}, {unknown_test_state, H}},
-    {State, SideEffects, Replies, [Err | Errs]}.
-
--define(MAX_Q_LEN, 5).
-
-simple_init_test() ->
-    Tests = [
-             {run, {init, [fms1]}}
-           ],
-    Results = runner_TEST(Tests),
-    ?assertEqual({[], [], []}, Results).
 
 -endif.

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -131,7 +131,8 @@ code_change(_OldVsn, State, _Extra) ->
 new_state(RegisteredName) ->
     #state{name = RegisteredName}.
 
-run_sub_qs_fn([]) -> ok;
+run_sub_qs_fn([]) ->
+    ok;
 run_sub_qs_fn([{{qry, Q}, {qid, QId}} | T]) ->
     Table = Q#riak_sql_v1.'FROM',
     Bucket = riak_kv_pb_timeseries:table_to_bucket(Table),
@@ -215,7 +216,7 @@ subqueries_done(QId,
             %   send the results to the waiting client process
             ReceiverPid ! {ok, QueryResult2},
             pop_next_query(),
-            %% drop indexes, serialize
+            % clean the state of query specfic data, ready for the next one
             new_state(State#state.name);
         _ ->
             % more sub queries are left to run


### PR DESCRIPTION
**Do not merge**
Support window aggregate functions in riak_kv, such as the following:

``` sql
SELECT count(*) FROM mytable
WHERE time > 1234560 AND time < 1234570 AND myfamily = 'family1' AND myseries = 'series1'
```

Run in the erlang shell using the erlang riak client looks like the following:

``` erlang
120> riakc_ts:query(Pid, "select count(myseries) from GeoCheckin where time > 1234560 and time < 1234570 and myfamily = 'family1' and myseries = 'series1'").   
{[<<"aggregate">>],[{3}]}
```

One current limitation is that all return column names are `<<"aggregate">>` and all column return types are `sint64`.  Column names will eventually be the selection e.g. `count(*)` in this case and the correct return type will be returned for that function by checking the type signature in riak_ql.
