### PR TITLE
RTS-980,RTS-981,RTS-982: Recompile DDL

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -209,10 +209,10 @@ start(_Type, _StartArgs) ->
                                           disabled),
 
             riak_core_capability:register({riak_kv, riak_ql_ddl_version},
-                                           riak_ql_ddl:get_compiler_capabilities(),
-                                           lists:last(riak_ql_ddl:get_compiler_capabilities())),
+                                           riak_ql_ddl_compiler:get_compiler_capabilities(),
+                                           lists:last(riak_ql_ddl_compiler:get_compiler_capabilities())),
 
-            riak_kv_ts_newtype:recompile_ddl(riak_ql_ddl:get_compiler_version()),
+            riak_kv_ts_newtype:recompile_ddl(riak_ql_ddl_compiler:get_compiler_version()),
 
             HealthCheckOn = app_helper:get_env(riak_kv, enable_health_checks, false),
             %% Go ahead and mark the riak_kv service as up in the node watcher.

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -127,13 +127,6 @@ start(_Type, _StartArgs) ->
     %% print out critical env limits for support/debugging purposes
     catch riak_kv_env:doc_env(),
 
-    %% TODO: Fix when DETS table is opened. Currently it's in riak_kv_ts_sup:init/0
-    %% Convert all legacy DDL compilation records to current format
-    %% riak_kv_compile_tab:upgrade_legacy_records(riak_ql_ddl:get_legacy_compiler_version()),
-
-    %% Clean up any lingering tables stuck in the compiling state
-    %% riak_kv_compile_tab:mark_compiling_for_retry(),
-
     %% Spin up supervisor
     case riak_kv_sup:start_link() of
         {ok, Pid} ->
@@ -219,9 +212,7 @@ start(_Type, _StartArgs) ->
                                            riak_ql_ddl:get_compiler_capabilities(),
                                            lists:last(riak_ql_ddl:get_compiler_capabilities())),
 
-            %% Q: Does KV need to be registered before getting a core_capability?
-            NegotiatedCompilerVersion = riak_core_capability:get({riak_kv, riak_ql_ddl_version}),
-            riak_kv_ts_newtype:recompile_ddl(NegotiatedCompilerVersion),
+            riak_kv_ts_newtype:recompile_ddl(riak_ql_ddl:get_compiler_version()),
 
             HealthCheckOn = app_helper:get_env(riak_kv, enable_health_checks, false),
             %% Go ahead and mark the riak_kv service as up in the node watcher.

--- a/src/riak_kv_compile_tab.erl
+++ b/src/riak_kv_compile_tab.erl
@@ -94,7 +94,7 @@ delete_dets(FileDir) ->
 
 %%
 -spec insert(BucketType :: binary(),
-             DDLVersion :: riak_ql_ddl_compiler:compiler_version(),
+             DDLVersion :: riak_ql_component:component_version(),
              DDL :: term(),
              CompilerPid :: pid(),
              State :: compiling_state()) -> ok | error.
@@ -146,7 +146,7 @@ get_state(BucketType) when is_binary(BucketType) ->
 
 %%
 -spec get_compiled_ddl_version(BucketType :: binary()) ->
-    riak_ql_ddl_compiler:compiler_version() | notfound.
+    riak_ql_component:component_version() | notfound.
 get_compiled_ddl_version(BucketType) when is_binary(BucketType) ->
     case dets:match(?TABLE, {BucketType,'$1','_','_','_'}) of
         [[Version]] ->
@@ -186,7 +186,7 @@ mark_compiling_for_retry() ->
     lists:foreach(fun([Pid]) -> update_state(Pid, retrying) end, CompilingPids).
 
 %% Get the list of records which need to be recompiled
--spec get_ddl_records_needing_recompiling(DDLVersion :: riak_ql_ddl_compiler:compiler_version()) ->
+-spec get_ddl_records_needing_recompiling(DDLVersion :: riak_ql_component:component_version()) ->
     [binary()].
 get_ddl_records_needing_recompiling(DDLVersion) ->
     %% First find all tables with a version

--- a/src/riak_kv_compile_tab.erl
+++ b/src/riak_kv_compile_tab.erl
@@ -66,7 +66,6 @@ new_table_result({ok, LegacyDets}, {ok, Dets}) ->
     %% Convert all legacy DDL compilation records to current format
     upgrade_legacy_records(),
 
