### PR TITLE
HTTP client API for TS

### DIFF
--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -56,7 +56,7 @@
 -define(E_BAD_QUERY,         1018).
 -define(E_TABLE_INACTIVE,    1019).
 -define(E_PARSE_ERROR,       1020).
--define(E_DELETE_NOTFOUND,   1021).
+-define(E_NOTFOUND,          1021).
 
 -define(FETCH_RETRIES, 10).  %% TODO make it configurable in tsqueryreq
 -define(TABLE_ACTIVATE_WAIT, 30). %% ditto
@@ -304,7 +304,7 @@ sub_tsgetreq(Mod, _DDL, #tsgetreq{table = Table,
         {error, {bad_key_length, Got, Need}} ->
             {reply, key_element_count_mismatch(Got, Need), State};
         {error, notfound} ->
-            {reply, tsgetresp, State};
+            {reply, make_rpberrresp(?E_NOTFOUND, "notfound"), State};
         {error, Reason} ->
             {reply, make_rpberrresp(?E_GET, to_string(Reason)), State}
     end.
@@ -328,7 +328,7 @@ sub_tsdelreq(Mod, _DDL, #tsdelreq{table = Table,
         {error, {bad_key_length, Got, Need}} ->
             {reply, key_element_count_mismatch(Got, Need), State};
         {error, notfound} ->
-            {reply, make_rpberrresp(?E_DELETE_NOTFOUND, "notfound"), State};
+            {reply, make_rpberrresp(?E_NOTFOUND, "notfound"), State};
         {error, Reason} ->
             {reply, failed_delete_response(Reason), State}
     end.

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -334,13 +334,6 @@ sub_tsdelreq(Mod, _DDL, #tsdelreq{table = Table,
     end.
 
 
--spec make_tscolumndescription_list([binary()], [riak_pb_ts_codec:tscolumntype()]) ->
-                                           [#tscolumndescription{}].
-make_tscolumndescription_list(ColumnNames, ColumnTypes) ->
-    [#tscolumndescription{name = Name, type = riak_pb_ts_codec:encode_field_type(Type)}
-     || {Name, Type} <- lists:zip(ColumnNames, ColumnTypes)].
-
-
 %% -----------
 %% listkeys
 %% -----------
@@ -475,6 +468,8 @@ check_table_and_call(Table, Fun, TsMessage, State) ->
     case riak_kv_ts_util:get_table_ddl(Table) of
         {ok, Mod, DDL} ->
             Fun(Mod, DDL, TsMessage, State);
+        {error, no_type} ->
+            {reply, table_not_activated_response(Table), State};
         {error, missing_helper_module} ->
             BucketProps = riak_core_bucket:get_bucket(
                             riak_kv_ts_util:table_to_bucket(Table)),

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -266,10 +266,14 @@ sub_putreq_common(Mod, Table, Data, State) ->
     case catch riak_kv_ts_util:validate_rows(Mod, Data) of
         [] ->
             case riak_kv_ts_util:put_data(Data, Table, Mod) of
-                0 ->
+                ok ->
                     {reply, #tsputresp{}, State};
-                ErrorCount ->
-                    {reply, failed_put_response(ErrorCount), State}
+                {error, {some_failed, ErrorCount}} ->
+                    {reply, failed_put_response(ErrorCount), State};
+                {error, no_type} ->
+                    {reply, table_not_activated_response(Table), State};
+                {error, OtherReason} ->
+                    {reply, make_rpberrresp(?E_PUT, to_string(OtherReason)), State}
             end;
         BadRowIdxs when is_list(BadRowIdxs) ->
             {reply, validate_rows_error_response(BadRowIdxs), State}
@@ -301,6 +305,8 @@ sub_tsgetreq(Mod, _DDL, #tsgetreq{table = Table,
             {reply, #tsgetresp{columns = make_tscolumndescription_list(
                                            ColumnNames, ColumnTypes),
                                rows = Rows}, State};
+        {error, no_type} ->
+            {reply, table_not_activated_response(Table), State};
         {error, {bad_key_length, Got, Need}} ->
             {reply, key_element_count_mismatch(Got, Need), State};
         {error, notfound} ->
@@ -325,6 +331,8 @@ sub_tsdelreq(Mod, _DDL, #tsdelreq{table = Table,
            CompoundKey, Table, Mod, Options, VClock) of
         ok ->
             {reply, tsdelresp, State};
+        {error, no_type} ->
+            {reply, table_not_activated_response(Table), State};
         {error, {bad_key_length, Got, Need}} ->
             {reply, key_element_count_mismatch(Got, Need), State};
         {error, notfound} ->
@@ -426,14 +434,9 @@ sub_tsqueryreq(_Mod, DDL, SQL, State) ->
         {ok, Data} when element(1, SQL) =:= riak_sql_describe_v1 ->
             {reply, make_describe_response(Data), State};
 
-        %% %% parser messages have a tuple for Reason:
-        %% {error, {E, Reason}} when is_atom(E), is_binary(Reason) ->
-        %%     ErrorMessage = flat_format("~p: ~s", [E, Reason]),
-        %%     {reply, make_rpberrresp(?E_SUBMIT, ErrorMessage), State};
-        %% parser errors are now handled uniformly (will be caught
-        %% here in the last case branch)
-
         %% the following timeouts are known and distinguished:
+        {error, no_type} ->
+            {reply, table_not_activated_response(DDL#ddl_v1.table), State};
         {error, qry_worker_timeout} ->
             %% the eleveldb process didn't send us any response after
             %% 10 sec (hardcoded in riak_kv_qry), and probably died
@@ -473,10 +476,7 @@ check_table_and_call(Table, Fun, TsMessage, State) ->
         {error, missing_helper_module} ->
             BucketProps = riak_core_bucket:get_bucket(
                             riak_kv_ts_util:table_to_bucket(Table)),
-            {reply, missing_helper_module(Table, BucketProps), State};
-        {error, _} ->
-            {reply, table_not_activated_response(Table),
-             State}
+            {reply, missing_helper_module(Table, BucketProps), State}
     end.
 
 

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -27,8 +27,6 @@
 -include_lib("riak_pb/include/riak_ts_pb.hrl").
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
--include("riak_kv_wm_raw.hrl").
-
 -behaviour(riak_api_pb_service).
 
 -export([init/0,
@@ -121,7 +119,7 @@ decode_query(SQL) ->
 
 -spec decode_query(Query::#tsinterpolation{}, term()) ->
     {error, _} | {ok, ts_query_types()}.
-decode_query(#tsinterpolation{ base = BaseQuery }, Cover) ->
+decode_query(#tsinterpolation{base = BaseQuery}, Cover) ->
     Lexed = riak_ql_lexer:get_tokens(binary_to_list(BaseQuery)),
     case riak_ql_parser:parse(Lexed) of
         {ok, ?SQL_SELECT{} = SQL} ->
@@ -265,9 +263,9 @@ sub_tsttbputreq(Mod, _DDL, #tsttbputreq{table = Table, rows = Data},
     sub_putreq_common(Mod, Table, Data, State).
 
 sub_putreq_common(Mod, Table, Data, State) ->
-    case catch validate_rows(Mod, Data) of
+    case catch riak_kv_ts_util:validate_rows(Mod, Data) of
         [] ->
-            case put_data(Data, Table, Mod) of
+            case riak_kv_ts_util:put_data(Data, Table, Mod) of
                 0 ->
                     {reply, #tsputresp{}, State};
                 ErrorCount ->
@@ -277,135 +275,28 @@ sub_putreq_common(Mod, Table, Data, State) ->
             {reply, validate_rows_error_response(BadRowIdxs), State}
     end.
 
-%% Give validate_rows/2 a DDL Module and a list of decoded rows,
-%% and it will return a list of strings that represent the invalid rows indexes.
--spec validate_rows(module(), list(tuple())) -> list(string()).
-validate_rows(Mod, Rows) ->
-    ValidateFn = fun(X, {Acc, BadRowIdxs}) ->
-        case Mod:validate_obj(X) of
-            true -> {Acc+1, BadRowIdxs};
-            _ -> {Acc+1, [integer_to_list(Acc) | BadRowIdxs]}
-        end
-    end,
-    {_, BadRowIdxs} = lists:foldl(ValidateFn, {1, []}, Rows),
-    lists:reverse(BadRowIdxs).
-
-
--spec put_data([riak_pb_ts_codec:tsrow()], binary(), module()) -> integer().
-%% return count of records we failed to put
-put_data(Data, Table, Mod) when is_binary(Table) ->
-    DDL = Mod:get_ddl(),
-    Bucket = riak_kv_ts_util:table_to_bucket(Table),
-    BucketProps = riak_core_bucket:get_bucket(Bucket),
-    NVal = proplists:get_value(n_val, BucketProps),
-
-    PartitionedData = partition_data(Data, Bucket, BucketProps, DDL, Mod),
-    PreflistData = add_preflists(PartitionedData, NVal,
-                                 riak_core_node_watcher:nodes(riak_kv)),
-
-    EncodeFn =
-        fun(O) -> riak_object:to_binary(v1, O, msgpack) end,
-
-    {ReqIds, FailReqs} =
-        lists:foldl(
-          fun({DocIdx, Preflist, Records}, {GlobalReqIds, GlobalErrorsCnt}) ->
-                  case riak_kv_w1c_worker:validate_options(
-                         NVal, Preflist, [], BucketProps) of
-                      {ok, W, PW} ->
-                          {Ids, Errs} =
-                              lists:foldl(
-                                fun(Record, {PartReqIds, PartErrors}) ->
-                                        {RObj, LK} =
-                                            build_object(Bucket, Mod, DDL,
-                                                         Record, DocIdx),
-
-                                        {ok, ReqId} =
-                                            riak_kv_w1c_worker:async_put(
-                                              RObj, W, PW, Bucket, NVal, LK,
-                                              EncodeFn, Preflist),
-                                        {[ReqId | PartReqIds], PartErrors}
-                                end,
-                                {[], 0}, Records),
-                          {GlobalReqIds ++ Ids, GlobalErrorsCnt + Errs};
-                      _Error ->
-                          {GlobalReqIds, GlobalErrorsCnt + length(Records)}
-                  end
-          end,
-          {[], 0}, PreflistData),
-    Responses = riak_kv_w1c_worker:async_put_replies(ReqIds, []),
-    length(lists:filter(fun({error, _}) -> true;
-                           (_) -> false
-                        end, Responses)) + FailReqs.
-
--spec partition_data(Data :: list(term()),
-                     Bucket :: {binary(), binary()},
-                     BucketProps :: proplists:proplist(),
-                     DDL :: #ddl_v1{},
-                     Mod :: module()) ->
-                            list(tuple(chash:index(), list(term()))).
-partition_data(Data, Bucket, BucketProps, DDL, Mod) ->
-    PartitionTuples =
-        [ { riak_core_util:chash_key({Bucket, row_to_key(R, DDL, Mod)},
-                                     BucketProps), R } || R <- Data ],
-    dict:to_list(
-      lists:foldl(fun({Idx, R}, Dict) ->
-                          dict:append(Idx, R, Dict)
-                  end,
-                  dict:new(),
-                  PartitionTuples)).
-
-row_to_key(Row, DDL, Mod) ->
-    riak_kv_ts_util:encode_typeval_key(
-      riak_ql_ddl:get_partition_key(DDL, Row, Mod)).
-
-add_preflists(PartitionedData, NVal, UpNodes) ->
-    lists:map(fun({Idx, Rows}) -> {Idx,
-                                   riak_core_apl:get_apl_ann(Idx, NVal, UpNodes),
-                                   Rows} end,
-              PartitionedData).
-
-build_object(Bucket, Mod, DDL, Row, PK) ->
-    Obj = Mod:add_column_info(Row),
-    LK  = riak_kv_ts_util:encode_typeval_key(
-            riak_ql_ddl:get_local_key(DDL, Row, Mod)),
-
-    RObj = riak_object:newts(
-             Bucket, PK, Obj,
-             dict:from_list([{?MD_DDL_VERSION, ?DDL_VERSION}])),
-    {RObj, LK}.
-
 
 %% -----------
 %% get and delete
 %% -----------
 
-sub_tsgetreq(Mod, DDL, #tsgetreq{table = Table,
-                                 key    = PbCompoundKey,
-                                 timeout = Timeout},
+sub_tsgetreq(Mod, _DDL, #tsgetreq{table = Table,
+                                  key    = PbCompoundKey,
+                                  timeout = Timeout},
              State) ->
     Options =
         if Timeout == undefined -> [];
            true -> [{timeout, Timeout}]
         end,
-
     CompoundKey = riak_pb_ts_codec:decode_cells(PbCompoundKey),
-
-    Result =
-        case riak_kv_ts_util:make_ts_keys(CompoundKey, DDL, Mod) of
-            {ok, PKLK} ->
-                riak_client:get(
-                  riak_kv_ts_util:table_to_bucket(Table), PKLK, Options,
-                  {riak_client, [node(), undefined]});
-            ErrorReason ->
-                ErrorReason
-        end,
-    case Result of
-        {ok, RObj} ->
-            Record = riak_object:get_value(RObj),
+    Mod = riak_ql_ddl:make_module_name(Table),
+    case riak_kv_ts_util:get_data(
+           CompoundKey, Table, Mod, Options) of
+        {ok, Record} ->
             {ColumnNames, Row} = lists:unzip(Record),
             %% the columns stored in riak_object are just
             %% names; we need names with types, so:
-            ColumnTypes = get_column_types(ColumnNames, Mod),
+            ColumnTypes = riak_kv_ts_util:get_column_types(ColumnNames, Mod),
             Rows = riak_pb_ts_codec:encode_rows(ColumnTypes, [Row]),
             {reply, #tsgetresp{columns = make_tscolumndescription_list(
                                            ColumnNames, ColumnTypes),
@@ -419,47 +310,19 @@ sub_tsgetreq(Mod, DDL, #tsgetreq{table = Table,
     end.
 
 
-sub_tsdelreq(Mod, DDL, #tsdelreq{table = Table,
-                                 key    = PbCompoundKey,
-                                 vclock  = PbVClock,
-                                 timeout  = Timeout},
+sub_tsdelreq(Mod, _DDL, #tsdelreq{table = Table,
+                                  key    = PbCompoundKey,
+                                  vclock  = VClock,
+                                  timeout  = Timeout},
              State) ->
-    %% Pass the {dw,all} option in to the delete FSM
-    %% to make sure all tombstones are written by the
-    %% async put before the reaping get runs otherwise
-    %% if the default {dw,quorum} is used there is the
-    %% possibility that the last tombstone put overlaps
-    %% inside the KV vnode with the reaping get and
-    %% prevents the tombstone removal.
     Options =
-        if Timeout == undefined -> [{dw, all}];
-           true -> [{timeout, Timeout}, {dw, all}]
+        if Timeout == undefined -> [];
+           true -> [{timeout, Timeout}]
         end,
-    VClock =
-        case PbVClock of
-            undefined ->
-                %% this will trigger a get in riak_kv_delete:delete to
-                %% retrieve the actual vclock
-                undefined;
-            PbVClock ->
-                %% else, clients may have it already (e.g., from an
-                %% earlier riak_object:get), which will short-circuit
-                %% to avoid a separate get
-                riak_object:decode_vclock(PbVClock)
-        end,
-
     CompoundKey = riak_pb_ts_codec:decode_cells(PbCompoundKey),
-
-    Result =
-        case riak_kv_ts_util:make_ts_keys(CompoundKey, DDL, Mod) of
-            {ok, PKLK} ->
-                riak_client:delete_vclock(
-                  riak_kv_ts_util:table_to_bucket(Table), PKLK, VClock, Options,
-                  {riak_client, [node(), undefined]});
-            ErrorReason ->
-                ErrorReason
-        end,
-    case Result of
+    Mod = riak_ql_ddl:make_module_name(Table),
+    case riak_kv_ts_util:delete_data(
+           CompoundKey, Table, Mod, Options, VClock) of
         ok ->
             {reply, tsdelresp, State};
         {error, {bad_key_length, Got, Need}} ->
@@ -469,6 +332,13 @@ sub_tsdelreq(Mod, DDL, #tsdelreq{table = Table,
         {error, Reason} ->
             {reply, failed_delete_response(Reason), State}
     end.
+
+
+-spec make_tscolumndescription_list([binary()], [riak_pb_ts_codec:tscolumntype()]) ->
+                                           [#tscolumndescription{}].
+make_tscolumndescription_list(ColumnNames, ColumnTypes) ->
+    [#tscolumndescription{name = Name, type = riak_pb_ts_codec:encode_field_type(Type)}
+     || {Name, Type} <- lists:zip(ColumnNames, ColumnTypes)].
 
 
 %% -----------
@@ -501,18 +371,22 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
 sub_tscoveragereq(Mod, _DDL, #tscoveragereq{table = Table,
                                             query = Q},
                   State) ->
-    case compile(Mod, catch decode_query(Q)) of
-        {error, #rpberrorresp{} = Error} ->
-            {reply, Error, State};
-        {error, _} ->
+    Client = {riak_client, [node(), undefined]},
+    case decode_query(Q) of
+        {ok, SQL} ->
+            case riak_kv_ts_util:compile_to_per_quantum_queries(Mod, SQL) of
+                {ok, Compiled} ->
+                    Bucket = riak_kv_ts_util:table_to_bucket(Table),
+                    convert_cover_list(
+                      riak_kv_ts_util:sql_to_cover(Client, Compiled, Bucket, []), State);
+                {error, Reason} ->
+                    make_rpberrresp(
+                      ?E_BAD_QUERY, flat_format("Failed to compile query: ~p", [Reason]))
+            end;
+        {error, Reason} ->
             {reply, make_rpberrresp(
-                      ?E_BAD_QUERY, "Failed to compile query"),
-             State};
-        SQL ->
-            %% SQL is a list of queries (1 per quantum)
-            Bucket = riak_kv_ts_util:table_to_bucket(Table),
-            Client = {riak_client, [node(), undefined]},
-            convert_cover_list(sql_to_cover(Client, SQL, Bucket, []), State)
+                      ?E_BAD_QUERY, flat_format("Failed to parse query: ~p", [Reason])),
+             State}
     end.
 
 %% Copied and modified from riak_kv_pb_coverage:convert_list. Would
@@ -549,101 +423,6 @@ assemble_ts_range({FieldName, {{StartVal, StartIncl}, {EndVal, EndIncl}}}, Text)
       }.
 
 
-%% Result from riak_client:get_cover is a nested list of coverage plan
-%% because KV coverage requests are designed that way, but in our case
-%% all we want is the singleton head
-
-%% If any of the results from get_cover are errors, we want that tuple
-%% to be the sole return value
-sql_to_cover(_Client, [], _Bucket, Accum) ->
-    lists:reverse(Accum);
-sql_to_cover(Client, [SQL|Tail], Bucket, Accum) ->
-    case Client:get_cover(riak_kv_qry_coverage_plan, Bucket, undefined,
-                          {SQL, Bucket}) of
-        {error, Error} ->
-            {error, Error};
-        [Cover] ->
-            {Description, RangeReplacement} = reverse_sql(SQL),
-            sql_to_cover(Client, Tail, Bucket, [{Cover, RangeReplacement,
-                                                 Description}|Accum])
-    end.
-
-%% Generate a human-readable description of the target
-%%     <<"<TABLE> / time > X and time < Y">>
-%% Generate a start/end timestamp for future replacement in a query
-reverse_sql(?SQL_SELECT{'FROM'  = Table,
-                        'WHERE' = KeyProplist,
-                        partition_key = PartitionKey}) ->
-    QuantumField = identify_quantum_field(PartitionKey),
-    RangeTuple = extract_time_boundaries(QuantumField, KeyProplist),
-    Desc = derive_description(Table, QuantumField, RangeTuple),
-    ReplacementValues = {QuantumField, RangeTuple},
-    {Desc, ReplacementValues}.
-
-
-derive_description(Table, Field, {{Start, StartInclusive}, {End, EndInclusive}}) ->
-    StartOp = pick_operator(">", StartInclusive),
-    EndOp = pick_operator("<", EndInclusive),
-    unicode:characters_to_binary(
-      flat_format("~ts / ~ts ~s ~B and ~ts ~s ~B",
-                  [Table, Field, StartOp, Start,
-                   Field, EndOp, End]), utf8).
-
-pick_operator(LGT, true) ->
-    LGT ++ "=";
-pick_operator(LGT, false) ->
-    LGT.
-
-extract_time_boundaries(FieldName, WhereList) ->
-    {FieldName, timestamp, Start} =
-        lists:keyfind(FieldName, 1, proplists:get_value(startkey, WhereList, [])),
-    {FieldName, timestamp, End} =
-        lists:keyfind(FieldName, 1, proplists:get_value(endkey, WhereList, [])),
-    StartInclusive = proplists:get_value(start_inclusive, WhereList, true),
-    EndInclusive = proplists:get_value(end_inclusive, WhereList, false),
-    {{Start, StartInclusive}, {End, EndInclusive}}.
-
-
-%%%%%%%%%%%%
-%% FRAGILE HORRIBLE BAD BAD BAD AST MANGLING
-identify_quantum_field(#key_v1{ast = KeyList}) ->
-    HashFn = find_hash_fn(KeyList),
-    P_V1 = hd(HashFn#hash_fn_v1.args),
-    hd(P_V1#param_v1.name).
-
-find_hash_fn([]) ->
-    throw(wtf);
-find_hash_fn([#hash_fn_v1{}=Hash|_T]) ->
-    Hash;
-find_hash_fn([_H|T]) ->
-    find_hash_fn(T).
-
-%%%%%%%%%%%%
-
-
-compile(_Mod, {error, Err}) ->
-    {error, make_decoder_error_response(Err)};
-compile(_Mod, {'EXIT', {Err, _}}) ->
-    {error, make_decoder_error_response(Err)};
-compile(Mod, {ok, SQL}) ->
-    case (catch Mod:get_ddl()) of
-        {_, {undef, _}} ->
-            {error, no_helper_module};
-        DDL ->
-            case riak_ql_ddl:is_query_valid(Mod, DDL, SQL) of
-                true ->
-                    case riak_kv_qry_compiler:compile(DDL, SQL, undefined) of
-                        {error,_} = Error ->
-                            Error;
-                        {ok, Queries} ->
-                            Queries
-                    end;
-                {false, _Errors} ->
-                    {error, invalid_query}
-            end
-    end.
-
-
 %% query
 %%
 
@@ -654,10 +433,12 @@ sub_tsqueryreq(_Mod, DDL, SQL, State) ->
         {ok, Data} when element(1, SQL) =:= riak_sql_describe_v1 ->
             {reply, make_describe_response(Data), State};
 
-        %% parser messages have a tuple for Reason:
-        {error, {E, Reason}} when is_atom(E), is_binary(Reason) ->
-            ErrorMessage = flat_format("~p: ~s", [E, Reason]),
-            {reply, make_rpberrresp(?E_SUBMIT, ErrorMessage), State};
+        %% %% parser messages have a tuple for Reason:
+        %% {error, {E, Reason}} when is_atom(E), is_binary(Reason) ->
+        %%     ErrorMessage = flat_format("~p: ~s", [E, Reason]),
+        %%     {reply, make_rpberrresp(?E_SUBMIT, ErrorMessage), State};
+        %% parser errors are now handled uniformly (will be caught
+        %% here in the last case branch)
 
         %% the following timeouts are known and distinguished:
         {error, qry_worker_timeout} ->
@@ -814,10 +595,6 @@ make_describe_response(DescribeTableRows) ->
     #tsqueryresp{columns = make_tscolumndescription_list(ColumnNames, ColumnTypes),
                  rows = riak_pb_ts_codec:encode_rows(ColumnTypes, DescribeTableRows)}.
 
--spec get_column_types(list(binary()), module()) -> [riak_pb_ts_codec:tscolumntype()].
-get_column_types(ColumnNames, Mod) ->
-    [Mod:get_field_type([N]) || N <- ColumnNames].
-
 -spec make_tscolumndescription_list([binary()], [riak_pb_ts_codec:tscolumntype()]) ->
                                            [#tscolumndescription{}].
 make_tscolumndescription_list(ColumnNames, ColumnTypes) ->
@@ -873,28 +650,28 @@ validate_rows_empty_test() ->
     {module, Mod} = test_helper_validate_rows_mod(),
     ?assertEqual(
         [],
-        validate_rows(Mod, [])
+        riak_kv_ts_util:validate_rows(Mod, [])
     ).
 
 validate_rows_1_test() ->
     {module, Mod} = test_helper_validate_rows_mod(),
     ?assertEqual(
         [],
-        validate_rows(Mod, [{<<"f">>, <<"s">>, 11}])
+        riak_kv_ts_util:validate_rows(Mod, [{<<"f">>, <<"s">>, 11}])
     ).
 
 validate_rows_bad_1_test() ->
     {module, Mod} = test_helper_validate_rows_mod(),
     ?assertEqual(
         ["1"],
-        validate_rows(Mod, [{}])
+        riak_kv_ts_util:validate_rows(Mod, [{}])
     ).
 
 validate_rows_bad_2_test() ->
     {module, Mod} = test_helper_validate_rows_mod(),
     ?assertEqual(
         ["1", "3", "4"],
-        validate_rows(Mod, [{}, {<<"f">>, <<"s">>, 11}, {a, <<"s">>, 12}, "hithere"])
+        riak_kv_ts_util:validate_rows(Mod, [{}, {<<"f">>, <<"s">>, 11}, {a, <<"s">>, 12}, "hithere"])
     ).
 
 validate_rows_error_response_1_test() ->

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -100,8 +100,17 @@ maybe_submit_to_queue(SQL, #ddl_v1{table = BucketType} = DDL) ->
                 {error,_} = Error ->
                     Error;
                 {ok, Queries} ->
-                    maybe_await_query_results(
-                        riak_kv_qry_queue:put_on_queue(self(), Queries, DDL))
+                    case maybe_await_query_results(
+                           riak_kv_qry_queue:put_on_queue(self(), Queries, DDL)) of
+                        {ok, {ColNames, ColTypes, PossiblyWithEmptyRecords}} ->
+                            %% filter out empty records
+                            {ok,
+                             {ColNames, ColTypes,
+                              [R || R <- PossiblyWithEmptyRecords,
+                                    R /= [[]]]}};
+                        {error, Reason} ->
+                            {error, Reason}
+                    end
             end;
         {false, Errors} ->
             {error, {invalid_query, format_query_syntax_errors(Errors)}}

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -351,8 +351,12 @@ get_data(Key, Table, Mod0, Options) ->
         end,
     case Result of
         {ok, RObj} ->
-            Record = riak_object:get_value(RObj),
-            {ok, Record};
+            case riak_object:get_value(RObj) of
+                [] ->
+                    {error, notfound};
+                Record ->
+                    {ok, Record}
+            end;
         ErrorReason2 ->
             ErrorReason2
     end.

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -227,18 +227,32 @@ validate_rows(Mod, Rows) ->
     lists:reverse(BadRowIdxs).
 
 
--spec put_data([[riak_pb_ts_codec:ldbvalue()]], binary()) -> integer().
-%% return count of records we failed to put
+-spec put_data([[riak_pb_ts_codec:ldbvalue()]], binary()) ->
+                      ok | {error, {some_failed, integer()}} | {error, term()}.
 put_data(Data, Table) ->
     put_data(Data, Table, riak_ql_ddl:make_module_name(Table)).
 
--spec put_data([[riak_pb_ts_codec:ldbvalue()]], binary(), module()) -> integer().
+-spec put_data([[riak_pb_ts_codec:ldbvalue()]], binary(), module()) ->
+                      ok | {error, {some_failed, integer()}} | {error, term()}.
 put_data(Data, Table, Mod) ->
     DDL = Mod:get_ddl(),
     Bucket = table_to_bucket(Table),
-    BucketProps = riak_core_bucket:get_bucket(Bucket),
-    NVal = proplists:get_value(n_val, BucketProps),
+    case riak_core_bucket:get_bucket(Bucket) of
+        {error, Reason} ->
+            %% happens when, for example, the table has not been
+            %% activated (Reason == no_type)
+            {error, Reason};
+        BucketProps ->
+            case put_data_to_partitions(Data, Bucket, BucketProps, DDL, Mod) of
+                0 ->
+                    ok;
+                NErrors ->
+                    {error, {some_failed, NErrors}}
+            end
+    end.
 
+put_data_to_partitions(Data, Bucket, BucketProps, DDL, Mod) ->
+    NVal = proplists:get_value(n_val, BucketProps),
     PartitionedData = partition_data(Data, Bucket, BucketProps, DDL, Mod),
     PreflistData = add_preflists(PartitionedData, NVal,
                                  riak_core_node_watcher:nodes(riak_kv)),
@@ -272,11 +286,13 @@ put_data(Data, Table, Mod) ->
           end,
           {[], 0}, PreflistData),
     Responses = riak_kv_w1c_worker:async_put_replies(ReqIds, []),
-    length(
-      lists:filter(
-        fun({error, _}) -> true;
-           (_) -> false
-        end, Responses)) + FailReqs.
+    _NErrors =
+        length(
+          lists:filter(
+            fun({error, _}) -> true;
+               (_) -> false
+            end, Responses)) + FailReqs.
+
 
 
 -spec partition_data(Data :: list(term()),

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -26,14 +26,21 @@
 
 -export([
          apply_timeseries_bucket_props/2,
+         compile_to_per_quantum_queries/2,
          encode_typeval_key/1,
+         get_column_types/2,
+         get_data/2, get_data/3, get_data/4,
          get_table_ddl/1,
+         delete_data/2, delete_data/3, delete_data/4, delete_data/5,
          lk/1,
          make_ts_keys/3,
          maybe_parse_table_def/2,
          pk/1,
+         put_data/2, put_data/3,
          queried_table/1,
-         table_to_bucket/1
+         sql_to_cover/4,
+         table_to_bucket/1,
+         validate_rows/2
         ]).
 
 %% NOTE on table_to_bucket/1: Clients will work with table
@@ -45,6 +52,7 @@
 %% bucket tuple. This function is a convenient mechanism for doing so
 %% and making that transition more obvious.
 
+-include("riak_kv_wm_raw.hrl").
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 
@@ -203,6 +211,307 @@ make_ts_keys(CompoundKey, DDL = #ddl_v1{local_key = #key_v1{ast = LKParams},
 %% riak_ql_ddl:get_local_key/3,
 encode_typeval_key(TypeVals) ->
     list_to_tuple([Val || {_Type, Val} <- TypeVals]).
+
+
+%% Give validate_rows/2 a DDL Module and a list of decoded rows,
+%% and it will return a list of strings that represent the invalid rows indexes.
+-spec validate_rows(module(), list(tuple())) -> list(string()).
+validate_rows(Mod, Rows) ->
+    ValidateFn = fun(X, {Acc, BadRowIdxs}) ->
+        case Mod:validate_obj(X) of
+            true -> {Acc+1, BadRowIdxs};
+            _ -> {Acc+1, [integer_to_list(Acc) | BadRowIdxs]}
+        end
+    end,
+    {_, BadRowIdxs} = lists:foldl(ValidateFn, {1, []}, Rows),
+    lists:reverse(BadRowIdxs).
+
+
+-spec put_data([[riak_pb_ts_codec:ldbvalue()]], binary()) -> integer().
+%% return count of records we failed to put
+put_data(Data, Table) ->
+    put_data(Data, Table, riak_ql_ddl:make_module_name(Table)).
+
+-spec put_data([[riak_pb_ts_codec:ldbvalue()]], binary(), module()) -> integer().
+put_data(Data, Table, Mod) ->
+    DDL = Mod:get_ddl(),
+    Bucket = table_to_bucket(Table),
+    BucketProps = riak_core_bucket:get_bucket(Bucket),
+    NVal = proplists:get_value(n_val, BucketProps),
+
+    PartitionedData = partition_data(Data, Bucket, BucketProps, DDL, Mod),
+    PreflistData = add_preflists(PartitionedData, NVal,
+                                 riak_core_node_watcher:nodes(riak_kv)),
+    EncodeFn =
+        fun(O) -> riak_object:to_binary(v1, O, msgpack) end,
+
+    {ReqIds, FailReqs} =
+        lists:foldl(
+          fun({DocIdx, Preflist, Records}, {GlobalReqIds, GlobalErrorsCnt}) ->
+                  case riak_kv_w1c_worker:validate_options(
+                         NVal, Preflist, [], BucketProps) of
+                      {ok, W, PW} ->
+                          {Ids, Errs} =
+                              lists:foldl(
+                                fun(Record, {PartReqIds, PartErrors}) ->
+                                        {RObj, LK} =
+                                            build_object(Bucket, Mod, DDL,
+                                                         Record, DocIdx),
+
+                                        {ok, ReqId} =
+                                            riak_kv_w1c_worker:async_put(
+                                              RObj, W, PW, Bucket, NVal, LK,
+                                              EncodeFn, Preflist),
+                                        {[ReqId | PartReqIds], PartErrors}
+                                end,
+                                {[], 0}, Records),
+                          {GlobalReqIds ++ Ids, GlobalErrorsCnt + Errs};
+                      _Error ->
+                          {GlobalReqIds, GlobalErrorsCnt + length(Records)}
+                  end
+          end,
+          {[], 0}, PreflistData),
+    Responses = riak_kv_w1c_worker:async_put_replies(ReqIds, []),
+    length(
+      lists:filter(
+        fun({error, _}) -> true;
+           (_) -> false
+        end, Responses)) + FailReqs.
+
+
+-spec partition_data(Data :: list(term()),
+                     Bucket :: {binary(), binary()},
+                     BucketProps :: proplists:proplist(),
+                     DDL :: #ddl_v1{},
+                     Mod :: module()) ->
+                            list(tuple(chash:index(), list(term()))).
+partition_data(Data, Bucket, BucketProps, DDL, Mod) ->
+    PartitionTuples =
+        [ { riak_core_util:chash_key({Bucket, row_to_key(R, DDL, Mod)},
+                                     BucketProps), R } || R <- Data ],
+    dict:to_list(
+      lists:foldl(fun({Idx, R}, Dict) ->
+                          dict:append(Idx, R, Dict)
+                  end,
+                  dict:new(),
+                  PartitionTuples)).
+
+row_to_key(Row, DDL, Mod) ->
+    encode_typeval_key(
+      riak_ql_ddl:get_partition_key(DDL, Row, Mod)).
+
+add_preflists(PartitionedData, NVal, UpNodes) ->
+    lists:map(fun({Idx, Rows}) -> {Idx,
+                                   riak_core_apl:get_apl_ann(Idx, NVal, UpNodes),
+                                   Rows} end,
+              PartitionedData).
+
+build_object(Bucket, Mod, DDL, Row, PK) ->
+    Obj = Mod:add_column_info(Row),
+    LK  = encode_typeval_key(
+            riak_ql_ddl:get_local_key(DDL, Row, Mod)),
+
+    RObj = riak_object:newts(
+             Bucket, PK, Obj,
+             dict:from_list([{?MD_DDL_VERSION, ?DDL_VERSION}])),
+    {RObj, LK}.
+
+
+
+
+-spec get_data([riak_pb_ts_codec:ldbvalue()], binary()) ->
+                      {ok, {[binary()], [[riak_pb_ts_codec:ldbvalue()]]}} | {error, term()}.
+get_data(Key, Table) ->
+    get_data(Key, Table, undefined, []).
+
+-spec get_data([riak_pb_ts_codec:ldbvalue()], binary(), module()) ->
+                      {ok, {[binary()], [[riak_pb_ts_codec:ldbvalue()]]}} | {error, term()}.
+get_data(Key, Table, Mod) ->
+    get_data(Key, Table, Mod, []).
+
+-spec get_data([riak_pb_ts_codec:ldbvalue()], binary(), module(), proplists:proplist()) ->
+                      {ok, [{binary(), riak_pb_ts_codec:ldbvalue()}]} | {error, term()}.
+get_data(Key, Table, Mod0, Options) ->
+    Mod =
+        case Mod0 of
+            undefined ->
+                riak_ql_ddl:make_module_name(Table);
+            Mod0 ->
+                Mod0
+        end,
+    DDL = Mod:get_ddl(),
+    Result =
+        case make_ts_keys(Key, DDL, Mod) of
+            {ok, PKLK} ->
+                riak_client:get(
+                  table_to_bucket(Table), PKLK, Options,
+                  {riak_client, [node(), undefined]});
+            ErrorReason ->
+                ErrorReason
+        end,
+    case Result of
+        {ok, RObj} ->
+            Record = riak_object:get_value(RObj),
+            {ok, Record};
+        ErrorReason2 ->
+            ErrorReason2
+    end.
+
+-spec get_column_types(list(binary()), module()) -> [riak_pb_ts_codec:tscolumntype()].
+get_column_types(ColumnNames, Mod) ->
+    [Mod:get_field_type([N]) || N <- ColumnNames].
+
+
+-spec delete_data([any()], riak_object:bucket()) ->
+                         ok | {error, term()}.
+delete_data(Key, Table) ->
+    delete_data(Key, Table, undefined, [], undefined).
+
+-spec delete_data([any()], riak_object:bucket(), module()) ->
+                         ok | {error, term()}.
+delete_data(Key, Table, Mod) ->
+    delete_data(Key, Table, Mod, [], undefined).
+
+-spec delete_data([any()], riak_object:bucket(), module(), proplists:proplist()) ->
+                         ok | {error, term()}.
+delete_data(Key, Table, Mod, Options) ->
+    delete_data(Key, Table, Mod, Options, undefined).
+
+-spec delete_data([any()], riak_object:bucket(), module(), proplists:proplist(),
+                  undefined | vclock:vclock()) ->
+                         ok | {error, term()}.
+delete_data(Key, Table, Mod0, Options0, VClock0) ->
+    Mod =
+        case Mod0 of
+            undefined ->
+                riak_ql_ddl:make_module_name(Table);
+            Mod0 ->
+                Mod0
+        end,
+    %% Pass the {dw,all} option in to the delete FSM
+    %% to make sure all tombstones are written by the
+    %% async put before the reaping get runs otherwise
+    %% if the default {dw,quorum} is used there is the
+    %% possibility that the last tombstone put overlaps
+    %% inside the KV vnode with the reaping get and
+    %% prevents the tombstone removal.
+    Options = lists:keystore(dw, 1, Options0, {dw, all}),
+    DDL = Mod:get_ddl(),
+    VClock =
+        case VClock0 of
+            undefined ->
+                %% this will trigger a get in riak_kv_delete:delete to
+                %% retrieve the actual vclock
+                undefined;
+            VClock0 ->
+                %% else, clients may have it already (e.g., from an
+                %% earlier riak_object:get), which will short-circuit
+                %% to avoid a separate get
+                riak_object:decode_vclock(VClock0)
+        end,
+    Result =
+        case make_ts_keys(Key, DDL, Mod) of
+            {ok, PKLK} ->
+                riak_client:delete_vclock(
+                  table_to_bucket(Table), PKLK, VClock, Options,
+                  {riak_client, [node(), undefined]});
+            ErrorReason ->
+                ErrorReason
+        end,
+    Result.
+
+
+%% Result from riak_client:get_cover is a nested list of coverage plan
+%% because KV coverage requests are designed that way, but in our case
+%% all we want is the singleton head
+
+%% If any of the results from get_cover are errors, we want that tuple
+%% to be the sole return value
+sql_to_cover(_Client, [], _Bucket, Accum) ->
+    lists:reverse(Accum);
+sql_to_cover(Client, [SQL|Tail], Bucket, Accum) ->
+    case Client:get_cover(riak_kv_qry_coverage_plan, Bucket, undefined,
+                          {SQL, Bucket}) of
+        {error, Error} ->
+            {error, Error};
+        [Cover] ->
+            {Description, RangeReplacement} = reverse_sql(SQL),
+            sql_to_cover(Client, Tail, Bucket, [{Cover, RangeReplacement,
+                                                 Description}|Accum])
+    end.
+
+-spec compile_to_per_quantum_queries(module(), ?SQL_SELECT{}) ->
+                                            {ok, [?SQL_SELECT{}]} | {error, any()}.
+%% @doc Break up a query into a list of per-quantum queries
+compile_to_per_quantum_queries(Mod, SQL) ->
+    case catch Mod:get_ddl() of
+        {_, {undef, _}} ->
+            {error, no_helper_module};
+        DDL ->
+            case riak_ql_ddl:is_query_valid(Mod, DDL, SQL) of
+                true ->
+                    riak_kv_qry_compiler:compile(DDL, SQL, undefined);
+                {false, _Errors} ->
+                    {error, invalid_query}
+            end
+    end.
+
+
+%% Generate a human-readable description of the target
+%%     <<"<TABLE> / time > X and time < Y">>
+%% Generate a start/end timestamp for future replacement in a query
+reverse_sql(?SQL_SELECT{'FROM'  = Table,
+                        'WHERE' = KeyProplist,
+                        partition_key = PartitionKey}) ->
+    QuantumField = identify_quantum_field(PartitionKey),
+    RangeTuple = extract_time_boundaries(QuantumField, KeyProplist),
+    Desc = derive_description(Table, QuantumField, RangeTuple),
+    ReplacementValues = {QuantumField, RangeTuple},
+    {Desc, ReplacementValues}.
+
+
+derive_description(Table, Field, {{Start, StartInclusive}, {End, EndInclusive}}) ->
+    StartOp = pick_operator(">", StartInclusive),
+    EndOp = pick_operator("<", EndInclusive),
+    unicode:characters_to_binary(
+      flat_format("~ts / ~ts ~s ~B and ~ts ~s ~B",
+                  [Table, Field, StartOp, Start,
+                   Field, EndOp, End]), utf8).
+
+pick_operator(LGT, true) ->
+    LGT ++ "=";
+pick_operator(LGT, false) ->
+    LGT.
+
+extract_time_boundaries(FieldName, WhereList) ->
+    {FieldName, timestamp, Start} =
+        lists:keyfind(FieldName, 1, proplists:get_value(startkey, WhereList, [])),
+    {FieldName, timestamp, End} =
+        lists:keyfind(FieldName, 1, proplists:get_value(endkey, WhereList, [])),
+    StartInclusive = proplists:get_value(start_inclusive, WhereList, true),
+    EndInclusive = proplists:get_value(end_inclusive, WhereList, false),
+    {{Start, StartInclusive}, {End, EndInclusive}}.
+
+
+%%%%%%%%%%%%
+%% FRAGILE HORRIBLE BAD BAD BAD AST MANGLING
+identify_quantum_field(#key_v1{ast = KeyList}) ->
+    HashFn = find_hash_fn(KeyList),
+    P_V1 = hd(HashFn#hash_fn_v1.args),
+    hd(P_V1#param_v1.name).
+
+find_hash_fn([]) ->
+    throw(wtf);
+find_hash_fn([#hash_fn_v1{}=Hash|_T]) ->
+    Hash;
+find_hash_fn([_H|T]) ->
+    find_hash_fn(T).
+
+%%%%%%%%%%%%
+
+
+flat_format(Format, Args) ->
+    lists:flatten(io_lib:format(Format, Args)).
 
 %%%
 %%% TESTS

--- a/src/riak_kv_web.erl
+++ b/src/riak_kv_web.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_kv_web: setup Riak's KV HTTP interface
 %%
-%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -121,7 +121,15 @@ raw_dispatch(Name) ->
      {Prefix ++ ["buckets", bucket, "index", field, '*'],
       riak_kv_wm_index, Props}
 
-    ] || {Prefix, Props} <- Props2 ]).
+    ] || {Prefix, Props} <- Props2 ]) ++
+
+    lists:flatten(
+      [
+       [{["ts", api_version, "tables", table, "keys"], riak_kv_wm_timeseries_listkeys, Props},
+        {["ts", api_version, "tables", table], riak_kv_wm_timeseries, Props},
+        {["ts", api_version, "query"], riak_kv_wm_timeseries, Props}
+        %% {["ts", api_version, "coverage"], riak_kv_wm_timeseries, Props}
+       ] || {_Prefix, Props} <- Props2]).
 
 is_post(Req) ->
     wrq:method(Req) == 'POST'.

--- a/src/riak_kv_web.erl
+++ b/src/riak_kv_web.erl
@@ -127,7 +127,7 @@ raw_dispatch(Name) ->
       [
        [{["ts", api_version, "tables", table, "keys"], riak_kv_wm_timeseries_listkeys, Props},
         {["ts", api_version, "tables", table], riak_kv_wm_timeseries, Props},
-        {["ts", api_version, "query"], riak_kv_wm_timeseries, Props}
+        {["ts", api_version, "query"], riak_kv_wm_timeseries_query, Props}
         %% {["ts", api_version, "coverage"], riak_kv_wm_timeseries, Props}
        ] || {_Prefix, Props} <- Props2]).
 

--- a/src/riak_kv_wm_timeseries.erl
+++ b/src/riak_kv_wm_timeseries.erl
@@ -492,10 +492,12 @@ call_api_function(RD, Ctx = #ctx{api_call = put,
             handle_error({no_such_table, Table}, RD, Ctx);
         [] ->
             case riak_kv_ts_util:put_data(Records, Table, Mod) of
-                0 ->
+                ok ->
                     prepare_data_in_body(RD, Ctx#ctx{result = ok});
-                ErrorCount ->
-                    handle_error({failed_some_puts, ErrorCount, Table}, RD, Ctx)
+                {error, {some_failed, ErrorCount}} ->
+                    handle_error({failed_some_puts, ErrorCount, Table}, RD, Ctx);
+                {error, no_ctype} ->
+                    handle_error({table_activate_fail, Table}, RD, Ctx)
             end;
         BadRowIdxs when is_list(BadRowIdxs) ->
             handle_error({invalid_data, BadRowIdxs}, RD, Ctx)

--- a/src/riak_kv_wm_timeseries.erl
+++ b/src/riak_kv_wm_timeseries.erl
@@ -1,0 +1,804 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_wm_timeseries: Webmachine resource for riak TS operations.
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Resource for Riak TS operations over HTTP.
+%%
+%% ```
+%% GET    /ts/v1/table/Table          single-key get
+%% DELETE /ts/v1/table/Table          single-key delete
+%% PUT    /ts/v1/table/Table          batch put
+%% GET    /ts/v1/coverage             coverage for a query
+%% GET/POST   /ts/v1/query            execute SQL query
+%% '''
+%%
+%% Request body is expected to be a JSON containing key and/or value(s).
+%% Response is a JSON containing data rows with column headers.
+%%
+
+-module(riak_kv_wm_timeseries).
+
+%% webmachine resource exports
+-export([
+         init/1,
+         service_available/2,
+         is_authorized/2,
+         forbidden/2,
+         allowed_methods/2,
+         process_post/2,
+         malformed_request/2,
+         content_types_accepted/2,
+         resource_exists/2,
+         delete_resource/2,
+         content_types_provided/2,
+         encodings_provided/2,
+         produce_doc_body/2,
+         accept_doc_body/2
+        ]).
+
+-include("riak_kv_wm_raw.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
+-include_lib("riak_ql/include/riak_ql_ddl.hrl").
+
+-record(ctx, {api_version,
+              method  :: atom(),
+              prefix,       %% string() - prefix for resource uris
+              timeout,      %% integer() - passed-in timeout value in ms
+              security,     %% security context
+              client,       %% riak_client() - the store client
+              riak,         %% local | {node(), atom()} - params for riak client
+              api_call :: undefined|get|put|delete|query|coverage,
+              table    :: undefined | binary(),
+              cover_context :: undefined | binary(),
+              %% data in/out: the following fields are either
+              %% extracted from the JSON that came in the request body
+              %% in case of a PUT, or filled out by retrieved values
+              %% for shipping (as JSON) in response body
+              key     :: undefined |  ts_rec(),  %% parsed out of JSON that came in the body
+              data    :: undefined | [ts_rec()], %% ditto
+              query   :: undefined | string(),
+              result  :: undefined | ok | {Headers::[binary()], Rows::[ts_rec()]}
+                                   | [{entry, proplists:proplist()}]
+             }).
+
+-define(DEFAULT_TIMEOUT, 60000).
+-define(TABLE_ACTIVATE_WAIT, 30).   %% wait until table's bucket type is activated
+
+-define(CB_RV_SPEC, {boolean(), #wm_reqdata{}, #ctx{}}).
+-type ts_rec() :: [riak_pb_ts_codec:ldbvalue()].
+
+
+-spec init(proplists:proplist()) -> {ok, #ctx{}}.
+%% @doc Initialize this resource.  This function extracts the
+%%      'prefix' and 'riak' properties from the dispatch args.
+init(Props) ->
+    {ok, #ctx{prefix = proplists:get_value(prefix, Props),
+              riak = proplists:get_value(riak, Props)}}.
+
+-spec service_available(#wm_reqdata{}, #ctx{}) ->
+    {boolean(), #wm_reqdata{}, #ctx{}}.
+%% @doc Determine whether or not a connection to Riak
+%%      can be established.  This function also takes this
+%%      opportunity to extract the 'bucket' and 'key' path
+%%      bindings from the dispatch, as well as any vtag
+%%      query parameter.
+service_available(RD, Ctx = #ctx{riak = RiakProps}) ->
+    case riak_kv_wm_utils:get_riak_client(
+           RiakProps, riak_kv_wm_utils:get_client_id(RD)) of
+        {ok, C} ->
+            {true, RD,
+             Ctx#ctx{api_version = wrq:path_info(api_version, RD),
+                     method = wrq:method(RD),
+                     client = C,
+                     table =
+                         case wrq:path_info(table, RD) of
+                             undefined -> undefined;
+                             B -> list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, B))
+                         end
+                    }};
+        Error ->
+            {false, wrq:set_resp_body(
+                      flat_format("Unable to connect to Riak: ~p", [Error]),
+                      wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx}
+    end.
+
+
+is_authorized(ReqData, Ctx) ->
+    case riak_api_web_security:is_authorized(ReqData) of
+        false ->
+            {"Basic realm=\"Riak\"", ReqData, Ctx};
+        {true, SecContext} ->
+            {true, ReqData, Ctx#ctx{security = SecContext}};
+        insecure ->
+            %% XXX 301 may be more appropriate here, but since the http and
+            %% https port are different and configurable, it is hard to figure
+            %% out the redirect URL to serve.
+            {{halt, 426},
+             wrq:append_to_resp_body(
+               <<"Security is enabled and "
+                 "Riak does not accept credentials over HTTP. Try HTTPS instead.">>, ReqData),
+             Ctx}
+    end.
+
+
+-spec forbidden(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+forbidden(RD, Ctx) ->
+    case riak_kv_wm_utils:is_forbidden(RD) of
+        true ->
+            {true, RD, Ctx};
+        false ->
+            %%preexec(RD, Ctx)
+            %%validate_request(RD, Ctx)
+            %% plug in early, and just do what it takes to do the job
+            {false, RD, Ctx}
+    end.
+%% Because webmachine chooses to (not) call certain callbacks
+%% depending on request method used, sometimes accept_doc_body is not
+%% called at all, and we arrive at produce_doc_body empty-handed.
+%% This is the case when curl is executed with -X GET and --data.
+
+
+-spec allowed_methods(#wm_reqdata{}, #ctx{}) ->
+    {[atom()], #wm_reqdata{}, #ctx{}}.
+%% @doc Get the list of methods this resource supports.
+allowed_methods(RD, Ctx) ->
+    {['GET', 'POST', 'PUT', 'DELETE'], RD, Ctx}.
+
+
+-spec malformed_request(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+%% @doc Determine whether query parameters, request headers,
+%%      and request body are badly-formed.
+malformed_request(RD, Ctx) ->
+    %% this is plugged because requests are validated against
+    %% effective parameters contained in the body (and hence, we need
+    %% accept_doc_body to parse and extract things out of JSON in the
+    %% body)
+    {false, RD, Ctx}.
+
+
+-spec preexec(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+%% * collect any parameters from request body or, failing that, from
+%%   POST k=v items;
+%% * check API version;
+%% * validate those parameters against URL and method;
+%% * determine which api call to do, and check permissions on that;
+preexec(RD, Ctx = #ctx{api_call = Call})
+  when Call /= undefined ->
+    %% been here, figured and executed api call, stored results for
+    %% shipping to client
+    {true, RD, Ctx};
+preexec(RD, Ctx) ->
+    case validate_request(RD, Ctx) of
+        {true, RD1, Ctx1} ->
+            case check_permissions(RD1, Ctx1) of
+                {false, RD2, Ctx2} ->
+                    call_api_function(RD2, Ctx2);
+                FalseWithDetails ->
+                    FalseWithDetails
+            end;
+        FalseWithDetails ->
+            FalseWithDetails
+    end.
+
+-spec validate_request(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+validate_request(RD, Ctx) ->
+    case wrq:path_info(api_version, RD) of
+        "v1" ->
+            validate_request_v1(RD, Ctx);
+        BadVersion ->
+            handle_error({unsupported_version, BadVersion}, RD, Ctx)
+    end.
+
+-spec validate_request_v1(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+validate_request_v1(RD, Ctx = #ctx{method = Method}) ->
+    Json = extract_json(RD),
+    case {Method, string:tokens(wrq:path(RD), "/"),
+          extract_key(Json), extract_data(Json),
+          extract_query(Json), extract_cover_context(Json)} of
+        %% single-key get
+        {'GET',
+         ["ts", "v1", "tables", Table],
+         Key, undefined, undefined, undefined}
+          when is_list(Table), Key /= undefined ->
+            valid_params(
+              RD, Ctx#ctx{api_version = "v1", api_call = get,
+                          table = list_to_binary(Table), key = Key});
+        %% single-key delete
+        {'DELETE',
+         ["ts", "v1", "tables", Table],
+         Key, undefined, undefined, undefined}
+          when is_list(Table), Key /= undefined ->
+            valid_params(
+              RD, Ctx#ctx{api_version = "v1", api_call = delete,
+                          table = list_to_binary(Table), key = Key});
+        %% batch put
+        {'PUT',
+         ["ts", "v1", "tables", Table],
+         undefined, Data, undefined, undefined}
+          when is_list(Table), Data /= undefined ->
+            valid_params(
+              RD, Ctx#ctx{api_version = "v1", api_call = put,
+                          table = list_to_binary(Table), data = Data});
+        %% coverage
+        {'GET',
+         ["ts", "v1", "coverage"],
+         undefined, undefined, Query, undefined}
+          when is_list(Query) ->
+            valid_params(
+              RD, Ctx#ctx{api_version = "v1", api_call = coverage,
+                          query = Query});
+        %% query
+        {Method,
+         ["ts", "v1", "query"],
+         undefined, undefined, Query, CoverContext}
+          when (Method == 'GET' orelse Method == 'POST' orelse Method == 'PUT')
+               andalso is_list(Query) ->
+            valid_params(
+              RD, Ctx#ctx{api_version = "v1", api_call = query,
+                          query = Query, cover_context = CoverContext});
+        _Invalid ->
+            handle_error({malformed_request, Method}, RD, Ctx)
+    end.
+
+
+-spec valid_params(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+valid_params(RD, Ctx) ->
+    case wrq:get_qs_value("timeout", none, RD) of
+        none ->
+            {true, RD, Ctx};
+        TimeoutStr ->
+            try
+                Timeout = list_to_integer(TimeoutStr),
+                {true, RD, Ctx#ctx{timeout = Timeout}}
+            catch
+                _:_ ->
+                    handle_error({bad_parameter, "timeout"}, RD, Ctx)
+            end
+    end.
+
+%% This is a special case for curl -G.  `curl -G host --data $data`
+%% will send the $data in URL instead of in the body, so we try to
+%% look for it in req_qs.
+extract_json(RD) ->
+    case proplists:get_value("json", RD#wm_reqdata.req_qs) of
+        undefined ->
+            %% if it was a PUT or POST, data is in body
+            binary_to_list(wrq:req_body(RD));
+        BodyInPost ->
+            BodyInPost
+    end.
+
+-spec extract_key(binary()) -> term().
+extract_key(Json) ->
+    case catch mochijson2:decode(Json) of
+        {struct, [{<<"key">>, Key}]} ->
+            %% key alone (it's a get or delete)
+            validate_ts_record(Key);
+        Decoded when is_list(Decoded) ->
+            %% key and data (it's a put)
+            validate_ts_record(
+              proplists:get_value(<<"key">>, Decoded));
+        _ ->
+            undefined
+    end.
+
+%% because, techically, key and data are 'arguments', we check they
+%% are well-formed, too.
+-spec extract_data(binary()) -> term().
+extract_data(Json) ->
+    case catch mochijson2:decode(Json) of
+        {struct, Decoded} when is_list(Decoded) ->
+            %% key and data (it's a put)
+            validate_ts_records(
+              proplists:get_value(<<"data">>, Decoded));
+        _ ->
+            undefined
+    end.
+
+-spec extract_query(binary()) -> term().
+extract_query(Json) ->
+    case catch mochijson2:decode(Json) of
+        {struct, Decoded} when is_list(Decoded) ->
+            validate_ts_query(
+              proplists:get_value(<<"query">>, Decoded));
+        _ ->
+            undefined
+    end.
+
+-spec extract_cover_context(binary()) -> term().
+extract_cover_context(Json) ->
+    case catch mochijson2:decode(Json) of
+        Decoded when is_list(Decoded) ->
+            validate_ts_cover_context(
+              proplists:get_value(<<"coverage_context">>, Decoded));
+        _ ->
+            undefined
+    end.
+
+
+validate_ts_record(undefined) ->
+    undefined;
+validate_ts_record(R) when is_list(R) ->
+    case lists:all(
+           %% check that all list elements are TS types
+           fun(X) -> is_integer(X) orelse is_float(X) orelse is_binary(X) end,
+           R) of
+        true ->
+            R;
+        false ->
+            undefined
+    end;
+validate_ts_record(_) ->
+    undefined.
+
+validate_ts_records(undefined) ->
+    undefined;
+validate_ts_records(RR) when is_list(RR) ->
+    case lists:all(fun(R) -> validate_ts_record(R) /= undefined end, RR) of
+        true ->
+            RR;
+        false ->
+            undefined
+    end;
+validate_ts_records(_) ->
+    undefined.
+
+validate_ts_query(Q) when is_binary(Q) ->
+    binary_to_list(Q);
+validate_ts_query(_) ->
+    undefined.
+
+validate_ts_cover_context(C) when is_binary(C) ->
+    C;
+validate_ts_cover_context(_) ->
+    undefined.
+
+
+-spec check_permissions(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+%% We have to defer checking permission until we have figured which
+%% api call it is, which is done in validate_request, which also needs
+%% body, which happens to not be available in Ctx when webmachine
+%% would normally call a forbidden callback. I *may* be missing
+%% something, but given the extent we have bent the REST rules here,
+%% checking permissions at a stage later than webmachine would have
+%% done is not a big deal.
+check_permissions(RD, Ctx = #ctx{security = undefined}) ->
+    validate_resource(RD, Ctx);
+check_permissions(RD, Ctx = #ctx{table = undefined}) ->
+    {false, RD, Ctx};
+check_permissions(RD, Ctx = #ctx{security = Security,
+                                 api_call = Call,
+                                 table = Table}) ->
+    case riak_core_security:check_permission(
+           {api_call_to_ts_perm(Call), {Table, Table}}, Security) of
+        {false, Error, _} ->
+            handle_error(
+              {not_permitted, unicode:characters_to_binary(Error, utf8, utf8)}, RD, Ctx);
+        _ ->
+            validate_resource(RD, Ctx)
+    end.
+
+api_call_to_ts_perm(get) ->
+    "riak_ts.get";
+api_call_to_ts_perm(put) ->
+    "riak_ts.put";
+api_call_to_ts_perm(delete) ->
+    "riak_ts.delete";
+api_call_to_ts_perm(query) ->
+    "riak_ts.query".
+
+-spec validate_resource(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+validate_resource(RD, Ctx = #ctx{api_call = Call})
+  when Call == query;
+       Call == coverage ->
+    %% there is always a resource for queries
+    {false, RD, Ctx};
+validate_resource(RD, Ctx = #ctx{table = Table}) ->
+    %% Ensure the bucket type exists, otherwise 404 early.
+    case riak_kv_wm_utils:bucket_type_exists(Table) of
+        true ->
+            {true, RD, Ctx};
+        false ->
+            handle_error({no_such_table, Table}, RD, Ctx)
+    end.
+
+
+-spec content_types_provided(#wm_reqdata{}, #ctx{}) ->
+                                    {[{ContentType::string(), Producer::atom()}],
+                                     #wm_reqdata{}, #ctx{}}.
+%% @doc List the content types available for representing this resource.
+content_types_provided(RD, Ctx) ->
+    {[{"application/json", produce_doc_body}], RD, Ctx}.
+
+
+-spec encodings_provided(#wm_reqdata{}, #ctx{}) ->
+                                {[{Encoding::string(), Producer::function()}],
+                                 #wm_reqdata{}, #ctx{}}.
+%% @doc List the encodings available for representing this resource.
+%%      "identity" and "gzip" are available.
+encodings_provided(RD, Ctx) ->
+    %% identity and gzip
+    {riak_kv_wm_utils:default_encodings(), RD, Ctx}.
+
+
+-spec content_types_accepted(#wm_reqdata{}, #ctx{}) ->
+                                    {[{ContentType::string(), Acceptor::atom()}],
+                                     #wm_reqdata{}, #ctx{}}.
+content_types_accepted(RD, Ctx) ->
+    {[{"application/json", accept_doc_body}], RD, Ctx}.
+
+
+-spec resource_exists(#wm_reqdata{}, #ctx{}) ->
+                             {boolean(), #wm_reqdata{}, #ctx{}}.
+resource_exists(RD0, Ctx0) ->
+    case preexec(RD0, Ctx0) of
+        {true, RD, Ctx} ->
+            call_api_function(RD, Ctx);
+        FalseWithDetails ->
+            FalseWithDetails
+    end.
+
+-spec process_post(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+%% @doc Pass through requests to allow POST to function
+%%      as PUT for clients that do not support PUT.
+process_post(RD, Ctx) ->
+    accept_doc_body(RD, Ctx).
+
+-spec delete_resource(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+%% same for DELETE
+delete_resource(RD, Ctx) ->
+    accept_doc_body(RD, Ctx).
+
+-spec accept_doc_body(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+accept_doc_body(RD0, Ctx0) ->
+    case preexec(RD0, Ctx0) of
+        {true, RD, Ctx} ->
+            call_api_function(RD, Ctx);
+        FalseWithDetails ->
+            FalseWithDetails
+    end.
+
+-spec call_api_function(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+call_api_function(RD, Ctx = #ctx{result = Result})
+  when Result /= undefined ->
+    lager:debug("Function already executed", []),
+    {true, RD, Ctx};
+call_api_function(RD, Ctx = #ctx{api_call = put,
+                                 table = Table, data = Data}) ->
+    Mod = riak_ql_ddl:make_module_name(Table),
+    %% convert records to tuples, just for put
+    Records = [list_to_tuple(R) || R <- Data],
+    case catch riak_kv_ts_util:validate_rows(Mod, Records) of
+        {_, {undef, _}} ->
+            handle_error({no_such_table, Table}, RD, Ctx);
+        [] ->
+            case riak_kv_ts_util:put_data(Records, Table, Mod) of
+                0 ->
+                    prepare_data_in_body(RD, Ctx#ctx{result = ok});
+                ErrorCount ->
+                    handle_error({failed_some_puts, ErrorCount, Table}, RD, Ctx)
+            end;
+        BadRowIdxs when is_list(BadRowIdxs) ->
+            handle_error({invalid_data, BadRowIdxs}, RD, Ctx)
+    end;
+
+call_api_function(RD, Ctx0 = #ctx{api_call = get,
+                                  table = Table, key = Key,
+                                  timeout = Timeout}) ->
+    Options =
+        if Timeout == undefined -> [];
+           true -> [{timeout, Timeout}]
+        end,
+    Mod = riak_ql_ddl:make_module_name(Table),
+    case catch riak_kv_ts_util:get_data(Key, Table, Mod, Options) of
+        {_, {undef, _}} ->
+            handle_error({no_such_table, Table}, RD, Ctx0);
+        {ok, Record} ->
+            {ColumnNames, Row} = lists:unzip(Record),
+            %% ColumnTypes = riak_kv_ts_util:get_column_types(ColumnNames, Mod),
+            %% We don't need column types here as well (for the PB interface, we
+            %% needed them in order to properly construct tscells)
+            DataOut = {ColumnNames, [Row]},
+            %% all results (from get as well as query) are returned in
+            %% a uniform 'tabular' form, hence the [] around Row
+            Ctx = Ctx0#ctx{result = DataOut},
+            prepare_data_in_body(RD, Ctx);
+        {error, notfound} ->
+            handle_error(notfound, RD, Ctx0);
+        {error, {bad_key_length, Got, Need}} ->
+            handle_error({key_element_count_mismatch, Got, Need}, RD, Ctx0);
+        {error, Reason} ->
+            handle_error({riak_error, Reason}, RD, Ctx0)
+    end;
+
+call_api_function(RD, Ctx = #ctx{api_call = delete,
+                                 table = Table, key = Key,
+                                 timeout = Timeout}) ->
+    Options =
+        if Timeout == undefined -> [];
+           true -> [{timeout, Timeout}]
+        end,
+    Mod = riak_ql_ddl:make_module_name(Table),
+    case catch riak_kv_ts_util:delete_data(Key, Table, Mod, Options) of
+        {_, {undef, _}} ->
+            handle_error({no_such_table, Table}, RD, Ctx);
+        ok ->
+            prepare_data_in_body(RD, Ctx#ctx{result = ok});
+        {error, {bad_key_length, Got, Need}} ->
+            handle_error({key_element_count_mismatch, Got, Need}, RD, Ctx);
+        {error, notfound} ->
+            handle_error(notfound, RD, Ctx);
+        {error, Reason} ->
+            handle_error({riak_error, Reason}, RD, Ctx)
+    end;
+
+call_api_function(RD, Ctx = #ctx{api_call = query,
+                                 method = Method,
+                                 query = Query, cover_context = CoverCtx}) ->
+    Lexed = riak_ql_lexer:get_tokens(Query),
+    case riak_ql_parser:parse(Lexed) of
+        {ok, SQL = ?SQL_SELECT{}} when Method == 'GET' ->
+            %% inject coverage context
+            process_query(SQL?SQL_SELECT{cover_context = CoverCtx}, RD, Ctx);
+        {ok, Other}
+          when (is_record(Other, ddl_v1)               andalso Method == 'POST') orelse
+               (is_record(Other, riak_sql_describe_v1) andalso Method ==  'GET') ->
+            process_query(Other, RD, Ctx);
+        {ok, _MethodMismatch} ->
+            handle_error({inappropriate_sql_for_method, Method}, RD, Ctx);
+        {error, Reason} ->
+            handle_error({query_parse_error, Reason}, RD, Ctx)
+    end;
+
+call_api_function(RD, Ctx = #ctx{api_call = coverage,
+                                 query = Query,
+                                 client = Client}) ->
+    Lexed = riak_ql_lexer:get_tokens(Query),
+    case riak_ql_parser:parse(Lexed) of
+        {ok, SQL = ?SQL_SELECT{'FROM' = Table}} ->
+            Mod = riak_ql_ddl:make_module_name(Table),
+            case riak_kv_ts_util:compile_to_per_quantum_queries(Mod, SQL) of
+                {ok, Compiled} ->
+                    Bucket = riak_kv_ts_util:table_to_bucket(Table),
+                    Results =
+                        [begin
+                             Node = proplists:get_value(node, Cover),
+                             {IP, Port} = riak_kv_pb_coverage:node_to_pb_details(Node),
+                             {entry,
+                              [
+                               {cover_context,
+                                riak_kv_pb_coverage:term_to_checksum_binary({Cover, Range})},
+                               {ip, IP},
+                               {port, Port},
+                               {range,
+                                [
+                                 {field_name, FieldName},
+                                 {lower_bound, StartVal},
+                                 {lower_bound_inclusive, StartIncl},
+                                 {upper_bound, EndVal},
+                                 {upper_bound_inclusive, EndIncl},
+                                 {desc, SQLtext}
+                                ]}
+                              ]}
+                         end || {Cover,
+                                 Range = {FieldName, {{StartVal, StartIncl}, {EndVal, EndIncl}}},
+                                 SQLtext}
+                                    <- riak_kv_ts_util:sql_to_cover(Client, Compiled, Bucket, [])],
+                    prepare_data_in_body(RD, Ctx#ctx{result = Results});
+                {error, _Reason} ->
+                    handle_error(query_compile_fail, RD, Ctx)
+            end;
+        {ok, _NonSelectQuery} ->
+            handle_error(inappropriate_sql_for_coverage, RD, Ctx);
+        {error, Reason} ->
+            handle_error({query_parse_error, Reason}, RD, Ctx)
+    end.
+
+
+process_query(DDL = #ddl_v1{table = Table}, RD, Ctx) ->
+    {ok, Props1} = riak_kv_ts_util:apply_timeseries_bucket_props(DDL, []),
+    Props2 = [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props1],
+    %% TODO: let's not bother collecting user properties from (say)
+    %% sidecar object in body JSON: when #ddl_v2 work is merged, we
+    %% will have a way to collect those bespoke table properties from
+    %% WITH clause.
+    case riak_core_bucket_type:create(Table, Props2) of
+        ok ->
+            wait_until_active(Table, RD, Ctx, ?TABLE_ACTIVATE_WAIT);
+        {error, Reason} ->
+            handle_error({table_create_fail, Table, Reason}, RD, Ctx)
+    end;
+
+process_query(SQL = ?SQL_SELECT{'FROM' = Table}, RD, Ctx0 = #ctx{}) ->
+    Mod = riak_ql_ddl:make_module_name(Table),
+    case catch Mod:get_ddl() of
+        {_, {undef, _}} ->
+            handle_error({no_such_table, Table}, RD, Ctx0);
+        DDL ->
+            case riak_kv_qry:submit(SQL, DDL) of
+                {ok, Data} ->
+                    {ColumnNames, _ColumnTypes, Rows} = Data,
+                    Ctx = Ctx0#ctx{result = {ColumnNames, Rows}},
+                    prepare_data_in_body(RD, Ctx);
+                %% the following timeouts are known and distinguished:
+                {error, qry_worker_timeout} ->
+                    %% the eleveldb process didn't send us any response after
+                    %% 10 sec (hardcoded in riak_kv_qry), and probably died
+                    handle_error(query_worker_timeout, RD, Ctx0);
+                {error, backend_timeout} ->
+                    %% the eleveldb process did manage to send us a timeout
+                    %% response
+                    handle_error(backend_timeout, RD, Ctx0);
+
+                {error, Reason} ->
+                    handle_error({query_exec_error, Reason}, RD, Ctx0)
+            end
+    end;
+
+process_query(SQL = #riak_sql_describe_v1{'DESCRIBE' = Table}, RD, Ctx0 = #ctx{}) ->
+    Mod = riak_ql_ddl:make_module_name(Table),
+    case catch Mod:get_ddl() of
+        {_, {undef, _}} ->
+            handle_error({no_such_table, Table}, RD, Ctx0);
+        DDL ->
+            case riak_kv_qry:submit(SQL, DDL) of
+                {ok, Data} ->
+                    ColumnNames = [<<"Column">>, <<"Type">>, <<"Is Null">>,
+                                   <<"Primary Key">>, <<"Local Key">>],
+                    Ctx = Ctx0#ctx{result = {ColumnNames, Data}},
+                    prepare_data_in_body(RD, Ctx);
+                {error, Reason} ->
+                    handle_error({query_exec_error, Reason}, RD, Ctx0)
+            end
+    end.
+
+
+wait_until_active(Table, RD, Ctx, 0) ->
+    handle_error({table_activate_fail, Table}, RD, Ctx);
+wait_until_active(Table, RD, Ctx, Seconds) ->
+    case riak_core_bucket_type:activate(Table) of
+        ok ->
+            prepare_data_in_body(RD, Ctx#ctx{result = {[], []}});
+            %% a way for CREATE TABLE queries to return 'ok' on success
+        {error, not_ready} ->
+            timer:sleep(1000),
+            wait_until_active(Table, RD, Ctx, Seconds - 1);
+        {error, undefined} ->
+            %% this is inconceivable because create(Table) has
+            %% just succeeded, so it's here mostly to pacify
+            %% the dialyzer (and of course, for the odd chance
+            %% of Erlang imps crashing nodes between create
+            %% and activate calls)
+            handle_error({table_created_missing, Table}, RD, Ctx)
+    end.
+
+prepare_data_in_body(RD0, Ctx0) ->
+    {Json, RD1, Ctx1} = produce_doc_body(RD0, Ctx0),
+    {true, wrq:append_to_response_body(Json, RD1), Ctx1}.
+
+
+-spec produce_doc_body(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+%% @doc Extract the value of the document, and place it in the
+%%      response body of the request.
+produce_doc_body(RD, Ctx = #ctx{result = ok}) ->
+    {<<"ok">>, RD, Ctx};
+produce_doc_body(RD, Ctx = #ctx{api_call = Call,
+                                result = {Columns, Rows}})
+  when Call == get;
+       Call == query ->
+    {mochijson2:encode(
+       {struct, [{<<"columns">>, Columns},
+                 {<<"rows">>, Rows}]}),
+     RD, Ctx};
+produce_doc_body(RD, Ctx = #ctx{api_call = Call,
+                                result = CoverageDetails})
+  when Call == coverage ->
+    SafeCoverageDetails =
+        [{entry, armor_entry(E)} || {entry, E} <- CoverageDetails],
+    {mochijson2:encode(
+       {struct, [{<<"coverage">>, SafeCoverageDetails}]}),
+     RD, Ctx}.
+
+armor_entry(EE) ->
+    lists:map(
+      fun({cover_context, Bin}) ->
+              %% prevent list to be read and converted by mochijson2
+              %% as utf8 binary
+              {cover_context, binary_to_list(Bin)};
+         (X) -> X
+      end, EE).
+
+
+error_out(Type, Fmt, Args, RD, Ctx) ->
+    {Type,
+     wrq:set_resp_header(
+       "Content-Type", "text/plain", wrq:append_to_response_body(
+                                       flat_format(Fmt, Args), RD)),
+     Ctx}.
+
+-spec handle_error(atom()|tuple(), #wm_reqdata{}, #ctx{}) -> {tuple(), #wm_reqdata{}, #ctx{}}.
+handle_error(Error, RD, Ctx) ->
+    case Error of
+        {unsupported_version, BadVersion} ->
+            error_out({halt, 412},
+                      "Unsupported API version ~s", [BadVersion], RD, Ctx);
+        {malformed_request, Method} ->
+            error_out({halt, 400},
+                      "Malformed ~s request", [Method], RD, Ctx);
+        {bad_parameter, Param} ->
+            error_out({halt, 400},
+                      "Bad value for parameter \"~s\"", [Param], RD, Ctx);
+        {no_such_table, Table} ->
+            error_out({halt, 404},
+                      "Table \"~ts\" does not exist", [Table], RD, Ctx);
+        {failed_some_puts, NoOfFailures, Table} ->
+            error_out({halt, 400},
+                      "Failed to put ~b records to table \"~ts\"", [NoOfFailures, Table], RD, Ctx);
+        {invalid_data, BadRowIdxs} ->
+            error_out({halt, 400},
+                      "Invalid record #~s", [hd(BadRowIdxs)], RD, Ctx);
+        {key_element_count_mismatch, Got, Need} ->
+            error_out({halt, 400},
+                      "Incorrect number of elements (~b) for key of length ~b", [Need, Got], RD, Ctx);
+        notfound ->
+            error_out({halt, 404},
+                      "Key not found", [], RD, Ctx);
+        {riak_error, Detailed} ->
+            error_out({halt, 500},
+                      "Internal riak error: ~p", [Detailed], RD, Ctx);
+        {query_parse_error, Detailed} ->
+            error_out({halt, 400},
+                      "Malformed query: ~ts", [Detailed], RD, Ctx);
+        inappropriate_sql_for_coverage ->
+            error_out({halt, 400},
+                      "Inappropriate query for coverage request", [], RD, Ctx);
+        query_compile_fail ->
+            error_out({halt, 400},
+                      "Failed to compile query for coverage request", [], RD, Ctx);
+        {table_create_fail, Table, Reason} ->
+            error_out({halt, 500},
+                      "Failed to create table \"~ts\": ~p", [Table, Reason], RD, Ctx);
+        query_worker_timeout ->
+            error_out({halt, 503},
+                      "Query worker timeout", [], RD, Ctx);
+        backend_timeout ->
+            error_out({halt, 503},
+                      "Storage backend timeout", [], RD, Ctx);
+        {query_exec_error, Detailed} ->
+            error_out({halt, 400},
+                      "Query execution failed: ~ts", [Detailed], RD, Ctx);
+        {table_activate_fail, Table} ->
+            error_out({halt, 500},
+                      "Failed to activate bucket type for table \"~ts\"", [Table], RD, Ctx);
+        {table_created_missing, Table} ->
+            error_out({halt, 500},
+                      "Bucket type for table \"~ts\" disappeared suddenly before activation", [Table], RD, Ctx);
+        {inappropriate_sql_for_method, Method} ->
+            error_out({halt, 400},
+                      "Inappropriate method ~s for SQL query type", [Method], RD, Ctx);
+        OutOfTheBlue ->
+            error_out({halt, 418},
+                      "Phantom error: ~p", [OutOfTheBlue], RD, Ctx)
+    end.
+
+flat_format(Format, Args) ->
+    lists:flatten(io_lib:format(Format, Args)).

--- a/src/riak_kv_wm_timeseries_listkeys.erl
+++ b/src/riak_kv_wm_timeseries_listkeys.erl
@@ -1,0 +1,186 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_wm_timeseries_listkeys: Webmachine resource for riak TS
+%%                                  streaming operations.
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Resource for Riak TS operations over HTTP.
+%%
+%% ```
+%% GET    /ts/v1/table/Table/keys     list_keys
+%% '''
+%%
+%% Request body is expected to be a JSON containing key and/or value(s).
+%% Response is a JSON containing data rows with column headers.
+%%
+
+-module(riak_kv_wm_timeseries_listkeys).
+
+%% webmachine resource exports
+-export([
+         init/1,
+         service_available/2,
+         allowed_methods/2,
+         is_authorized/2,
+         forbidden/2,
+         resource_exists/2,
+         content_types_provided/2,
+         encodings_provided/2,
+         produce_doc_body/2
+        ]).
+
+-include("riak_kv_wm_raw.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
+
+-record(ctx, {api_version,
+              riak,
+              security,
+              client,
+              table    :: undefined | binary()
+             }).
+
+-define(CB_RV_SPEC, {boolean(), #wm_reqdata{}, #ctx{}}).
+
+-define(DEFAULT_TIMEOUT, 60000).
+
+-spec init(proplists:proplist()) -> {ok, #ctx{}}.
+%% @doc Initialize this resource.  This function extracts the
+%%      'prefix' and 'riak' properties from the dispatch args.
+init(Props) ->
+    {ok, #ctx{api_version = proplists:get_value(api_version, Props),
+              riak = proplists:get_value(riak, Props),
+              table = proplists:get_value(table, Props)}}.
+
+-spec service_available(#wm_reqdata{}, #ctx{}) ->
+    {boolean(), #wm_reqdata{}, #ctx{}}.
+%% @doc Determine whether or not a connection to Riak
+%%      can be established.  This function also takes this
+%%      opportunity to extract the 'bucket' and 'key' path
+%%      bindings from the dispatch, as well as any vtag
+%%      query parameter.
+service_available(RD, Ctx = #ctx{riak = RiakProps}) ->
+    case riak_kv_wm_utils:get_riak_client(
+           RiakProps, riak_kv_wm_utils:get_client_id(RD)) of
+        {ok, C} ->
+            {true, RD,
+             Ctx#ctx{api_version = wrq:path_info(api_version, RD),
+                     client = C,
+                     table =
+                         case wrq:path_info(table, RD) of
+                             undefined -> undefined;
+                             B -> list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, B))
+                         end
+                    }};
+        Error ->
+            {false, wrq:set_resp_body(
+                      flat_format("Unable to connect to Riak: ~p", [Error]),
+                      wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx}
+    end.
+
+
+is_authorized(ReqData, Ctx) ->
+    case riak_api_web_security:is_authorized(ReqData) of
+        false ->
+            {"Basic realm=\"Riak\"", ReqData, Ctx};
+        {true, SecContext} ->
+            {true, ReqData, Ctx#ctx{security = SecContext}};
+        insecure ->
+            {{halt, 426},
+             wrq:append_to_resp_body(
+               <<"Security is enabled and "
+                 "Riak does not accept credentials over HTTP. Try HTTPS instead.">>, ReqData),
+             Ctx}
+    end.
+
+
+-spec forbidden(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+forbidden(RD, Ctx) ->
+    case riak_kv_wm_utils:is_forbidden(RD) of
+        true ->
+            {true, RD, Ctx};
+        false ->
+            {false, RD, Ctx}
+    end.
+
+-spec allowed_methods(#wm_reqdata{}, #ctx{}) ->
+    {[atom()], #wm_reqdata{}, #ctx{}}.
+%% @doc Get the list of methods this resource supports.
+allowed_methods(RD, Ctx) ->
+    {['GET'], RD, Ctx}.
+
+
+-spec resource_exists(#wm_reqdata{}, #ctx{}) ->
+                             {boolean(), #wm_reqdata{}, #ctx{}}.
+resource_exists(RD, #ctx{table = Table} = Ctx) ->
+    {riak_kv_wm_utils:bucket_type_exists(Table), RD, Ctx}.
+
+
+-spec encodings_provided(#wm_reqdata{}, #ctx{}) ->
+                                {[{Encoding::string(), Producer::function()}],
+                                 #wm_reqdata{}, #ctx{}}.
+%% @doc List the encodings available for representing this resource.
+%%      "identity" and "gzip" are available.
+encodings_provided(RD, Ctx) ->
+    {riak_kv_wm_utils:default_encodings(), RD, Ctx}.
+
+-spec content_types_provided(#wm_reqdata{}, #ctx{}) ->
+                                    {[{ContentType::string(), Producer::atom()}],
+                                     #wm_reqdata{}, #ctx{}}.
+%% @doc List the content types available for representing this resource.
+content_types_provided(RD, Ctx) ->
+    {[{"application/json", produce_doc_body}], RD, Ctx}.
+
+
+produce_doc_body(RD, Ctx = #ctx{table = Table,
+                                client = Client}) ->
+    F = fun() ->
+                {ok, ReqId} = riak_client:stream_list_keys(
+                                {Table, Table}, undefined, Client),
+                stream_keys(ReqId)
+        end,
+    {{stream, {<<>>, F}}, RD, Ctx}.
+
+stream_keys(ReqId) ->
+    receive
+        %% skip empty shipments
+        {ReqId, {keys, []}} ->
+            stream_keys(ReqId);
+        {ReqId, From, {keys, []}} ->
+            _ = riak_kv_keys_fsm:ack_keys(From),
+            stream_keys(ReqId);
+        {ReqId, From, {keys, Keys}} ->
+            _ = riak_kv_keys_fsm:ack_keys(From),
+            {ts_keys_to_json(Keys), fun() -> stream_keys(ReqId) end};
+        {ReqId, {keys, Keys}} ->
+            {ts_keys_to_json(Keys), fun() -> stream_keys(ReqId) end};
+        {ReqId, done} ->
+            {<<>>, done};
+        {ReqId, {error, timeout}} ->
+            {mochijson2:encode({struct, [{error, timeout}]}), done}
+    end.
+
+ts_keys_to_json(Keys) ->
+    KeysTerm = [tuple_to_list(sext:decode(A))
+                || A <- Keys, A /= []],
+    mochijson2:encode({struct, [{<<"keys">>, KeysTerm}]}).
+
+flat_format(Format, Args) ->
+    lists:flatten(io_lib:format(Format, Args)).

--- a/src/riak_kv_wm_timeseries_query.erl
+++ b/src/riak_kv_wm_timeseries_query.erl
@@ -1,0 +1,493 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_wm_timeseries_query: Webmachine resource for riak TS query call.
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Resource for Riak TS operations over HTTP.
+%%
+%% ```
+%% GET/POST   /ts/v1/query   execute SQL query
+%% '''
+%%
+%% Request body is expected to be a JSON containing key and/or value(s).
+%% Response is a JSON containing data rows with column headers.
+%%
+
+-module(riak_kv_wm_timeseries_query).
+
+%% webmachine resource exports
+-export([
+         init/1,
+         service_available/2,
+         is_authorized/2,
+         forbidden/2,
+         allowed_methods/2,
+         process_post/2,
+         malformed_request/2,
+         content_types_accepted/2,
+         resource_exists/2,
+         content_types_provided/2,
+         encodings_provided/2,
+         produce_doc_body/2,
+         accept_doc_body/2
+        ]).
+
+-include("riak_kv_wm_raw.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
+-include_lib("riak_ql/include/riak_ql_ddl.hrl").
+
+-record(ctx, {api_version,
+              method  :: atom(),
+              prefix,       %% string() - prefix for resource uris
+              timeout,      %% integer() - passed-in timeout value in ms
+              security,     %% security context
+              client,       %% riak_client() - the store client
+              riak,         %% local | {node(), atom()} - params for riak client
+              table          :: undefined | binary(),
+              cover_context  :: undefined | binary(),
+              query          :: undefined | string(),
+              compiled_query :: undefined | #ddl_v1{} | #riak_sql_describe_v1{} | ?SQL_SELECT{},
+              result         :: undefined | ok | {Headers::[binary()], Rows::[ts_rec()]} |
+                                [{entry, proplists:proplist()}]
+             }).
+
+-define(DEFAULT_TIMEOUT, 60000).
+-define(TABLE_ACTIVATE_WAIT, 30).   %% wait until table's bucket type is activated
+
+-define(CB_RV_SPEC, {boolean(), #wm_reqdata{}, #ctx{}}).
+-type ts_rec() :: [riak_pb_ts_codec:ldbvalue()].
+
+
+-spec init(proplists:proplist()) -> {ok, #ctx{}}.
+%% @doc Initialize this resource.  This function extracts the
+%%      'prefix' and 'riak' properties from the dispatch args.
+init(Props) ->
+    {ok, #ctx{prefix = proplists:get_value(prefix, Props),
+              riak = proplists:get_value(riak, Props)}}.
+
+-spec service_available(#wm_reqdata{}, #ctx{}) ->
+    {boolean(), #wm_reqdata{}, #ctx{}}.
+%% @doc Determine whether or not a connection to Riak
+%%      can be established.  This function also takes this
+%%      opportunity to extract the 'bucket' and 'key' path
+%%      bindings from the dispatch, as well as any vtag
+%%      query parameter.
+service_available(RD, Ctx = #ctx{riak = RiakProps}) ->
+    case riak_kv_wm_utils:get_riak_client(
+           RiakProps, riak_kv_wm_utils:get_client_id(RD)) of
+        {ok, C} ->
+            {true, RD,
+             Ctx#ctx{api_version = wrq:path_info(api_version, RD),
+                     method = wrq:method(RD),
+                     client = C,
+                     table =
+                         case wrq:path_info(table, RD) of
+                             undefined -> undefined;
+                             B -> list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, B))
+                         end
+                    }};
+        Error ->
+            {false, wrq:set_resp_body(
+                      flat_format("Unable to connect to Riak: ~p", [Error]),
+                      wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx}
+    end.
+
+
+is_authorized(ReqData, Ctx) ->
+    case riak_api_web_security:is_authorized(ReqData) of
+        false ->
+            {"Basic realm=\"Riak\"", ReqData, Ctx};
+        {true, SecContext} ->
+            {true, ReqData, Ctx#ctx{security = SecContext}};
+        insecure ->
+            %% XXX 301 may be more appropriate here, but since the http and
+            %% https port are different and configurable, it is hard to figure
+            %% out the redirect URL to serve.
+            {{halt, 426},
+             wrq:append_to_resp_body(
+               <<"Security is enabled and "
+                 "Riak does not accept credentials over HTTP. Try HTTPS instead.">>, ReqData),
+             Ctx}
+    end.
+
+
+-spec forbidden(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+forbidden(RD, Ctx) ->
+    case riak_kv_wm_utils:is_forbidden(RD) of
+        true ->
+            {true, RD, Ctx};
+        false ->
+            %% plug in early, and just do what it takes to do the job
+            {false, RD, Ctx}
+    end.
+%% Because webmachine chooses to (not) call certain callbacks
+%% depending on request method used, sometimes accept_doc_body is not
+%% called at all, and we arrive at produce_doc_body empty-handed.
+%% This is the case when curl is executed with -G and --data.
+
+
+-spec allowed_methods(#wm_reqdata{}, #ctx{}) ->
+    {[atom()], #wm_reqdata{}, #ctx{}}.
+allowed_methods(RD, Ctx) ->
+    {['GET', 'POST'], RD, Ctx}.
+
+
+-spec malformed_request(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+malformed_request(RD, Ctx) ->
+    %% this is plugged because requests are validated against
+    %% effective query contained in the body (and hence, we need
+    %% accept_doc_body to parse and extract things out of JSON first)
+    {false, RD, Ctx}.
+
+
+-spec preexec(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+%% * extract query from request body or, failing that, from
+%%   POST k=v items, try to compile it;
+%% * check API version;
+%% * validate query type against HTTP method;
+%% * check permissions on the query type.
+preexec(RD, Ctx) ->
+    case validate_request(RD, Ctx) of
+        {true, RD1, Ctx1} ->
+            case check_permissions(RD1, Ctx1) of
+                {false, RD2, Ctx2} ->
+                    call_api_function(RD2, Ctx2);
+                FalseWithDetails ->
+                    FalseWithDetails
+            end;
+        FalseWithDetails ->
+            FalseWithDetails
+    end.
+
+-spec validate_request(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+validate_request(RD, Ctx) ->
+    case wrq:path_info(api_version, RD) of
+        "v1" ->
+            validate_request_v1(RD, Ctx);
+        BadVersion ->
+            handle_error({unsupported_version, BadVersion}, RD, Ctx)
+    end.
+
+-spec validate_request_v1(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+validate_request_v1(RD, Ctx = #ctx{method = Method}) ->
+    Json = extract_json(RD),
+    case {Method, string:tokens(wrq:path(RD), "/"),
+          extract_query(Json), extract_cover_context(Json)} of
+        {Method, ["ts", "v1", "query"],
+         Query, CoverContext}
+          when (Method == 'GET' orelse Method == 'POST')
+               andalso is_list(Query) ->
+            case riak_ql_parser:parse(
+                   riak_ql_lexer:get_tokens(Query)) of
+                {ok, CompiledQry} ->
+                    valid_params(
+                      RD, Ctx#ctx{api_version = "v1",
+                                  query = Query, cover_context = CoverContext,
+                                  compiled_query = CompiledQry});
+                {error, Reason} ->
+                    handle_error({query_parse_error, Reason}, RD, Ctx)
+            end;
+        _Invalid ->
+            handle_error({malformed_request, Method}, RD, Ctx)
+    end.
+
+
+-spec valid_params(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+valid_params(RD, Ctx) ->
+    %% no params currently for query
+    {true, RD, Ctx}.
+
+%% This is a special case for curl -G.  `curl -G host --data $data`
+%% will send the $data in URL instead of in the body, so we try to
+%% look for it in req_qs.
+extract_json(RD) ->
+    case proplists:get_value("json", RD#wm_reqdata.req_qs) of
+        undefined ->
+            %% if it was a PUT or POST, data is in body
+            binary_to_list(wrq:req_body(RD));
+        BodyInPost ->
+            BodyInPost
+    end.
+
+-spec extract_query(binary()) -> term().
+extract_query(Json) ->
+    try mochijson2:decode(Json) of
+        {struct, Decoded} when is_list(Decoded) ->
+            validate_ts_query(
+              proplists:get_value(<<"query">>, Decoded))
+    catch
+        _:_ ->
+            undefined
+    end.
+
+-spec extract_cover_context(binary()) -> term().
+extract_cover_context(Json) ->
+    try mochijson2:decode(Json) of
+        {struct, Decoded} when is_list(Decoded) ->
+            validate_ts_cover_context(
+              proplists:get_value(<<"coverage_context">>, Decoded))
+    catch
+        _:_ ->
+            undefined
+    end.
+
+
+validate_ts_query(Q) when is_binary(Q) ->
+    binary_to_list(Q);
+validate_ts_query(_) ->
+    undefined.
+
+validate_ts_cover_context(C) when is_binary(C) ->
+    C;
+validate_ts_cover_context(_) ->
+    undefined.
+
+
+-spec check_permissions(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+check_permissions(RD, Ctx = #ctx{security = undefined}) ->
+    {false, RD, Ctx};
+check_permissions(RD, Ctx = #ctx{security = Security,
+                                 compiled_query = CompiledQry}) ->
+    case riak_core_security:check_permission(
+           decode_query_permissions(CompiledQry), Security) of
+        {false, Error, _} ->
+            handle_error(
+              {not_permitted, unicode:characters_to_binary(Error, utf8, utf8)}, RD, Ctx);
+        _ ->
+            {false, RD, Ctx}
+    end.
+
+decode_query_permissions(#ddl_v1{table = NewBucketType}) ->
+    {"riak_kv.ts_create_table", NewBucketType};
+decode_query_permissions(?SQL_SELECT{'FROM' = Table}) ->
+    {"riak_kv.ts_query", Table};
+decode_query_permissions(#riak_sql_describe_v1{'DESCRIBE' = Table}) ->
+    {"riak_kv.ts_describe", Table}.
+
+
+-spec content_types_provided(#wm_reqdata{}, #ctx{}) ->
+                                    {[{ContentType::string(), Producer::atom()}],
+                                     #wm_reqdata{}, #ctx{}}.
+content_types_provided(RD, Ctx) ->
+    {[{"application/json", produce_doc_body}], RD, Ctx}.
+
+
+-spec encodings_provided(#wm_reqdata{}, #ctx{}) ->
+                                {[{Encoding::string(), Producer::function()}],
+                                 #wm_reqdata{}, #ctx{}}.
+encodings_provided(RD, Ctx) ->
+    {riak_kv_wm_utils:default_encodings(), RD, Ctx}.
+
+
+-spec content_types_accepted(#wm_reqdata{}, #ctx{}) ->
+                                    {[{ContentType::string(), Acceptor::atom()}],
+                                     #wm_reqdata{}, #ctx{}}.
+content_types_accepted(RD, Ctx) ->
+    {[{"application/json", accept_doc_body}], RD, Ctx}.
+
+
+-spec resource_exists(#wm_reqdata{}, #ctx{}) ->
+                             {boolean(), #wm_reqdata{}, #ctx{}}.
+resource_exists(RD0, Ctx0) ->
+    case preexec(RD0, Ctx0) of
+        {true, RD, Ctx} ->
+            call_api_function(RD, Ctx);
+        FalseWithDetails ->
+            FalseWithDetails
+    end.
+
+-spec process_post(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+%% @doc Pass through requests to allow POST to function
+%%      as PUT for clients that do not support PUT.
+process_post(RD, Ctx) ->
+    accept_doc_body(RD, Ctx).
+
+-spec accept_doc_body(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+accept_doc_body(RD0, Ctx0) ->
+    case preexec(RD0, Ctx0) of
+        {true, RD, Ctx} ->
+            call_api_function(RD, Ctx);
+        FalseWithDetails ->
+            FalseWithDetails
+    end.
+
+-spec call_api_function(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+call_api_function(RD, Ctx = #ctx{result = Result})
+  when Result /= undefined ->
+    lager:debug("Function already executed", []),
+    {true, RD, Ctx};
+call_api_function(RD, Ctx = #ctx{method = Method,
+                                 compiled_query = CompiledQry,
+                                 cover_context = CoverCtx}) ->
+    case CompiledQry of
+        SQL = ?SQL_SELECT{} when Method == 'GET' ->
+            %% inject coverage context
+            process_query(SQL?SQL_SELECT{cover_context = CoverCtx}, RD, Ctx);
+        Other when (is_record(Other, ddl_v1)               andalso Method == 'POST') orelse
+                   (is_record(Other, riak_sql_describe_v1) andalso Method ==  'GET') ->
+            process_query(Other, RD, Ctx);
+        _Other ->
+            handle_error({inappropriate_sql_for_method, Method}, RD, Ctx)
+    end.
+
+
+process_query(DDL = #ddl_v1{table = Table}, RD, Ctx) ->
+    {ok, Props1} = riak_kv_ts_util:apply_timeseries_bucket_props(DDL, []),
+    Props2 = [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props1],
+    %% TODO: let's not bother collecting user properties from (say)
+    %% sidecar object in body JSON: when #ddl_v2 work is merged, we
+    %% will have a way to collect those bespoke table properties from
+    %% WITH clause.
+    case riak_core_bucket_type:create(Table, Props2) of
+        ok ->
+            wait_until_active(Table, RD, Ctx, ?TABLE_ACTIVATE_WAIT);
+        {error, Reason} ->
+            handle_error({table_create_fail, Table, Reason}, RD, Ctx)
+    end;
+
+process_query(SQL = ?SQL_SELECT{'FROM' = Table}, RD, Ctx0 = #ctx{}) ->
+    Mod = riak_ql_ddl:make_module_name(Table),
+    case catch Mod:get_ddl() of
+        {_, {undef, _}} ->
+            handle_error({no_such_table, Table}, RD, Ctx0);
+        DDL ->
+            case riak_kv_qry:submit(SQL, DDL) of
+                {ok, Data} ->
+                    {ColumnNames, _ColumnTypes, Rows} = Data,
+                    Ctx = Ctx0#ctx{result = {ColumnNames, Rows}},
+                    prepare_data_in_body(RD, Ctx);
+                %% the following timeouts are known and distinguished:
+                {error, qry_worker_timeout} ->
+                    %% the eleveldb process didn't send us any response after
+                    %% 10 sec (hardcoded in riak_kv_qry), and probably died
+                    handle_error(query_worker_timeout, RD, Ctx0);
+                {error, backend_timeout} ->
+                    %% the eleveldb process did manage to send us a timeout
+                    %% response
+                    handle_error(backend_timeout, RD, Ctx0);
+
+                {error, Reason} ->
+                    handle_error({query_exec_error, Reason}, RD, Ctx0)
+            end
+    end;
+
+process_query(SQL = #riak_sql_describe_v1{'DESCRIBE' = Table}, RD, Ctx0 = #ctx{}) ->
+    Mod = riak_ql_ddl:make_module_name(Table),
+    case catch Mod:get_ddl() of
+        {_, {undef, _}} ->
+            handle_error({no_such_table, Table}, RD, Ctx0);
+        DDL ->
+            case riak_kv_qry:submit(SQL, DDL) of
+                {ok, Data} ->
+                    ColumnNames = [<<"Column">>, <<"Type">>, <<"Is Null">>,
+                                   <<"Primary Key">>, <<"Local Key">>],
+                    Ctx = Ctx0#ctx{result = {ColumnNames, Data}},
+                    prepare_data_in_body(RD, Ctx);
+                {error, Reason} ->
+                    handle_error({query_exec_error, Reason}, RD, Ctx0)
+            end
+    end.
+
+
+wait_until_active(Table, RD, Ctx, 0) ->
+    handle_error({table_activate_fail, Table}, RD, Ctx);
+wait_until_active(Table, RD, Ctx, Seconds) ->
+    case riak_core_bucket_type:activate(Table) of
+        ok ->
+            prepare_data_in_body(RD, Ctx#ctx{result = {[],[]}});
+            %% a way for CREATE TABLE queries to return 'ok' on success
+        {error, not_ready} ->
+            timer:sleep(1000),
+            wait_until_active(Table, RD, Ctx, Seconds - 1);
+        {error, undefined} ->
+            %% this is inconceivable because create(Table) has
+            %% just succeeded, so it's here mostly to pacify
+            %% the dialyzer (and of course, for the odd chance
+            %% of Erlang imps crashing nodes between create
+            %% and activate calls)
+            handle_error({table_created_missing, Table}, RD, Ctx)
+    end.
+
+prepare_data_in_body(RD0, Ctx0) ->
+    {Json, RD1, Ctx1} = produce_doc_body(RD0, Ctx0),
+    {true, wrq:append_to_response_body(Json, RD1), Ctx1}.
+
+
+-spec produce_doc_body(#wm_reqdata{}, #ctx{}) -> ?CB_RV_SPEC.
+%% @doc Extract the value of the document, and place it in the
+%%      response body of the request.
+produce_doc_body(RD, Ctx = #ctx{result = {Columns, Rows}}) ->
+    {mochijson2:encode(
+       {struct, [{<<"columns">>, Columns},
+                 {<<"rows">>, Rows}]}),
+     RD, Ctx}.
+
+
+error_out(Type, Fmt, Args, RD, Ctx) ->
+    {Type,
+     wrq:set_resp_header(
+       "Content-Type", "text/plain", wrq:append_to_response_body(
+                                       flat_format(Fmt, Args), RD)),
+     Ctx}.
+
+-spec handle_error(atom()|tuple(), #wm_reqdata{}, #ctx{}) -> {tuple(), #wm_reqdata{}, #ctx{}}.
+handle_error(Error, RD, Ctx) ->
+    case Error of
+        {unsupported_version, BadVersion} ->
+            error_out({halt, 412},
+                      "Unsupported API version ~s", [BadVersion], RD, Ctx);
+        {not_permitted, Table} ->
+            error_out({halt, 401},
+                      "Access to table ~s not allowed", [Table], RD, Ctx);
+        {malformed_request, Method} ->
+            error_out({halt, 400},
+                      "Malformed ~s request", [Method], RD, Ctx);
+        {no_such_table, Table} ->
+            error_out({halt, 404},
+                      "Table \"~ts\" does not exist", [Table], RD, Ctx);
+        {query_parse_error, Detailed} ->
+            error_out({halt, 400},
+                      "Malformed query: ~ts", [Detailed], RD, Ctx);
+        {table_create_fail, Table, Reason} ->
+            error_out({halt, 500},
+                      "Failed to create table \"~ts\": ~p", [Table, Reason], RD, Ctx);
+        query_worker_timeout ->
+            error_out({halt, 503},
+                      "Query worker timeout", [], RD, Ctx);
+        backend_timeout ->
+            error_out({halt, 503},
+                      "Storage backend timeout", [], RD, Ctx);
+        {query_exec_error, Detailed} ->
+            error_out({halt, 400},
+                      "Query execution failed: ~ts", [Detailed], RD, Ctx);
+        {table_activate_fail, Table} ->
+            error_out({halt, 500},
+                      "Failed to activate bucket type for table \"~ts\"", [Table], RD, Ctx);
+        {table_created_missing, Table} ->
+            error_out({halt, 500},
+                      "Bucket type for table \"~ts\" disappeared suddenly before activation", [Table], RD, Ctx);
+        {inappropriate_sql_for_method, Method} ->
+            error_out({halt, 400},
+                      "Inappropriate method ~s for SQL query type", [Method], RD, Ctx)
+    end.
+
+flat_format(Format, Args) ->
+    lists:flatten(io_lib:format(Format, Args)).


### PR DESCRIPTION
RTS-258

Implement these HTTP API calls (intending eventually to comply with https://docs.google.com/document/d/19cxGPEo7rQdjsC3jUw_40eiICwAN_OzPuT_F-eLXTt8):

```
GET       /ts/v1/table/Table          single-key get
DELETE    /ts/v1/table/Table          single-key delete
PUT       /ts/v1/table/Table          batch put
GET       /ts/v1/table/Table/keys     streaming list_keys
GET       /ts/v1/coverage             coverage for a query *
GET/POST  /ts/v1/query                execute an SQL query (SELECT or DESCRIBE with GET,
                                      CREATE TABLE with POST)
```

(*) commented out for now.

The keys, data and query for arguments to particular calls are to be submitted in request body, as in the real-world use case with curl: https://gist.github.com/hmmr/94abdb4d648a44009e93 and in r_t module https://github.com/basho/riak_test/pull/996.

The required TS extensions to riak-erlang-http-client are in https://github.com/basho/riak-erlang-http-client/pull/55. A tweak in riak-erlang-client for `riakc_ts:get/3` return value is in https://github.com/basho/riak-erlang-client/pull/261. (These are not dependencies of the present PR.)

The get/put/delete calls do not yet support specification of keys directly in URL, pending discussions in the draft on whether to accept keys as family/series and/or explicit identifiers.
