### PR TITLE
Postcommit support for timeseries

### DIFF
--- a/src/riak_kv_hooks.erl
+++ b/src/riak_kv_hooks.erl
@@ -105,7 +105,7 @@ del_timeseries_postcommit(Hook) ->
 %% This function invokes each registered timeseries postcommit
 %% hook.
 -spec call_timeseries_postcommit(tuple(), bucket(), list()) -> ok.
-call_timeseries_postcommit({_PK, _Data}=Batch, Bucket, BucketProps) ->
+call_timeseries_postcommit({_PartitionIdx, _Data}=Batch, Bucket, BucketProps) ->
     Hooks = get_hooks(timeseries_postcommit),
     lists:foreach(fun({Mod, Fun}) ->
                           Mod:Fun(Batch, Bucket, BucketProps)

--- a/src/riak_kv_hooks.erl
+++ b/src/riak_kv_hooks.erl
@@ -24,12 +24,16 @@
          del_conditional_postcommit/1,
          get_conditional_postcommit/2]).
 
+-export([add_timeseries_postcommit/1,
+         del_timeseries_postcommit/1,
+         call_timeseries_postcommit/3]).
+
 %% Exported for internal use by `riak_kv_sup'
 -export([create_table/0]).
 
 %% Types
 -type hook()      :: {module(), atom()}.
--type hook_type() :: conditional_postcommit.
+-type hook_type() :: conditional_postcommit|timeseries_postcommit.
 -type bucket() :: riak_object:bucket().
 -type bucket_props() :: riak_kv_bucket:props().
 
@@ -77,6 +81,36 @@ get_conditional_postcommit({BucketType, Bucket}, BucketProps) ->
 get_conditional_postcommit(_BKey, _BucketProps) ->
     %% For now, we only support typed buckets.
     [].
+
+%% @doc
+%% Add a global timeseries postcommit hook that is called for each
+%% timeseries PUT operation. The hook is of the form `{Module, Fun}'. The specified
+%% function will be called with three arguments:
+%%    {PartitionKey, ListOfEncodedValues}, {BucketType, Bucket}, BucketProps
+%%
+%% Unlike conditional postcommits, this *is* the postcommit hook. If a
+%% table/bucket type should not be subject to realtime replication,
+%% the bucket type properties should include `{repl, false}` or
+%% `{repl, fullsync}`.
+-spec add_timeseries_postcommit(hook()) -> ok.
+add_timeseries_postcommit(Hook) ->
+    add_hook(timeseries_postcommit, Hook).
+
+%% @doc Remove a previously registered timeseries postcommit hook
+-spec del_timeseries_postcommit(hook()) -> ok.
+del_timeseries_postcommit(Hook) ->
+    del_hook(timeseries_postcommit, Hook).
+
+%% @doc
+%% This function invokes each registered timeseries postcommit
+%% hook.
+-spec call_timeseries_postcommit(tuple(), bucket(), list()) -> ok.
+call_timeseries_postcommit({_PK, _Data}=Batch, Bucket, BucketProps) ->
+    Hooks = get_hooks(timeseries_postcommit),
+    lists:foreach(fun({Mod, Fun}) ->
+                          Mod:Fun(Batch, Bucket, BucketProps)
+                  end, Hooks),
+    ok.
 
 %%%===================================================================
 

--- a/src/riak_kv_hooks.erl
+++ b/src/riak_kv_hooks.erl
@@ -31,7 +31,6 @@
 -type hook()      :: {module(), atom()}.
 -type hook_type() :: conditional_postcommit.
 -type bucket() :: riak_object:bucket().
--type key()    :: riak_object:key().
 -type bucket_props() :: riak_kv_bucket:props().
 
 %%%===================================================================
