### PR TITLE
💀WIP 💀: Feature/rts 759

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -482,7 +482,7 @@ init([Index]) ->
                 true ->
                     erlang:function_exported(Mod, async_put, 5);
                 _ ->
-                    erlang:function_exported(Mod, sync_put, 5)
+		    false
             end,
             State = #state{idx=Index,
                            async_folding=AsyncFolding,


### PR DESCRIPTION
Performance improvements for TS1.0 left this code in a weird state.  The code had defaulted to allow_async_put=true, and we modified the async put path to do fast synchronous writes instead.

This created a situation where allow_async_put=true actually called down to eleveldb:sync_put to do synchronous writes, and allow_async_put=false called down to eleveldb:put, which is a sort-of synchronous put.  

This PR attempts to correct the logic controlling synchronous puts, so that:

1) the version of handle_command(?KV_W1C_PUT_REQ...) called when allow_async_put=false causes the code to call eleveldb:sync_put, which does the most performant synchronous writes

2) the version of handle_command(?KV_W1C_PUT_REQ...) called when allow_async_put=true causes the code to call eleveldb:async_put (the old default behavior), which does less-performant asynchronous writes

3) allow_async_put defaults to false, so that the most performant behavior is now the default

NB: these changes were coupled with removal of the vnode stats update, which was found to consume an inordinate amount of the put-path time.  The async_put path in this version is unmodified, and relies on eleveldb to send a reply, handled in handle_info({{w1c_async_put,...}}) which updates vnode stats, and generates the ?KV_W1C_PUT_REPLY.  The sync_put path in this version bypasses the vnode stats update and generates the ?KV_W1C_PUT_REPLY directly.
