### PR TITLE
Wrap the call to update_index_info in global:trans [JIRA: RIAK-2441]

### DIFF
--- a/src/riak_kv_entropy_info.erl
+++ b/src/riak_kv_entropy_info.erl
@@ -174,12 +174,10 @@ update_index_info_impl(Key, Cmd) ->
     %% contention if lots of different pieces of code are all relying on
     %% it at once.
     %%
-    %% If we do ever want to remove the call to global:trans and replace
-    %% it with something better, I think we could come up with some code
-    %% to allow concurrent updates by writing multiple versions of the
-    %% record to ETS, and then we could detect that on read and resolve
-    %% the conflict based on how we want the stats to be calculated. This
-    %% would be trickier to implement, but should yield great performance.
+    %% If we find that the call to global:trans is a bottleneck, we can
+    %% explore other options (probably either synchronizing updates through
+    %% a pool of workers, or maybe some sort of CRDT-style conflict
+    %% resolution mechanism).
     Info = case ets:lookup(?ETS, {index, Key}) of
                [] ->
                    #index_info{};


### PR DESCRIPTION
This fixes a race condition that was causing stats corruption if two
processes tried to update the data for the same index at the same time.

As detailed in the code comments, this may not have the best possible
performance characteristics, but it seems to be fine in practice and is a
very easy workaround for the problems we found.

For future reference, we originally found and reproduced this bug using
yz_aae_test. It didn't always trigger the race, but adding a short
timer:sleep call in between the lookup and insert calls made it very
easy to catch.
