### PR TITLE
relax DDL check in is_type_compiled

### DIFF
--- a/src/riak_kv_metadata_store_listener.erl
+++ b/src/riak_kv_metadata_store_listener.erl
@@ -56,8 +56,7 @@ handle_event(_Event, State) ->
     {ok, State}.
 
 handle_call({is_type_compiled, [BucketType, DDL]}, State) ->
-    IsCompiled = (riak_kv_compile_tab:get_state(BucketType) == compiled andalso
-                  riak_kv_compile_tab:get_ddl(BucketType) == DDL),
+    IsCompiled = (riak_kv_compile_tab:get_state(BucketType) == compiled),
     {ok, IsCompiled, State};
 handle_call(_Request, State) ->
     Reply = ok,


### PR DESCRIPTION
The check for type availability uses a match on DDL bodies of argument
DDL and that previously compiled and stored in metadata. That check is
not strictly necessary, but more importantly, it is bound to fail when
DDLs are produced from the same schema but in different #ddl_vX{} versions.

Relaxing this check will allow post-1.2 nodes to see DDLs compiled by
different ddl record versions, and thus do not be a blocker in
upgrade/downgrade scenarios.
