### PR TITLE
make outgoing PB messages TTB-friendly

### DIFF
--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -64,9 +64,9 @@ describe_table_columns(?DDL{fields = FieldSpecs,
                             partition_key = #key_v1{ast = PKSpec},
                             local_key     = #key_v1{ast = LKSpec}}) ->
     {ok,
-     [[Name, list_to_binary(atom_to_list(Type)), Nullable,
+     [{Name, list_to_binary(atom_to_list(Type)), Nullable,
        column_pk_position_or_blank(Name, PKSpec),
-       column_lk_position_or_blank(Name, LKSpec)]
+       column_lk_position_or_blank(Name, LKSpec)}
       || #riak_field_v1{name = Name,
                         type = Type,
                         optional = Nullable} <- FieldSpecs]}.
@@ -83,7 +83,7 @@ column_lk_position_or_blank(Col, KSpec) ->
     count_to_position(Col, KSpec, 1).
 
 count_to_position(_, [], _) ->
-    undefined;
+    [];
 count_to_position(Col, [#param_v1{name = [Col]} | _], Pos) ->
     Pos;
 count_to_position(Col, [#hash_fn_v1{args = [#param_v1{name = [Col]} | _]} | _], Pos) ->
@@ -152,10 +152,10 @@ describe_table_columns_test() ->
             " f, s, t))")),
     ?assertEqual(
        describe_table_columns(DDL),
-       {ok, [[<<"f">>, <<"varchar">>,   false, 1,  1],
-             [<<"s">>, <<"varchar">>,   false, 2,  2],
-             [<<"t">>, <<"timestamp">>, false, 3,  3],
-             [<<"w">>, <<"sint64">>, false, undefined, undefined],
-             [<<"p">>, <<"double">>, true,  undefined, undefined]]}).
+       {ok, [{<<"f">>, <<"varchar">>,   false, 1,  1},
+             {<<"s">>, <<"varchar">>,   false, 2,  2},
+             {<<"t">>, <<"timestamp">>, false, 3,  3},
+             {<<"w">>, <<"sint64">>, false, [], []},
+             {<<"p">>, <<"double">>, true,  [], []}]}).
 
 -endif.

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -801,7 +801,7 @@ check_table_and_call(Table, Fun, TsMessage, State) ->
 -spec make_rpberrresp(integer(), string()) -> #rpberrorresp{}.
 make_rpberrresp(Code, Message) ->
     #rpberrorresp{errcode = Code,
-                  errmsg = lists:flatten(Message)}.
+                  errmsg = iolist_to_binary(Message)}.
 
 %%
 -spec missing_helper_module(Table::binary(),

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -1002,7 +1002,7 @@ validate_rows_error_response_1_test() ->
     Msg = "Invalid data found at row index(es) ",
     ?assertEqual(
         #rpberrorresp{errcode = ?E_IRREG,
-                      errmsg = Msg ++ "1" },
+                      errmsg = list_to_binary(Msg ++ "1")},
         validate_rows_error_response(["1"])
     ).
 
@@ -1010,7 +1010,7 @@ validate_rows_error_response_2_test() ->
     Msg = "Invalid data found at row index(es) ",
     ?assertEqual(
         #rpberrorresp{errcode = ?E_IRREG,
-                      errmsg = Msg ++ "1, 2, 3" },
+                      errmsg = list_to_binary(Msg ++ "1, 2, 3")},
         validate_rows_error_response(["1", "2", "3"])
     ).
 


### PR DESCRIPTION
Ensure that
- all error messages in `#rpberrresp` are binaries;
- present NULLs as `[]` not `undefined` in DESCRIBE query returned table;
- also, present rows as tuples, not lists.