-    %% TODO: Use this once 1.2 support has been removed
     %% Clean up any lingering records stuck in the compiling state
     mark_compiling_for_retry(),
     {ok, LegacyDets, Dets};
@@ -199,7 +198,7 @@ get_ddl_records_needing_recompiling(DDLVersion) ->
 %% TODO: Remove this once 1.2 support has been removed
 %% Convert all pre-1.3 records to include the DDL compiler version in the
 %% DETS table.  Simply recompile everything all the time since we don't
-%% know if this is a downgrade or not.
+%% know if this is an upgrade following a downgrade or not.
 -spec upgrade_legacy_records() -> ok.
 upgrade_legacy_records() ->
     LegacyVersion = 1,

--- a/src/riak_kv_compile_tab.erl
+++ b/src/riak_kv_compile_tab.erl
@@ -81,6 +81,7 @@ insert(BucketType, DDLVersion, DDL, CompilerPid, State) ->
     lager:info("DDL DETS Update: ~p, ~p, ~p, ~p, ~p",
                [BucketType, DDLVersion, DDL, CompilerPid, State]),
     dets:insert(?TABLE, {BucketType, DDLVersion, DDL, CompilerPid, State}),
+    dets:sync(?TABLE),
     ok.
 
 %% Check if the bucket type is in the compiling state.

--- a/src/riak_kv_compile_tab.erl
+++ b/src/riak_kv_compile_tab.erl
@@ -2,7 +2,7 @@
 %%
 %% Store the state about what bucket type DDLs have been compiled.
 %%
-%% Copyright (c) 2015 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2015-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -22,22 +22,30 @@
 
 -module(riak_kv_compile_tab).
 
--export([is_compiling/1]).
--export([get_state/1]).
--export([get_ddl/1]).
--export([new/1]).
--export([insert/4]).
--export([update_state/2]).
+-export([
+         cleanup_old_tables/1,
+         delete_dets/1,
+         get_compiled_ddl_versions/1,
+         get_ddl/2,
+         get_state/2,
+         get_tables_needing_recompiling/1,
+         insert/5,
+         is_compiling/2,
+         mark_compiling_for_retry/0,
+         new/1,
+         update_state/2,
+         upgrade_legacy_records/1]).
 
 -define(TABLE, ?MODULE).
 
--type compiling_state() :: compiling | compiled | failed.
+-type compiling_state() :: compiling | compiled | failed | retrying.
 -export_type([compiling_state/0]).
 
 -define(is_compiling_state(S),
         (S == compiling orelse
          S == compiled orelse
-         S == failed)).
+         S == failed orelse
+         S == retrying)).
 
 %% 
 -spec new(file:name()) ->
@@ -47,19 +55,29 @@ new(FileDir) ->
     dets:open_file(?TABLE, [{type, set}, {repair, force}, {file, FilePath}]).
 
 %%
+-spec delete_dets(file:name()) ->
+    ok | {error, any()}.
+delete_dets(FileDir) ->
+    FilePath = filename:join(FileDir, [?TABLE, ".dets"]),
+    dets:close(FilePath),
+    file:delete(FilePath).
+
+%%
 -spec insert(BucketType :: binary(),
+             DDLVersion :: riak_ql_ddl:compiler_version_type(),
              DDL :: term(),
              CompilerPid :: pid(),
              State :: compiling_state()) -> ok.
-insert(BucketType, DDL, CompilerPid, State) ->
-    dets:insert(?TABLE, {BucketType, DDL, CompilerPid, State}),
+insert(BucketType, DDLVersion, DDL, CompilerPid, State) ->
+    dets:insert(?TABLE, {{BucketType, DDLVersion}, DDL, CompilerPid, State}),
     ok.
 
 %% Check if the bucket type is in the compiling state.
--spec is_compiling(BucketType :: binary()) ->
+-spec is_compiling(BucketType :: binary(),
+                   DDLVersion :: riak_ql_ddl:compiler_version_type()) ->
     {true, pid()} | false.
