### PR TITLE
Return an error when deleting a key that does not exist RTS-894

### DIFF
--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -58,6 +58,7 @@
 -define(E_BAD_QUERY,         1018).
 -define(E_TABLE_INACTIVE,    1019).
 -define(E_PARSE_ERROR,       1020).
+-define(E_DELETE_NOTFOUND,   1021).
 
 -define(FETCH_RETRIES, 10).  %% TODO make it configurable in tsqueryreq
 -define(TABLE_ACTIVATE_WAIT, 30). %% ditto
@@ -464,7 +465,7 @@ sub_tsdelreq(Mod, DDL, #tsdelreq{table = Table,
         {error, {bad_key_length, Got, Need}} ->
             {reply, key_element_count_mismatch(Got, Need), State};
         {error, notfound} ->
-            {reply, tsdelresp, State};
+            {reply, make_rpberrresp(?E_DELETE_NOTFOUND, "notfound"), State};
         {error, Reason} ->
             {reply, failed_delete_response(Reason), State}
     end.


### PR DESCRIPTION
Currently `ok` is returned when a single key delete is issued against a key that does not exist.

With this change `{error, {1021, <<"notfound">>}}` is returned instead. 1021 is a new error code for the case where the key does not exist.
