### PR TITLE
Added back row encoding

### DIFF
--- a/src/riak_kv_ttb_ts.erl
+++ b/src/riak_kv_ttb_ts.erl
@@ -73,7 +73,7 @@ encode_response({reply, {tsqueryresp, {_, _, []}}, State}) ->
     Encoded = #tsqueryresp{columns={[], []}, rows=[]},
     {reply, Encoded, State};
 encode_response({reply, {tsqueryresp, {CNames, CTypes, Rows}}, State}) ->
-    Encoded = #tsqueryresp{columns={CNames, CTypes}, rows=Rows},
+    Encoded = #tsqueryresp{columns={CNames, CTypes}, rows=riak_ttb_codec:encode_ts_rows(Rows)},
     {reply, Encoded, State};
 encode_response({reply, {tsgetresp, {CNames, CTypes, Rows}}, State}) ->
     Encoded = #tsgetresp{columns={CNames, CTypes}, rows=Rows},


### PR DESCRIPTION
Single-line change to add back row encoding.  This got dropped in the recent TTB changes.  

The only change in this PR is that query rows are returned to the client as a list of tuples instead of a list of lists.  This is the format in which rows were previously returned by the PB encoding layer, and by the earlier version of TTB encoding.