-is_compiling(BucketType) ->
-    case dets:lookup(?TABLE, BucketType) of
+is_compiling(BucketType, DDLVersion) ->
+    case dets:lookup(?TABLE, {BucketType, DDLVersion}) of
         [{_,_,Pid,compiling}] ->
             {true, Pid};
         _ ->
@@ -67,10 +85,12 @@ is_compiling(BucketType) ->
     end.
 
 %%
--spec get_state(BucketType :: binary()) ->
+-spec get_state(BucketType :: binary(),
+                DDLVersion :: riak_ql_ddl:compiler_version_type()) ->
         compiling_state() | notfound.
-get_state(BucketType) when is_binary(BucketType) ->
-    case dets:lookup(?TABLE, BucketType) of
+get_state(BucketType, DDLVersion) when is_binary(BucketType),
+                                       is_integer(DDLVersion)->
+    case dets:lookup(?TABLE, {BucketType, DDLVersion}) of
         [{_,_,_,State}] ->
             State;
         [] ->
@@ -78,10 +98,23 @@ get_state(BucketType) when is_binary(BucketType) ->
     end.
 
 %%
--spec get_ddl(BucketType :: binary()) ->
+-spec get_compiled_ddl_versions(BucketType :: binary()) ->
+    riak_ql_ddl:compiler_version_type() | notfound.
+get_compiled_ddl_versions(BucketType) when is_binary(BucketType) ->
+    case dets:match(?TABLE, {{BucketType, '$1'},'_','_','_'}) of
+        [Versions] ->
+            Versions;
+        [] ->
+            notfound
+    end.
+
+%%
+-spec get_ddl(BucketType :: binary(),
+              DDLVersion :: riak_ql_ddl:compiler_version_type()) ->
         term() | notfound.
-get_ddl(BucketType) when is_binary(BucketType) ->
-    case dets:lookup(?TABLE, BucketType) of
+get_ddl(BucketType, DDLVersion) when is_binary(BucketType),
+                         is_integer(DDLVersion) ->
+    case dets:lookup(?TABLE, {BucketType, DDLVersion}) of
         [{_,DDL,_,_}] ->
             DDL;
         [] ->
@@ -89,16 +122,56 @@ get_ddl(BucketType) when is_binary(BucketType) ->
     end.
 
 %% Update the compilation state using the compiler pid as a key.
+%% Since it has an active Pid, it is assumed to have a DDL version already.
 -spec update_state(CompilerPid :: pid(), State :: compiling_state()) ->
         ok | notfound.
 update_state(CompilerPid, State) when is_pid(CompilerPid),
                                        ?is_compiling_state(State) ->
-    case dets:match(?TABLE, {'$1','$2',CompilerPid,'_'}) of
-        [[BucketType, DDL]] ->
-            insert(BucketType, DDL, CompilerPid, State);
+    case dets:match(?TABLE, {{'$1','$2'},'$3',CompilerPid,'_'}) of
+        [[BucketType, DDLVersion, DDL]] ->
+            insert(BucketType, DDLVersion, DDL, CompilerPid, State);
         [] ->
             notfound
     end.
