### PR TITLE
allow non-3-tuple keys when assisted sext decoding in eleveldb_backend fold_object fun

### DIFF
--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -1059,12 +1059,17 @@ orig_from_object_key(LKey) ->
 %% so that the key in the riak object structure will be a binary on decode.
 %% All support tooling/usual methods for visiting objects should still work.
 %%
+%% 2016-04-23 @hmmr:
+%% Because flexible keys work by @andytill has lifted the 3-field
+%% restriction on TS keys, we should, correspondingly, allow the 5th
+%% byte of the binary (which is the number of elements in the encoded
+%% tuple) to be any number.
 from_object_key(<<16,0,0,0,3, %% 3-tuple - outer
                   12,183,128,8, %% o-atom
-                  Rest/binary>>=Bin) ->
+                  Rest/binary>> = Bin) ->
     {Bucket, Rest1} = sext:decode_next(Rest), % grabs the two-tuple of bucket type/name
     case Rest1 of
-        <<16,0,0,0,3,_TSKeyElements/binary>> = TSKey ->
+        <<16,0,0,0,_NTupleElements,_TSKeyElements/binary>> = TSKey ->
             {Bucket, TSKey}; % small risk not checking for junk at the end of the TSKeyElements
         _ ->
             case catch sext:decode_next(Rest1) of


### PR DESCRIPTION
RTS-1083

The hand-written sext-decoder in `riak_kv_eleveldb_backend:from_object_key` does some binary matching to skip one call to `sext:decode` when converting the object to a `{Bucket, Key}` tuple before it is handed over to key folding function. That matching expects the key to be a three-tuple.

Because flexible keys work by @andytill has lifted the 3-field restriction on TS keys, we should, correspondingly, allow the 5th byte of the binary (the number of elements in the encoded tuple) to be any number.

With the tuple size hard-coded at 3, keys with the number of fields other than 3 were treated as non-TS data, and were returned already sext-decoded, eventually breaking the client code which attempted decoding on its own. In particular, there was a workaround for this, which is now being removed (the change in `riak_kv_wm_timeseries_listkeys:ts_keys_to_body`).
