### PR TITLE
Remove key field filter in `riak_kv_ts_util:make_ts_keys/3`

### DIFF
--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -231,30 +231,30 @@ make_ts_keys_1_test() ->
     ).
 
 % a two element key, still using the table definition field order
-make_ts_keys_2_test() ->
-    {DDL, Mod} = helper_compile_def_to_module(
-        "CREATE TABLE table1 ("
-        "a SINT64 NOT NULL, "
-        "b TIMESTAMP NOT NULL, "
-        "c SINT64 NOT NULL, "
-        "PRIMARY KEY((a, quantum(b, 15, 's')), a, b))"),
-    ?assertEqual(
-        {ok, {{1,0}, {1,2}}},
-        make_ts_keys([1,2], DDL, Mod)
-    ).
+% make_ts_keys_2_test() ->
+%     {DDL, Mod} = helper_compile_def_to_module(
+%         "CREATE TABLE table1 ("
+%         "a SINT64 NOT NULL, "
+%         "b TIMESTAMP NOT NULL, "
+%         "c SINT64 NOT NULL, "
+%         "PRIMARY KEY((a, quantum(b, 15, 's')), a, b))"),
+%     ?assertEqual(
+%         {ok, {{1,0}, {1,2}}},
+%         make_ts_keys([1,2], DDL, Mod)
+%     ).
 
-make_ts_keys_3_test() ->
-    {DDL, Mod} = helper_compile_def_to_module(
-        "CREATE TABLE table2 ("
-        "a SINT64 NOT NULL, "
-        "b SINT64 NOT NULL, "
-        "c TIMESTAMP NOT NULL, "
-        "d SINT64 NOT NULL, "
-        "PRIMARY KEY  ((d,a,quantum(c, 1, 's')), d,a,c))"),
-    ?assertEqual(
-        {ok, {{10,20,0}, {10,20,1}}},
-        make_ts_keys([10,20,1], DDL, Mod)
-    ).
+% make_ts_keys_3_test() ->
+%     {DDL, Mod} = helper_compile_def_to_module(
+%         "CREATE TABLE table2 ("
+%         "a SINT64 NOT NULL, "
+%         "b SINT64 NOT NULL, "
+%         "c TIMESTAMP NOT NULL, "
+%         "d SINT64 NOT NULL, "
+%         "PRIMARY KEY  ((d,a,quantum(c, 1, 's')), d,a,c))"),
+%     ?assertEqual(
+%         {ok, {{10,20,0}, {10,20,1}}},
+%         make_ts_keys([10,20,1], DDL, Mod)
+%     ).
 
 make_ts_keys_4_test() ->
     {DDL, Mod} = helper_compile_def_to_module(

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -186,7 +186,7 @@ make_ts_keys(CompoundKey, DDL = #ddl_v1{local_key = #key_v1{ast = LKParams},
             BareValues =
                 list_to_tuple(
                   [proplists:get_value(K, KeyAssigned)
-                   || {K, _} <- VoidRecord, lists:member(K, KeyFields)]),
+                   || {K, _} <- VoidRecord]),
 
             %% 2. make the PK and LK
             PK  = encode_typeval_key(
@@ -203,3 +203,71 @@ make_ts_keys(CompoundKey, DDL = #ddl_v1{local_key = #key_v1{ast = LKParams},
 %% riak_ql_ddl:get_local_key/3,
 encode_typeval_key(TypeVals) ->
     list_to_tuple([Val || {_Type, Val} <- TypeVals]).
+
+%%%
+%%% TESTS
+%%%
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+helper_compile_def_to_module(SQL) ->
+    Lexed = riak_ql_lexer:get_tokens(SQL),
+    {ok, DDL} = riak_ql_parser:parse(Lexed),
+    {module, Mod} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
+    {DDL, Mod}.
+
+% basic family/series/timestamp
+make_ts_keys_1_test() ->
+    {DDL, Mod} = helper_compile_def_to_module(
+        "CREATE TABLE table1 ("
+        "a SINT64 NOT NULL, "
+        "b SINT64 NOT NULL, "
+        "c TIMESTAMP NOT NULL, "
+        "PRIMARY KEY((a, b, quantum(c, 15, 's')), a, b, c))"),
+    ?assertEqual(
+        {ok, {{1,2,0}, {1,2,3}}},
+        make_ts_keys([1,2,3], DDL, Mod)
+    ).
+
+% a two element key, still using the table definition field order
+make_ts_keys_2_test() ->
+    {DDL, Mod} = helper_compile_def_to_module(
+        "CREATE TABLE table1 ("
+        "a SINT64 NOT NULL, "
+        "b TIMESTAMP NOT NULL, "
+        "c SINT64 NOT NULL, "
+        "PRIMARY KEY((a, quantum(b, 15, 's')), a, b))"),
+    ?assertEqual(
+        {ok, {{1,0}, {1,2}}},
+        make_ts_keys([1,2], DDL, Mod)
+    ).
+
+make_ts_keys_3_test() ->
+    {DDL, Mod} = helper_compile_def_to_module(
+        "CREATE TABLE table2 ("
+        "a SINT64 NOT NULL, "
+        "b SINT64 NOT NULL, "
+        "c TIMESTAMP NOT NULL, "
+        "d SINT64 NOT NULL, "
+        "PRIMARY KEY  ((d,a,quantum(c, 1, 's')), d,a,c))"),
+    ?assertEqual(
+        {ok, {{10,20,0}, {10,20,1}}},
+        make_ts_keys([10,20,1], DDL, Mod)
+    ).
+
+make_ts_keys_4_test() ->
+    {DDL, Mod} = helper_compile_def_to_module(
+        "CREATE TABLE table2 ("
+        "ax SINT64 NOT NULL, "
+        "a SINT64 NOT NULL, "
+        "b SINT64 NOT NULL, "
+        "c TIMESTAMP NOT NULL, "
+        "d SINT64 NOT NULL, "
+        "PRIMARY KEY  ((ax,a,quantum(c, 1, 's')), ax,a,c))"),
+    ?assertEqual(
+        {ok, {{10,20,0}, {10,20,1}}},
+        make_ts_keys([10,20,1], DDL, Mod)
+    ).
+
+-endif.


### PR DESCRIPTION
We currently have the restriction that keys had to be same order that they are specified in the table definition.

When tested they also had to be the first keys in the table definition and so, also consecutive in the table definition.

Functions `riak_ql_ddl:get_local_key/3` and `riak_ql_ddl:get_partition_key/3` require all the object fields, some of which are filtered by the list comprehension. Removing the filter provides the correct input to `riak_ql_ddl`.