+
+%% Mark any lingering compilations as being retried
+-spec mark_compiling_for_retry() -> ok.
+mark_compiling_for_retry() ->
+    CompilingPids = dets:match(?TABLE, {{'_','_'},'_','$1',compiling}),
+    lists:foreach(fun([Pid]) -> update_state(Pid, retrying) end, CompilingPids).
+
+%% Get the list of tables which need to be recompiled
+-spec get_tables_needing_recompiling(DDLVersion :: riak_ql_ddl:compiler_version_type()) ->
+    [{binary(), riak_ql_ddl:compiler_version_type(), riak_ql_ddl:ddl()}].
+get_tables_needing_recompiling(DDLVersion) ->
+    %% First find all tables with a version
+%%    CompiledTables = dets:match(?TABLE, {{'$1','$2'},'$3','_',compiled}),
+%%    MismatchedTables = lists:filter(fun([_, Vsn, _DDL]) -> Vsn /= DDLVersion end, CompiledTables),
+    MismatchedTables = dets:select(?TABLE, [{{{'$1','$2'},'$3','_',compiled},[{'/=','$2', DDLVersion}],['$$']}]),
+    RetryingTables = dets:match(?TABLE, {{'$1','$2'},'$3','_',retrying}),
+    [list_to_tuple(X) || X <- MismatchedTables ++ RetryingTables].
+
+%% Delete all versions of the DDL compilation record which do not match
+%% the current one specified by a Pid.
+-spec cleanup_old_tables(Pid :: pid()) -> ok.
+cleanup_old_tables(Pid) ->
+    [[BucketType, Version]] = dets:match(?TABLE, {{'$1','$2'},'_',Pid,compiled}),
+    OldVersions = dets:select(?TABLE, [{{{BucketType,'$1'},'_','_',compiled},[{'/=','$1', Version}],['$$']}]),
+    lists:foreach(fun([Vsn]) ->
+                       dets:delete(?TABLE, {BucketType, Vsn})
+                  end, OldVersions),
+    ok.
+
+%% Convert all pre-1.3 records to include the DDL compiler version in the
+%% DETS primary key
+-spec upgrade_legacy_records(LegacyVersion :: riak_ql_ddl:compiler_version_type()) -> ok.
+upgrade_legacy_records(LegacyVersion) ->
+    OldVersions = dets:select(?TABLE, [{{'$1','$2','$3','$4'},[{is_binary,'$1'}],['$$']}]),
+    lists:foreach(fun([BucketType, DDL, Pid, State]) ->
+                       ok = dets:insert(?TABLE, {{BucketType, LegacyVersion}, DDL, Pid, State}),
+                       ok = dets:delete(?TABLE, BucketType)
+                  end, OldVersions),
+    ok.
 
 %% ===================================================================
 %% EUnit tests
