### PR TITLE
Account for n_vals associated with bucket types when determining responsible preflists

### DIFF
--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -213,7 +213,7 @@ responsible_preflists(Index) ->
 
 -spec responsible_preflists(index(), riak_core_ring()) -> [index_n()].
 responsible_preflists(Index, Ring) ->
-    AllN = determine_all_n(Ring),
+    AllN = riak_core_bucket:all_n(Ring),
     responsible_preflists(Index, AllN, Ring).
 
 -spec responsible_preflists(index(), [pos_integer(),...], riak_core_ring())
@@ -234,19 +234,8 @@ responsible_preflists_n(RevIndices, N) ->
 
 -spec determine_max_n(riak_core_ring()) -> pos_integer().
 determine_max_n(Ring) ->
-    lists:max(determine_all_n(Ring)).
+    lists:max(riak_core_bucket:all_n(Ring)).
 
--spec determine_all_n(riak_core_ring()) -> [pos_integer(),...].
-determine_all_n(Ring) ->
-    Buckets = riak_core_ring:get_buckets(Ring),
-    BucketProps = [riak_core_bucket:get_bucket(Bucket, Ring) || Bucket <- Buckets],
-    Default = app_helper:get_env(riak_core, default_bucket_props),
-    DefaultN = proplists:get_value(n_val, Default),
-    AllN = lists:foldl(fun(Props, AllN) ->
-                               N = proplists:get_value(n_val, Props),
-                               ordsets:add_element(N, AllN)
-                       end, [DefaultN], BucketProps),
-    AllN.
 
 fix_incorrect_index_entries() ->
     fix_incorrect_index_entries([]).


### PR DESCRIPTION
The KV and YZ hash tree subsystems build hash trees based on the size of preflists for all buckets stored in the ring.  However, the calculation of preflists does not currently account for bucket types, resulting in an incorrect set of hash trees if a bucket type specifies an n_val different from the default.

This patch adds the n_vals from all bucket types to the responsible preflists calculation.

In addition, this PR add convenience `clear_trees` and `expire_trees` operations to the `riak_kv_entropy_manager` module.

This PR requires https://github.com/basho/riak_core/pull/832
