### PR TITLE
Perf/ttb newmsg ts1.0 release candidate v2

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -38,7 +38,7 @@
                    {riak_kv_pb_counter, 50, 53}, %% counter requests
                    {riak_kv_pb_coverage, 70, 71}, %% coverage requests
                    {riak_kv_pb_crdt, 80, 83}, %% CRDT requests
-                   {riak_kv_pb_timeseries, 90, 99} %% time series requests
+                   {riak_kv_pb_timeseries, 90, 100} %% time series requests
                   ]).
 -define(MAX_FLUSH_PUT_FSM_RETRIES, 10).
 

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -38,7 +38,7 @@
                    {riak_kv_pb_counter, 50, 53}, %% counter requests
                    {riak_kv_pb_coverage, 70, 71}, %% coverage requests
                    {riak_kv_pb_crdt, 80, 83}, %% CRDT requests
-                   {riak_kv_pb_timeseries, 90, 100} %% time series requests
+                   {riak_kv_pb_timeseries, 90, 104} %% time series requests
                   ]).
 -define(MAX_FLUSH_PUT_FSM_RETRIES, 10).
 

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -122,70 +122,48 @@ encode(Message) ->
     {ok, riak_pb_codec:encode(Message)}.
 
 
+-spec process_tsreq(atom() | #tsputreq{} | #tsputreqttb{}, term(), #state{}) ->
+{reply, #tsqueryresp{} | #rpberrorresp{}, #state{}}.
+process_tsreq(#tsputreq{table = Table, columns = _Columns, rows = _Rows}, Data, State) ->
+  Mod = riak_ql_ddl:make_module_name(Table),
+
+  case (catch validate_rows(Mod, Data)) of
+    [] ->
+      try
+        case put_data(Data, Table, Mod) of
+          0 ->
+            {reply, #tsputresp{}, State};
+          ErrorCount ->
+            EPutMessage = flat_format("Failed to put ~b record(s)", [ErrorCount]),
+            {reply, make_rpberrresp(?E_PUT, EPutMessage), State}
+        end
+      catch
+        Class:Exception ->
+          lager:error("error: ~p:~p~n~p", [Class,Exception,erlang:get_stacktrace()]),
+          Error = make_rpberrresp(?E_IRREG, to_string({Class, Exception})),
+          {reply, Error, State}
+      end;
+    BadRowIdxs when is_list(BadRowIdxs) ->
+      {reply, validate_rows_error_response(BadRowIdxs), State};
+    {_, {undef, _}} ->
+      BucketProps = riak_core_bucket:get_bucket(table_to_bucket(Table)),
+      {reply, missing_helper_module(Table, BucketProps), State}
+  end.
+
 -spec process(atom() | #tsputreq{} | #tsputreqttb{} | #tsdelreq{} | #tsgetreq{} | #tslistkeysreq{}
               | #ddl_v1{} | ?SQL_SELECT{} | #riak_sql_describe_v1{}, #state{}) ->
                      {reply, #tsqueryresp{} | #rpberrorresp{}, #state{}}.
 process(#tsputreq{rows = []}, State) ->
     {reply, #tsputresp{}, State};
-process(#tsputreq{table = Table, columns = _Columns, rows = Rows}, State) ->
-    Mod = riak_ql_ddl:make_module_name(Table),
+process(#tsputreq{rows = Rows} = Req, State) ->
     Data = riak_pb_ts_codec:decode_rows(Rows),
-
-    case (catch validate_rows(Mod, Data)) of
-        [] ->
-            try
-                case put_data(Data, Table, Mod) of
-                    0 ->
-                        {reply, #tsputresp{}, State};
-                    ErrorCount ->
-                        EPutMessage = flat_format("Failed to put ~b record(s)", [ErrorCount]),
-                        {reply, make_rpberrresp(?E_PUT, EPutMessage), State}
-                end
-            catch
-                Class:Exception ->
-                    lager:error("error: ~p:~p~n~p", [Class,Exception,erlang:get_stacktrace()]),
-                    Error = make_rpberrresp(?E_IRREG, to_string({Class, Exception})),
-                    {reply, Error, State}
-            end;
-        BadRowIdxs when is_list(BadRowIdxs) ->
-            {reply, validate_rows_error_response(BadRowIdxs), State};
-        {_, {undef, _}} ->
-            BucketProps = riak_core_bucket:get_bucket(table_to_bucket(Table)),
-            {reply, missing_helper_module(Table, BucketProps), State}
-    end;
+    process_tsreq(Req, Data, State);
 
 process(#tsputreqttb{rows = []}, State) ->
     {reply, #tsputresp{}, State};
-process(#tsputreqttb{table = Table, columns = _Columns, rows = Rows}, State) ->
-
-    Mod = riak_ql_ddl:make_module_name(Table),
+process(#tsputreqttb{rows = Rows} = Req, State) ->
     Data = Rows,
-
-    %% validate only the first row as we trust the client to send us
-    %% perfectly uniform data wrt types and order
-    case (catch Mod:validate_obj(hd(Data))) of
-        true ->
-            %% however, prevent bad data to crash us
-            try
-                case put_data(Data, Table, Mod) of
-                    0 ->
-                        {reply, #tsputresp{}, State};
-                    ErrorCount ->
-                        EPutMessage = flat_format("Failed to put ~b record(s)", [ErrorCount]),
-                        {reply, make_rpberrresp(?E_PUT, EPutMessage), State}
-                end
-            catch
-                Class:Exception ->
-                    lager:error("error: ~p:~p~n~p", [Class,Exception,erlang:get_stacktrace()]),
-                    Error = make_rpberrresp(?E_IRREG, to_string({Class, Exception})),
-                    {reply, Error, State}
-            end;
-        false ->
-            {reply, make_rpberrresp(?E_IRREG, "Invalid data"), State};
-        {_, {undef, _}} ->
-            BucketProps = riak_core_bucket:get_bucket(table_to_bucket(Table)),
-            {reply, missing_helper_module(Table, BucketProps), State}
-    end;
+    process_tsreq(Req, Data, State);
 
 process(#tsgetreq{table = Table, key = PbCompoundKey,
                   timeout = Timeout},

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -84,7 +84,7 @@ init() ->
 
 
 -spec decode(integer(), binary()) ->
-                    {ok, #tsputreq{} | #tsttbputreq{} | #tsdelreq{} | #tsgetreq{} | #tslistkeysreq{}
+                    {ok, #tsputreq{} | #tsputreqttb{} | #tsdelreq{} | #tsgetreq{} | #tslistkeysreq{}
                      | #ddl_v1{} | ?SQL_SELECT{} | #riak_sql_describe_v1{},
                      {PermSpec::string(), Table::binary()}} |
                     {error, _}.
@@ -105,7 +105,7 @@ decode(Code, Bin) ->
             {ok, Msg, {"riak_kv.ts_get", Table}};
         #tsputreq{table = Table} ->
             {ok, Msg, {"riak_kv.ts_put", Table}};
-        #tsttbputreq{table = Table} ->
+        #tsputreqttb{table = Table} ->
             {ok, Msg, {"riak_kv.ts_put", Table}};
         #tsdelreq{table = Table} ->
             {ok, Msg, {"riak_kv.ts_del", Table}};
@@ -119,7 +119,7 @@ encode(Message) ->
     {ok, riak_pb_codec:encode(Message)}.
 
 
--spec process(atom() | #tsputreq{} | #tsttbputreq{} | #tsdelreq{} | #tsgetreq{} | #tslistkeysreq{}
+-spec process(atom() | #tsputreq{} | #tsputreqttb{} | #tsdelreq{} | #tsgetreq{} | #tslistkeysreq{}
               | #ddl_v1{} | ?SQL_SELECT{} | #riak_sql_describe_v1{}, #state{}) ->
                      {reply, #tsqueryresp{} | #rpberrorresp{}, #state{}}.
 process(#tsputreq{rows = []}, State) ->
@@ -151,9 +151,9 @@ process(#tsputreq{table = Table, columns = _Columns, rows = Rows}, State) ->
             {reply, missing_helper_module(Table, BucketProps), State}
     end;
 
-process(#tsttbputreq{rows = []}, State) ->
+process(#tsputreqttb{rows = []}, State) ->
     {reply, #tsputresp{}, State};
-process(#tsttbputreq{table = Table, columns = _Columns, rows = Rows}, State) ->
+process(#tsputreqttb{table = Table, columns = _Columns, rows = Rows}, State) ->
 
     Mod = riak_ql_ddl:make_module_name(Table),
     Data = Rows,

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -124,7 +124,7 @@ encode(Message) ->
 
 -spec process_tsreq(atom() | #tsputreq{} | #tsttbputreq{}, term(), #state{}) ->
 {reply, #tsqueryresp{} | #rpberrorresp{}, #state{}}.
-process_tsreq(#tsputreq{table = Table, columns = _Columns, rows = _Rows}, Data, State) ->
+process_tsreq(Table, Data, State) ->
   Mod = riak_ql_ddl:make_module_name(Table),
 
   case (catch validate_rows(Mod, Data)) of
@@ -155,15 +155,15 @@ process_tsreq(#tsputreq{table = Table, columns = _Columns, rows = _Rows}, Data, 
                      {reply, #tsqueryresp{} | #rpberrorresp{}, #state{}}.
 process(#tsputreq{rows = []}, State) ->
     {reply, #tsputresp{}, State};
-process(#tsputreq{rows = Rows} = Req, State) ->
+process(#tsputreq{table=Table, rows = Rows}, State) ->
     Data = riak_pb_ts_codec:decode_rows(Rows),
-    process_tsreq(Req, Data, State);
+    process_tsreq(Table, Data, State);
 
 process(#tsttbputreq{rows = []}, State) ->
     {reply, #tsputresp{}, State};
-process(#tsttbputreq{rows = Rows} = Req, State) ->
+process(#tsttbputreq{table = Table, rows = Rows}, State) ->
     Data = Rows,
-    process_tsreq(Req, Data, State);
+    process_tsreq(Table, Data, State);
 
 process(#tsgetreq{table = Table, key = PbCompoundKey,
                   timeout = Timeout},

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -122,7 +122,7 @@ encode(Message) ->
     {ok, riak_pb_codec:encode(Message)}.
 
 
--spec process_tsreq(atom() | #tsputreq{} | #tsttbputreq{}, term(), #state{}) ->
+-spec process_tsreq(binary(), term(), #state{}) ->
 {reply, #tsqueryresp{} | #rpberrorresp{}, #state{}}.
 process_tsreq(Table, Data, State) ->
   Mod = riak_ql_ddl:make_module_name(Table),


### PR DESCRIPTION
This is one of three related PRs (https://github.com/basho/riak_pb/pull/176 is the corresponding one for riak_pb, https://github.com/basho/riak-erlang-client/pull/259 is the corresponding one for riakc) to streamline put requests using TTB encoding instead of PB.
As with the current end-to-end/timeseries branch, the TTB encoded messages are still handled by the riak_kv_pb service; even though they are not PB-encoded messages, they reuse the erlang infrastructure around generating erlang messages from the .proto definitions.

Changes here are:

1) extend the riak_kv_pb_timeseries registration to handle MsgCodes 90-100, where 100 is the new streamlined message

2) add a case statement to decode(), switching on the new message type (tsputreqttb)

3) add new process() variants to handle the new message type

NB: This branch will fail to build unless rebar.config is modified to pick up the same branch of riak_pb.  I didn't want to commit that change, because as JD has pointed out, that risks merging into the mainline