@@ -111,6 +184,7 @@ update_state(CompilerPid, State) when is_pid(CompilerPid),
     Self = self(),
     spawn_link(
         fun() ->
+            ok = riak_kv_compile_tab:delete_dets("."),
             _ = riak_kv_compile_tab:new("."),
             TestCode,
             Self ! test_ok
@@ -124,10 +198,10 @@ insert_test() ->
     ?in_process(
         begin
             Pid = spawn(fun() -> ok end),
-            ok = insert(<<"my_type">>, {ddl_v1}, Pid, compiling),
+            ok = insert(<<"my_type">>, 2, {ddl_v1}, Pid, compiling),
             ?assertEqual(
                 compiling,
-                get_state(<<"my_type">>)
+                get_state(<<"my_type">>, 2)
             )
         end).
 
@@ -135,11 +209,11 @@ update_state_test() ->
     ?in_process(
         begin
             Pid = spawn(fun() -> ok end),
-            ok = insert(<<"my_type">>, {ddl_v1}, Pid, compiling),
+            ok = insert(<<"my_type">>, 3, {ddl_v1}, Pid, compiling),
             ok = update_state(Pid, compiled),
             ?assertEqual(
                 compiled,
-                get_state(<<"my_type">>)
+                get_state(<<"my_type">>, 3)
             )
         end).
 
@@ -147,11 +221,89 @@ is_compiling_test() ->
     ?in_process(
         begin
             Pid = spawn(fun() -> ok end),
-            ok = insert(<<"my_type">>, {ddl_v1}, Pid, compiling),
+            ok = insert(<<"my_type">>, 4, {ddl_v1}, Pid, compiling),
             ?assertEqual(
                 {true, Pid},
-                is_compiling(<<"my_type">>)
+                is_compiling(<<"my_type">>, 4)
             )
         end).
 
+compiled_version_test() ->
+    ?in_process(
+        begin
+            Pid = spawn(fun() -> ok end),
+            ok = insert(<<"my_type">>, 5, {ddl_v1}, Pid, compiled),
+            ?assertEqual(
+                [5],
+                get_compiled_ddl_versions(<<"my_type">>)
+            )
+        end).
+
+get_ddl_test() ->
+    ?in_process(
+        begin
+            Pid = spawn(fun() -> ok end),
+            ok = insert(<<"my_type">>, 6, {ddl_v1}, Pid, compiled),
+            ?assertEqual(
+                {ddl_v1},
+                get_ddl(<<"my_type">>, 6)
+            )
+        end).
+
+recompile_ddl_test() ->
+    ?in_process(
+        begin
+            Pid = spawn(fun() -> ok end),
+            Pid2 = spawn(fun() -> ok end),
+            Pid3 = spawn(fun() -> ok end),
+            Pid4 = spawn(fun() -> ok end),
+            ok = insert(<<"my_type1">>, 6, {ddl_v1}, Pid, compiling),
+            ok = insert(<<"my_type2">>, 7, {ddl_v1}, Pid2, compiled),
+            ok = insert(<<"my_type3">>, 6, {ddl_v1}, Pid3, compiling),
+            ok = insert(<<"my_type4">>, 8, {ddl_v1}, Pid4, compiled),
+            mark_compiling_for_retry(),
+            ?assertEqual(
+                [{<<"my_type1">>, 6, {ddl_v1}},
+                 {<<"my_type2">>, 7, {ddl_v1}},
+                 {<<"my_type3">>, 6, {ddl_v1}}
+                ],
+                lists:sort(get_tables_needing_recompiling(8))
+            )
+        end).
+
+cleanup_old_ddl_test() ->
+    ?in_process(
+        begin
+            Pid = spawn(fun() -> ok end),
+            Pid2 = spawn(fun() -> ok end),
+            Pid3 = spawn(fun() -> ok end),
+            Pid4 = spawn(fun() -> ok end),
+            ok = insert(<<"my_type">>, 5, {ddl_v1}, Pid, compiled),
+            ok = insert(<<"my_type">>, 7, {ddl_v1}, Pid2, compiled),
+            ok = insert(<<"my_type">>, 6, {ddl_v1}, Pid3, compiled),
+            ok = insert(<<"my_type1">>, 8, {ddl_v1}, Pid4, compiled),
+            cleanup_old_tables(Pid),
+            ?assertEqual(
+                [[5]],
+                dets:match(?TABLE, {{<<"my_type">>,'$1'},'_','_','_'})
+            )
+        end).
+
+update_legacy_ddl_test() ->
+    ?in_process(
+        begin
+            Pid = spawn(fun() -> ok end),
+            Pid2 = spawn(fun() -> ok end),
+            Pid3 = spawn(fun() -> ok end),
+            Pid4 = spawn(fun() -> ok end),
+            ok = dets:insert(?TABLE, {<<"my_type">>, {ddl_v1}, Pid, compiled}),
+            ok = dets:insert(?TABLE, {<<"my_type1">>, {ddl_v1}, Pid2, compiled}),
+            ok = dets:insert(?TABLE, {<<"my_type2">>, {ddl_v1}, Pid3, compiled}),
+            ok = dets:insert(?TABLE, {<<"my_type3">>, {ddl_v1}, Pid4, compiled}),
+            upgrade_legacy_records(4),
+            ?assertEqual(
+                [[<<"my_type">>],[<<"my_type1">>],[<<"my_type2">>],[<<"my_type3">>]],
+                lists:sort(dets:match(?TABLE, {{'$1',4},'_','_','_'}))
+            )
+        end).
 -endif.

--- a/src/riak_kv_compile_tab.erl
+++ b/src/riak_kv_compile_tab.erl
@@ -94,7 +94,7 @@ delete_dets(FileDir) ->
 
 %%
 -spec insert(BucketType :: binary(),
-             DDLVersion :: riak_ql_ddl:compiler_version_type(),
+             DDLVersion :: riak_ql_ddl_compiler:compiler_version(),
              DDL :: term(),
              CompilerPid :: pid(),
              State :: compiling_state()) -> ok | error.
@@ -146,7 +146,7 @@ get_state(BucketType) when is_binary(BucketType) ->
 
 %%
 -spec get_compiled_ddl_version(BucketType :: binary()) ->
-    riak_ql_ddl:compiler_version_type() | notfound.
+    riak_ql_ddl_compiler:compiler_version() | notfound.
 get_compiled_ddl_version(BucketType) when is_binary(BucketType) ->
     case dets:match(?TABLE, {BucketType,'$1','_','_','_'}) of
         [[Version]] ->
@@ -186,7 +186,7 @@ mark_compiling_for_retry() ->
     lists:foreach(fun([Pid]) -> update_state(Pid, retrying) end, CompilingPids).
 
 %% Get the list of records which need to be recompiled
--spec get_ddl_records_needing_recompiling(DDLVersion :: riak_ql_ddl:compiler_version_type()) ->
+-spec get_ddl_records_needing_recompiling(DDLVersion :: riak_ql_ddl_compiler:compiler_version()) ->
     [binary()].
 get_ddl_records_needing_recompiling(DDLVersion) ->
     %% First find all tables with a version

--- a/src/riak_kv_metadata_store_listener.erl
+++ b/src/riak_kv_metadata_store_listener.erl
@@ -56,8 +56,10 @@ handle_event(_Event, State) ->
     {ok, State}.
 
 handle_call({is_type_compiled, [BucketType, DDL]}, State) ->
-    IsCompiled = (riak_kv_compile_tab:get_state(BucketType) == compiled andalso
-                  riak_kv_compile_tab:get_ddl(BucketType) == DDL),
+    %% TODO: Where should the version come from?
+    DDLVersion = riak_ql_ddl:get_compiler_version(),
+    IsCompiled = (riak_kv_compile_tab:get_state(BucketType, DDLVersion) == compiled andalso
+                  riak_kv_compile_tab:get_ddl(BucketType, DDLVersion) == DDL),
     {ok, IsCompiled, State};
 handle_call(_Request, State) ->
     Reply = ok,

--- a/src/riak_kv_metadata_store_listener.erl
+++ b/src/riak_kv_metadata_store_listener.erl
@@ -56,10 +56,8 @@ handle_event(_Event, State) ->
     {ok, State}.
 
 handle_call({is_type_compiled, [BucketType, DDL]}, State) ->
-    %% TODO: Where should the version come from?
-    DDLVersion = riak_ql_ddl:get_compiler_version(),
-    IsCompiled = (riak_kv_compile_tab:get_state(BucketType, DDLVersion) == compiled andalso
-                  riak_kv_compile_tab:get_ddl(BucketType, DDLVersion) == DDL),
+    IsCompiled = (riak_kv_compile_tab:get_state(BucketType) == compiled andalso
+                  riak_kv_compile_tab:get_ddl(BucketType) == DDL),
     {ok, IsCompiled, State};
 handle_call(_Request, State) ->
     Reply = ok,

--- a/src/riak_kv_ts_newtype.erl
+++ b/src/riak_kv_ts_newtype.erl
@@ -119,7 +119,7 @@ do_new_type(BucketType) ->
     maybe_compile_ddl(BucketType,
                       retrieve_ddl_from_metadata(BucketType),
                       riak_kv_compile_tab:get_ddl(BucketType),
-                      riak_ql_ddl:get_compiler_version(),
+                      riak_ql_ddl_compiler:get_compiler_version(),
                       riak_kv_compile_tab:get_compiled_ddl_version(BucketType)).
 
 maybe_compile_ddl(BucketType, NewDDL, NewDDL, NewVsn, NewVsn) ->
@@ -189,7 +189,7 @@ start_compilation(BucketType, DDL) ->
             ok = compile_and_store(ddl_ebin_directory(), DDL)
         end),
     lager:info("Starting DDL compilation of ~s on Pid ~p", [BucketType, Pid]),
