### PR TITLE
Enable DDL schema export

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -35,6 +35,6 @@
         {riak_api,         ".*", {git, "git://github.com/basho/riak_api.git",          {branch, "end-to-end/timeseries"}}},
         {riak_dt,          ".*", {git, "git://github.com/basho/riak_dt.git",           {branch, "develop"}}},
         {msgpack,          ".*", {git, "git://github.com/msgpack/msgpack-erlang.git",  {tag,    "0.3.5"}}},
-        {riak_ql,          ".*", {git, "git@github.com:basho/riak_ql.git",             {branch, "ts1.1/timeseries"}}},
+        {riak_ql,          ".*", {git, "git@github.com:basho/riak_ql.git",             {branch, "develop"}}},
         {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag,    "0.1.2"}}}
        ]}.

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -31,7 +31,7 @@
 
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
--spec submit(string() | #riak_sql_v1{}, #ddl_v1{}) ->
+-spec submit(string() | #riak_sql_v1{} | #riak_sql_describe_v1{}, #ddl_v1{}) ->
     {ok, [{Key::binary(), riak_pb_ts_codec:ldbvalue()}]} | {error, any()}.
 %% @doc Parse, validate against DDL, and submit a query for execution.
 %%      To get the results of running the query, use fetch/1.
@@ -43,8 +43,49 @@ submit(SQLString, DDL) when is_list(SQLString) ->
         {ok, SQL} ->
             submit(SQL, DDL)
     end;
-submit(SQL, DDL) ->
+
+submit(#riak_sql_describe_v1{}, DDL) ->
+    describe_table_columns(DDL);
+
+submit(SQL = #riak_sql_v1{}, DDL) ->
     maybe_submit_to_queue(SQL, DDL).
+
+%% ---------------------
+%% local functions
+
+-spec describe_table_columns(#ddl_v1{}) ->
+                                    {ok, [[binary() | boolean() | integer() | undefined]]}.
+describe_table_columns(#ddl_v1{fields = FieldSpecs,
+                               partition_key = #key_v1{ast = PKSpec},
+                               local_key     = #key_v1{ast = LKSpec}}) ->
+    {ok,
+     [[Name, list_to_binary(atom_to_list(Type)), Nullable,
+       column_pk_position_or_blank(Name, PKSpec),
+       column_lk_position_or_blank(Name, LKSpec)]
+      || #riak_field_v1{name = Name,
+                        type = Type,
+                        optional = Nullable} <- FieldSpecs]}.
+
+%% the following two functions are identical, for the way fields and
+%% keys are represented as of 2015-12-18; duplication here is a hint
+%% of things to come.
+-spec column_pk_position_or_blank(binary(), [#param_v1{}]) -> integer() | undefined.
+column_pk_position_or_blank(Col, KSpec) ->
+    count_to_position(Col, KSpec, 1).
+
+-spec column_lk_position_or_blank(binary(), [#param_v1{}]) -> integer() | undefined.
+column_lk_position_or_blank(Col, KSpec) ->
+    count_to_position(Col, KSpec, 1).
+
+count_to_position(_, [], _) ->
+    undefined;
+count_to_position(Col, [#param_v1{name = [Col]} | _], Pos) ->
+    Pos;
+count_to_position(Col, [#hash_fn_v1{args = [#param_v1{name = [Col]} | _]} | _], Pos) ->
+    Pos;
+count_to_position(Col, [_ | Rest], Pos) ->
+    count_to_position(Col, Rest, Pos + 1).
+
 
 maybe_submit_to_queue(SQL, #ddl_v1{table = BucketType} = DDL) ->
     Mod = riak_ql_ddl:make_module_name(BucketType),
@@ -89,6 +130,24 @@ format_query_syntax_errors(Errors) ->
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
-%% specific unit tests are in riak_kv_qry_{worker,queue}.erl
+describe_table_columns_test() ->
+    {ok, DDL} =
+        riak_ql_parser:parse(
+          riak_ql_lexer:get_tokens(
+            "CREATE TABLE fafa ("
+            " f varchar   not null,"
+            " s varchar   not null,"
+            " t timestamp not null,"
+            " w sint64    not null,"
+            " p double,"
+            " PRIMARY KEY ((f, s, quantum(t, 15, m)), "
+            " f, s, t))")),
+    ?assertEqual(
+       describe_table_columns(DDL),
+       {ok, [[<<"f">>, <<"varchar">>,   false, 1,  1],
+             [<<"s">>, <<"varchar">>,   false, 2,  2],
+             [<<"t">>, <<"timestamp">>, false, 3,  3],
+             [<<"w">>, <<"sint64">>, false, undefined, undefined],
+             [<<"p">>, <<"double">>, true,  undefined, undefined]]}).
 
 -endif.


### PR DESCRIPTION
RTS-568

Depends on ~~https://github.com/basho/riak_pb/pull/174~~ https://github.com/basho/riak_ql/pull/70.

Support DDL schema export (aka DESCRIBE TABLE), as defined in https://docs.google.com/document/d/1tWR2_w0seowNBWlGe1fzK4Po9SiOOaJrWIuviO2ljpQ, section 5.b.vii.
