### PR TITLE
Convert Output Lists to tuples for TTB

### DIFF
--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -490,11 +490,11 @@ sub_tsgetreq(Mod, DDL, #tsgetreq{table = Table,
             %% the columns stored in riak_object are just
             %% names; we need names with types, so:
             ColumnTypes = get_column_types(ColumnNames, Mod),
-            {reply, {tsgetresp, {ColumnNames, ColumnTypes, [Row]}}, State};
+            {reply, {tsgetresp, {ColumnNames, ColumnTypes, [list_to_tuple(Row)]}}, State};
         {error, {bad_key_length, Got, Need}} ->
             {reply, key_element_count_mismatch(Got, Need), State};
         {error, notfound} ->
-            {reply, make_rpberrresp(?E_NOTFOUND, "notfound"), State};
+            {reply, {tsgetresp, {[], [], []}}, State};
         {error, Reason} ->
             {reply, make_rpberrresp(?E_GET, to_string(Reason)), State}
     end.
@@ -910,7 +910,7 @@ invoke_async_put(BuildRObjFun, _AsyncPutFun, BatchPutFun, {batches, Batches}) ->
 make_tsqueryresp({_, _, []}) ->
     {tsqueryresp, {[], [], []}};
 make_tsqueryresp({ColumnNames, ColumnTypes, Rows}) ->
-    {tsqueryresp, {ColumnNames, ColumnTypes, Rows}}.
+    {tsqueryresp, {ColumnNames, ColumnTypes, [list_to_tuple(X) || X <- Rows]}}.
 
 -spec make_describe_response([[term()]]) -> ts_query_response().
 make_describe_response(Rows) ->


### PR DESCRIPTION
Get and query responses are now lists of tuples.  Also change the get "not found" response to be empty lists.