-    ok = riak_kv_compile_tab:insert(BucketType, riak_ql_ddl:get_compiler_version(), DDL, Pid, compiling),
+    ok = riak_kv_compile_tab:insert(BucketType, riak_ql_ddl_compiler:get_compiler_version(), DDL, Pid, compiling),
     Pid.
 
 %%
@@ -240,7 +240,7 @@ add_ddl_ebin_to_path() ->
     ok.
 
 %%
--spec recompile_ddl(DDLVersion :: riak_ql_ddl:compiler_version_type()) -> ok.
+-spec recompile_ddl(DDLVersion :: riak_ql_ddl_compiler:compiler_version()) -> ok.
 recompile_ddl(DDLVersion) ->
     %% Get list of tables to recompile
     Tables = riak_kv_compile_tab:get_ddl_records_needing_recompiling(DDLVersion),

--- a/src/riak_kv_ts_newtype.erl
+++ b/src/riak_kv_ts_newtype.erl
@@ -240,7 +240,7 @@ add_ddl_ebin_to_path() ->
     ok.
 
 %%
--spec recompile_ddl(DDLVersion :: riak_ql_ddl_compiler:compiler_version()) -> ok.
+-spec recompile_ddl(DDLVersion :: riak_ql_component:component_version()) -> ok.
 recompile_ddl(DDLVersion) ->
     %% Get list of tables to recompile
     Tables = riak_kv_compile_tab:get_ddl_records_needing_recompiling(DDLVersion),

