### PR TITLE
Flexible key changes from review

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -1024,7 +1024,7 @@ bucket_type_and_table_error_local_key_test() ->
         "user   varchar   not null, ",
         "time   timestamp not null, ",
         "other  varchar   not null, ",
-        "PRIMARY KEY ((series, user, quantum(time, 15, m)), seriesd, user, time, other))">>,
+        "PRIMARY KEY ((series, user, quantum(time, 15, m)), seriesTYPO, user, time))">>,
     JSON = json_props([{bucket_type, my_type},
                        {table_def, TableDef}]),
     ?assertEqual(


### PR DESCRIPTION
Review changes for PR https://github.com/basho/riak_kv/pull/1357

Regarding comment https://github.com/basho/riak_kv/pull/1357#discussion_r55276708 this is clear to me at least, it is the arguments from the quantum function e.g. `quantum(mycol,15,s)`. The Q stands for quantum, but writing Quantum so many times was too verbose. How can it be made clearer?

cc @jonmeredith 
