### PR TITLE
Output some query debug information

### DIFF
--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -37,6 +37,8 @@
          build_sql_record/3,
          sql_record_to_tuple/1
         ]).
+-export([explain_query/1, explain_query/2]).
+-export([explain_query_print/1]).
 
 %% NOTE on table_to_bucket/1: Clients will work with table
 %% names. Those names map to a bucket type/bucket name tuple in Riak,
@@ -235,6 +237,97 @@ make_ts_keys(CompoundKey, DDL = #ddl_v1{local_key = #key_v1{ast = LKParams},
 %% riak_ql_ddl:get_local_key/3,
 encode_typeval_key(TypeVals) ->
     list_to_tuple([Val || {_Type, Val} <- TypeVals]).
+
+explain_query_print(QueryString) ->
+    explain_query_print2(1, explain_query(QueryString)).
+
+explain_query_print2(_, []) ->
+    ok;
+explain_query_print2(Index, [{Start, End, Filter}|Tail]) ->
+    io:format("SUB QUERY ~p~n~s ~s~n~s~n",
+        [Index,Start,filter_to_string(Filter),End]),
+    explain_query_print2(Index+1, Tail).
+
+%%
+explain_query(QueryString) ->
+    {ok, ?SQL_SELECT{ 'FROM' = Table } = Select} =
+        explain_compile_query(QueryString),
+    {ok, _Mod, DDL} = get_table_ddl(Table),
+    explain_query(DDL, Select).
+
+%% Explain a query using the ddl and select records. The select can be a query
+%% string.
+%%
+%% Have a flexible API because it is a debugging function.
+explain_query(DDL, ?SQL_SELECT{} = Select) ->
+    {ok, SubQueries} = riak_kv_qry_compiler:compile(DDL, Select, 10000),
+    [explain_sub_query(SQ) || SQ <- SubQueries];
+explain_query(DDL, QueryString) ->
+    {ok, Select} = explain_compile_query(QueryString),
+    explain_query(DDL, Select).
+
+%%
+explain_compile_query(QueryString) ->
+    {ok, Q} = riak_ql_parser:parse(riak_ql_lexer:get_tokens(QueryString)),
+    build_sql_record(select, Q, undefined).
+
+%%
+explain_sub_query(#riak_select_v1{ 'WHERE' = SubQueryWhere } = _SubQuery) ->
+    %% LOCAL KEY
+    %% a:sint64/b:timestamp/c:sint64/
+    %% SUB QUERY 1
+    %% >  10/1000/20 d = 10 OR e = 12
+    %% <= 10/2000/20
+    {_, StartKey1} = lists:keyfind(startkey, 1, SubQueryWhere),
+    {_, EndKey1} = lists:keyfind(endkey, 1, SubQueryWhere),
+    {_, Filters} = lists:keyfind(filter, 1, SubQueryWhere),
+    explain_query_keys(StartKey1, EndKey1, Filters).
+
+%%
+explain_query_keys(StartKey1, EndKey1, Filters) ->
+    StartKey2 = [[key_element_to_string(V), $/] || {_,_,V} <- StartKey1],
+    EndKey2 = [[key_element_to_string(V), $/] || {_,_,V} <- EndKey1],
+    case lists:keyfind(start_inclusive, 1, StartKey1) of
+        {start_inclusive,true} ->
+            StartKey3 = [">= ", StartKey2];
+        _ ->
+            StartKey3 = [">  ", StartKey2]
+    end,
+    case lists:keyfind(end_inclusive, 1, EndKey1) of
+        {end_inclusive,true} ->
+            EndKey3 = ["<= ", EndKey2];
+        _ ->
+            EndKey3 = ["<  ", EndKey2]
+    end,
+    {StartKey3, EndKey3, Filters}.
+
+%%
+key_element_to_string(V) when is_binary(V) -> varchar_quotes(V);
+key_element_to_string(V) when is_float(V) -> mochinum:digits(V);
+key_element_to_string(V) -> io_lib:format("~p", [V]).
+
+%%
+filter_to_string([]) ->
+    "NO FILTER";
+filter_to_string(Filter) ->
+    ["FILTER ", filter_to_string2(Filter)].
+
+%%
+filter_to_string2({const,V}) ->
+    key_element_to_string(V);
+filter_to_string2({field,V,_}) ->
+    V;
+filter_to_string2({Op, A, B}) ->
+    [filter_to_string2(A), op_to_string(Op), filter_to_string2(B)].
+
+%%
+op_to_string(and_) -> " AND ";
+op_to_string(or_) -> " OR ";
+op_to_string(Op) -> " " ++ atom_to_list(Op) ++ " ".
+
+%%
+varchar_quotes(V) ->
+    <<"'", V/binary, "'">>.
 
 %%%
 %%% TESTS


### PR DESCRIPTION
Utility functions for printing basic debug information about queries to the shell.

To use, attach a riak shell and call `riak_kv_ts_util:explain_query_print/1` with a select query. The target table must exist and be activated.

Example output:

``` erlang
(dev1@127.0.0.1)36> riak_kv_ts_util:explain_query_print("SELECT * FROM table2 WHERE a = 1 AND b = 1 AND c >= 1999 AND c <= 5000 AND d = 'lol' AND e > 10 AND d = true").
SUB QUERY 1
>  1/1/1999/ FILTER d = 'lol' AND e > 10 AND d = true
<  1/1/2000/
SUB QUERY 2
>  1/1/2000/ FILTER d = 'lol' AND e > 10 AND d = true
<  1/1/3000/
SUB QUERY 3
>  1/1/3000/ FILTER d = 'lol' AND e > 10 AND d = true
<  1/1/4000/
SUB QUERY 4
>  1/1/4000/ FILTER d = 'lol' AND e > 10 AND d = true
<  1/1/5000/
SUB QUERY 5
>  1/1/5000/ FILTER d = 'lol' AND e > 10 AND d = true
<  1/1/5000/
```
