### PR TITLE
Add extra details to vnodeid warning for KV679  [JIRA: RIAK-2375]

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -2583,8 +2583,9 @@ maybe_new_key_epoch(true, State, LocalObj, IncomingObj) ->
                     B = riak_object:bucket(LocalObj),
                     K = riak_object:key(LocalObj),
 
-                    lager:error("Inbound clock entry for ~p in ~p/~p greater than local",
-                               [VId, B, K]),
+                    lager:warning("Inbound clock entry for ~p in ~p/~p greater than local." ++
+                                      "Epochs: {In:~p Local:~p}. Counters: {In:~p Local:~p}.",
+                                  [VId, B, K, InEpoch, LocalEpoch, InCntr, LocalCntr]),
                     new_key_epoch(State);
                 _ ->
                     %% just use local id


### PR DESCRIPTION
And downgrade the level to warn from error since the per-key-epoch code
stops this from being an error, merely a warning that something is
rotten in Denmark
