### PR TITLE
bucket type properties in CREATE WITH clause

### DIFF
--- a/src/riak_kv_bucket.erl
+++ b/src/riak_kv_bucket.erl
@@ -2,7 +2,7 @@
 %%
 %% riak_kv_bucket: bucket validation functions
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -24,6 +24,7 @@
 -module(riak_kv_bucket).
 
 -export([validate/4]).
+-export([is_valid_property/1]).
 
 -include("riak_kv_types.hrl").
 
@@ -42,6 +43,43 @@
 -type errors() :: [error()].
 
 -export_type([props/0]).
+
+-define(VALID_PROPERTIES,
+        ["allow_mult",
+         "basic_quorum",
+         "big_vclock",
+         "bucket_type",
+         "chash_keyfun",
+         "dvv_enabled",
+         "dw",
+         "last_write_wins",
+         "linkfun",
+         "n_val",
+         "notfound_ok",
+         "old_vclock",
+         "postcommit",
+         "pr",
+         "precommit",
+         "pw",
+         "r",
+         "rw",
+         "small_vclock",
+         "w",
+         "write_once",
+         "young_vclock",
+         %% TS-specific ones:
+         "ddl",
+         "table_def"
+        ]).
+
+-spec is_valid_property(string() | binary()) -> boolean().
+%% @doc Checks whether a given binary or string is a valid bucket type
+%%      property.
+is_valid_property(P) when is_list(P) ->
+    lists:member(P, ?VALID_PROPERTIES);
+is_valid_property(P) when is_binary(P) ->
+    is_valid_property(binary_to_list(P)).
+
 
 %% @doc called by riak_core in a few places to ensure bucket
 %%  properties are sane. The arguments combinations have the following

--- a/src/riak_kv_bucket.erl
+++ b/src/riak_kv_bucket.erl
@@ -44,7 +44,7 @@
 
 -export_type([props/0]).
 
--define(VALID_PROPERTIES,
+-define(COMMON_BUCKET_PROPERTIES,
         ["allow_mult",
          "basic_quorum",
          "big_vclock",
@@ -73,10 +73,10 @@
         ]).
 
 -spec is_valid_property(string() | binary()) -> boolean().
-%% @doc Checks whether a given binary or string is a valid bucket type
+%% @doc Checks whether a given binary or string is a common bucket type
 %%      property.
 is_valid_property(P) when is_list(P) ->
-    lists:member(P, ?VALID_PROPERTIES);
+    lists:member(P, ?COMMON_BUCKET_PROPERTIES);
 is_valid_property(P) when is_binary(P) ->
     is_valid_property(binary_to_list(P)).
 

--- a/src/riak_kv_bucket.erl
+++ b/src/riak_kv_bucket.erl
@@ -24,7 +24,6 @@
 -module(riak_kv_bucket).
 
 -export([validate/4]).
--export([is_valid_property/1]).
 
 -include("riak_kv_types.hrl").
 
@@ -43,43 +42,6 @@
 -type errors() :: [error()].
 
 -export_type([props/0]).
-
--define(COMMON_BUCKET_PROPERTIES,
-        ["allow_mult",
-         "basic_quorum",
-         "big_vclock",
-         "bucket_type",
-         "chash_keyfun",
-         "dvv_enabled",
-         "dw",
-         "last_write_wins",
-         "linkfun",
-         "n_val",
-         "notfound_ok",
-         "old_vclock",
-         "postcommit",
-         "pr",
-         "precommit",
-         "pw",
-         "r",
-         "rw",
-         "small_vclock",
-         "w",
-         "write_once",
-         "young_vclock",
-         %% TS-specific ones:
-         "ddl",
-         "table_def"
-        ]).
-
--spec is_valid_property(string() | binary()) -> boolean().
-%% @doc Checks whether a given binary or string is a common bucket type
-%%      property.
-is_valid_property(P) when is_list(P) ->
-    lists:member(P, ?COMMON_BUCKET_PROPERTIES);
-is_valid_property(P) when is_binary(P) ->
-    is_valid_property(binary_to_list(P)).
-
 
 %% @doc called by riak_core in a few places to ensure bucket
 %%  properties are sane. The arguments combinations have the following

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -875,6 +875,7 @@ bucket_error_xlate(X) ->
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
 json_props(Props) ->
     lists:flatten(mochijson2:encode([{props, Props}])).
@@ -991,9 +992,10 @@ bucket_type_create_with_timeseries_table_with_two_element_key_test() ->
         mochijson2:decode(JSON)
     ),
     % just assert that this returns a ddl prop
