### PR TITLE
Major refactor of Query Worker for timeseries 1.1

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -3,6 +3,8 @@ riak_core_pb.erl
 Callback info about the riak_core_vnode_worker behaviour is not available
 Callback info about the riak_core_coverage_fsm behaviour is not available
 Callback info about the riak_kv_backend behaviour is not available
+The created fun has no local return
+Function select_column_clause_folder/3 has no local return
 Unknown functions:
   cluster_info:dump_all_connected/1
   cluster_info:dump_nodes/2

--- a/rebar.config
+++ b/rebar.config
@@ -35,6 +35,6 @@
         {riak_api,         ".*", {git, "git://github.com/basho/riak_api.git",          {branch, "end-to-end/timeseries"}}},
         {riak_dt,          ".*", {git, "git://github.com/basho/riak_dt.git",           {branch, "develop"}}},
         {msgpack,          ".*", {git, "git://github.com/msgpack/msgpack-erlang.git",  {tag,    "0.3.5"}}},
-        {riak_ql,          ".*", {git, "git@github.com:basho/riak_ql.git",             {branch, "ts1.1/timeseries"}}},
+        {riak_ql,          ".*", {git, "git@github.com:basho/riak_ql.git",             {branch, "develop"}}},
         {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag,    "0.1.2"}}}
        ]}.

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -381,7 +381,7 @@ validate_rows(Mod, Rows) ->
         end
     end,
 
-    {_, BadRowIdxs} = lists:foldl(ValidateFn, {0,[]}, Rows),
+    {_, BadRowIdxs} = lists:foldl(ValidateFn, {1, []}, Rows),
     BadRowIdxs.
 
 -spec make_rpberrresp(integer(), string()) -> #rpberrorresp{}.

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -598,9 +598,7 @@ make_ts_keys(CompoundKey, DDL = #ddl_v1{local_key = #key_v1{ast = LKParams},
 %% ---------------------------------------------------
 % functions supporting SELECT
 
--spec make_tsqueryresp([{binary(), term()}]) -> #tsqueryresp{}.
-make_tsqueryresp([]) ->
-    #tsqueryresp{columns = [], rows = []};
+-spec make_tsqueryresp({[binary()], [simple_field_type()], [any()]}) -> #tsqueryresp{}.
 make_tsqueryresp({ColumnNames, ColumnTypes, JustRows}) ->
     #tsqueryresp{columns = make_tscolumndescription_list(ColumnNames, ColumnTypes),
                  rows = riak_pb_ts_codec:encode_rows(ColumnTypes, JustRows)}.
@@ -612,7 +610,8 @@ make_describe_response(DescribeTableRows) ->
     #tsqueryresp{columns = make_tscolumndescription_list(ColumnNames, ColumnTypes),
                  rows = riak_pb_ts_codec:encode_rows(ColumnTypes, DescribeTableRows)}.
 
--spec get_column_types(list(binary()), module()) -> list(riak_pb_ts_codec:tscolumntype()).
+-spec get_column_types(list(binary()), module()) ->
+            [{binary(), riak_pb_ts_codec:tscolumntype()}].
 get_column_types(ColumnNames, Mod) ->
     [{N, Mod:get_field_type(N)} || N <- ColumnNames].
 

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -381,7 +381,7 @@ validate_rows(Mod, Rows) ->
         end
     end,
 
