### PR TITLE
Finish TS batching

### DIFF
--- a/include/riak_kv_ts.hrl
+++ b/include/riak_kv_ts.hrl
@@ -34,7 +34,7 @@
         {
           calc_type        = rows :: select_result_type(),
           initial_state    = []   :: [any()],
-          col_return_types = []   :: [field_type()],
+          col_return_types = []   :: [riak_ql_ddl:field_type()],
           col_names        = []   :: [binary()],
           clause           = []   :: [riak_kv_qry_compiler:compiled_select()],
           finalisers       = []   :: [skip | function()]
@@ -44,9 +44,9 @@
         {
           'SELECT'              :: #riak_sel_clause_v1{},
           'FROM'        = <<>>  :: binary() | {list, [binary()]} | {regex, list()},
-          'WHERE'       = []    :: [filter()],
-          'ORDER BY'    = []    :: [sorter()],
-          'LIMIT'       = []    :: [limit()],
+          'WHERE'       = []    :: [riak_ql_ddl:filter()],
+          'ORDER BY'    = []    :: [riak_ql_ddl:sorter()],
+          'LIMIT'       = []    :: [riak_ql_ddl:limit()],
           helper_mod            :: atom(),
           %% will include groups when we get that far
           partition_key = none  :: none | #key_v1{},

--- a/include/riak_kv_vnode.hrl
+++ b/include/riak_kv_vnode.hrl
@@ -19,6 +19,17 @@
     type :: primary | fallback
 }).
 
+%% Currently only for timeseries batches
+-record(riak_kv_w1c_batch_put_req_v1, {
+    objs :: list({{binary(), binary()}, binary()}),
+    type :: primary | fallback
+}).
+
+-record(riak_kv_w1c_batch_put_reply_v1, {
+    reply :: ok | {error, term()},
+    type :: primary | fallback
+}).
+
 -record(riak_kv_get_req_v1, {
           bkey :: {binary(), binary()},
           req_id :: non_neg_integer()}).
