### PR TITLE
Obsolete: Support aggregation functions and arithmetic RTS-848

### DIFF
--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -80,9 +80,10 @@ expand_query(#ddl_v1{local_key = LK, partition_key = PK},
             {ok, SubQueries}
     end.
 
-%%
-
-finalise_aggregate(#riak_sel_clause_v1{ finalisers = FinaliserFns }, Row) ->
+%% Calulate the final result for an aggregate.
+-spec finalise_aggregate(#riak_sel_clause_v1{}, [any()]) -> [any()].
+finalise_aggregate(#riak_sel_clause_v1{ calc_type = aggregate,
+                                        finalisers = FinaliserFns }, Row) ->
     finalise_aggregate2(FinaliserFns, Row, Row).
 
 %%
@@ -154,7 +155,7 @@ compile_select_clause(DDL, ?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{ clause = 
 -spec get_col_names(#ddl_v1{}, ?SQL_SELECT{}) -> [binary()].
 get_col_names(DDL, Q) ->
     ColNames = riak_ql_to_string:col_names_from_select(Q),
-    % flatten because * gets expanded to multiple columns
+    %% flatten because * gets expanded to multiple columns
     lists:flatten(
       [get_col_names2(DDL, N) || N <- ColNames]
     ).
@@ -182,7 +183,7 @@ get_col_names2(_, Name) ->
                 {set(), #riak_sel_clause_v1{}}.
 select_column_clause_folder(DDL, ColAST1, 
                             {TypeSet1, #riak_sel_clause_v1{ finalisers = Finalisers } = SelClause}) ->
-    % extract the stateful functions then treat them as separate select columns
+    %% extract the stateful functions then treat them as separate select columns
     LenFinalisers = length(Finalisers),
     case extract_stateful_functions(ColAST1, LenFinalisers) of
         {ColAST2, []} ->
@@ -220,8 +221,8 @@ select_column_clause_exploded_folder(DDL, {ColAst, Finaliser}, {TypeSet1, SelCla
     RunFn2  = RunFnX ++ [S#single_sel_column.clause],
     Finalisers2 = Finalisers1 ++ [Finaliser],
     IsValid2 = merge_validation(S#single_sel_column.is_valid, IsValid1),
-    % ColTypes are messy because <<"*">> represents many
-    % so you need to flatten the list
+    %% ColTypes are messy because <<"*">> represents many
+    %% so you need to flatten the list
     SelClause2 = #riak_sel_clause_v1{
                     initial_state    = Init2,
                     col_return_types = lists:flatten(ColRet2),
@@ -234,7 +235,7 @@ select_column_clause_exploded_folder(DDL, {ColAst, Finaliser}, {TypeSet1, SelCla
 %% from the row.
 -spec compile_select_col(DDL::#ddl_v1{}, ColumnSpec::any()) ->
                                 #single_sel_column{}.
-compile_select_col(DDL, {{window_agg_fn, FnName}, [FnArg1]}) ->
+compile_select_col(DDL, {{window_agg_fn, FnName}, [FnArg1]}) when is_atom(FnName) ->
     case riak_ql_window_agg_fns:start_state(FnName) of
         stateless ->
             {ColTypes1, IsValid1, Fn} = compile_select_col_stateless(DDL, FnArg1),
@@ -265,7 +266,7 @@ compile_select_col(DDL, {{window_agg_fn, FnName}, [FnArg1]}) ->
     end;
 compile_select_col(DDL, Select) ->
     {ColTypes, IsValid, Fn} = compile_select_col_stateless(DDL, Select),
-    % Finalisers = lists:duplicate(length(ColTypes), fun(State) -> State end),
+    %% Finalisers = lists:duplicate(length(ColTypes), fun(State) -> State end),
     #single_sel_column{ calc_type        = rows,
                         initial_state    = undefined,
                         col_return_types = ColTypes,
@@ -302,11 +303,18 @@ compile_select_col_stateless(_, {Type, V}) when Type == float ->
     %% TODO ditto float and double
     {[double], true, fun(_,_) -> V end};
 compile_select_col_stateless(_, {return_state, N}) when is_integer(N) ->
-    % FIXME calculate type
-    {[sint64], true, fun(Row,_) -> lists:nth(N, Row) end};
+    %% FIXME calculate type
+    {[sint64], true, fun(Row,_) -> pull_from_row(N, Row) end};
+compile_select_col_stateless(_, {finalise_aggregation, FnName, N}) ->
+    FinaliseFn =
+        fun(Row,_) ->
+            ColValue = pull_from_row(N, Row),
+            riak_ql_window_agg_fns:finalise(FnName, ColValue)
+        end,
+    {[sint64], true, FinaliseFn};
 compile_select_col_stateless(#ddl_v1{ fields = Fields }, {identifier, ColumnName}) ->
     {Index, Type} = col_index_and_type_of(Fields, to_column_name_binary(ColumnName)),
-    {[Type], true, fun(Row,_) -> lists:nth(Index, Row) end};
+    {[Type], true, fun(Row,_) -> pull_from_row(Index, Row) end};
 compile_select_col_stateless(DDL, {Op, A, B}) ->
     {Ta, IsValida, Arg_a} = compile_select_col_stateless(DDL, A),
     {Tb, IsValidb, Arg_b} = compile_select_col_stateless(DDL, B),
@@ -322,6 +330,10 @@ compile_select_col_stateless(DDL, {Op, A, B}) ->
     end.
 
 %%
+pull_from_row(N, Row) ->
+    lists:nth(N, Row).
+
+%%
 -spec extract_stateful_functions(selection(), integer()) ->
         {selection() | {return_state, integer()}, [selection_function()]}.
 extract_stateful_functions(Selection1, FinaliserLen) when is_integer(FinaliserLen) ->
@@ -330,7 +342,7 @@ extract_stateful_functions(Selection1, FinaliserLen) when is_integer(FinaliserLe
 
 %% extract stateful functions from the selection
 -spec extract_stateful_functions2(selection(), integer(), [selection_function()]) ->
-        {selection() | {return_state, integer()}, [selection_function()]}.
+        {selection() | {finalise_aggregation, FnName::atom(), integer()}, [selection_function()]}.
 extract_stateful_functions2({Op, ArgA1, ArgB1}, FinaliserLen, Fns1) ->
     {ArgA2, Fns2} = extract_stateful_functions2(ArgA1, FinaliserLen, Fns1),
     {ArgB2, Fns3} = extract_stateful_functions2(ArgB1, FinaliserLen, Fns2),
@@ -339,9 +351,9 @@ extract_stateful_functions2({Tag, _} = Node, _, Fns)
         when Tag == identifier; Tag == sint64; Tag == integer; Tag == float;
              Tag == binary;     Tag == varchar; Tag == boolean; Tag == negate ->
     {Node, Fns};
-extract_stateful_functions2({{window_agg_fn, _}, _} = Function, FinaliserLen, Fns1) ->
+extract_stateful_functions2({{window_agg_fn, FnName}, _} = Function, FinaliserLen, Fns1) ->
     Fns2 = [Function | Fns1],
-    {{return_state, FinaliserLen + length(Fns2)}, Fns2}.
+    {{finalise_aggregation, FnName, FinaliserLen + length(Fns2)}, Fns2}.
 
 %% TODO rewrite so that all the operators are just functions
 %% then we can eliminate the double code for creating return types
@@ -772,6 +784,7 @@ modify_where_key(TupleList, Field, NewVal) ->
     lists:keyreplace(Field, 1, TupleList, {Field, FieldType, NewVal}).
 
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 
 %%
 %% Helper Fns for unit tests
@@ -1796,7 +1809,7 @@ extract_stateful_function_1_test() ->
     CountFn1 = {{window_agg_fn, 'COUNT'}, [{identifier, [<<"col1">>]}]},
     CountFn2 = {{window_agg_fn, 'COUNT'}, [{identifier, [<<"col2">>]}]},
     ?assertEqual(
-        {{'+', {return_state, 1}, {return_state, 2}}, [CountFn1,CountFn2]},
+        {{'+', {finalise_aggregation, 'COUNT', 1}, {finalise_aggregation, 'COUNT', 2}}, [CountFn1,CountFn2]},
         extract_stateful_functions(Select, 0)
     ).
 
@@ -1869,11 +1882,25 @@ count_plus_seven_sum_fsinalise_test() ->
         finalise_aggregate(Select, [1])
       ).
 
+avg_finalise_test() ->
+    {ok, Rec} = get_query(
+        "SELECT AVG(mydouble) FROM mytab"),
+    {ok, #riak_sel_clause_v1{ clause = [AvgFn] } = Select} =
+        compile_select_clause(get_sel_ddl(), Rec),
+    InitialState = riak_ql_window_agg_fns:start_state('AVG'),
+    Rows = [[x,x,x,x,N,x] || N <- lists:seq(1, 5)],
+    AverageResult = lists:foldl(AvgFn, InitialState, Rows),
+    ?assertEqual(
+        [lists:sum(lists:seq(1, 5)) / 5],
+        finalise_aggregate(Select, [AverageResult])
+    ).
+
 finalise_aggregate_test() ->
     ?assertEqual(
         [1,2,3],
         finalise_aggregate(
             #riak_sel_clause_v1 {
+                calc_type = aggregate,
                 finalisers = lists:duplicate(3, fun(_,S) -> S end) },
             [1,2,3]
         )

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -251,23 +251,15 @@ prepare_final_results(#riak_sel_clause_v1{calc_type = rows} = Select,
     %% sort by index, to reassemble according to coverage plan
     {_, R2} = lists:unzip(lists:sort(IndexedChunks)),
     prepare_final_results2(Select, lists:append(R2));
-prepare_final_results(#riak_sel_clause_v1{ calc_type = aggregate,
-                                           finalisers = FinaliserFns } = Select,
+prepare_final_results(#riak_sel_clause_v1{ calc_type = aggregate } = Select,
                       Aggregate1) ->
-    Aggregate2 = finalise_aggregate(Aggregate1, FinaliserFns, []),
+    Aggregate2 = riak_kv_qry_compiler:finalise_aggregate(Select, Aggregate1),
     prepare_final_results2(Select, [Aggregate2]).
 
 %%
 prepare_final_results2(#riak_sel_clause_v1{ col_return_types = ColTypes,
                                             col_names = ColNames}, Rows) ->
     {ColNames, ColTypes, Rows}.
-
-%%
-finalise_aggregate([], _, Acc) ->
-    lists:reverse(Acc);
-finalise_aggregate([Cell | Row], [CellFn | Fns], Acc) ->
-    FinalisedCell = CellFn(Cell),
-    finalise_aggregate(Row, Fns, [FinalisedCell | Acc]).
 
 %%%===================================================================
 %%% Unit tests


### PR DESCRIPTION
Support aggregation functions and arithmetic. For example.

``` sql
COUNT(foo) + 1
```

And

``` sql
COUNT(foo) + COUNT(bar)
```

Clauses like.

``` sql
COUNT(COUNT(foo))
```

Will not be supported.  Depends on riak_ql PR https://github.com/basho/riak_ql/pull/90 && https://github.com/basho/riak_ql/pull/93