+    HaveDDL = proplists:get_value(ddl, Result),
     ?assertMatch(
-        [{ddl, _}|_],
-        Result
+        ?DDL{},
+        HaveDDL
     ).
 
 bucket_type_create_with_timeseries_table_error_with_misplaced_quantum_test() ->

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -523,8 +523,14 @@ bucket_type_create(CreateTypeFn, Type, {struct, Fields}) ->
             case catch riak_kv_ts_util:maybe_parse_table_def(Type, Props1) of
                 {ok, Props2} ->
                     case catch [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props2] of
-                        {bad_bucket_property, BadProp} ->
-                            io:format("Invalid bucket type property: ~ts\n", [BadProp]),
+                        {bad_linkfun_modfun, {M, F}} ->
+                            io:format("Invalid link mod or fun in bucket type properties: ~p:~p\n", [M, F]),
+                            error;
+                        {bad_linkfun_bkey, {B, K}} ->
+                            io:format("Malformed bucket/key for anon link fun in bucket type properties: ~p/~p\n", [B, K]),
+                            error;
+                        {bad_chash_keyfun, {M, F}} ->
+                            io:format("Invalid chash mod or fun in bucket type properties: ~p:~p\n", [M, F]),
                             error;
                         Props3 ->
                             CreateTypeFn(Props3)

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -74,7 +74,7 @@
 -type ts_responses() :: #tsputresp{} |
                         #tsdelresp{} | #tsgetresp{} | #tslistkeysresp{} | #tsqueryresp{} |
                         #rpberrorresp{}.