--- a/src/riak_kv_ts_newtype.erl
+++ b/src/riak_kv_ts_newtype.erl
@@ -127,7 +127,7 @@ maybe_compile_ddl(BucketType, NewDDL, NewDDL, NewVsn, NewVsn) ->
     %% Do nothing; we're seeing a CMD update but the DDL hasn't changed
     ok;
 maybe_compile_ddl(BucketType, NewDDL, NewDDL, NewVsn, OldVsn) when is_record(NewDDL, ?DDL_RECORD_NAME),
-                                                                   is_integer(OldVsn), is_integer(NewVsn) ->
+                                                                   is_integer(NewVsn), is_integer(OldVsn) ->
     lager:info("Recompiling same DDL for bucket type ~s from version ~b to ~b",
                [BucketType, OldVsn, NewVsn]),
     actually_compile_ddl(BucketType, NewDDL);
@@ -135,6 +135,11 @@ maybe_compile_ddl(BucketType, NewDDL, _OldDDL, NewVsn, OldVsn) when is_record(Ne
                                                                     is_integer(OldVsn), is_integer(NewVsn) ->
     lager:info("Compiling new DDL for bucket type ~s from version ~b to ~b",
                [BucketType, OldVsn, NewVsn]),
+    actually_compile_ddl(BucketType, NewDDL);
+maybe_compile_ddl(BucketType, NewDDL, _OldDDL, NewVsn, notfound) when is_record(NewDDL, ?DDL_RECORD_NAME),
+                                                                      is_integer(NewVsn) ->
+    lager:info("Compiling new DDL for bucket type ~s with version ~b",
+               [BucketType, NewVsn]),
     actually_compile_ddl(BucketType, NewDDL);
 maybe_compile_ddl(BucketType, NewDDL, _OldDDL, NewVsn, OldVsn) ->
     lager:error("Unknown DDL version type ~p for bucket type ~s "

--- a/src/riak_kv_ts_newtype.erl
+++ b/src/riak_kv_ts_newtype.erl
@@ -238,7 +238,7 @@ add_ddl_ebin_to_path() ->
 -spec recompile_ddl(DDLVersion :: riak_ql_ddl:compiler_version_type()) -> ok.
 recompile_ddl(DDLVersion) ->
     %% Get list of tables to recompile
-    Tables = riak_kv_compile_tab:get_tables_needing_recompiling(DDLVersion),
+    Tables = riak_kv_compile_tab:get_ddl_records_needing_recompiling(DDLVersion),
     lists:foreach(fun(Table) ->
                       new_type(Table)
                   end,

--- a/src/riak_kv_ts_sup.erl
+++ b/src/riak_kv_ts_sup.erl
@@ -64,7 +64,7 @@ start_link() ->
 %% @end
 %%--------------------------------------------------------------------
 init([]) ->
-    riak_kv_compile_tab:new(app_helper:get_env(riak_core, platform_data_dir)),
+    {ok, _, _} = riak_kv_compile_tab:new(app_helper:get_env(riak_core, platform_data_dir)),
 
     RestartStrategy = one_for_one,
     MaxRestarts = 1000,

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -151,7 +151,7 @@ process_stream({ReqId, Error}, ReqId,
 -spec create_table({?DDL{}, proplists:proplist()}, #state{}) ->
                           {reply, #tsqueryresp{} | #rpberrorresp{}, #state{}}.
 create_table({DDL = ?DDL{table = Table}, WithProps}, State) ->
-    {ok, Props1} = riak_kv_ts_util:apply_timeseries_bucket_props(DDL, WithProps),
+    {ok, Props1} = riak_kv_ts_util:apply_timeseries_bucket_props(DDL, riak_ql_ddl:get_compiler_version(), WithProps),
     case catch [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props1] of
         {bad_linkfun_modfun, {M, F}} ->
             {reply, table_create_fail_response(

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -151,7 +151,7 @@ process_stream({ReqId, Error}, ReqId,
 -spec create_table({?DDL{}, proplists:proplist()}, #state{}) ->
                           {reply, #tsqueryresp{} | #rpberrorresp{}, #state{}}.
 create_table({DDL = ?DDL{table = Table}, WithProps}, State) ->
-    {ok, Props1} = riak_kv_ts_util:apply_timeseries_bucket_props(DDL, riak_ql_ddl:get_compiler_version(), WithProps),
+    {ok, Props1} = riak_kv_ts_util:apply_timeseries_bucket_props(DDL, riak_ql_ddl_compiler:get_compiler_version(), WithProps),
     case catch [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props1] of
         {bad_linkfun_modfun, {M, F}} ->
             {reply, table_create_fail_response(

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -145,7 +145,7 @@ get_table_ddl(Table) when is_binary(Table) ->
 
 %%
 -spec apply_timeseries_bucket_props(DDL::?DDL{},
-                                    DDLVersion::riak_ql_ddl:compiler_version_type(),
+                                    DDLVersion::riak_ql_ddl_compiler:compiler_version(),
                                     Props1::[proplists:property()]) ->
         {ok, Props2::[proplists:property()]}.
 apply_timeseries_bucket_props(DDL, DDLVersion, Props1) ->
@@ -177,7 +177,7 @@ maybe_parse_table_def(BucketType, Props) ->
                     MergedProps = merge_props_with_preference(
                                     PropsNoDef, WithProps),
                     ok = assert_write_once_not_false(BucketType, MergedProps),
-                    apply_timeseries_bucket_props(DDL, riak_ql_ddl:get_compiler_version(), MergedProps);
+                    apply_timeseries_bucket_props(DDL, riak_ql_ddl_compiler:get_compiler_version(), MergedProps);
                 {'EXIT', {Reason, _}} ->
                     % the lexer throws exceptions, the reason should always be a
                     % binary

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -144,9 +144,9 @@ get_table_ddl(Table) when is_binary(Table) ->
 
 
 %%
--spec apply_timeseries_bucket_props(DDL::?DDL{},
-                                    DDLVersion::riak_ql_ddl_compiler:compiler_version(),
-                                    Props1::[proplists:property()]) ->
+-spec apply_timeseries_bucket_props(DDL :: ?DDL{},
+                                    DDLVersion :: riak_ql_component:component_version(),
+                                    Props1 :: [proplists:property()]) ->
         {ok, Props2::[proplists:property()]}.
 apply_timeseries_bucket_props(DDL, DDLVersion, Props1) ->
     Props2 = lists:keystore(

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -154,7 +154,7 @@ apply_timeseries_bucket_props(DDL, DDLVersion, Props1) ->
     Props3 = lists:keystore(
         <<"ddl">>, 1, Props2, {<<"ddl">>, DDL}),
     Props4 = lists:keystore(
-        <<"compiler_version">>, 1, Props3, {<<"compiler_version">>, DDLVersion}),
+        <<"ddl_compiler_version">>, 1, Props3, {<<"ddl_compiler_version">>, DDLVersion}),
     {ok, Props4}.
 
 

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -416,6 +416,8 @@ erlify_bucket_prop({?JSON_CHASH, {struct, Props}}) ->
     end;
 erlify_bucket_prop({<<"ddl">>, Value}) ->
     {ddl, Value};
+erlify_bucket_prop({<<"ddl_compiler_version">>, Value}) ->
+    {ddl_compiler_version, Value};
 erlify_bucket_prop({Prop, Value}) ->
     {validate_bucket_property(binary_to_list(Prop)), Value}.
 


### PR DESCRIPTION
Store the DDL compiler version in DETS and at startup if the version does not match, recompile it.  Also update all pre-1.2 DETS entries to include the legacy version so they update cleanly as well.  Any DETS entries which were stuck in the `compiling` state when the node went down are now marked as `retrying` and recompiled.  The versions are registered as a `riak_core_capability` but are not used as of yet.

**NOTE:** This PR requires https://github.com/basho/riak_ql/pull/115
