### PR TITLE
Prepare internal API for shared use between PB and WM callbacks [1/3]

### DIFF
--- a/include/riak_kv_ts.hrl
+++ b/include/riak_kv_ts.hrl
@@ -76,14 +76,4 @@
           helper_mod            :: atom()
         }).
 
--type ts_requests() :: #tsputreq{} | #tsdelreq{} | #tsgetreq{} |
-                       #tslistkeysreq{} | #tsqueryreq{}.
--type ts_responses() :: #tsputresp{} | #tsdelresp{} | #tsgetresp{} |
-                        #tslistkeysresp{} | #tsqueryresp{} |
-                        #rpberrorresp{}.
--type ts_get_response() :: {tsgetresp, {list(binary()), list(atom()), list(list(term()))}}.
--type ts_query_response() :: {tsqueryresp, {list(binary()), list(atom()), list(list(term()))}}.
--type ts_query_responses() :: #tsqueryresp{} | ts_query_response().
--type ts_query_types() :: ?DDL{} | ?SQL_SELECT{} | #riak_sql_describe_v1{} |
-                          #riak_sql_insert_v1{}.
 -endif.

--- a/include/riak_kv_ts.hrl
+++ b/include/riak_kv_ts.hrl
@@ -40,7 +40,7 @@
         {
           calc_type        = rows :: select_result_type(),
           initial_state    = []   :: [any()],
-          col_return_types = []   :: [riak_ql_ddl:field_type()],
+          col_return_types = []   :: [riak_ql_ddl:simple_field_type()],
           col_names        = []   :: [binary()],
           clause           = []   :: [riak_kv_qry_compiler:compiled_select()],
           finalisers       = []   :: [skip | function()]

--- a/include/riak_kv_ts_svc.hrl
+++ b/include/riak_kv_ts_svc.hrl
@@ -24,32 +24,6 @@
 -ifndef(RIAK_KV_TS_SVC_HRL).
 -define(RIAK_KV_TS_SVC_HRL, included).
 
-%% per RIAK-1437, error codes assigned to TS are in the 1000-1500 range
--define(E_SUBMIT,            1001).
--define(E_FETCH,             1002).
--define(E_IRREG,             1003).
--define(E_PUT,               1004).
--define(E_NOCREATE,          1005).   %% unused
--define(E_NOT_TS_TYPE,       1006).
--define(E_MISSING_TYPE,      1007).
--define(E_MISSING_TS_MODULE, 1008).
--define(E_DELETE,            1009).
--define(E_GET,               1010).
--define(E_BAD_KEY_LENGTH,    1011).
--define(E_LISTKEYS,          1012).
--define(E_TIMEOUT,           1013).
--define(E_CREATE,            1014).
--define(E_CREATED_INACTIVE,  1015).
--define(E_CREATED_GHOST,     1016).
--define(E_ACTIVATE,          1017).
--define(E_BAD_QUERY,         1018).
--define(E_TABLE_INACTIVE,    1019).
--define(E_PARSE_ERROR,       1020).
--define(E_NOTFOUND,          1021).
-
--define(FETCH_RETRIES, 10).  %% TODO make it configurable in tsqueryreq
--define(TABLE_ACTIVATE_WAIT, 30). %% ditto
-
 -record(state, {
           req,
           req_ctx,

--- a/src/riak_kv_pb_ts.erl
+++ b/src/riak_kv_pb_ts.erl
@@ -50,15 +50,15 @@ decode(Code, Bin) when Code >= 90, Code =< 103 ->
         #tsqueryreq{query = Q, cover_context = Cover} ->
             riak_kv_ts_svc:decode_query_common(Q, Cover);
         #tsgetreq{table = Table}->
-            {ok, Msg, {"riak_kv.ts_get", Table}};
+            {ok, Msg, {riak_kv_ts_api:api_call_to_perm(get), Table}};
         #tsputreq{table = Table} ->
-            {ok, Msg, {"riak_kv.ts_put", Table}};
+            {ok, Msg, {riak_kv_ts_api:api_call_to_perm(put), Table}};
         #tsdelreq{table = Table} ->
-            {ok, Msg, {"riak_kv.ts_del", Table}};
+            {ok, Msg, {riak_kv_ts_api:api_call_to_perm(delete), Table}};
         #tslistkeysreq{table = Table} ->
-            {ok, Msg, {"riak_kv.ts_listkeys", Table}};
+            {ok, Msg, {riak_kv_ts_api:api_call_to_perm(listkeys), Table}};
         #tscoveragereq{table = Table} ->
-            {ok, Msg, {"riak_kv.ts_cover", Table}}
+            {ok, Msg, {riak_kv_ts_api:api_call_to_perm(coverage), Table}}
     end.
 
 -spec encode(tuple()) -> {ok, iolist()}.

--- a/src/riak_kv_pb_ts.erl
+++ b/src/riak_kv_pb_ts.erl
@@ -76,16 +76,16 @@ process_stream(Message, ReqId, State) ->
     riak_kv_ts_svc:process_stream(Message, ReqId, State).
 
 encode_response({reply, {tsqueryresp, {_, _, []}}, State}) ->
-    Encoded = #tsqueryresp{columns=[], rows=[]},
+    Encoded = #tsqueryresp{columns = {[], []}, rows = []},
     {reply, Encoded, State};
 encode_response({reply, {tsqueryresp, {CNames, CTypes, Rows}}, State}) ->
-    Encoded = #tsqueryresp{columns=riak_pb_ts_codec:encode_columns(CNames, CTypes),
-                           rows=riak_pb_ts_codec:encode_rows(CTypes, Rows)},
+    Encoded = #tsqueryresp{columns = riak_pb_ts_codec:encode_columns(CNames, CTypes),
+                           rows = riak_pb_ts_codec:encode_rows(CTypes, Rows)},
     {reply, Encoded, State};
 encode_response({reply, {tsgetresp, {CNames, CTypes, Rows}}, State}) ->
     C = riak_pb_ts_codec:encode_columns(CNames, CTypes),
     R = riak_pb_ts_codec:encode_rows(CTypes, Rows),
-    Encoded = #tsgetresp{columns=C, rows=R},
+    Encoded = #tsgetresp{columns = C, rows = R},
     {reply, Encoded, State};
 encode_response(Response) ->
-    Response. 
+    Response.

--- a/src/riak_kv_pb_ts.erl
+++ b/src/riak_kv_pb_ts.erl
@@ -42,7 +42,7 @@ init() ->
     #state{}.
 
 -spec decode(integer(), binary()) ->
-                    {ok, ts_requests(), {PermSpec::string(), Table::binary()}} |
+                    {ok, riak_kv_ts_svc:ts_requests(), {PermSpec::string(), Table::binary()}} |
                     {error, _}.
 decode(Code, Bin) when Code >= 90, Code =< 103 ->
     Msg = riak_pb_codec:decode(Code, Bin),
@@ -65,8 +65,8 @@ decode(Code, Bin) when Code >= 90, Code =< 103 ->
 encode(Message) ->
     {ok, riak_pb_codec:encode(Message)}.
 
--spec process(atom() | ts_requests() | ts_query_types(), #state{}) ->
-                     {reply, ts_responses(), #state{}}.
+-spec process(atom() | riak_kv_ts_svc:ts_requests() | riak_kv_ts_svc:ts_query_types(), #state{}) ->
+                     {reply, riak_kv_ts_svc:ts_responses(), #state{}}.
 process(Request, State) ->
     encode_response(riak_kv_ts_svc:process(Request, State)).
 

--- a/src/riak_kv_pb_ts.erl
+++ b/src/riak_kv_pb_ts.erl
@@ -75,9 +75,6 @@ process(Request, State) ->
 process_stream(Message, ReqId, State) ->
     riak_kv_ts_svc:process_stream(Message, ReqId, State).
 
-encode_response({reply, {tsqueryresp, {_, _, []}}, State}) ->
-    Encoded = #tsqueryresp{columns = {[], []}, rows = []},
-    {reply, Encoded, State};
 encode_response({reply, {tsqueryresp, {CNames, CTypes, Rows}}, State}) ->
     Encoded = #tsqueryresp{columns = riak_pb_ts_codec:encode_columns(CNames, CTypes),
                            rows = riak_pb_ts_codec:encode_rows(CTypes, Rows)},

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -197,9 +197,9 @@ do_describe(?DDL{fields = FieldSpecs,
     ColumnNames = [<<"Column">>, <<"Type">>, <<"Is Null">>, <<"Primary Key">>, <<"Local Key">>],
     ColumnTypes = [   varchar,     varchar,     boolean,        sint64,             sint64    ],
     Rows =
-        [[Name, list_to_binary(atom_to_list(Type)), Nullable,
+        [{Name, list_to_binary(atom_to_list(Type)), Nullable,
           column_pk_position_or_blank(Name, PKSpec),
-          column_lk_position_or_blank(Name, LKSpec)]
+          column_lk_position_or_blank(Name, LKSpec)}
          || #riak_field_v1{name = Name,
                            type = Type,
                            optional = Nullable} <- FieldSpecs],

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -60,6 +60,8 @@ submit(SQLString, DDL) when is_list(SQLString) ->
                  riak_ql_lexer:get_tokens(SQLString)) of
         {error, _Reason} = Error ->
             Error;
+        {'EXIT', Reason} ->  %% lexer problem
+            {error, Reason};
         {ok, SQL} ->
             submit(SQL, DDL)
     end;

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -27,19 +27,37 @@
 
 -export([
          submit/2,
+         empty_result/0,
          format_query_syntax_errors/1
         ]).
 
 -include("riak_kv_ts.hrl").
 
+%% enumerate all current SQL query types
+-type query_type() ::
+        ddl | select | describe | insert.
+%% and also their corresponding records (mainly for use in specs)
+-type sql_query_type_record() ::
+        ?SQL_SELECT{} |
+        #riak_sql_describe_v1{} |
+        #riak_sql_insert_v1{}.
+
+-type query_tabular_result() :: {[riak_pb_ts_codec:tscolumnname()],
+                                 [riak_pb_ts_codec:tscolumntype()],
+                                 [list(riak_pb_ts_codec:ldbvalue())]}.
+
+-export_type([query_type/0, sql_query_type_record/0,
+              query_tabular_result/0]).
+
+
 %% No coverage plan for parallel requests
--spec submit(string() | ?SQL_SELECT{} | #riak_sql_describe_v1{} | #riak_sql_insert_v1{}, ?DDL{}) ->
-    {ok, any()} | {error, any()}.
+-spec submit(string() | sql_query_type_record(), ?DDL{}) ->
+    {ok, query_tabular_result()} | {error, any()}.
 %% @doc Parse, validate against DDL, and submit a query for execution.
 %%      To get the results of running the query, use fetch/1.
 submit(SQLString, DDL) when is_list(SQLString) ->
-    Lexed = riak_ql_lexer:get_tokens(SQLString),
-    case riak_ql_parser:parse(Lexed) of
+    case catch riak_ql_parser:parse(
+                 riak_ql_lexer:get_tokens(SQLString)) of
         {error, _Reason} = Error ->
             Error;
         {ok, SQL} ->
@@ -47,38 +65,153 @@ submit(SQLString, DDL) when is_list(SQLString) ->
     end;
 
 submit(#riak_sql_describe_v1{}, DDL) ->
-    describe_table_columns(DDL);
-
+    do_describe(DDL);
 submit(SQL = #riak_sql_insert_v1{}, _DDL) ->
-    {ok, SQL};
-
+    do_insert(SQL);
 submit(SQL = ?SQL_SELECT{}, DDL) ->
-    maybe_submit_to_queue(SQL, DDL).
+    do_select(SQL, DDL).
+
 
 %% ---------------------
 %% local functions
 
--spec describe_table_columns(?DDL{}) ->
-                                    {ok, [[binary() | boolean() | integer() | undefined]]}.
-describe_table_columns(?DDL{fields = FieldSpecs,
-                            partition_key = #key_v1{ast = PKSpec},
-                            local_key     = #key_v1{ast = LKSpec}}) ->
-    {ok,
-     [{Name, list_to_binary(atom_to_list(Type)), Nullable,
-       column_pk_position_or_blank(Name, PKSpec),
-       column_lk_position_or_blank(Name, LKSpec)}
-      || #riak_field_v1{name = Name,
-                        type = Type,
-                        optional = Nullable} <- FieldSpecs]}.
+%%
+%% INSERT statements
+%%
+-spec do_insert(#riak_sql_insert_v1{}) -> {ok, query_tabular_result()} | {error, term()}.
+do_insert(#riak_sql_insert_v1{'INSERT' = Table,
+                              fields = Fields,
+                              values = Values}) ->
+    Mod = riak_ql_ddl:make_module_name(Table),
+    case lookup_field_positions(Mod, Fields) of
+        {ok, Positions} ->
+            Empty = make_empty_row(Mod),
+            case xlate_insert_to_putdata(Values, Positions, Empty) of
+                {error, Reason} ->
+                    {error, Reason};
+                {ok, Data} ->
+                    insert_putreqs(Mod, Table, Data)
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+insert_putreqs(Mod, Table, Data) ->
+    case riak_kv_ts_util:validate_rows(Mod, Data) of
+        [] ->
+            case riak_kv_ts_api:put_data(Data, Table, Mod) of
+                ok ->
+                    {ok, empty_result()};
+                {error, {some_failed, ErrorCount}} ->
+                    {error, io_lib:format("Failed to put ~b record(s)", [ErrorCount])};
+                {error, no_type} ->
+                    {error, io_lib:format("~ts is not an active table", [Table])};
+                {error, OtherReason} ->
+                    {error, OtherReason}
+            end;
+        BadRowIdxs when is_list(BadRowIdxs) ->
+            {error, {invalid_data, BadRowIdxs}}
+    end.
+
+%%
+%% Return an all-null empty row ready to be populated by the values
+%%
+-spec make_empty_row(module()) -> tuple(undefined).
+make_empty_row(Mod) ->
+    Positions = Mod:get_field_positions(),
+    list_to_tuple(lists:duplicate(length(Positions), undefined)).
+
+%%
+%% Lookup the index of the field names selected to insert.
+%%
+%% This *requires* that once schema changes take place the DDL fields are left in order.
+%%
+-spec lookup_field_positions(module(), [riak_ql_ddl:field_identifier()]) ->
+                           {ok, [pos_integer()]} | {error, string()}.
+lookup_field_positions(Mod, FieldIdentifiers) ->
+    GoodBadPositions =
+        lists:foldl(
+          fun({identifier, FieldName}, {Good, Bad}) ->
+                  case Mod:is_field_valid(FieldName) of
+                      false ->
+                          {Good, [FieldName | Bad]};
+                      true ->
+                          {[Mod:get_field_position(FieldName) | Good], Bad}
+                  end
+          end, {[], []}, FieldIdentifiers),
+    case GoodBadPositions of
+        {Positions, []} ->
+            {ok, lists:reverse(Positions)};
+        {_, Errors} ->
+            {error, {undefined_fields, Errors}}
+    end.
+
+%%
+%% Map the list of values from statement order into the correct place in the tuple.
+%% If there are less values given than the field list the NULL will carry through
+%% and the general validation rules should pick that up.
+%% If there are too many values given for the fields it returns an error.
+%%
+-spec xlate_insert_to_putdata([[riak_ql_ddl:data_value()]], [pos_integer()], tuple(undefined)) ->
+                              {ok, [tuple()]} | {error, string()}.
+xlate_insert_to_putdata(Values, Positions, Empty) ->
+    ConvFn = fun(RowVals, {Good, Bad, RowNum}) ->
+                 case make_insert_row(RowVals, Positions, Empty) of
+                     {ok, Row} ->
+                         {[Row | Good], Bad, RowNum + 1};
+                     {error, _Reason} ->
+                         {Good, [RowNum | Bad], RowNum + 1}
+                 end
+             end,
+    Converted = lists:foldl(ConvFn, {[], [], 1}, Values),
+    case Converted of
+        {PutData, [], _} ->
+            {ok, lists:reverse(PutData)};
+        {_, Errors, _} ->
+            {error, {too_many_insert_values, lists:reverse(Errors)}}
+    end.
+
+-spec make_insert_row([] | [riak_ql_ddl:data_value()], [] | [pos_integer()], tuple()) ->
+                      {ok, tuple()} | {error, string()}.
+make_insert_row([], _Positions, Row) when is_tuple(Row) ->
+    %% Out of entries in the value - row is populated with default values
+    %% so if we run out of data for implicit/explicit fieldnames can just return
+    {ok, Row};
+make_insert_row(_, [], Row) when is_tuple(Row) ->
+    %% Too many values for the field
+    {error, too_many_values};
+%% Make sure the types match
+make_insert_row([{_Type, Val} | Values], [Pos | Positions], Row) when is_tuple(Row) ->
+    make_insert_row(Values, Positions, setelement(Pos, Row, Val)).
+
+
+%% DESCRIBE
+
+-spec do_describe(?DDL{}) ->
+                         {ok, query_tabular_result()} | {error, term()}.
+do_describe(?DDL{fields = FieldSpecs,
+                 partition_key = #key_v1{ast = PKSpec},
+                 local_key     = #key_v1{ast = LKSpec}}) ->
+    ColumnNames = [<<"Column">>, <<"Type">>, <<"Is Null">>, <<"Primary Key">>, <<"Local Key">>],
+    ColumnTypes = [   varchar,     varchar,     boolean,        sint64,             sint64    ],
+    Rows =
+        [[Name, list_to_binary(atom_to_list(Type)), Nullable,
+          column_pk_position_or_blank(Name, PKSpec),
+          column_lk_position_or_blank(Name, LKSpec)]
+         || #riak_field_v1{name = Name,
+                           type = Type,
+                           optional = Nullable} <- FieldSpecs],
+    {ok, {ColumnNames, ColumnTypes, Rows}}.
+
 
 %% the following two functions are identical, for the way fields and
 %% keys are represented as of 2015-12-18; duplication here is a hint
 %% of things to come.
--spec column_pk_position_or_blank(binary(), [#param_v1{}]) -> integer() | undefined.
+-spec column_pk_position_or_blank(binary(), [#param_v1{}]) -> integer() | [].
 column_pk_position_or_blank(Col, KSpec) ->
     count_to_position(Col, KSpec, 1).
 
--spec column_lk_position_or_blank(binary(), [#param_v1{}]) -> integer() | undefined.
+-spec column_lk_position_or_blank(binary(), [#param_v1{}]) -> integer() | [].
 column_lk_position_or_blank(Col, KSpec) ->
     count_to_position(Col, KSpec, 1).
 
@@ -92,7 +225,11 @@ count_to_position(Col, [_ | Rest], Pos) ->
     count_to_position(Col, Rest, Pos + 1).
 
 
-maybe_submit_to_queue(SQL, ?DDL{table = BucketType} = DDL) ->
+%% SELECT
+
+-spec do_select(?SQL_SELECT{}, ?DDL{}) ->
+                       {ok, query_tabular_result()} | {error, term()}.
+do_select(SQL, ?DDL{table = BucketType} = DDL) ->
     Mod = riak_ql_ddl:make_module_name(BucketType),
     MaxSubQueries =
         app_helper:get_env(riak_kv, timeseries_query_max_quanta_span),
@@ -102,9 +239,9 @@ maybe_submit_to_queue(SQL, ?DDL{table = BucketType} = DDL) ->
             case riak_kv_qry_compiler:compile(DDL, SQL, MaxSubQueries) of
                 {error,_} = Error ->
                     Error;
-                {ok, Queries} ->
+                {ok, SubQueries} ->
                     maybe_await_query_results(
-                        riak_kv_qry_queue:put_on_queue(self(), Queries, DDL))
+                      riak_kv_qry_queue:put_on_queue(self(), SubQueries, DDL))
             end;
         {false, Errors} ->
             {error, {invalid_query, format_query_syntax_errors(Errors)}}
@@ -118,8 +255,10 @@ maybe_await_query_results(_) ->
     % we can't use a gen_server call here because the reply needs to be
     % from an fsm but one is not assigned if the query is queued.
     receive
-        Result ->
-            Result
+        {ok, Result} ->
+            {ok, Result};
+        {error, Reason} ->
+            {error, Reason}
     after
         Timeout ->
             {error, qry_worker_timeout}
@@ -130,6 +269,11 @@ maybe_await_query_results(_) ->
 format_query_syntax_errors(Errors) ->
     iolist_to_binary(
         [["\n", riak_ql_ddl:syntax_error_to_msg(E)] || E <- Errors]).
+
+
+-spec empty_result() -> query_tabular_result().
+empty_result() ->
+    {[], [], []}.
 
 %%%===================================================================
 %%% Unit tests
@@ -150,12 +294,58 @@ describe_table_columns_test() ->
             " p double,"
             " PRIMARY KEY ((f, s, quantum(t, 15, m)), "
             " f, s, t))")),
+    Res = do_describe(DDL),
+    ?assertMatch(
+       {ok, {_, _,
+             [[<<"f">>, <<"varchar">>,   false, 1,  1],
+              [<<"s">>, <<"varchar">>,   false, 2,  2],
+              [<<"t">>, <<"timestamp">>, false, 3,  3],
+              [<<"w">>, <<"sint64">>, false, [], []],
+              [<<"p">>, <<"double">>, true,  [], []]]}},
+       Res).
+
+validate_make_insert_row_basic_test() ->
+    Data = [{integer,4}, {binary,<<"bamboozle">>}, {float, 3.14}],
+    Positions = [3, 1, 2],
+    Row = {undefined, undefined, undefined},
+    Result = make_insert_row(Data, Positions, Row),
     ?assertEqual(
-       describe_table_columns(DDL),
-       {ok, [{<<"f">>, <<"varchar">>,   false, 1,  1},
-             {<<"s">>, <<"varchar">>,   false, 2,  2},
-             {<<"t">>, <<"timestamp">>, false, 3,  3},
-             {<<"w">>, <<"sint64">>, false, [], []},
-             {<<"p">>, <<"double">>, true,  [], []}]}).
+        {ok, {<<"bamboozle">>, 3.14, 4}},
+        Result
+    ).
+
+validate_make_insert_row_too_many_test() ->
+    Data = [{integer,4}, {binary,<<"bamboozle">>}, {float, 3.14}, {integer, 8}],
+    Positions = [3, 1, 2],
+    Row = {undefined, undefined, undefined},
+    Result = make_insert_row(Data, Positions, Row),
+    ?assertEqual(
+        {error, too_many_values},
+        Result
+    ).
+
+
+validate_xlate_insert_to_putdata_ok_test() ->
+    Empty = list_to_tuple(lists:duplicate(5, undefined)),
+    Values = [[{integer, 4}, {binary, <<"babs">>}, {float, 5.67}, {binary, <<"bingo">>}],
+              [{integer, 8}, {binary, <<"scat">>}, {float, 7.65}, {binary, <<"yolo!">>}]],
+    Positions = [5, 3, 1, 2, 4],
+    Result = xlate_insert_to_putdata(Values, Positions, Empty),
+    ?assertEqual(
+        {ok,[{5.67,<<"bingo">>,<<"babs">>,undefined,4},
+             {7.65,<<"yolo!">>,<<"scat">>,undefined,8}]},
+        Result
+    ).
+
+validate_xlate_insert_to_putdata_too_many_values_test() ->
+    Empty = list_to_tuple(lists:duplicate(5, undefined)),
+    Values = [[{integer, 4}, {binary, <<"babs">>}, {float, 5.67}, {binary, <<"bingo">>}, {integer, 7}],
+           [{integer, 8}, {binary, <<"scat">>}, {float, 7.65}, {binary, <<"yolo!">>}]],
+    Positions = [3, 1, 2, 4],
+    Result = xlate_insert_to_putdata(Values, Positions, Empty),
+    ?assertEqual(
+        {error,{too_many_insert_values, [1]}},
+        Result
+    ).
 
 -endif.

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -299,11 +299,11 @@ describe_table_columns_test() ->
     Res = do_describe(DDL),
     ?assertMatch(
        {ok, {_, _,
-             [[<<"f">>, <<"varchar">>,   false, 1,  1],
-              [<<"s">>, <<"varchar">>,   false, 2,  2],
-              [<<"t">>, <<"timestamp">>, false, 3,  3],
-              [<<"w">>, <<"sint64">>, false, [], []],
-              [<<"p">>, <<"double">>, true,  [], []]]}},
+             [{<<"f">>, <<"varchar">>,   false, 1,  1},
+              {<<"s">>, <<"varchar">>,   false, 2,  2},
+              {<<"t">>, <<"timestamp">>, false, 3,  3},
+              {<<"w">>, <<"sint64">>, false, [], []},
+              {<<"p">>, <<"double">>, true,  [], []}]}},
        Res).
 
 validate_make_insert_row_basic_test() ->

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -531,7 +531,7 @@ hash_timestamp_to_quanta(QField, QSize, QUnit, QIndex, MaxSubQueries, Where1) ->
             %% the end_inclusive flag because the end key is not used to hash
             make_wheres(Where2, QField, Min2, Max1, Boundaries);
         NoSubQueries > MaxSubQueries ->
-            {error, {too_many_subqueries, NoSubQueries}}
+            {error, {too_many_subqueries, ?E_TOO_MANY_SUBQUERIES(NoSubQueries)}}
     end.
 
 make_wheres(Where, QField, Min, Max, Boundaries) ->

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% riak_kv_ts_util: supporting functions for timeseries code paths
+%% riak_kv_ts_api: supporting functions for timeseries code paths
 %%
 %% Copyright (c) 2016 Basho Technologies, Inc.  All Rights Reserved.
 %%

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -1,0 +1,311 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_ts_util: supporting functions for timeseries code paths
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Internal API for TS calls: single-key get and delete, batch
+%%      put, coverage and query
+
+-module(riak_kv_ts_api).
+
+-export([
+         api_call_from_sql_type/1,
+         api_call_to_perm/1,
+         put_data/2, put_data/3,
+         get_data/2, get_data/3, get_data/4,
+         delete_data/2, delete_data/3, delete_data/4, delete_data/5,
+         query/2,
+         compile_to_per_quantum_queries/2  %% coverage
+         %% To reassemble the broken-up queries into coverage entries
+         %% for returning to pb or http clients (each needing to
+         %% convert and repackage entry details in their own way),
+         %% respective callbacks in riak_kv_{pb,wm}_timeseries will
+         %% use riak_kv_ts_util:sql_to_cover/4.
+        ]).
+
+-include_lib("riak_ql/include/riak_ql_ddl.hrl").
+-include("riak_kv_wm_raw.hrl").
+-include("riak_kv_ts.hrl").
+
+%% external API calls enumerated
+-type query_api_call() :: query_create_table | query_select | query_describe | query_insert.
+-type api_call() :: get | put | delete | listkeys | coverage | query_api_call().
+-export_type([query_api_call/0, api_call/0]).
+
+-spec api_call_from_sql_type(riak_kv_qry:query_type()) -> query_api_call().
+api_call_from_sql_type(ddl)      -> query_create_table;
+api_call_from_sql_type(select)   -> query_select;
+api_call_from_sql_type(describe) -> query_describe;
+api_call_from_sql_type(insert)   -> query_insert.
+
+-spec api_call_to_perm(api_call()) -> string().
+api_call_to_perm(get) ->
+    "riak_ts.get";
+api_call_to_perm(put) ->
+    "riak_ts.put";
+api_call_to_perm(delete) ->
+    "riak_ts.delete";
+api_call_to_perm(listkeys) ->
+    "riak_ts.listkeys";
+api_call_to_perm(coverage) ->
+    "riak_ts.coverage";
+api_call_to_perm(query_create_table) ->
+    "riak_ts.query_create_table";
+api_call_to_perm(query_select) ->
+    "riak_ts.query_select";
+api_call_to_perm(query_describe) ->
+    "riak_ts.query_describe".
+
+
+-spec query(string() | riak_kv_qry:sql_query_type_record(), ?DDL{}) ->
+                   {ok, riak_kv_qry:query_tabular_result()} |
+                   {error, term()}.
+query(QueryStringOrSQL, DDL) ->
+    riak_kv_qry:submit(QueryStringOrSQL, DDL).
+
+
+-spec put_data([[riak_pb_ts_codec:ldbvalue()]], binary()) ->
+                      ok | {error, {some_failed, integer()}} | {error, term()}.
+put_data(Data, Table) ->
+    put_data(Data, Table, riak_ql_ddl:make_module_name(Table)).
+
+-spec put_data([[riak_pb_ts_codec:ldbvalue()]], binary(), module()) ->
+                      ok | {error, {some_failed, integer()}} | {error, term()}.
+put_data(Data, Table, Mod) ->
+    DDL = Mod:get_ddl(),
+    Bucket = riak_kv_ts_util:table_to_bucket(Table),
+    case riak_core_bucket:get_bucket(Bucket) of
+        {error, Reason} ->
+            %% happens when, for example, the table has not been
+            %% activated (Reason == no_type)
+            {error, Reason};
+        BucketProps ->
+            case put_data_to_partitions(Data, Bucket, BucketProps, DDL, Mod) of
+                0 ->
+                    ok;
+                NErrors ->
+                    {error, {some_failed, NErrors}}
+            end
+    end.
+
+put_data_to_partitions(Data, Bucket, BucketProps, DDL, Mod) ->
+    NVal = proplists:get_value(n_val, BucketProps),
+    PartitionedData = partition_data(Data, Bucket, BucketProps, DDL, Mod),
+    PreflistData = add_preflists(PartitionedData, NVal,
+                                 riak_core_node_watcher:nodes(riak_kv)),
+    EncodeFn =
+        fun(O) -> riak_object:to_binary(v1, O, msgpack) end,
+
+    {ReqIds, FailReqs} =
+        lists:foldl(
+          fun({DocIdx, Preflist, Records}, {GlobalReqIds, GlobalErrorsCnt}) ->
+                  case riak_kv_w1c_worker:validate_options(
+                         NVal, Preflist, [], BucketProps) of
+                      {ok, W, PW} ->
+                          {Ids, Errs} =
+                              lists:foldl(
+                                fun(Record, {PartReqIds, PartErrors}) ->
+                                        {RObj, LK} =
+                                            build_object(Bucket, Mod, DDL,
+                                                         Record, DocIdx),
+
+                                        {ok, ReqId} =
+                                            riak_kv_w1c_worker:async_put(
+                                              RObj, W, PW, Bucket, NVal, LK,
+                                              EncodeFn, Preflist),
+                                        {[ReqId | PartReqIds], PartErrors}
+                                end,
+                                {[], 0}, Records),
+                          {GlobalReqIds ++ Ids, GlobalErrorsCnt + Errs};
+                      _Error ->
+                          {GlobalReqIds, GlobalErrorsCnt + length(Records)}
+                  end
+          end,
+          {[], 0}, PreflistData),
+    Responses = riak_kv_w1c_worker:async_put_replies(ReqIds, []),
+    _NErrors =
+        length(
+          lists:filter(
+            fun({error, _}) -> true;
+               (_) -> false
+            end, Responses)) + FailReqs.
+
+
+
+-spec partition_data(Data :: list(term()),
+                     Bucket :: {binary(), binary()},
+                     BucketProps :: proplists:proplist(),
+                     DDL :: ?DDL{},
+                     Mod :: module()) ->
+                            list(tuple(chash:index(), list(term()))).
+partition_data(Data, Bucket, BucketProps, DDL, Mod) ->
+    PartitionTuples =
+        [ { riak_core_util:chash_key({Bucket, row_to_key(R, DDL, Mod)},
+                                     BucketProps), R } || R <- Data ],
+    dict:to_list(
+      lists:foldl(fun({Idx, R}, Dict) ->
+                          dict:append(Idx, R, Dict)
+                  end,
+                  dict:new(),
+                  PartitionTuples)).
+
+row_to_key(Row, DDL, Mod) ->
+    riak_kv_ts_util:encode_typeval_key(
+      riak_ql_ddl:get_partition_key(DDL, Row, Mod)).
+
+add_preflists(PartitionedData, NVal, UpNodes) ->
+    lists:map(fun({Idx, Rows}) -> {Idx,
+                                   riak_core_apl:get_apl_ann(Idx, NVal, UpNodes),
+                                   Rows} end,
+              PartitionedData).
+
+build_object(Bucket, Mod, DDL, Row, PK) ->
+    Obj = Mod:add_column_info(Row),
+    LK  = riak_kv_ts_util:encode_typeval_key(
+            riak_ql_ddl:get_local_key(DDL, Row, Mod)),
+
+    RObj = riak_object:newts(
+             Bucket, PK, Obj,
+             dict:from_list([{?MD_DDL_VERSION, ?DDL_VERSION}])),
+    {RObj, LK}.
+
+
+
+
+-spec get_data([riak_pb_ts_codec:ldbvalue()], binary()) ->
+                      {ok, {[binary()], [[riak_pb_ts_codec:ldbvalue()]]}} | {error, term()}.
+get_data(Key, Table) ->
+    get_data(Key, Table, undefined, []).
+
+-spec get_data([riak_pb_ts_codec:ldbvalue()], binary(), module()) ->
+                      {ok, {[binary()], [[riak_pb_ts_codec:ldbvalue()]]}} | {error, term()}.
+get_data(Key, Table, Mod) ->
+    get_data(Key, Table, Mod, []).
+
+-spec get_data([riak_pb_ts_codec:ldbvalue()], binary(), module(), proplists:proplist()) ->
+                      {ok, [{binary(), riak_pb_ts_codec:ldbvalue()}]} | {error, term()}.
+get_data(Key, Table, Mod0, Options) ->
+    Mod =
+        case Mod0 of
+            undefined ->
+                riak_ql_ddl:make_module_name(Table);
+            Mod0 ->
+                Mod0
+        end,
+    DDL = Mod:get_ddl(),
+    Result =
+        case riak_kv_ts_util:make_ts_keys(Key, DDL, Mod) of
+            {ok, PKLK} ->
+                riak_client:get(
+                  riak_kv_ts_util:table_to_bucket(Table), PKLK, Options,
+                  {riak_client, [node(), undefined]});
+            ErrorReason ->
+                ErrorReason
+        end,
+    case Result of
+        {ok, RObj} ->
+            case riak_object:get_value(RObj) of
+                [] ->
+                    {error, notfound};
+                Record ->
+                    {ok, Record}
+            end;
+        ErrorReason2 ->
+            ErrorReason2
+    end.
+
+
+-spec delete_data([any()], riak_object:bucket()) ->
+                         ok | {error, term()}.
+delete_data(Key, Table) ->
+    delete_data(Key, Table, undefined, [], undefined).
+
+-spec delete_data([any()], riak_object:bucket(), module()) ->
+                         ok | {error, term()}.
+delete_data(Key, Table, Mod) ->
+    delete_data(Key, Table, Mod, [], undefined).
+
+-spec delete_data([any()], riak_object:bucket(), module(), proplists:proplist()) ->
+                         ok | {error, term()}.
+delete_data(Key, Table, Mod, Options) ->
+    delete_data(Key, Table, Mod, Options, undefined).
+
+-spec delete_data([any()], riak_object:bucket(), module(), proplists:proplist(),
+                  undefined | vclock:vclock()) ->
+                         ok | {error, term()}.
+delete_data(Key, Table, Mod0, Options0, VClock0) ->
+    Mod =
+        case Mod0 of
+            undefined ->
+                riak_ql_ddl:make_module_name(Table);
+            Mod0 ->
+                Mod0
+        end,
+    %% Pass the {dw,all} option in to the delete FSM
+    %% to make sure all tombstones are written by the
+    %% async put before the reaping get runs otherwise
+    %% if the default {dw,quorum} is used there is the
+    %% possibility that the last tombstone put overlaps
+    %% inside the KV vnode with the reaping get and
+    %% prevents the tombstone removal.
+    Options = lists:keystore(dw, 1, Options0, {dw, all}),
+    DDL = Mod:get_ddl(),
+    VClock =
+        case VClock0 of
+            undefined ->
+                %% this will trigger a get in riak_kv_delete:delete to
+                %% retrieve the actual vclock
+                undefined;
+            VClock0 ->
+                %% else, clients may have it already (e.g., from an
+                %% earlier riak_object:get), which will short-circuit
+                %% to avoid a separate get
+                riak_object:decode_vclock(VClock0)
+        end,
+    Result =
+        case riak_kv_ts_util:make_ts_keys(Key, DDL, Mod) of
+            {ok, PKLK} ->
+                riak_client:delete_vclock(
+                  riak_kv_ts_util:table_to_bucket(Table), PKLK, VClock, Options,
+                  {riak_client, [node(), undefined]});
+            ErrorReason ->
+                ErrorReason
+        end,
+    Result.
+
+
+
+
+-spec compile_to_per_quantum_queries(module(), ?SQL_SELECT{}) ->
+                                            {ok, [?SQL_SELECT{}]} | {error, any()}.
+%% @doc Break up a query into a list of per-quantum queries
+compile_to_per_quantum_queries(Mod, SQL) ->
+    case catch Mod:get_ddl() of
+        {_, {undef, _}} ->
+            {error, no_helper_module};
+        DDL ->
+            case riak_ql_ddl:is_query_valid(
+                   Mod, DDL, riak_kv_ts_util:sql_record_to_tuple(SQL)) of
+                true ->
+                    riak_kv_qry_compiler:compile(DDL, SQL, undefined);
+                {false, _Errors} ->
+                    {error, invalid_query}
+            end
+    end.

--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -87,3 +87,9 @@
         ["The '", ParamName, "' parameter is part the primary key, and must have an ",
          "equals clause in the query but the ", atom_to_list(Op), " operator was used."])
 ).
+
+-define(
+   E_TOO_MANY_SUBQUERIES(N),
+   iolist_to_binary(
+     ["Too many subqueries (",integer_to_list(N),")"])
+).

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -680,6 +680,17 @@ to_string(X) ->
 make_tsgetresp(ColumnNames, ColumnTypes, Rows) ->
     {tsgetresp, {ColumnNames, ColumnTypes, Rows}}.
 
+make_tsqueryresp({_ColumnNames, _ColumnTypes, []}) ->
+    %% tests (and probably docs, too) expect an empty result set to be
+    %% returned as {[], []} (with column names omitted). Before the
+    %% TTB merge, the columns info was dropped in
+    %% riak_kv_pb_ts:encode_response({reply, {tsqueryresp, Data}, _}).
+    %% Now, because the TTB encoder is dumb, leaving the special case
+    %% treatment in the PB-specific riak_kv_pb_ts lets empty query
+    %% results going through TTB still have the columns info, which is
+    %% not what the caller might expect. We ensure uniform {[], []}
+    %% for bot PB and TTB by preparing this term in advance, here.
+    {tsqueryresp, {[], [], []}};
 make_tsqueryresp(Data = {_ColumnNames, _ColumnTypes, _Rows}) ->
     {tsqueryresp, Data}.
 

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -478,8 +478,6 @@ find_hash_fn([_H|T]) ->
 
 compile(_Mod, {error, Err}) ->
     {error, make_decoder_error_response(Err)};
-compile(_Mod, {'EXIT', {Err, _}}) ->
-    {error, make_decoder_error_response(Err)};
 compile(Mod, {ok, ?SQL_SELECT{}=SQL}) ->
     case (catch Mod:get_ddl()) of
         {_, {undef, _}} ->

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -238,109 +238,6 @@ wait_until_active(Table, State, Seconds) ->
 %% functions called from check_table_and_call, one per ts* request
 %% ---------------------------------------------------
 
-%%
-%% INSERT statements, called from check_table_and_call.
-%%
--spec make_insert_response(module(), #riak_sql_insert_v1{}) -> tsqueryresp | #rpberrorresp{}.
-make_insert_response(Mod, #riak_sql_insert_v1{'INSERT' = Table, fields = Fields, values = Values}) ->
-    case lookup_field_positions(Mod, Fields) of
-    {ok, Positions} ->
-        Empty = make_empty_row(Mod),
-        case xlate_insert_to_putdata(Values, Positions, Empty) of
-            {error, ValueReason} ->
-                make_rpberrresp(?E_BAD_QUERY, ValueReason);
-            {ok, Data} ->
-                insert_putreqs(Mod, Table, Data)
-            end;
-    {error, FieldReason} ->
-        make_rpberrresp(?E_BAD_QUERY, FieldReason)
-    end.
-
-insert_putreqs(Mod, Table, Data) ->
-    case catch validate_rows(Mod, Data) of
-        [] ->
-            case put_data(Data, Table, Mod) of
-                0 ->
-                    tsqueryresp;
-                ErrorCount ->
-                    failed_put_response(ErrorCount)
-            end;
-        BadRowIdxs when is_list(BadRowIdxs) ->
-            validate_rows_error_response(BadRowIdxs)
-    end.
-
-%%
-%% Return an all-null empty row ready to be populated by the values
-%%
--spec make_empty_row(module()) -> tuple(undefined).
-make_empty_row(Mod) ->
-    Positions = Mod:get_field_positions(),
-    list_to_tuple(lists:duplicate(length(Positions), undefined)).
-
-%%
-%% Lookup the index of the field names selected to insert.
-%%
-%% This *requires* that once schema changes take place the DDL fields are left in order.
-%%
--spec lookup_field_positions(module(), [riak_ql_ddl:field_identifier()]) ->
-                           {ok, [pos_integer()]} | {error, string()}.
-lookup_field_positions(Mod, FieldIdentifiers) ->
-    case lists:foldl(
-           fun({identifier, FieldName}, {Good, Bad}) ->
-                   case Mod:is_field_valid(FieldName) of
-               false ->
-                   {Good, [FieldName | Bad]};
-               true ->
-                   {[Mod:get_field_position(FieldName) | Good], Bad}
-                   end
-           end, {[], []}, FieldIdentifiers)
-    of
-        {Positions, []} ->
-            {ok, lists:reverse(Positions)};
-        {_, Errors} ->
-            {error, flat_format("undefined fields: ~s",
-                                [string:join(lists:reverse(Errors), ", ")])}
-    end.
-
-%%
-%% Map the list of values from statement order into the correct place in the tuple.
-%% If there are less values given than the field list the NULL will carry through
-%% and the general validation rules should pick that up.
-%% If there are too many values given for the fields it returns an error.
-%%
--spec xlate_insert_to_putdata([[riak_ql_ddl:data_value()]], [pos_integer()], tuple(undefined)) ->
-                              {ok, [tuple()]} | {error, string()}.
-xlate_insert_to_putdata(Values, Positions, Empty) ->
-    ConvFn = fun(RowVals, {Good, Bad, RowNum}) ->
-                 case make_insert_row(RowVals, Positions, Empty) of
-                     {ok, Row} ->
-                         {[Row | Good], Bad, RowNum + 1};
-                     {error, _Reason} ->
-                         {Good, [integer_to_list(RowNum) | Bad], RowNum + 1}
-                 end
-             end,
-    Converted = lists:foldl(ConvFn, {[], [], 1}, Values),
-    case Converted of
-        {PutData, [], _} ->
-            {ok, lists:reverse(PutData)};
-        {_, Errors, _} ->
-            {error, flat_format("too many values in row index(es) ~s",
-                                [string:join(lists:reverse(Errors), ", ")])}
-    end.
-
--spec make_insert_row([] | [riak_ql_ddl:data_value()], [] | [pos_integer()], tuple()) ->
-                      {ok, tuple()} | {error, string()}.
-make_insert_row([], _Positions, Row) when is_tuple(Row) ->
-    %% Out of entries in the value - row is populated with default values
-    %% so if we run out of data for implicit/explicit fieldnames can just return
-    {ok, Row};
-make_insert_row(_, [], Row) when is_tuple(Row) ->
-    %% Too many values for the field
-    {error, "too many values"};
-%% Make sure the types match
-make_insert_row([{_Type, Val} | Values], [Pos | Positions], Row) when is_tuple(Row) ->
-    make_insert_row(Values, Positions, setelement(Pos, Row, Val)).
-
 
 %% -----------
 %% put
@@ -777,11 +674,6 @@ make_tsqueryresp({_, _, []}) ->
 make_tsqueryresp({ColumnNames, ColumnTypes, Rows}) ->
     {tsqueryresp, {ColumnNames, ColumnTypes, Rows}}.
 
--spec make_describe_response([[term()]]) -> ts_query_response().
-make_describe_response(Rows) ->
-    ColumnNames = [<<"Column">>, <<"Type">>, <<"Is Null">>, <<"Primary Key">>, <<"Local Key">>],
-    ColumnTypes = [   varchar,     varchar,     boolean,        sint64,             sint64    ],
-    {tsqueryresp, {ColumnNames, ColumnTypes, Rows}}.
 
 
 make_decoder_error_response({LineNo, riak_ql_parser, Msg}) when is_integer(LineNo) ->
@@ -817,76 +709,7 @@ missing_helper_module_not_ts_type_test() ->
 missing_helper_module_test() ->
     ?assertMatch(
         #rpberrorresp{errcode = ?E_MISSING_TS_MODULE },
-        missing_helper_module(<<"mytype">>, [{ddl, ?DDL{}}])
-    ).
-
-
-batch_1_test() ->
-    ?assertEqual(lists:reverse([[1, 2, 3, 4], [5, 6, 7, 8], [9]]),
-                 create_batches([1, 2, 3, 4, 5, 6, 7, 8, 9], 4)).
-
-batch_2_test() ->
-    ?assertEqual(lists:reverse([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10]]),
-                 create_batches([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 4)).
-
-batch_3_test() ->
-    ?assertEqual(lists:reverse([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
-                 create_batches([1, 2, 3, 4, 5, 6, 7, 8, 9], 3)).
-
-batch_undersized1_test() ->
-    ?assertEqual([[1, 2, 3, 4, 5, 6]],
-                 create_batches([1, 2, 3, 4, 5, 6], 6)).
-
-batch_undersized2_test() ->
-    ?assertEqual([[1, 2, 3, 4, 5, 6]],
-                 create_batches([1, 2, 3, 4, 5, 6], 7)).
-
-batch_almost_undersized_test() ->
-    ?assertEqual(lists:reverse([[1, 2, 3, 4, 5], [6]]),
-                 create_batches([1, 2, 3, 4, 5, 6], 5)).
-
-validate_make_insert_row_basic_test() ->
-    Data = [{integer,4}, {binary,<<"bamboozle">>}, {float, 3.14}],
-    Positions = [3, 1, 2],
-    Row = {undefined, undefined, undefined},
-    Result = make_insert_row(Data, Positions, Row),
-    ?assertEqual(
-        {ok, {<<"bamboozle">>, 3.14, 4}},
-        Result
-    ).
-
-validate_make_insert_row_too_many_test() ->
-    Data = [{integer,4}, {binary,<<"bamboozle">>}, {float, 3.14}, {integer, 8}],
-    Positions = [3, 1, 2],
-    Row = {undefined, undefined, undefined},
-    Result = make_insert_row(Data, Positions, Row),
-    ?assertEqual(
-        {error, "too many values"},
-        Result
-    ).
-
-
-validate_xlate_insert_to_putdata_ok_test() ->
-    Empty = list_to_tuple(lists:duplicate(5, undefined)),
-    Values = [[{integer, 4}, {binary, <<"babs">>}, {float, 5.67}, {binary, <<"bingo">>}],
-              [{integer, 8}, {binary, <<"scat">>}, {float, 7.65}, {binary, <<"yolo!">>}]],
-    Positions = [5, 3, 1, 2, 4],
-    Result = xlate_insert_to_putdata(Values, Positions, Empty),
-    ?assertEqual(
-        {ok,[{5.67,<<"bingo">>,<<"babs">>,undefined,4},
-             {7.65,<<"yolo!">>,<<"scat">>,undefined,8}]},
-        Result
-    ).
-
-validate_xlate_insert_to_putdata_too_many_values_test() ->
-    Empty = list_to_tuple(lists:duplicate(5, undefined)),
-    Values = [[{integer, 4}, {binary, <<"babs">>}, {float, 5.67}, {binary, <<"bingo">>}, {integer, 7}],
-           [{integer, 8}, {binary, <<"scat">>}, {float, 7.65}, {binary, <<"yolo!">>}]],
-    Positions = [3, 1, 2, 4],
-    Result = xlate_insert_to_putdata(Values, Positions, Empty),
-    ?assertEqual(
-        {error,"too many values in row index(es) 1"},
-        Result
+        make_missing_helper_module_resp(<<"mytype">>, [{ddl, ?DDL{}}])
     ).
 
 -endif.

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -597,7 +597,7 @@ make_missing_helper_module_resp(Table, BucketProps)
 make_missing_type_resp(Table) ->
     make_rpberrresp(
       ?E_MISSING_TYPE,
-      flat_format("Time Series table ~s does not exist.", [Table])).
+      flat_format("Time Series table ~s does not exist", [Table])).
 
 %%
 -spec make_nonts_type_resp(Table::binary()) -> #rpberrorresp{}.
@@ -616,7 +616,7 @@ make_missing_table_module_resp(Table) ->
 make_key_element_count_mismatch_resp(Got, Need) ->
     make_rpberrresp(
       ?E_BAD_KEY_LENGTH,
-      flat_format("Key element count mismatch (key has ~b elements but ~b supplied).", [Need, Got])).
+      flat_format("Key element count mismatch (key has ~b elements but ~b supplied)", [Need, Got])).
 
 -spec make_validate_rows_error_resp([integer()]) -> #rpberrorresp{}.
 make_validate_rows_error_resp(BadRowIdxs) ->

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -29,9 +29,49 @@
 -include("riak_kv_ts.hrl").
 -include("riak_kv_ts_svc.hrl").
 
+%% per RIAK-1437, error codes assigned to TS are in the 1000-1500 range
+-define(E_SUBMIT,            1001).
+-define(E_FETCH,             1002).
+-define(E_IRREG,             1003).
+-define(E_PUT,               1004).
+-define(E_NOCREATE,          1005).   %% unused
+-define(E_NOT_TS_TYPE,       1006).
+-define(E_MISSING_TYPE,      1007).
+-define(E_MISSING_TS_MODULE, 1008).
+-define(E_DELETE,            1009).
+-define(E_GET,               1010).
+-define(E_BAD_KEY_LENGTH,    1011).
+-define(E_LISTKEYS,          1012).
+-define(E_TIMEOUT,           1013).
+-define(E_CREATE,            1014).
+-define(E_CREATED_INACTIVE,  1015).
+-define(E_CREATED_GHOST,     1016).
+-define(E_ACTIVATE,          1017).
+-define(E_BAD_QUERY,         1018).
+-define(E_TABLE_INACTIVE,    1019).
+-define(E_PARSE_ERROR,       1020).
+-define(E_NOTFOUND,          1021).
+
+-define(FETCH_RETRIES, 10).  %% TODO make it configurable in tsqueryreq
+-define(TABLE_ACTIVATE_WAIT, 30). %% ditto
+
 -export([decode_query_common/2,
          process/2,
          process_stream/3]).
+
+-type ts_requests() :: #tsputreq{} | #tsdelreq{} | #tsgetreq{} |
+                       #tslistkeysreq{} | #tsqueryreq{}.
+-type ts_responses() :: #tsputresp{} | #tsdelresp{} | #tsgetresp{} |
+                        #tslistkeysresp{} | #tsqueryresp{} |
+                        #tscoverageresp{} |
+                        #rpberrorresp{}.
+-type ts_get_response() :: {tsgetresp, {list(binary()), list(atom()), list(list(term()))}}.
+-type ts_query_response() :: {tsqueryresp, {list(binary()), list(atom()), list(list(term()))}}.
+-type ts_query_responses() :: #tsqueryresp{} | ts_query_response().
+-type ts_query_types() :: ?DDL{} | riak_kv_qry:sql_query_type_record().
+-export_type([ts_requests/0, ts_responses/0,
+              ts_query_response/0, ts_query_responses/0,
+              ts_query_types/0]).
 
 decode_query_common(Q, Cover) ->
     %% convert error returns to ok's, this means it will be passed into

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -186,17 +186,17 @@ create_table({DDL = ?DDL{table = Table}, WithProps}, State) ->
     {ok, Props1} = riak_kv_ts_util:apply_timeseries_bucket_props(DDL, riak_ql_ddl_compiler:get_compiler_version(), WithProps),
     case catch [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props1] of
         {bad_linkfun_modfun, {M, F}} ->
-            {reply, table_create_fail_response(
+            {reply, make_table_create_fail_resp(
                       Table, flat_format(
                                "Invalid link mod or fun in bucket type properties: ~p:~p\n", [M, F])),
              State};
         {bad_linkfun_bkey, {B, K}} ->
-            {reply, table_create_fail_response(
+            {reply, make_table_create_fail_resp(
                       Table, flat_format(
                                "Malformed bucket/key for anon link fun in bucket type properties: ~p/~p\n", [B, K])),
              State};
         {bad_chash_keyfun, {M, F}} ->
-            {reply, table_create_fail_response(
+            {reply, make_table_create_fail_resp(
                       Table, flat_format(
                                "Invalid chash mod or fun in bucket type properties: ~p:~p\n", [M, F])),
              State};
@@ -205,12 +205,12 @@ create_table({DDL = ?DDL{table = Table}, WithProps}, State) ->
                 ok ->
                     wait_until_active(Table, State, ?TABLE_ACTIVATE_WAIT);
                 {error, Reason} ->
-                    {reply, table_create_fail_response(Table, Reason), State}
+                    {reply, make_table_create_fail_resp(Table, Reason), State}
             end
     end.
 
 wait_until_active(Table, State, 0) ->
-    {reply, table_activate_fail_response(Table), State};
+    {reply, make_table_activate_fail_resp(Table), State};
 wait_until_active(Table, State, Seconds) ->
     case riak_core_bucket_type:activate(Table) of
         ok ->
@@ -224,7 +224,7 @@ wait_until_active(Table, State, Seconds) ->
             %% the dialyzer (and of course, for the odd chance
             %% of Erlang imps crashing nodes between create
             %% and activate calls)
-            {reply, table_created_missing_response(Table), State}
+            {reply, make_table_created_missing_resp(Table), State}
     end.
 
 
@@ -343,7 +343,7 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
             {reply, {stream, ReqId}, State#state{req = Req, req_ctx = ReqId,
                                                  column_info = ColumnInfo}};
         {error, Reason} ->
-            {reply, failed_listkeys_response(Reason), State}
+            {reply, make_failed_listkeys_resp(Reason), State}
     end.
 
 
@@ -539,15 +539,9 @@ sub_tsqueryreq(_Mod, DDL = ?DDL{table = Table}, SQL, State) ->
             {reply, make_rpberrresp(?E_SUBMIT, DDLCompilerErrDesc), State};
 
         {error, Reason} ->
-            {reply, make_rpberrresp(?E_SUBMIT, to_string(Reason)), State}
+            {reply, make_rpberrresp(?E_SUBMIT, Reason), State}
     end.
 
-make_tsquery_resp(_Mod, ?SQL_SELECT{}, Data) ->
-    make_tsqueryresp(Data);
-make_tsquery_resp(_Mod, #riak_sql_describe_v1{}, Data) ->
-    make_describe_response(Data);
-make_tsquery_resp(Mod, SQL = #riak_sql_insert_v1{}, _Data) ->
-    make_insert_response(Mod, SQL).
 
 %% ---------------------------------------------------
 %% local functions
@@ -594,39 +588,38 @@ make_missing_helper_module_resp(Table, {error, _}) ->
 make_missing_helper_module_resp(Table, BucketProps)
   when is_binary(Table), is_list(BucketProps) ->
     case lists:keymember(ddl, 1, BucketProps) of
-        true  -> missing_table_module_response(Table);
-        false -> not_timeseries_type_response(Table)
+        true  -> make_missing_table_module_resp(Table);
+        false -> make_nonts_type_resp(Table)
     end.
 
 %%
--spec missing_type_response(Table::binary()) -> #rpberrorresp{}.
-missing_type_response(Table) ->
+-spec make_missing_type_resp(Table::binary()) -> #rpberrorresp{}.
+make_missing_type_resp(Table) ->
     make_rpberrresp(
       ?E_MISSING_TYPE,
       flat_format("Time Series table ~s does not exist.", [Table])).
 
 %%
--spec not_timeseries_type_response(Table::binary()) -> #rpberrorresp{}.
-not_timeseries_type_response(Table) ->
+-spec make_nonts_type_resp(Table::binary()) -> #rpberrorresp{}.
+make_nonts_type_resp(Table) ->
     make_rpberrresp(
       ?E_NOT_TS_TYPE,
-      flat_format("Attempt Time Series operation on non Time Series table ~s.", [Table])).
+      flat_format("Attempt Time Series operation on non Time Series table ~s", [Table])).
 
--spec missing_table_module_response(Table::binary()) -> #rpberrorresp{}.
-missing_table_module_response(Table) ->
+-spec make_missing_table_module_resp(Table::binary()) -> #rpberrorresp{}.
+make_missing_table_module_resp(Table) ->
     make_rpberrresp(
       ?E_MISSING_TS_MODULE,
-      flat_format("The compiled module for Time Series table ~s cannot be loaded.", [Table])).
+      flat_format("The compiled module for Time Series table ~s cannot be loaded", [Table])).
 
--spec key_element_count_mismatch(Got::integer(), Need::integer()) -> #rpberrorresp{}.
-key_element_count_mismatch(Got, Need) ->
+-spec make_key_element_count_mismatch_resp(Got::integer(), Need::integer()) -> #rpberrorresp{}.
+make_key_element_count_mismatch_resp(Got, Need) ->
     make_rpberrresp(
       ?E_BAD_KEY_LENGTH,
       flat_format("Key element count mismatch (key has ~b elements but ~b supplied).", [Need, Got])).
 
--spec validate_rows_error_response([string()]) ->#rpberrorresp{}.
-validate_rows_error_response(BadRowIdxs) ->
-    BadRowsString = string:join(BadRowIdxs,", "),
+-spec make_validate_rows_error_resp([integer()]) -> #rpberrorresp{}.
+make_validate_rows_error_resp(BadRowIdxs) ->
     make_rpberrresp(
       ?E_IRREG,
       flat_format("Invalid data found at row index(es) ~s", [BadRowsString])).
@@ -647,31 +640,31 @@ make_failed_put_resp(ErrorCount) ->
       ?E_PUT,
       flat_format("Failed to put ~b record(s)", [ErrorCount])).
 
-failed_delete_response(Reason) ->
+make_failed_delete_resp(Reason) ->
     make_rpberrresp(
       ?E_DELETE,
       flat_format("Failed to delete record: ~p", [Reason])).
 
-failed_listkeys_response(Reason) ->
+make_failed_listkeys_resp(Reason) ->
     make_rpberrresp(
       ?E_LISTKEYS,
       flat_format("Failed to list keys: ~p", [Reason])).
 
-table_create_fail_response(Table, Reason) ->
+make_table_create_fail_resp(Table, Reason) ->
     make_rpberrresp(
       ?E_CREATE, flat_format("Failed to create table ~s: ~p", [Table, Reason])).
 
-table_activate_fail_response(Table) ->
+make_table_activate_fail_resp(Table) ->
     make_rpberrresp(
       ?E_ACTIVATE,
       flat_format("Failed to activate table ~s", [Table])).
 
-table_not_activated_response(Table) ->
+make_table_not_activated_resp(Table) ->
     make_rpberrresp(
       ?E_TABLE_INACTIVE,
-      flat_format("~ts is not an active table.", [Table])).
+      flat_format("~ts is not an active table", [Table])).
 
-table_created_missing_response(Table) ->
+make_table_created_missing_resp(Table) ->
     make_rpberrresp(
       ?E_CREATED_GHOST,
       flat_format("Table ~s has been created but found missing", [Table])).
@@ -682,14 +675,11 @@ to_string(X) ->
 
 %% helpers to make various responses
 
--spec make_tsqueryresp([] | {[riak_pb_ts_codec:tscolumnname()],
-                             [riak_pb_ts_codec:tscolumntype()],
-                             [[riak_pb_ts_codec:ldbvalue()]]}) -> ts_query_response().
-make_tsqueryresp({_, _, []}) ->
-    {tsqueryresp, {[], [], []}};
-make_tsqueryresp({ColumnNames, ColumnTypes, Rows}) ->
-    {tsqueryresp, {ColumnNames, ColumnTypes, Rows}}.
+make_tsgetresp(ColumnNames, ColumnTypes, Rows) ->
+    {tsgetresp, {ColumnNames, ColumnTypes, Rows}}.
 
+make_tsqueryresp(Data = {_ColumnNames, _ColumnTypes, _Rows}) ->
+    {tsqueryresp, Data}.
 
 
 make_decoder_error_response({lexer_error, Msg}) ->
@@ -712,13 +702,13 @@ flat_format(Format, Args) ->
 missing_helper_module_missing_type_test() ->
     ?assertMatch(
         #rpberrorresp{errcode = ?E_MISSING_TYPE },
-        missing_helper_module(<<"mytype">>, {error, any})
+        make_missing_helper_module_resp(<<"mytype">>, {error, any})
     ).
 
 missing_helper_module_not_ts_type_test() ->
     ?assertMatch(
         #rpberrorresp{errcode = ?E_NOT_TS_TYPE },
-        missing_helper_module(<<"mytype">>, []) % no ddl property
+        make_missing_helper_module_resp(<<"mytype">>, []) % no ddl property
     ).
 
 %% if the bucket properties exist and they contain a ddl property then

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -183,7 +183,8 @@ process_stream({ReqId, Error}, ReqId,
 -spec create_table({?DDL{}, proplists:proplist()}, #state{}) ->
                           {reply, tsqueryresp | #rpberrorresp{}, #state{}}.
 create_table({DDL = ?DDL{table = Table}, WithProps}, State) ->
-    {ok, Props1} = riak_kv_ts_util:apply_timeseries_bucket_props(DDL, riak_ql_ddl_compiler:get_compiler_version(), WithProps),
+    {ok, Props1} = riak_kv_ts_util:apply_timeseries_bucket_props(
+                     DDL, riak_ql_ddl_compiler:get_compiler_version(), WithProps),
     case catch [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props1] of
         {bad_linkfun_modfun, {M, F}} ->
             {reply, make_table_create_fail_resp(

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -26,10 +26,8 @@
 
 -include_lib("riak_pb/include/riak_kv_pb.hrl").
 -include_lib("riak_pb/include/riak_ts_pb.hrl").
-
 -include("riak_kv_ts.hrl").
 -include("riak_kv_ts_svc.hrl").
--include("riak_kv_wm_raw.hrl").
 
 -export([decode_query_common/2,
          process/2,
@@ -304,252 +302,94 @@ make_insert_row([{_Type, Val} | Values], [Pos | Positions], Row) when is_tuple(R
     make_insert_row(Values, Positions, setelement(Pos, Row, Val)).
 
 
+%% -----------
 %% put
+%% -----------
+
 %% NB: since this method deals with PB and TTB messages, the message must be fully
 %% decoded before sub_tsputreq is called
 sub_tsputreq(Mod, _DDL, #tsputreq{table = Table, rows = Rows},
              State) ->
-    case catch validate_rows(Mod, Rows) of
+    case riak_kv_ts_util:validate_rows(Mod, Rows) of
         [] ->
-            case put_data(Rows, Table, Mod) of
-                0 ->
+            case riak_kv_ts_api:put_data(Rows, Table, Mod) of
+                ok ->
                     {reply, #tsputresp{}, State};
-                ErrorCount ->
-                    {reply, failed_put_response(ErrorCount), State}
+                {error, {some_failed, ErrorCount}} ->
+                    {reply, make_failed_put_resp(ErrorCount), State};
+                {error, no_type} ->
+                    {reply, make_table_not_activated_resp(Table), State};
+                {error, OtherReason} ->
+                    {reply, make_rpberrresp(?E_PUT, to_string(OtherReason)), State}
             end;
-        BadRowIdxs when is_list(BadRowIdxs) ->
-            {reply, validate_rows_error_response(BadRowIdxs), State}
+        BadRowIdxs ->
+            {reply, make_validate_rows_error_resp(BadRowIdxs), State}
     end.
 
-%% Give validate_rows/2 a DDL Module and a list of decoded rows,
-%% and it will return a list of strings that represent the invalid rows indexes.
--spec validate_rows(module(), list(tuple())) -> list(string()).
-validate_rows(Mod, Rows) ->
-    ValidateFn = fun(X, {Acc, BadRowIdxs}) ->
-        case Mod:validate_obj(X) of
-            true -> {Acc+1, BadRowIdxs};
-            _ -> {Acc+1, [integer_to_list(Acc) | BadRowIdxs]}
-        end
-    end,
-    {_, BadRowIdxs} = lists:foldl(ValidateFn, {1, []}, Rows),
-    lists:reverse(BadRowIdxs).
 
-
--spec put_data([riak_pb_ts_codec:tsrow()], binary(), module()) -> integer().
-%% return count of records we failed to put
-put_data(Data, Table, Mod) when is_binary(Table) ->
-    DDL = Mod:get_ddl(),
-    Bucket = riak_kv_ts_util:table_to_bucket(Table),
-    BucketProps = riak_core_bucket:get_bucket(Bucket),
-    NVal = proplists:get_value(n_val, BucketProps),
-
-    PartitionedData = partition_data(Data, Bucket, BucketProps, DDL, Mod),
-    PreflistData = add_preflists(PartitionedData, NVal,
-                                 riak_core_node_watcher:nodes(riak_kv)),
-
-    SendFullBatches = riak_core_capability:get({riak_kv, w1c_batch_vnode}, false),
-    %% Default to 1MB for a max batch size to not overwhelm disterl
-    CappedBatchSize = app_helper:get_env(riak_kv, timeseries_max_batch_size,
-                                         1024 * 1024),
-
-    EncodeFn =
-        fun(O) -> riak_object:to_binary(v1, O, msgpack) end,
-
-    {ReqIds, FailReqs} =
-        lists:foldl(
-          fun({DocIdx, Preflist, Records}, {GlobalReqIds, GlobalErrorsCnt}) ->
-                  case riak_kv_w1c_worker:validate_options(
-                         NVal, Preflist, [], BucketProps) of
-                      {ok, W, PW} ->
-                          DataForVnode = pick_batch_option(SendFullBatches,
-                                                           CappedBatchSize,
-                                                           Records,
-                                                           termsize(hd(Records)),
-                                                           length(Records)),
-                          Ids =
-                              invoke_async_put(fun(Record) ->
-                                                       build_object(Bucket, Mod, DDL,
-                                                                    Record, DocIdx)
-                                               end,
-                                               fun(RObj, LK) ->
-                                                       riak_kv_w1c_worker:async_put(
-                                                         RObj, W, PW, Bucket, NVal, LK,
-                                                         EncodeFn, Preflist)
-                                               end,
-                                               fun(RObjs) ->
-                                                       riak_kv_w1c_worker:ts_batch_put(
-                                                         RObjs, W, PW, Bucket, NVal,
-                                                         EncodeFn, Preflist)
-                                               end,
-                                               DataForVnode),
-                          {GlobalReqIds ++ Ids, GlobalErrorsCnt};
-                      _Error ->
-                          {GlobalReqIds, GlobalErrorsCnt + length(Records)}
-                  end
-          end,
-          {[], 0}, PreflistData),
-    Responses = riak_kv_w1c_worker:async_put_replies(ReqIds, []),
-    length(lists:filter(fun({error, _}) -> true;
-                           (_) -> false
-                        end, Responses)) + FailReqs.
-
--spec partition_data(Data :: list(term()),
-                     Bucket :: {binary(), binary()},
-                     BucketProps :: proplists:proplist(),
-                     DDL :: ?DDL{},
-                     Mod :: module()) ->
-                            list(tuple(chash:index(), list(term()))).
-partition_data(Data, Bucket, BucketProps, DDL, Mod) ->
-    PartitionTuples =
-        [ { riak_core_util:chash_key({Bucket, row_to_key(R, DDL, Mod)},
-                                     BucketProps), R } || R <- Data ],
-    dict:to_list(
-      lists:foldl(fun({Idx, R}, Dict) ->
-                          dict:append(Idx, R, Dict)
-                  end,
-                  dict:new(),
-                  PartitionTuples)).
-
-row_to_key(Row, DDL, Mod) ->
-    riak_kv_ts_util:encode_typeval_key(
-      riak_ql_ddl:get_partition_key(DDL, Row, Mod)).
-
-%%%%%%%%
-%% Utility functions for batch delivery of records
-termsize(Term) ->
-    size(term_to_binary(Term)).
-
-pick_batch_option(_, _, Records, _, 1) ->
-    {individual, Records};
-pick_batch_option(true, MaxBatch, Records, SampleSize, _NumRecs) ->
-    {batches, create_batches(Records,
-                             estimated_row_count(SampleSize, MaxBatch))};
-pick_batch_option(false, _, Records, _, _) ->
-    {individual, Records}.
-
-estimated_row_count(SampleRowSize, MaxBatchSize) ->
-    %% Assume some rows will be larger, so introduce a fudge factor of
-    %% roughly 10 percent.
-    RowSizeFudged = (SampleRowSize * 10) div 9,
-    MaxBatchSize div RowSizeFudged.
-
-create_batches(Rows, MaxSize) ->
-    create_batches(Rows, MaxSize, []).
-
-create_batches([], _MaxSize, Accum) ->
-    Accum;
-create_batches(Rows, MaxSize, Accum) when length(Rows) < MaxSize ->
-    [Rows|Accum];
-create_batches(Rows, MaxSize, Accum) ->
-    {First, Rest} = lists:split(MaxSize, Rows),
-    create_batches(Rest, MaxSize, [First|Accum]).
-%%%%%%%%
-
-add_preflists(PartitionedData, NVal, UpNodes) ->
-    lists:map(fun({Idx, Rows}) -> {Idx,
-                                   riak_core_apl:get_apl_ann(Idx, NVal, UpNodes),
-                                   Rows} end,
-              PartitionedData).
-
-build_object(Bucket, Mod, DDL, Row, PK) ->
-    Obj = Mod:add_column_info(Row),
-    LK  = riak_kv_ts_util:encode_typeval_key(
-            riak_ql_ddl:get_local_key(DDL, Row, Mod)),
-
-    RObj = riak_object:newts(
-             Bucket, PK, Obj,
-             dict:from_list([{?MD_DDL_VERSION, ?DDL_VERSION}])),
-    {LK, RObj}.
-
-
+%% -----------
 %% get
+%% -----------
+
 %% NB: since this method deals with PB and TTB messages, the message must be fully
 %% decoded before sub_tsgetreq is called
-sub_tsgetreq(Mod, DDL, #tsgetreq{table = Table,
-                                 key    = CompoundKey,
-                                 timeout = Timeout},
+sub_tsgetreq(Mod, _DDL, #tsgetreq{table = Table,
+                                  key    = CompoundKey,
+                                  timeout = Timeout},
              State) ->
     Options =
         if Timeout == undefined -> [];
            true -> [{timeout, Timeout}]
         end,
-
-    Result =
-        case riak_kv_ts_util:make_ts_keys(CompoundKey, DDL, Mod) of
-            {ok, PKLK} ->
-                riak_client:get(
-                  riak_kv_ts_util:table_to_bucket(Table), PKLK, Options,
-                  {riak_client, [node(), undefined]});
-            ErrorReason ->
-                ErrorReason
-        end,
-    case Result of
-        {ok, RObj} ->
-            Record = riak_object:get_value(RObj),
+    %%CompoundKey = riak_pb_ts_codec:decode_cells(PbCompoundKey),
+    %% decoding is done per wire protocol (ttb or pb), see riak_kv_ts.erl
+    Mod = riak_ql_ddl:make_module_name(Table),
+    case riak_kv_ts_api:get_data(
+           CompoundKey, Table, Mod, Options) of
+        {ok, Record} ->
             {ColumnNames, Row} = lists:unzip(Record),
             %% the columns stored in riak_object are just
             %% names; we need names with types, so:
-            ColumnTypes = get_column_types(ColumnNames, Mod),
-            {reply, {tsgetresp, {ColumnNames, ColumnTypes, [list_to_tuple(Row)]}}, State};
+            ColumnTypes = riak_kv_ts_util:get_column_types(ColumnNames, Mod),
+            {reply, make_tsgetresp(ColumnNames, ColumnTypes, [list_to_tuple(Row)]), State};
+        {error, no_type} ->
+            {reply, make_table_not_activated_resp(Table), State};
         {error, {bad_key_length, Got, Need}} ->
-            {reply, key_element_count_mismatch(Got, Need), State};
+            {reply, make_key_element_count_mismatch_resp(Got, Need), State};
         {error, notfound} ->
-            {reply, {tsgetresp, {[], [], []}}, State};
+            {reply, make_tsgetresp([], [], []), State};
         {error, Reason} ->
             {reply, make_rpberrresp(?E_GET, to_string(Reason)), State}
     end.
 
 
+%% -----------
 %% delete
-sub_tsdelreq(Mod, DDL, #tsdelreq{table = Table,
-                                 key    = PbCompoundKey,
-                                 vclock  = PbVClock,
-                                 timeout  = Timeout},
+%% -----------
+
+sub_tsdelreq(Mod, _DDL, #tsdelreq{table = Table,
+                                  key    = PbCompoundKey,
+                                  vclock  = VClock,
+                                  timeout  = Timeout},
              State) ->
-    %% Pass the {dw,all} option in to the delete FSM
-    %% to make sure all tombstones are written by the
-    %% async put before the reaping get runs otherwise
-    %% if the default {dw,quorum} is used there is the
-    %% possibility that the last tombstone put overlaps
-    %% inside the KV vnode with the reaping get and
-    %% prevents the tombstone removal.
     Options =
-        if Timeout == undefined -> [{dw, all}];
-           true -> [{timeout, Timeout}, {dw, all}]
+        if Timeout == undefined -> [];
+           true -> [{timeout, Timeout}]
         end,
-    VClock =
-        case PbVClock of
-            undefined ->
-                %% this will trigger a get in riak_kv_delete:delete to
-                %% retrieve the actual vclock
-                undefined;
-            PbVClock ->
-                %% else, clients may have it already (e.g., from an
-                %% earlier riak_object:get), which will short-circuit
-                %% to avoid a separate get
-                riak_object:decode_vclock(PbVClock)
-        end,
-
     CompoundKey = riak_pb_ts_codec:decode_cells(PbCompoundKey),
-
-    Result =
-        case riak_kv_ts_util:make_ts_keys(CompoundKey, DDL, Mod) of
-            {ok, PKLK} ->
-                riak_client:delete_vclock(
-                  riak_kv_ts_util:table_to_bucket(Table), PKLK, VClock, Options,
-                  {riak_client, [node(), undefined]});
-            ErrorReason ->
-                ErrorReason
-        end,
-    case Result of
+    Mod = riak_ql_ddl:make_module_name(Table),
+    case riak_kv_ts_api:delete_data(
+           CompoundKey, Table, Mod, Options, VClock) of
         ok ->
             {reply, tsdelresp, State};
+        {error, no_type} ->
+            {reply, make_table_not_activated_resp(Table), State};
         {error, {bad_key_length, Got, Need}} ->
-            {reply, key_element_count_mismatch(Got, Need), State};
+            {reply, make_key_element_count_mismatch_resp(Got, Need), State};
         {error, notfound} ->
             {reply, make_rpberrresp(?E_NOTFOUND, "notfound"), State};
         {error, Reason} ->
-            {reply, failed_delete_response(Reason), State}
+            {reply, make_failed_delete_resp(Reason), State}
     end.
 
 
@@ -726,26 +566,26 @@ compile(Mod, {ok, ?SQL_SELECT{}=SQL}) ->
             end
     end.
 
+%% ----------
 %% query
+%% ----------
+
 %% NB: since this method deals with PB and TTB messages, the message must be fully
 %% decoded before sub_tsqueryreq is called
--spec sub_tsqueryreq(module(), #ddl_v1{},
-                     ?SQL_SELECT{} | #riak_sql_describe_v1{} | #riak_sql_insert_v1{},
-                     #state{}) ->
-                     {reply,
-                      ts_query_responses() | #rpberrorresp{},
-                      #state{}}.
-sub_tsqueryreq(Mod, DDL, SQL, State) ->
-    case riak_kv_qry:submit(SQL, DDL) of
-        {ok, Data}  ->
-            {reply, make_tsquery_resp(Mod, SQL, Data), State};
+-spec sub_tsqueryreq(module(), ?DDL{}, riak_kv_qry:sql_query_type_record(), #state{}) ->
+                     {reply, ts_query_responses() | #rpberrorresp{}, #state{}}.
+sub_tsqueryreq(_Mod, DDL = ?DDL{table = Table}, SQL, State) ->
+    case riak_kv_ts_api:query(SQL, DDL) of
+        {ok, Data} ->
+            {reply, make_tsqueryresp(Data), State};
 
         %% parser messages have a tuple for Reason:
         {error, {E, Reason}} when is_atom(E), is_binary(Reason) ->
             ErrorMessage = flat_format("~p: ~s", [E, Reason]),
             {reply, make_rpberrresp(?E_SUBMIT, ErrorMessage), State};
-
         %% the following timeouts are known and distinguished:
+        {error, no_type} ->
+            {reply, make_table_not_activated_resp(Table), State};
         {error, qry_worker_timeout} ->
             %% the eleveldb process didn't send us any response after
             %% 10 sec (hardcoded in riak_kv_qry), and probably died
@@ -886,21 +726,6 @@ table_created_missing_response(Table) ->
 to_string(X) ->
     flat_format("~p", [X]).
 
-%% Returns a tuple with a list of request IDs and an error tally
-invoke_async_put(BuildRObjFun, AsyncPutFun, _BatchPutFun, {individual, Records}) ->
-    lists:map(fun(Record) ->
-                      {LK, RObj} = BuildRObjFun(Record),
-                      {ok, ReqId} = AsyncPutFun(RObj, LK),
-                      ReqId
-                end,
-              Records);
-invoke_async_put(BuildRObjFun, _AsyncPutFun, BatchPutFun, {batches, Batches}) ->
-    lists:map(fun(Batch) ->
-                      RObjs = lists:map(BuildRObjFun, Batch),
-                      {ok, ReqId} = BatchPutFun(RObjs),
-                      ReqId
-                end,
-              Batches).
 
 %% helpers to make various responses
 
@@ -918,9 +743,6 @@ make_describe_response(Rows) ->
     ColumnTypes = [   varchar,     varchar,     boolean,        sint64,             sint64    ],
     {tsqueryresp, {ColumnNames, ColumnTypes, Rows}}.
 
--spec get_column_types(list(binary()), module()) -> [riak_pb_ts_codec:tscolumntype()].
-get_column_types(ColumnNames, Mod) ->
-    [Mod:get_field_type([N]) || N <- ColumnNames].
 
 make_decoder_error_response({LineNo, riak_ql_parser, Msg}) when is_integer(LineNo) ->
     make_rpberrresp(?E_PARSE_ERROR, flat_format("~ts", [Msg]));
@@ -958,61 +780,6 @@ missing_helper_module_test() ->
         missing_helper_module(<<"mytype">>, [{ddl, ?DDL{}}])
     ).
 
-test_helper_validate_rows_mod() ->
-    {ddl, DDL, []} =
-        riak_ql_parser:ql_parse(
-          riak_ql_lexer:get_tokens(
-            "CREATE TABLE mytable ("
-            "family VARCHAR NOT NULL,"
-            "series VARCHAR NOT NULL,"
-            "time TIMESTAMP NOT NULL,"
-            "PRIMARY KEY ((family, series, quantum(time, 1, 'm')),"
-            " family, series, time))")),
-    riak_ql_ddl_compiler:compile_and_load_from_tmp(DDL).
-
-validate_rows_empty_test() ->
-    {module, Mod} = test_helper_validate_rows_mod(),
-    ?assertEqual(
-        [],
-        validate_rows(Mod, [])
-    ).
-
-validate_rows_1_test() ->
-    {module, Mod} = test_helper_validate_rows_mod(),
-    ?assertEqual(
-        [],
-        validate_rows(Mod, [{<<"f">>, <<"s">>, 11}])
-    ).
-
-validate_rows_bad_1_test() ->
-    {module, Mod} = test_helper_validate_rows_mod(),
-    ?assertEqual(
-        ["1"],
-        validate_rows(Mod, [{}])
-    ).
-
-validate_rows_bad_2_test() ->
-    {module, Mod} = test_helper_validate_rows_mod(),
-    ?assertEqual(
-        ["1", "3", "4"],
-        validate_rows(Mod, [{}, {<<"f">>, <<"s">>, 11}, {a, <<"s">>, 12}, "hithere"])
-    ).
-
-validate_rows_error_response_1_test() ->
-    Msg = "Invalid data found at row index(es) ",
-    ?assertEqual(
-        #rpberrorresp{errcode = ?E_IRREG,
-                      errmsg = list_to_binary(Msg ++ "1")},
-        validate_rows_error_response(["1"])
-    ).
-
-validate_rows_error_response_2_test() ->
-    Msg = "Invalid data found at row index(es) ",
-    ?assertEqual(
-        #rpberrorresp{errcode = ?E_IRREG,
-                      errmsg = list_to_binary(Msg ++ "1, 2, 3")},
-        validate_rows_error_response(["1", "2", "3"])
-    ).
 
 batch_1_test() ->
     ?assertEqual(lists:reverse([[1, 2, 3, 4], [5, 6, 7, 8], [9]]),

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -620,6 +620,7 @@ make_key_element_count_mismatch_resp(Got, Need) ->
 
 -spec make_validate_rows_error_resp([integer()]) -> #rpberrorresp{}.
 make_validate_rows_error_resp(BadRowIdxs) ->
+    BadRowsString = string:join([integer_to_list(I) || I <- BadRowIdxs],", "),
     make_rpberrresp(
       ?E_IRREG,
       flat_format("Invalid data found at row index(es) ~s", [BadRowsString])).

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -355,18 +355,19 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
 sub_tscoveragereq(Mod, _DDL, #tscoveragereq{table = Table,
                                             query = Q},
                   State) ->
-    case compile(Mod, catch decode_query(Q, undefined)) of
+    {select, SQL} = decode_query(Q, undefined),
+    case compile(Mod, SQL) of
         {error, #rpberrorresp{} = Error} ->
             {reply, Error, State};
         {error, _} ->
             {reply, make_rpberrresp(
                       ?E_BAD_QUERY, "Failed to compile query"),
              State};
-        SQL ->
+        Queries ->
             %% SQL is a list of queries (1 per quantum)
             Bucket = riak_kv_ts_util:table_to_bucket(Table),
             Client = {riak_client, [node(), undefined]},
-            convert_cover_list(sql_to_cover(Client, SQL, Bucket, []), State)
+            convert_cover_list(sql_to_cover(Client, Queries, Bucket, []), State)
     end.
 
 %% Copied and modified from riak_kv_pb_coverage:convert_list. Would

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -121,8 +121,9 @@ table_to_bucket(Table) when is_binary(Table) ->
     {Table, Table}.
 
 
--spec queried_table(#riak_sql_describe_v1{} | ?SQL_SELECT{} | #riak_sql_insert_v1{}) -> binary().
+-spec queried_table(riak_kv_qry:sql_query_type_record() | ?DDL{}) -> binary().
 %% Extract table name from various sql records.
+queried_table(?DDL{table = Table}) -> Table;
 queried_table(#riak_sql_describe_v1{'DESCRIBE' = Table}) -> Table;
 queried_table(?SQL_SELECT{'FROM' = Table})               -> Table;
 queried_table(#riak_sql_insert_v1{'INSERT' = Table})     -> Table.

--- a/src/riak_kv_ttb_ts.erl
+++ b/src/riak_kv_ttb_ts.erl
@@ -51,9 +51,9 @@ decode(?TTB_MSG_CODE, Bin) ->
         #tsqueryreq{query = Q, cover_context = Cover} ->
             riak_kv_ts_svc:decode_query_common(Q, Cover);
         #tsgetreq{table = Table}->
-            {ok, Msg, {"riak_kv.ts_get", Table}};
+            {ok, Msg, {riak_kv_ts_api:api_call_to_perm(get), Table}};
         #tsputreq{table = Table} ->
-            {ok, Msg, {"riak_kv.ts_put", Table}}
+            {ok, Msg, {riak_kv_ts_api:api_call_to_perm(put), Table}}
     end.
 
 -spec encode(tuple()) -> {ok, iolist()}.

--- a/src/riak_kv_ttb_ts.erl
+++ b/src/riak_kv_ttb_ts.erl
@@ -43,7 +43,7 @@ init() ->
     #state{}.
 
 -spec decode(integer(), binary()) ->
-                    {ok, ts_requests(), {PermSpec::string(), Table::binary()}} |
+                    {ok, riak_kv_ts_svc:ts_requests(), {PermSpec::string(), Table::binary()}} |
                     {error, _}.
 decode(?TTB_MSG_CODE, Bin) ->
     Msg = riak_ttb_codec:decode(Bin),
@@ -60,8 +60,8 @@ decode(?TTB_MSG_CODE, Bin) ->
 encode(Message) ->
     {ok, riak_ttb_codec:encode(Message)}.
 
--spec process(atom() | ts_requests() | ts_query_types(), #state{}) ->
-                     {reply, ts_responses(), #state{}}.
+-spec process(atom() | riak_kv_ts_svc:ts_requests() | riak_kv_ts_svc:ts_query_types(), #state{}) ->
+                     {reply, riak_kv_ts_svc:ts_responses(), #state{}}.
 process(Request, State) ->
     riak_kv_ts_svc:process(Request, State).
 

--- a/src/riak_kv_w1c_worker.erl
+++ b/src/riak_kv_w1c_worker.erl
@@ -1,5 +1,5 @@
 %% -------------------------------------------------------------------
-%% Copyright (c) 2015 Basho Technologies, Inc. All Rights Reserved.
+%% Copyright (c) 2015, 2016 Basho Technologies, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -80,27 +80,31 @@ start_link(Name) ->
 %%       {error, term()}
 put(RObj0, Options) ->
     Bucket = riak_object:bucket(RObj0),
-    BucketProps = riak_core_bucket:get_bucket(Bucket),
-    NVal = proplists:get_value(n_val, BucketProps),
-    {RObj, Key, EncodeFn} = kv_or_ts_details(RObj0,
-                                             riak_object:get_ts_local_key(RObj0)),
-    DocIdx = chash_key(Bucket, Key, BucketProps),
-    Preflist =
-        case proplists:get_value(sloppy_quorum, Options, true) of
-            true ->
-                UpNodes = riak_core_node_watcher:nodes(riak_kv),
-                riak_core_apl:get_apl_ann(DocIdx, NVal, UpNodes);
-            false ->
-                riak_core_apl:get_primary_apl(DocIdx, NVal, riak_kv)
-        end,
+    case riak_core_bucket:get_bucket(Bucket) of
+        {error, Reason} ->
+            {error, Reason};
+        BucketProps ->
+            NVal = proplists:get_value(n_val, BucketProps),
+            {RObj, Key, EncodeFn} =
+                kv_or_ts_details(RObj0, riak_object:get_ts_local_key(RObj0)),
+            DocIdx = chash_key(Bucket, Key, BucketProps),
+            Preflist =
+                case proplists:get_value(sloppy_quorum, Options, true) of
+                    true ->
+                        UpNodes = riak_core_node_watcher:nodes(riak_kv),
+                        riak_core_apl:get_apl_ann(DocIdx, NVal, UpNodes);
+                    false ->
+                        riak_core_apl:get_primary_apl(DocIdx, NVal, riak_kv)
+                end,
 
-    case validate_options(NVal, Preflist, Options, BucketProps) of
-        {ok, W, PW} ->
-            synchronize_put(
-              async_put(
-                RObj, W, PW, Bucket, NVal, Key, EncodeFn, Preflist), Options);
-        Error ->
-            Error
+            case validate_options(NVal, Preflist, Options, BucketProps) of
+                {ok, W, PW} ->
+                    synchronize_put(
+                      async_put(
+                        RObj, W, PW, Bucket, NVal, Key, EncodeFn, Preflist), Options);
+                Error ->
+                    Error
+            end
     end.
 
 -spec async_put(RObj :: riak_object:riak_object(),


### PR DESCRIPTION
This is Part 1/3 of #1382 broken up and reassembled into new commits.

After the merge of TTB branch, and in anticipation of the merge of HTTP API branch, this PR proposes a code reorg consisting of the following steps:
1. Move functions shared between PB and WM callbacks from riak_kv_ts_svc to riak_kv_ts_util;
2. Further move functions `get_data`, `put_data`, `delete_data`, `query` and `compile_to_per_quantum_queries` (used to produce coverage results, with `riak_kv_ts_util:sql_to_cover`) into the newly created module `riak_kv_ts_api`. These will constitute the **TS internal API**.
3. Move code serving the INSERT query from `riak_kv_ts_svc` into `riak_kv_qry`. Now the call to `riak_kv_qry:submit("INSERT ...")` will actually take effect (previously, the 'submit' part was a no-op while all the validations, conversions and the eventual call of `riak_kv_ts_util:put_data` happened as a side effect).