@@ -67,8 +66,8 @@ del_conditional_postcommit(Hook) ->
 %% This function invokes each registered conditional postcommit
 %% hook. Each hook will return either `false' or a list of active
 %% hooks. This function then returns the combined list of active hooks.
--spec get_conditional_postcommit({bucket(), key()}, bucket_props()) -> [any()].
-get_conditional_postcommit({{BucketType, Bucket}, _Key}, BucketProps) ->
+-spec get_conditional_postcommit(bucket(), bucket_props()) -> [any()].
+get_conditional_postcommit({BucketType, Bucket}, BucketProps) ->
     Hooks = get_hooks(conditional_postcommit),
     ActiveHooks =
         [ActualHook || {Mod, Fun} <- Hooks,

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -339,7 +339,7 @@ put_data(Data, Table, Mod) when is_binary(Table) ->
                                                fun(RObjs) ->
                                                        riak_kv_w1c_worker:ts_batch_put(
                                                          RObjs, W, PW, Bucket, NVal,
-                                                         EncodeFn, Preflist)
+                                                         EncodeFn, DocIdx, Preflist)
                                                end,
                                                DataForVnode),
                           {GlobalReqIds ++ Ids, GlobalErrorsCnt};

--- a/src/riak_kv_pb_timeseries.erl
+++ b/src/riak_kv_pb_timeseries.erl
@@ -462,7 +462,7 @@ put_data(Data, Table, Mod) when is_binary(Table) ->
                                                end,
                                                fun(RObj, LK) ->
                                                        riak_kv_w1c_worker:async_put(
-                                                         RObj, W, PW, Bucket, NVal, LK,
+                                                         RObj, W, PW, Bucket, NVal, {DocIdx, LK},
                                                          EncodeFn, Preflist)
                                                end,
                                                fun(RObjs) ->

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -46,6 +46,7 @@
          waiting_local_vnode/2,
          waiting_remote_vnode/2,
          postcommit/2, finish/2]).
+-export([get_hooks/2, get_hooks/3]).
 
 -type detail_info() :: timing.
 -type detail() :: true |
@@ -394,6 +395,7 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                                       robj = RObj0,
                                       n=N, bucket_props = BucketProps,
                                       trace = Trace,
+                                      bkey = {Bucket, _Key},
                                       preflist2 = Preflist2}) ->
     Timeout = get_option(timeout, Options0, ?DEFAULT_TIMEOUT),
     PW0 = get_option(pw, Options0, default),
@@ -446,7 +448,7 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                 end,
             Postcommit =
                 if Disable -> [];
-                   true -> get_hooks(postcommit, BucketProps, StateData0)
+                   true -> get_hooks(postcommit, BucketProps, Bucket)
                 end,
             {VNodeOpts0, ReturnBody} =
                 case get_option(returnbody, Options) of
@@ -980,9 +982,9 @@ get_hooks(HookType, BucketProps) ->
             Hooks
     end.
 
-get_hooks(postcommit, BucketProps, #state{bkey=BKey}) ->
+get_hooks(postcommit, BucketProps, Bucket) ->
     BaseHooks = get_hooks(postcommit, BucketProps),
-    CondHooks = riak_kv_hooks:get_conditional_postcommit(BKey, BucketProps),
+    CondHooks = riak_kv_hooks:get_conditional_postcommit(Bucket, BucketProps),
     BaseHooks ++ (CondHooks -- BaseHooks).
 
 get_option(Name, Options) ->

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -46,7 +46,6 @@
          waiting_local_vnode/2,
          waiting_remote_vnode/2,
          postcommit/2, finish/2]).
--export([get_hooks/2, get_hooks/3]).
 
 -type detail_info() :: timing.
 -type detail() :: true |

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -139,13 +139,13 @@ put_data_to_partitions(Data, Bucket, BucketProps, DDL, Mod) ->
                                                end,
                                                fun(RObj, LK) ->
                                                        riak_kv_w1c_worker:async_put(
-                                                         RObj, W, PW, Bucket, NVal, LK,
+                                                         RObj, W, PW, Bucket, NVal, {DocIdx, LK},
                                                          EncodeFn, Preflist)
                                                end,
                                                fun(RObjs) ->
                                                        riak_kv_w1c_worker:ts_batch_put(
                                                          RObjs, W, PW, Bucket, NVal,
-                                                         EncodeFn, Preflist)
+                                                         EncodeFn, DocIdx, Preflist)
                                                end,
                                                DataForVnode),
                           {GlobalReqIds ++ Ids, GlobalErrorsCnt};

--- a/src/riak_kv_w1c_worker.erl
+++ b/src/riak_kv_w1c_worker.erl
@@ -115,7 +115,7 @@ put(RObj0, Options) ->
 
 async_put(RObj, W, PW, Bucket, NVal, {_PK, LK}, EncodeFn, Preflist) when is_tuple(LK) ->
     async_put(RObj, W, PW, Bucket, NVal, LK, EncodeFn, Preflist);
-async_put(RObj, W, PW, Bucket, NVal, LocalKey, EncodeFn, Preflist) ->
+async_put(RObj, W, PW, Bucket, NVal, Key, EncodeFn, Preflist) ->
     StartTS = os:timestamp(),
     Worker = random_worker(),
     ReqId = erlang:monitor(process, Worker),

--- a/src/riak_kv_w1c_worker.erl
+++ b/src/riak_kv_w1c_worker.erl
@@ -359,7 +359,7 @@ validate_options(NVal, Preflist, Options, BucketProps) ->
             {ok, W, PW}
     end.
 
-send_vnodes(Preflist, Proxies, Bucket, {_PK, LK}, EncodedVal, ReqId) ->
+send_vnodes(Preflist, Proxies, Bucket, {_PK, LK}, EncodedVal, ReqId) when is_tuple(LK) ->
     send_vnodes(Preflist, Proxies, Bucket, LK, EncodedVal, ReqId);
 send_vnodes([], Proxies, _Bucket, _Key, _EncodedVal, _ReqId) ->
     Proxies;

--- a/src/riak_kv_w1c_worker.erl
+++ b/src/riak_kv_w1c_worker.erl
@@ -108,13 +108,13 @@ put(RObj0, Options) ->
                 PW :: pos_integer(),
                 Bucket :: binary()|{binary(), binary()},
                 NVal :: pos_integer(),
-                Key :: binary()|{binary(), binary()},
+                Key :: tuple()|{binary(), tuple()},
                 EncodeFn :: fun((riak_object:riak_object()) -> binary()),
                 Preflist :: term()) ->
                        {ok, {reference(), atom()}}.
 
-async_put(RObj, W, PW, Bucket, NVal, {PK, LK}, EncodeFn, Preflist) when is_tuple(LK) ->
-    async_put(RObj, W, PW, Bucket, NVal, PK, LK, EncodeFn, Preflist);
+async_put(RObj, W, PW, Bucket, NVal, {PartIdx, LK}, EncodeFn, Preflist) when is_tuple(LK) ->
+    async_put(RObj, W, PW, Bucket, NVal, PartIdx, LK, EncodeFn, Preflist);
 async_put(RObj, W, PW, Bucket, NVal, Key, EncodeFn, Preflist) ->
     async_put(RObj, W, PW, Bucket, NVal, undefined, Key, EncodeFn, Preflist).
 

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -130,8 +130,7 @@ new(B, K, V, MD) when is_binary(B), is_binary(K) ->
 newts(B, K, V, MD) ->
     new_int2(B, K, V, MD).
 
-%% {true, DDL-version}
-%% false
+-spec is_ts(riak_object()) -> {'true', pos_integer()} | 'false'.
 is_ts(RObj) ->
     check_for_ddl(get_contents(RObj)).
 

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -134,7 +134,9 @@ newts(B, K, V, MD) ->
 is_ts(RObj) ->
     check_for_ddl(get_contents(RObj)).
 
-check_for_ddl([{Metadata, _V}]) ->
+%% Presence or absence of ddl in the metadata for the head object
+%% is sufficient. Shouldn't have siblings for TS ordinarily anyway.
+check_for_ddl([{Metadata, _V}|_Tail]) ->
     case dict:find(<<"ddl">>, Metadata) of
         {ok, Version} ->
             {true, Version};

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -134,9 +134,7 @@ newts(B, K, V, MD) ->
 is_ts(RObj) ->
     check_for_ddl(get_contents(RObj)).
 
-%% Presence or absence of ddl in the metadata for the head object
-%% is sufficient. Shouldn't have siblings for TS ordinarily anyway.
-check_for_ddl([{Metadata, _V}|_Tail]) ->
+check_for_ddl([{Metadata, _V}]) ->
     case dict:find(<<"ddl">>, Metadata) of
         {ok, Version} ->
             {true, Version};

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -101,6 +101,7 @@
 -export([update_last_modified/1, update_last_modified/2]).
 -export([strict_descendant/2]).
 -export([get_ts_local_key/1]).
+-export([is_ts/1]).
 
 %% @doc Constructor for new riak objects.
 -spec new(Bucket::bucket(), Key::key(), Value::value()) -> riak_object().
@@ -129,6 +130,20 @@ new(B, K, V, MD) when is_binary(B), is_binary(K) ->
 newts(B, K, V, MD) ->
     new_int2(B, K, V, MD).
 
+%% {true, DDL-version}
+%% false
+is_ts(RObj) ->
+    check_for_ddl(get_contents(RObj)).
+
+check_for_ddl([{Metadata, _V}]) ->
+    case dict:find(<<"ddl">>, Metadata) of
+        {ok, Version} ->
+            {true, Version};
+        _ ->
+            false
+    end;
+check_for_ddl(_) ->
+    false.
 
 %% internal version after all validation has been done
 new_int(B, K, V, MD) ->
@@ -228,7 +243,7 @@ reconcile(Objects, AllowMultiple) ->
 -spec get_ts_local_key(riak_object()) ->
         {ok, key()} | error.
 get_ts_local_key(RObj) when is_record(RObj, r_object) ->
-    % TODO 
+    % TODO
     % using update metadata while testing with ts_run2, updates should
     % be applied by this point!
     dict:find(?MD_TS_LOCAL_KEY, get_update_metadata(RObj)).
@@ -1072,7 +1087,7 @@ fold_meta_to_bin(Key, Value, {{_Vt,_Del,_Lm}=Elems,RestBin}) ->
     {Elems, <<RestBin/binary, MetaBin/binary>>}.
 
 %% @doc Encode the contents of a riak object, either using
-%% term_to_binary   (if Enc == erlang), or 
+%% term_to_binary   (if Enc == erlang), or
 %% msgpack encoding (if Enc == msgpack)
 encode(Bin, erlang) ->
     encode_maybe_binary(Bin);


### PR DESCRIPTION
Add support for postcommit hooks. This is a streamlined version of the KV postcommit hooks.

Also provides a new batch put interface designed for batches of data that are already msgpack-encoded.
Required for basho/riak_repl#738 (RIAK-1546) (RIAK-1823)