--type ts_query_types() :: #ddl_v1{} | ?SQL_SELECT{} | #riak_sql_describe_v1{} |
+-type ts_query_types() :: ?DDL{} | ?SQL_SELECT{} | #riak_sql_describe_v1{} |
                           #riak_sql_insert_v1{}.
 
 -type process_retval() :: {reply, RpbOrTsMessage::tuple(), #state{}}.
@@ -456,7 +456,7 @@ put_data(Data, Table, Mod) when is_binary(Table) ->
 -spec partition_data(Data :: list(term()),
                      Bucket :: {binary(), binary()},
                      BucketProps :: proplists:proplist(),
-                     DDL :: #ddl_v1{},
+                     DDL :: ?DDL{},
                      Mod :: module()) ->
                             list(tuple(chash:index(), list(term()))).
 partition_data(Data, Bucket, BucketProps, DDL, Mod) ->
@@ -602,7 +602,7 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
         {ok, ReqId} ->
             ColumnInfo =
                 [Mod:get_field_type(N)
-                 || #param_v1{name = N} <- DDL#ddl_v1.local_key#key_v1.ast],
+                 || #param_v1{name = N} <- DDL?DDL.local_key#key_v1.ast],
             {reply, {stream, ReqId}, State#state{req = Req, req_ctx = ReqId,
                                                  column_info = ColumnInfo}};
         {error, Reason} ->
@@ -804,7 +804,7 @@ make_tsquery_resp(Mod, SQL = #riak_sql_insert_v1{}, _Data) ->
 %% ---------------------------------------------------
 
 -spec check_table_and_call(Table::binary(),
-                           WorkItem::fun((module(), #ddl_v1{},
+                           WorkItem::fun((module(), ?DDL{},
                                           OrigMessage::tuple(), #state{}) ->
                                                 process_retval()),
                            OrigMessage::tuple(),
@@ -982,7 +982,7 @@ missing_helper_module_not_ts_type_test() ->
 missing_helper_module_test() ->
     ?assertMatch(
         #rpberrorresp{errcode = ?E_MISSING_TS_MODULE },
-        missing_helper_module(<<"mytype">>, [{ddl, #ddl_v1{}}])
+        missing_helper_module(<<"mytype">>, [{ddl, ?DDL{}}])
     ).
 
 test_helper_validate_rows_mod() ->

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -58,7 +58,7 @@
 -define(E_BAD_QUERY,         1018).
 -define(E_TABLE_INACTIVE,    1019).
 -define(E_PARSE_ERROR,       1020).
--define(E_DELETE_NOTFOUND,   1021).
+-define(E_NOTFOUND,          1021).
 
 -define(FETCH_RETRIES, 10).  %% TODO make it configurable in tsqueryreq
 -define(TABLE_ACTIVATE_WAIT, 30). %% ditto
@@ -529,7 +529,7 @@ sub_tsgetreq(Mod, DDL, #tsgetreq{table = Table,
         {error, {bad_key_length, Got, Need}} ->
             {reply, key_element_count_mismatch(Got, Need), State};
         {error, notfound} ->
-            {reply, tsgetresp, State};
+            {reply, make_rpberrresp(?E_NOTFOUND, "notfound"), State};
         {error, Reason} ->
             {reply, make_rpberrresp(?E_GET, to_string(Reason)), State}
     end.
@@ -581,7 +581,7 @@ sub_tsdelreq(Mod, DDL, #tsdelreq{table = Table,
         {error, {bad_key_length, Got, Need}} ->
             {reply, key_element_count_mismatch(Got, Need), State};
         {error, notfound} ->
-            {reply, make_rpberrresp(?E_DELETE_NOTFOUND, "notfound"), State};
+            {reply, make_rpberrresp(?E_NOTFOUND, "notfound"), State};
         {error, Reason} ->
             {reply, failed_delete_response(Reason), State}
     end.

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -33,7 +33,7 @@
 -include("riak_kv_ts.hrl").
 
 %% No coverage plan for parallel requests
--spec submit(string() | ?SQL_SELECT{} | #riak_sql_describe_v1{} | #riak_sql_insert_v1{}, #ddl_v1{}) ->
+-spec submit(string() | ?SQL_SELECT{} | #riak_sql_describe_v1{} | #riak_sql_insert_v1{}, ?DDL{}) ->
     {ok, any()} | {error, any()}.
 %% @doc Parse, validate against DDL, and submit a query for execution.
 %%      To get the results of running the query, use fetch/1.
@@ -58,11 +58,11 @@ submit(SQL = ?SQL_SELECT{}, DDL) ->
 %% ---------------------
 %% local functions
 
--spec describe_table_columns(#ddl_v1{}) ->
+-spec describe_table_columns(?DDL{}) ->
                                     {ok, [[binary() | boolean() | integer() | undefined]]}.
-describe_table_columns(#ddl_v1{fields = FieldSpecs,
-                               partition_key = #key_v1{ast = PKSpec},
-                               local_key     = #key_v1{ast = LKSpec}}) ->
+describe_table_columns(?DDL{fields = FieldSpecs,
+                            partition_key = #key_v1{ast = PKSpec},
+                            local_key     = #key_v1{ast = LKSpec}}) ->
     {ok,
      [[Name, list_to_binary(atom_to_list(Type)), Nullable,
        column_pk_position_or_blank(Name, PKSpec),
@@ -92,7 +92,7 @@ count_to_position(Col, [_ | Rest], Pos) ->
     count_to_position(Col, Rest, Pos + 1).
 
 
-maybe_submit_to_queue(SQL, #ddl_v1{table = BucketType} = DDL) ->
+maybe_submit_to_queue(SQL, ?DDL{table = BucketType} = DDL) ->
     Mod = riak_ql_ddl:make_module_name(BucketType),
     MaxSubQueries =
         app_helper:get_env(riak_kv, timeseries_query_max_quanta_span),

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -139,8 +139,8 @@ format_query_syntax_errors(Errors) ->
 -include_lib("eunit/include/eunit.hrl").
 
 describe_table_columns_test() ->
-    {ok, DDL} =
-        riak_ql_parser:parse(
+    {ddl, DDL, []} =
+        riak_ql_parser:ql_parse(
           riak_ql_lexer:get_tokens(
             "CREATE TABLE fafa ("
             " f varchar   not null,"

--- a/src/riak_kv_qry_queue.erl
+++ b/src/riak_kv_qry_queue.erl
@@ -67,7 +67,7 @@
 %%% API
 %%%===================================================================
 
--spec put_on_queue(pid(), [qry()], #ddl_v1{}) ->
+-spec put_on_queue(pid(), [qry()], ?DDL{}) ->
         {ok, query_id()} | {error, term()}.
 %% @doc Enqueue a prepared query for execution.  The query should be
 %%      compatible with the DDL supplied.

--- a/src/riak_kv_ts_newtype.erl
+++ b/src/riak_kv_ts_newtype.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% riak_kv_ts_newtype 
+%% riak_kv_ts_newtype
 %%
 %% Copyright (c) 2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
@@ -43,7 +43,7 @@
 
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 
-%%% 
+%%%
 %%% API.
 %%%
 
@@ -55,7 +55,7 @@ start_link() ->
 new_type(BucketType) ->
     gen_server:cast(?MODULE, {new_type, BucketType}).
 
-%%% 
+%%%
 %%% gen_server.
 %%%
 
@@ -117,7 +117,7 @@ do_new_type(BucketType) ->
 maybe_compile_ddl(_BucketType, NewDDL, NewDDL) ->
     %% Do nothing; we're seeing a CMD update but the DDL hasn't changed
     ok;
-maybe_compile_ddl(BucketType, NewDDL, _OldDDL) when is_record(NewDDL, ddl_v1) ->
+maybe_compile_ddl(BucketType, NewDDL, _OldDDL) when is_record(NewDDL, ?DDL_RECORD_NAME) ->
     ok = maybe_stop_current_compilation(BucketType),
     ok = start_compilation(BucketType, NewDDL);
 maybe_compile_ddl(_BucketType, _NewDDL, _OldDDL) ->

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -150,7 +150,9 @@ get_table_ddl(Table) when is_binary(Table) ->
 apply_timeseries_bucket_props(DDL, Props1) ->
     Props2 = lists:keystore(
         <<"write_once">>, 1, Props1, {<<"write_once">>, true}),
-    {ok, [{<<"ddl">>, DDL} | Props2]}.
+    Props3 = lists:keystore(
+        <<"ddl">>, 1, Props2, {<<"ddl">>, DDL}),
+    {ok, Props3}.
 
 
 -spec maybe_parse_table_def(BucketType :: binary(),
@@ -164,8 +166,9 @@ maybe_parse_table_def(BucketType, Props) ->
         false ->
             {ok, Props};
         {value, {<<"table_def">>, TableDef}, PropsNoDef} ->
-            case catch riak_ql_parser:parse(riak_ql_lexer:get_tokens(binary_to_list(TableDef))) of
-                {ok, DDL} ->
+            case catch riak_ql_parser:ql_parse(
+                         riak_ql_lexer:get_tokens(binary_to_list(TableDef))) of
+                {ddl, DDL = ?DDL{}, WithProps} ->
                     ok = assert_type_and_table_name_same(BucketType, DDL),
                     ok = try_compile_ddl(DDL),
                     MergedProps = merge_props_with_preference(
@@ -198,6 +201,16 @@ assert_write_once_not_false(BucketType, Props) ->
         _ ->
             ok
     end.
+
+-spec merge_props_with_preference(proplists:proplist(), proplists:proplist()) ->
+                                         proplists:proplist().
+%% If same keys appear in RpbBucketProps as well as embedded in the
+%% query ("CREATE TABLE ... WITH"), we merge the two proplists giving
+%% preference to the latter.
+merge_props_with_preference(PbProps, WithProps) ->
+    lists:foldl(
+      fun({K, _} = P, Acc) -> lists:keystore(K, 1, Acc, P) end,
+      PbProps, WithProps).
 
 %% Ensure table name in DDL and bucket type are the same.
 assert_type_and_table_name_same(BucketType, #ddl_v1{table = BucketType}) ->
@@ -356,7 +369,7 @@ varchar_quotes(V) ->
 
 helper_compile_def_to_module(SQL) ->
     Lexed = riak_ql_lexer:get_tokens(SQL),
-    {ok, DDL} = riak_ql_parser:parse(Lexed),
+    {ok, {DDL, _Props}} = riak_ql_parser:parse(Lexed),
     {module, Mod} = riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL),
     {DDL, Mod}.
 

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -124,7 +124,7 @@ queried_table(#riak_sql_insert_v1{'INSERT' = Table})     -> Table.
 
 
 -spec get_table_ddl(binary()) ->
-                           {ok, module(), #ddl_v1{}} |
+                           {ok, module(), ?DDL{}} |
                            {error, term()}.
 %% Check that Table is in good standing and ready for TS operations
 %% (its bucket type has been activated and it has a DDL in its props)
@@ -144,7 +144,7 @@ get_table_ddl(Table) when is_binary(Table) ->
 
 
 %%
--spec apply_timeseries_bucket_props(DDL::#ddl_v1{},
+-spec apply_timeseries_bucket_props(DDL::?DDL{},
                                     Props1::[proplists:property()]) ->
         {ok, Props2::[proplists:property()]}.
 apply_timeseries_bucket_props(DDL, Props1) ->
@@ -213,9 +213,9 @@ merge_props_with_preference(PbProps, WithProps) ->
       PbProps, WithProps).
 
 %% Ensure table name in DDL and bucket type are the same.
-assert_type_and_table_name_same(BucketType, #ddl_v1{table = BucketType}) ->
+assert_type_and_table_name_same(BucketType, ?DDL{table = BucketType}) ->
     ok;
-assert_type_and_table_name_same(BucketType1, #ddl_v1{table = BucketType2}) ->
+assert_type_and_table_name_same(BucketType1, ?DDL{table = BucketType2}) ->
     throw({error,
            {table_name,
             flat_format(
@@ -231,14 +231,14 @@ try_compile_ddl(DDL) ->
     ok.
 
 
--spec make_ts_keys([riak_pb_ts_codec:ldbvalue()], #ddl_v1{}, module()) ->
+-spec make_ts_keys([riak_pb_ts_codec:ldbvalue()], ?DDL{}, module()) ->
                           {ok, {binary(), binary()}} |
                           {error, {bad_key_length, integer(), integer()}}.
 %% Given a list of values (of appropriate types) and a DDL, produce a
 %% partition and local key pair, which can be used in riak_client:get
 %% to fetch TS objects.
-make_ts_keys(CompoundKey, DDL = #ddl_v1{local_key = #key_v1{ast = LKParams},
-                                        fields = Fields}, Mod) ->
+make_ts_keys(CompoundKey, DDL = ?DDL{local_key = #key_v1{ast = LKParams},
+                                     fields = Fields}, Mod) ->
     %% 1. use elements in Key to form a complete data record:
     KeyFields = [F || #param_v1{name = [F]} <- LKParams],
     Got = length(CompoundKey),

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -219,7 +219,7 @@ assert_type_and_table_name_same(BucketType1, ?DDL{table = BucketType2}) ->
     throw({error,
            {table_name,
             flat_format(
-              "Time series bucket type and table name mismatch (~s != ~s)",
+              "Time series bucket type and table name do not match (~s != ~s)",
               [BucketType1, BucketType2])}}).
 
 %% Attempt to compile the DDL but don't do anything with the output, this is

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -398,7 +398,19 @@ erlify_bucket_prop({?JSON_CHASH, {struct, Props}}) ->
 erlify_bucket_prop({<<"ddl">>, Value}) ->
     {ddl, Value};
 erlify_bucket_prop({Prop, Value}) ->
-    {list_to_existing_atom(binary_to_list(Prop)), Value}.
+    {validate_bucket_property(binary_to_list(Prop)), Value}.
+
+%% this serves to narrow the property name check to a set of
+%% known properties, rather than use list_to_existing_atom which
+%% is too broad, and also to report a meaningful exception, for
+%% callers to deal with and report further.
+validate_bucket_property(P) ->
+    case riak_kv_bucket:is_valid_property(P) of
+        true ->
+            list_to_atom(P);
+        false ->
+            throw({bad_bucket_property, P})
+    end.
 
 %% @doc Populates the resource's context/state with the bucket type
 %% from the path info, if not already set.

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -362,20 +362,16 @@ jsonify_bucket_prop({Prop, Value}) ->
           {Property::atom(), erlpropvalue()}.
 %% @doc The reverse of jsonify_bucket_prop/1.  Converts JSON representation
 %%      of bucket properties to their Erlang form.
-erlify_bucket_prop({?JSON_DATATYPE, Type}) when is_binary(Type) ->
-    {datatype, binary_to_existing_atom(Type, utf8)};
+erlify_bucket_prop({?JSON_DATATYPE, Type}) ->
+    try
+        {datatype, binary_to_existing_atom(Type, utf8)}
+    catch
+        error:badarg ->
+            throw({bad_datatype, Type})
+    end;
 erlify_bucket_prop({?JSON_LINKFUN, {struct, Props}}) ->
     case {proplists:get_value(?JSON_MOD, Props),
           proplists:get_value(?JSON_FUN, Props)} of
-        {Mod, Fun} when is_binary(Mod), is_binary(Fun) ->
-            try
-                {linkfun, {modfun,
-                           list_to_existing_atom(binary_to_list(Mod)),
-                           list_to_existing_atom(binary_to_list(Fun))}}
-            catch
-                error:badarg ->
-                    throw({bad_linkfun_modfun, {Mod, Fun}})
-            end;
         {undefined, undefined} ->
             case proplists:get_value(?JSON_JSFUN, Props) of
                 Name when is_binary(Name) ->
@@ -391,18 +387,29 @@ erlify_bucket_prop({?JSON_LINKFUN, {struct, Props}}) ->
                                     throw({bad_linkfun_bkey, {Bucket, Key}})
                             end;
                         Source when is_binary(Source) ->
-                            {linkfun, {jsanon, Source}}
-                    end
+                            {linkfun, {jsanon, Source}};
+                        NotBinary ->
+                            throw({bad_linkfun_modfun, {jsanon, NotBinary}})
+                    end;
+                NotBinary ->
+                    throw({bad_linkfun_modfun, NotBinary})
+            end;
+        {Mod, Fun} ->
+            try
+                {linkfun, {modfun,
+                           binary_to_existing_atom(Mod, utf8),
+                           binary_to_existing_atom(Fun, utf8)}}
+            catch
+                error:badarg ->
+                    throw({bad_linkfun_modfun, {Mod, Fun}})
             end
     end;
 erlify_bucket_prop({?JSON_CHASH, {struct, Props}}) ->
     Mod = proplists:get_value(?JSON_MOD, Props),
     Fun = proplists:get_value(?JSON_FUN, Props),
     try
-        {chash_keyfun, {list_to_existing_atom(
-                          binary_to_list(Mod)),
-                        list_to_existing_atom(
-                          binary_to_list(Fun))}}
+        {chash_keyfun, {binary_to_existing_atom(Mod, utf8),
+                        binary_to_existing_atom(Fun, utf8)}}
     catch
         error:badarg ->
             throw({bad_chash_keyfun, {Mod, Fun}})
@@ -461,3 +468,47 @@ method_to_perm('GET') ->
     "riak_kv.get";
 method_to_perm('DELETE') ->
     "riak_kv.delete".
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+erlify_property_check_valid_test() ->
+    ?assertEqual({datatype, integer},
+                 erlify_bucket_prop({?JSON_DATATYPE, <<"integer">>})),
+
+    ?assertEqual({linkfun, {modfun, erlang, halt}},
+                 erlify_bucket_prop({?JSON_LINKFUN, {struct, [{?JSON_MOD, <<"erlang">>},
+                                                              {?JSON_FUN, <<"halt">>}]}})),
+    ?assertEqual({linkfun, {jsfun, <<"js_never_dies">>}},
+                 erlify_bucket_prop({?JSON_LINKFUN, {struct, [{?JSON_JSFUN, <<"js_never_dies">>}]}})),
+
+    ?assertEqual({linkfun, {jsanon, {<<"face">>, <<"book">>}}},
+                 erlify_bucket_prop({?JSON_LINKFUN, {struct, [{?JSON_JSANON, {struct, [{?JSON_JSBUCKET, <<"face">>},
+                                                                                       {?JSON_JSKEY, <<"book">>}]}}]}})),
+    ?assertEqual({chash_keyfun, {re, run}},
+                 erlify_bucket_prop({?JSON_CHASH, {struct, [{?JSON_MOD, <<"re">>},
+                                                            {?JSON_FUN, <<"run">>}]}})).
+
+erlify_property_check_exceptions_test() ->
+    ?assertThrow({bad_datatype, 42},
+                 erlify_bucket_prop({?JSON_DATATYPE, 42})),
+    ?assertThrow({bad_datatype, <<"tatadype">>},
+                 erlify_bucket_prop({?JSON_DATATYPE, <<"tatadype">>})),
+
+    ?assertThrow({bad_linkfun_modfun, {<<"nomod">>, <<"nofun">>}},
+                 erlify_bucket_prop({?JSON_LINKFUN, {struct, [{?JSON_MOD, <<"nomod">>},
+                                                              {?JSON_FUN, <<"nofun">>}]}})),
+    ?assertThrow({bad_linkfun_modfun, {<<"nomod">>, 368}},
+                 erlify_bucket_prop({?JSON_LINKFUN, {struct, [{?JSON_MOD, <<"nomod">>},
+                                                              {?JSON_FUN, 368}]}})),
+    ?assertThrow({bad_linkfun_modfun, 635},
+                 erlify_bucket_prop({?JSON_LINKFUN, {struct, [{?JSON_JSFUN, 635}]}})),
+
+    ?assertThrow({bad_linkfun_bkey, {nobinarybucket, 89}},
+                 erlify_bucket_prop({?JSON_LINKFUN, {struct, [{?JSON_JSANON, {struct, [{?JSON_JSBUCKET, nobinarybucket},
+                                                                                       {?JSON_JSKEY, 89}]}}]}})),
+    ?assertThrow({bad_chash_keyfun, {<<"nomod">>, <<"nofun">>}},
+                 erlify_bucket_prop({?JSON_CHASH, {struct, [{?JSON_MOD, <<"nomod">>},
+                                                            {?JSON_FUN, <<"nofun">>}]}})).
+
+-endif.

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -413,11 +413,12 @@ erlify_bucket_prop({Prop, Value}) ->
     {validate_bucket_property(binary_to_list(Prop)), Value}.
 
 validate_bucket_property(P) ->
-    case riak_kv_bucket:is_valid_property(P) of
-        true ->
-            list_to_atom(P);
-        false ->
-            lager:info("setting custom bucket property: ~s", [P]),
+    %% there's no validation; free-form properties are all allowed
+    try
+        list_to_existing_atom(P)
+    catch
+        error:badarg ->
+            lager:info("Setting new custom bucket type property '~s'", [P]),
             list_to_atom(P)
     end.
 


### PR DESCRIPTION
RTS-865

This PR is a refurbished #1328, obsoletes #1332. Requires https://github.com/basho/riak_ql/pull/113.

KV support for setting custom table properties in an optional WITH clause of the CREATE TABLE query. This allows clients to create TS tables with custom properties via query API call.

There is also a more strict and accurate validation of property names accepted in WITH clause (as well as in json supplied to `riak-admin bucket-type create` command. Now an attempt to create a bucket type with an unknown property will result in appropriate error message.