-    {_, BadRowIdxs} = lists:foldl(ValidateFn, {1, []}, Rows),
+    {_, BadRowIdxs} = lists:foldl(ValidateFn, {0,[]}, Rows),
     BadRowIdxs.
 
 -spec make_rpberrresp(integer(), string()) -> #rpberrorresp{}.

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -32,7 +32,7 @@
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 -spec submit(string() | #riak_sql_v1{} | #riak_sql_describe_v1{}, #ddl_v1{}) ->
-    {ok, [{Key::binary(), riak_pb_ts_codec:ldbvalue()}]} | {error, any()}.
+    {ok, any()} | {error, any()}.
 %% @doc Parse, validate against DDL, and submit a query for execution.
 %%      To get the results of running the query, use fetch/1.
 submit(SQLString, DDL) when is_list(SQLString) ->

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -31,7 +31,7 @@
 
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
--spec submit(string() | #riak_sql_v1{}, #ddl_v1{}) ->
+-spec submit(string() | #riak_sql_v1{} | #riak_sql_describe_v1{}, #ddl_v1{}) ->
     {ok, [{Key::binary(), riak_pb_ts_codec:ldbvalue()}]} | {error, any()}.
 %% @doc Parse, validate against DDL, and submit a query for execution.
 %%      To get the results of running the query, use fetch/1.
@@ -43,8 +43,49 @@ submit(SQLString, DDL) when is_list(SQLString) ->
         {ok, SQL} ->
             submit(SQL, DDL)
     end;
-submit(SQL, DDL) ->
+
+submit(#riak_sql_describe_v1{}, DDL) ->
+    describe_table_columns(DDL);
+
+submit(SQL = #riak_sql_v1{}, DDL) ->
     maybe_submit_to_queue(SQL, DDL).
+
+%% ---------------------
+%% local functions
+
+-spec describe_table_columns(#ddl_v1{}) ->
+                                    {ok, [[binary() | boolean() | integer() | undefined]]}.
+describe_table_columns(#ddl_v1{fields = FieldSpecs,
+                               partition_key = #key_v1{ast = PKSpec},
+                               local_key     = #key_v1{ast = LKSpec}}) ->
+    {ok,
+     [[Name, list_to_binary(atom_to_list(Type)), Nullable,
+       column_pk_position_or_blank(Name, PKSpec),
+       column_lk_position_or_blank(Name, LKSpec)]
+      || #riak_field_v1{name = Name,
+                        type = Type,
+                        optional = Nullable} <- FieldSpecs]}.
+
+%% the following two functions are identical, for the way fields and
+%% keys are represented as of 2015-12-18; duplication here is a hint
+%% of things to come.
+-spec column_pk_position_or_blank(binary(), [#param_v1{}]) -> integer() | undefined.
+column_pk_position_or_blank(Col, KSpec) ->
+    count_to_position(Col, KSpec, 1).
+
+-spec column_lk_position_or_blank(binary(), [#param_v1{}]) -> integer() | undefined.
+column_lk_position_or_blank(Col, KSpec) ->
+    count_to_position(Col, KSpec, 1).
+
+count_to_position(_, [], _) ->
+    undefined;
+count_to_position(Col, [#param_v1{name = [Col]} | _], Pos) ->
+    Pos;
+count_to_position(Col, [#hash_fn_v1{args = [#param_v1{name = [Col]} | _]} | _], Pos) ->
+    Pos;
+count_to_position(Col, [_ | Rest], Pos) ->
+    count_to_position(Col, Rest, Pos + 1).
+
 
 maybe_submit_to_queue(SQL, #ddl_v1{table = BucketType} = DDL) ->
     Mod = riak_ql_ddl:make_module_name(BucketType),
@@ -89,6 +130,24 @@ format_query_syntax_errors(Errors) ->
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
-%% specific unit tests are in riak_kv_qry_{worker,queue}.erl
+describe_table_columns_test() ->
+    {ok, DDL} =
+        riak_ql_parser:parse(
+          riak_ql_lexer:get_tokens(
+            "CREATE TABLE fafa ("
+            " f varchar   not null,"
+            " s varchar   not null,"
+            " t timestamp not null,"
+            " w sint64    not null,"
+            " p double,"
+            " PRIMARY KEY ((f, s, quantum(t, 15, m)), "
+            " f, s, t))")),
+    ?assertEqual(
+       describe_table_columns(DDL),
+       {ok, [[<<"f">>, <<"varchar">>,   false, 1,  1],
+             [<<"s">>, <<"varchar">>,   false, 2,  2],
+             [<<"t">>, <<"timestamp">>, false, 3,  3],
+             [<<"w">>, <<"sint64">>, false, undefined, undefined],
+             [<<"p">>, <<"double">>, true,  undefined, undefined]]}).
 
 -endif.

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -478,7 +478,7 @@ get_standard_ddl() ->
 get_ddl(SQL) ->
     Lexed = riak_ql_lexer:get_tokens(SQL),
     {ok, DDL} = riak_ql_parser:parse(Lexed),
-    {module, _Module} = riak_ql_ddl_compiler:make_helper_mod(DDL),
+    {module, _Module} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     DDL.
 
 get_standard_pk() ->

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -72,8 +72,8 @@ expand_query(#ddl_v1{local_key = LK, partition_key = PK},
     end.
 
 %% Run the selection spec for all selection columns that was created by
--spec run_select(SelectionSpec::[compiled_select()], Row::riak_object:value()) ->
-                        riak_object:value().
+-spec run_select(SelectionSpec::[compiled_select()], Row::any()) ->
+                        any().
 run_select(Select, Row) ->
     %% the second argument is the state, if we're return row query results then
     %% there is no long running state
@@ -160,6 +160,7 @@ select_column_clause_folder(DDL, ColX, {TypeSet1, SelClause1}) ->
     {TypeSet2, SelClause2}.
 
 %%
+-spec get_col_names(#ddl_v1{}, #riak_sql_v1{}) -> [binary()].
 get_col_names(DDL, Q) ->
     ColNames = riak_ql_to_string:col_names_from_select(Q),
     % flatten because * gets expanded to multiple columns
@@ -1598,22 +1599,22 @@ function_2_initial_state_test() ->
         Select
     ).
 
-% FIXME
 % basic_select_window_agg_fn_arith_1_test() ->
-%     DDL = get_sel_ddl(),
-%     SQL = "SELECT count(location) + 1 from mytab WHERE myfamily = 'familyX' and myseries = 'seriesX' and time > 1 and time < 2",
-%     {ok, Rec} = get_query(SQL),
-%     {ok, Sel} = compile_select_clause(DDL, Rec),
-%     ?assertMatch(#riak_sel_clause_v1{calc_type        = aggregate,
-%                                      col_return_types = [
-%                                                          sint64
-%                                                         ],
-%                                      col_names        = [
-%                                                          <<"COUNT(location)+1">>
-%                                                         ]
-%                                     },
-%                  Sel).
+%     {ok, Rec} = get_query(
+%         "SELECT count(location) + 1 from mytab "
+%         "WHERE myfamily = 'familyX' "
+%         "AND myseries = 'seriesX' AND time > 1 AND time < 2"
+%     ),
+%     {ok, Selection} = compile_select_clause(get_sel_ddl(), Rec),
+%     ?assertMatch(
+%         #riak_sel_clause_v1{
+%             calc_type = aggregate,
+%             col_return_types = [sint64],
+%             col_names = [<<"COUNT(location)+1">>] },
+%         Selection
+%     ).
 
+% FIXME
 %% basic_select_window_agg_fn_arith_2_test() ->
 %%     DDL = get_sel_ddl(),
 %%     SQL = "SELECT count(location + 1.0) from mytab WHERE myfamily = 'familyX' and myseries = 'seriesX' and time > 1 and time < 2",

--- a/src/riak_kv_ts_newtype.erl
+++ b/src/riak_kv_ts_newtype.erl
@@ -26,6 +26,7 @@
 %% API.
 -export([start_link/0]).
 -export([new_type/1]).
+-export([retrieve_ddl_from_metadata/1]).
 
 %% gen_server.
 -export([init/1]).
@@ -187,7 +188,7 @@ ddl_ebin_directory() ->
 %% Would be nice to have a function in riak_core_bucket_type or
 %% similar to get either the prefix or the actual metadata instead
 %% of including a riak_core header file for this prefix
-retrieve_ddl_from_metadata(BucketType) ->
+retrieve_ddl_from_metadata(BucketType) when is_binary(BucketType) ->
     retrieve_ddl_2(riak_core_metadata:get(?BUCKET_TYPE_PREFIX, BucketType,
                                           [{allow_put, false}])).
 

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -25,6 +25,7 @@
 -module(riak_kv_ts_util).
 
 -export([maybe_parse_table_def/2,
+         apply_timeseries_bucket_props/2,
          encode_typeval_key/1]).
 
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").


### PR DESCRIPTION
Support window aggregate functions in riak_kv, such as the following:

``` sql
SELECT count(*) FROM mytable
WHERE time > 1234560 AND time < 1234570 AND myfamily = 'family1' AND myseries = 'series1'
```

Run in the erlang shell using the erlang riak client looks like the following:

``` erlang
120> riakc_ts:query(Pid, "select count(myseries) from GeoCheckin where time > 1234560 and time < 1234570 and myfamily = 'family1' and myseries = 'series1'").   
{[<<"aggregate">>],[{3}]}
```

One current limitation is that all return column names are `<<"aggregate">>` and all column return types are `sint64`.  Column names will eventually be the selection e.g. `count(*)` in this case and the correct return type will be returned for that function by checking the type signature in riak_ql.
