### PR TITLE
Removed erroneous call to decode_query with tscoveragereq as second a…

### DIFF
--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -583,7 +583,7 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
 sub_tscoveragereq(Mod, _DDL, #tscoveragereq{table = Table,
                                             query = Q},
                   State) ->
-    case compile(Mod, catch decode_query(Q, tscoveragereq)) of
+    case compile(Mod, catch decode_query(Q, undefined)) of
         {error, #rpberrorresp{} = Error} ->
             {reply, Error, State};
         {error, _} ->


### PR DESCRIPTION
…rgument, and replaced it with undefined.

This was a typo that crept in when the original TTB PRs were reworked from a single (riak_kv_pb_timeseries) service that handled separate sets of messages, to a model where the riak_kv_pb_timeseries was split into two separate services for the different encodings.

In my original PR, the code had to keep track of the originating request to know what response to generate.  This was passed as an extra argument to decode_query/2 and decode_query/3 as a request atom.   With @lukebakken's more elegant solution, this was no longer needed,  decode_query/3 was removed, the request atoms were deleted, and the meaning of the second arg to decode_query/2 was changed from a request atom to a Cover.

This one, however, was missed, so although decode_query(Q, Cover) is now expecting a Cover as the second arg, it is instead getting a tscoveragereq atom in sub_tscoveragereq.  This will break any test that exercises the coverage request.

This PR changes that erroneous request atom to the atom 'undefined', which is what riak_kv_qry_worker:run_sub_qs_fn expects when no cover_context is present