@@ -75,6 +86,8 @@
 -define(KV_PUT_REQ, #riak_kv_put_req_v1).
 -define(KV_W1C_PUT_REQ, #riak_kv_w1c_put_req_v1).
 -define(KV_W1C_PUT_REPLY, #riak_kv_w1c_put_reply_v1).
+-define(KV_W1C_BATCH_PUT_REQ, #riak_kv_w1c_batch_put_req_v1).
+-define(KV_W1C_BATCH_PUT_REPLY, #riak_kv_w1c_batch_put_reply_v1).
 -define(KV_GET_REQ, #riak_kv_get_req_v1).
 -define(KV_LISTBUCKETS_REQ, #riak_kv_listbuckets_req_v1).
 -define(KV_LISTKEYS_REQ, #riak_kv_listkeys_req_v4).

--- a/src/riak_kv.app.src
+++ b/src/riak_kv.app.src
@@ -84,6 +84,15 @@
 
          {timeseries_query_max_quanta_span, 5},
 
-         {timeseries_max_concurrent_queries, 3}
+         {timeseries_max_concurrent_queries, 3},
+
+         %% Max batch size (in bytes) of data distributed between
+         %% nodes during a put operation. Highly recommended that you
+         %% not increase this above 1MB.
+         %%
+         %% This is not a hard cap; the number of records to generate
+         %% a batch under this value will be estimated based on the
+         %% size of the first record.
+         {timeseries_max_batch_size, 1048576}
         ]}
  ]}.

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -155,6 +155,10 @@ start(_Type, _StartArgs) ->
                                           [true, false],
                                           false),
 
+            riak_core_capability:register({riak_kv, w1c_batch_vnode},
+                                          [true, false],
+                                          false),
+
             %% mapred_system should remain until no nodes still exist
             %% that would propose 'legacy' as the default choice
             riak_core_capability:register({riak_kv, mapred_system},

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -393,6 +393,8 @@ estimated_row_count(SampleRowSize, MaxBatchSize) ->
     RowSizeFudged = (SampleRowSize * 10) div 9,
     MaxBatchSize div RowSizeFudged.
 
+create_batches(Rows, MaxSize) when length(Rows) =< MaxSize ->
+    [Rows];
 %% May be a more efficient way to do this. Take a list of arbitrary
 %% data (expected to be a list of lists for this use case) and create
 %% a list of MaxSize lists.
@@ -989,4 +991,15 @@ batch_3_test() ->
     ?assertEqual([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
                  create_batches([1, 2, 3, 4, 5, 6, 7, 8, 9], 3)).
 
+batch_undersized1_test() ->
+    ?assertEqual([[1, 2, 3, 4, 5, 6]],
+                 create_batches([1, 2, 3, 4, 5, 6], 6)).
+
+batch_undersized2_test() ->
+    ?assertEqual([[1, 2, 3, 4, 5, 6]],
+                 create_batches([1, 2, 3, 4, 5, 6], 7)).
+
+batch_almost_undersized_test() ->
+    ?assertEqual([[1, 2, 3, 4, 5], [6]],
+                 create_batches([1, 2, 3, 4, 5, 6], 5)).
 -endif.

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -402,7 +402,7 @@ create_batches(Rows, MaxSize) ->
     create_batches(Rows, MaxSize, MaxSize, [], []).
 
 create_batches([], _Counter, _Max, ThisBatch, AllBatches) ->
-    AllBatches ++ [ThisBatch];
+    [ThisBatch|AllBatches];
 create_batches(Rows, 0, Max, ThisBatch, AllBatches) ->
     create_batches(Rows, Max, Max, [], AllBatches ++ [ThisBatch]);
 create_batches([H|T], Counter, Max, ThisBatch, AllBatches) ->

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -393,7 +393,7 @@ build_object(Bucket, Mod, DDL, Row, PK) ->
     RObj = riak_object:newts(
              Bucket, PK, Obj,
              dict:from_list([{?MD_DDL_VERSION, ?DDL_VERSION}])),
-    {RObj, LK}.
+    {LK, RObj}.
 
 
 %% -----------
@@ -819,7 +819,7 @@ to_string(X) ->
 %% Returns a tuple with a list of request IDs and an error tally
 invoke_async_put(BuildRObjFun, AsyncPutFun, _BatchPutFun, {individual, Records}) ->
     lists:map(fun(Record) ->
-                      {RObj, LK} = BuildRObjFun(Record),
+                      {LK, RObj} = BuildRObjFun(Record),
                       {ok, ReqId} = AsyncPutFun(RObj, LK),
                       ReqId
                 end,

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -845,7 +845,7 @@ handle_command({get_index_entries, Opts},
 %% For now, ignore async_put. This is currently TS-only, and TS
 %% supports neither AAE nor YZ.
 handle_command(?KV_W1C_BATCH_PUT_REQ{objs=Objs, type=Type},
-                From, State=#state{mod=Mod, idx=Idx, modstate=ModState}) ->
+                From, State=#state{mod=Mod, modstate=ModState}) ->
     StartTS = os:timestamp(),
     Context = {w1c_batch_put, From, Type, Objs, StartTS},
     case Mod:batch_put(Context, Objs, [], ModState) of

--- a/src/riak_kv_w1c_worker.erl
+++ b/src/riak_kv_w1c_worker.erl
@@ -22,6 +22,7 @@
 
 %% API
 -export([start_link/1, put/2, async_put/8, async_put_replies/2,
+         ts_batch_put/7,
          workers/0, validate_options/4]).
 -export([init/1,
     handle_call/3,
@@ -118,10 +119,7 @@ async_put(RObj, W, PW, Bucket, NVal, LocalKey, EncodeFn, Preflist) ->
     StartTS = os:timestamp(),
     Worker = random_worker(),
     ReqId = erlang:monitor(process, Worker),
-    RObj2 = riak_object:set_vclock(RObj, vclock:fresh(<<0:8>>, 1)),
-    RObj3 = riak_object:update_last_modified(RObj2),
-    RObj4 = riak_object:apply_updates(RObj3),
-    EncodedVal = EncodeFn(RObj4),
+    EncodedVal = EncodeFn(w1c_vclock(RObj)),
 
     gen_server:cast(
       Worker,
@@ -130,6 +128,37 @@ async_put(RObj, W, PW, Bucket, NVal, LocalKey, EncodeFn, Preflist) ->
             start_ts=StartTS,
             size=size(EncodedVal)}}),
     {ok, {ReqId, Worker}}.
+
+-spec ts_batch_put(RObjs :: [{riak_object:key(), riak_object:riak_object()}],
+                   W :: pos_integer(),
+                   PW :: pos_integer(),
+                   Bucket :: binary()|{binary(), binary()},
+                   NVal :: pos_integer(),
+                   EncodeFn :: fun((riak_object:riak_object()) -> binary()),
+                   Preflist :: term()) ->
+                          {ok, {reference(), atom()}}.
+
+ts_batch_put(RObjs, W, PW, Bucket, NVal, EncodeFn, Preflist) ->
+    StartTS = os:timestamp(),
+    Worker = random_worker(),
+    ReqId = erlang:monitor(process, Worker),
+    EncodedVals =
+        lists:map(fun({K, O}) -> {{Bucket, K}, EncodeFn(w1c_vclock(O))} end,
+                  RObjs),
+    Size = lists:sum(lists:map(fun({_BK, O}) -> size(O) end, EncodedVals)),
+
+    gen_server:cast(
+      Worker,
+      {batch_put, EncodedVals, ReqId, Preflist,
+       #rec{w=W, pw=PW, n_val=NVal, from=self(),
+            start_ts=StartTS,
+            size=Size}}),
+    {ok, {ReqId, Worker}}.
+
+w1c_vclock(RObj) ->
+    RObj2 = riak_object:set_vclock(RObj, vclock:fresh(<<0:8>>, 1)),
+    RObj3 = riak_object:update_last_modified(RObj2),
+    riak_object:apply_updates(RObj3).
 
 -spec async_put_replies(ReqIdTuples :: list({reference(), pid()}), proplists:proplist()) ->
                                        list(term()).
@@ -152,6 +181,15 @@ handle_cast({put, Bucket, Key, EncodedVal, ReqId, Preflist, #rec{from=From}=Rec}
     NewState = case store_request_record(ReqId, Rec, State) of
         {undefined, S} ->
             S#state{proxies=send_vnodes(Preflist, Proxies, Bucket, Key, EncodedVal, ReqId)};
+        {_, S} ->
+            reply(From, ReqId, {error, request_id_already_defined}),
+            S
+    end,
+    {noreply, NewState};
+handle_cast({batch_put, EncodedVals, ReqId, Preflist, #rec{from=From}=Rec}, #state{proxies=Proxies}=State) ->
+    NewState = case store_request_record(ReqId, Rec, State) of
+        {undefined, S} ->
+            S#state{proxies=batch_send_vnodes(Preflist, Proxies, EncodedVals, ReqId)};
         {_, S} ->
             reply(From, ReqId, {error, request_id_already_defined}),
             S
@@ -267,6 +305,16 @@ send_vnodes([{{Idx, Node}, Type}|Rest], Proxies, Bucket, Key, EncodedVal, ReqId)
     ),
     send_vnodes(Rest, NewProxies, Bucket, Key, EncodedVal, ReqId).
 
+batch_send_vnodes([], Proxies, _EncodedVals, _ReqId) ->
+    Proxies;
+batch_send_vnodes([{{Idx, Node}, Type}|Rest], Proxies, EncodedVals, ReqId) ->
+    {Proxy, NewProxies} = get_proxy(Idx, Proxies),
+    Message = ?KV_W1C_BATCH_PUT_REQ{objs=EncodedVals, type=Type},
+    gen_fsm:send_event(
+        {Proxy, Node},
+        riak_core_vnode_master:make_request(Message, {raw, ReqId, self()}, Idx)
+    ),
+    batch_send_vnodes(Rest, NewProxies, EncodedVals, ReqId).
 
 get_proxy(Idx, Proxies) ->
     case ?DICT_TYPE:find(Idx, Proxies) of

--- a/src/riak_kv_w1c_worker.erl
+++ b/src/riak_kv_w1c_worker.erl
@@ -207,7 +207,14 @@ handle_cast({cancel, ReqId}, State) ->
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
+handle_info({ReqId, ?KV_W1C_BATCH_PUT_REPLY{reply=Reply, type=Type}}, State) ->
+    handle_put_reply(ReqId, Reply, Type, State);
 handle_info({ReqId, ?KV_W1C_PUT_REPLY{reply=Reply, type=Type}}, State) ->
+    handle_put_reply(ReqId, Reply, Type, State);
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+handle_put_reply(ReqId, Reply, Type, State) ->
     case get_request_record(ReqId, State) of
         undefined->
             % the entry was likely purged by the timeout mechanism
@@ -247,9 +254,7 @@ handle_info({ReqId, ?KV_W1C_PUT_REPLY{reply=Reply, type=Type}}, State) ->
                     {_, NewState} = store_request_record(ReqId, NewRec, State)
             end,
             {noreply, NewState}
-    end;
-handle_info(_Msg, State) ->
-    {noreply, State}.
+    end.
 
 terminate(_Reason, _State) ->
     ok.


### PR DESCRIPTION
This PR completes the incremental extension of batch uploads of data all the way through to the target vnodes. Previously, data was batched until it was divvied up into single records to be pushed via the `w1c_worker` processes.

Corresponding `eleveldb` and `riak_test` PRs to follow. Still waiting on final benchmarking numbers from @BrianMMcClain but an earlier version of this set of changes with a max batch size of 200 records showed a dramatic performance boost.
