### PR TITLE
enable table creation via sql statement

### DIFF
--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -478,7 +478,7 @@ get_standard_ddl() ->
 get_ddl(SQL) ->
     Lexed = riak_ql_lexer:get_tokens(SQL),
     {ok, DDL} = riak_ql_parser:parse(Lexed),
-    {module, _Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, _Module} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     DDL.
 
 get_standard_pk() ->

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -25,6 +25,7 @@
 -module(riak_kv_ts_util).
 
 -export([maybe_parse_table_def/2,
+         apply_timeseries_bucket_props/2,
          encode_typeval_key/1]).
 
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").


### PR DESCRIPTION
RTS-783.

This enables clients to just go riakc_ts:query("CREATE TABLE ..."). **Edit:** Now with table activation.

A riak_test module is in https://github.com/basho/riak_test/pull/965.

Note, however, that

(1) there is no way to provide a non-default n_val for the newly
    created table;
(2) security procedures are yet to be defined for this operation:
    ("So, a bucket type can be created via a client, but no one would
    have access to it (if security is enabled)").
