### PR TITLE
Fix memory leak in TimeRef ETS table in memory_backend [RIAK-1576]

### DIFF
--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -228,6 +228,8 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, State=#state{data_ref=DataRef,
             [{_BKey, {{ts, OldTimestamp}, _OldVal}}=OldObject] ->
                 %% prevents leak in the TimeRef table on update
                 delete_time_entry(TimeRef, OldTimestamp),
+                object_size(OldObject);
+            [OldObject] ->
                 object_size(OldObject)
         end,
     {ok, Size} = do_put(Bucket, PrimaryKey, Val1, IndexSpecs, DataRef, IndexRef),
@@ -799,6 +801,43 @@ regression_367_key_range_test_() ->
      ?_assertEqual({ok, [<<"obj01">>]}, fold_keys(Folder, [], [{index, Bucket, {eq, <<"$key">>, <<"obj01">>}}], State1)),
      ?_assertEqual(ok, stop(State1))
     ].
+
+ttl_ets_timeref_leak_put_path_test() ->
+    Config = [{ttl, 5}, {max_memory, 1024*10}], %% Need max_memory to get Timer, thus TimeRef
+    {ok, State} = start(142, Config),
+
+    Bucket = <<"Bucket">>,
+    Key = <<"Key">>,
+    Value = <<"Value">>,
+
+
+    %% Put an object, but ignore its put_obj_size
+    {ok, State1} = put(Bucket, Key, [], Value, State),
+    {ok, #state{time_ref=TimeRef} = State2} = put(Bucket, Key, [], Value, State1),
+    ?assertEqual(1, get_time_ref_count(TimeRef)),
+    {ok, _State3} = put(Bucket, Key, [], Value, State2),
+    ?assertEqual(1, get_time_ref_count(TimeRef)).
+
+ttl_ets_timeref_leak_get_after_expiry_test() ->
+    Config = [{ttl, 1}, {max_memory, 1024*10}], %% Need max_memory to get Timer, thus TimeRef
+    {ok, State} = start(142, Config),
+
+    Bucket = <<"Bucket">>,
+    Key = <<"Key">>,
+    Value = <<"Value">>,
+
+
+    %% Put an object, but ignore its put_obj_size
+    {ok, State1} = put(Bucket, Key, [], Value, State),
+    {ok, #state{time_ref=TimeRef} = State2} = put(Bucket, Key, [], Value, State1),
+    ?assertEqual(1, get_time_ref_count(TimeRef)),
+    timer:sleep(timer:seconds(1)),
+    {error, not_found, _State3} = get(Bucket, Key, State2),
+    ?assertEqual(0, get_time_ref_count(TimeRef)).
+
+get_time_ref_count(TimeRef) ->
+    ets:info(TimeRef, size).
+
 
 -ifdef(EQC).
 

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -185,10 +185,7 @@ get(Bucket, Key, State=#state{data_ref=DataRef,
                     ets:delete(DataRef, {Bucket, Key}),
                     ets:match_delete(IndexRef, ?DELETE_PTN(Bucket, Key)),
                     %% prevents leak in the TimeRef table on expire
-                    case TimeRef of
-                      undefined -> ok;
-                      _ -> ets:delete(TimeRef, Timestamp)
-                    end,
+                    delete_time_entry(TimeRef, Timestamp),
                     case MaxMemory of
                         undefined ->
                             UsedMemory1 = UsedMemory;
@@ -230,10 +227,7 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, State=#state{data_ref=DataRef,
                 0;
             [{_BKey, {{ts, OldTimestamp}, _OldVal}}=OldObject] ->
                 %% prevents leak in the TimeRef table on update
-                case TimeRef of
-                    undefined -> ok;
-                    _ -> ets:delete(TimeRef, OldTimestamp)
-                end,
+                delete_time_entry(TimeRef, OldTimestamp),
                 object_size(OldObject)
         end,
     {ok, Size} = do_put(Bucket, PrimaryKey, Val1, IndexSpecs, DataRef, IndexRef),
@@ -663,6 +657,13 @@ update_indexes(Bucket, Key, [{add, Field, Value}|Rest], IndexRef) ->
 %% @private
 time_entry(Bucket, Key, Now, TimeRef) ->
     ets:insert(TimeRef, {Now, {Bucket, Key}}).
+
+%% @private
+delete_time_entry(TimeRef, Timestamp) ->
+    case TimeRef of
+      undefined -> ok;
+      _ -> ets:delete(TimeRef, Timestamp)
+    end.
 
 %% @private
 %% @doc Dump some entries if the max memory size has


### PR DESCRIPTION
When using the max_memory setting in the memory backend, a list of timers is kept in ETS. In certain circumstances, these timer references were not deleted when the item had expired, or when a new value was put to the table.

This should resolve RIAK-1576 - needs to be merged forward to 2.1 once CI is complete and this is merged.

Thanks to @nerophon for finding and helping to fix this issue.
