### PR TITLE
Don't filter empty ts rows

### DIFF
--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -278,9 +278,7 @@ prepare_final_results(#state{
 %%
 prepare_final_results2(#riak_sel_clause_v1{col_return_types = ColTypes,
                                            col_names = ColNames}, Rows) ->
-    %% filter out empty records
-    FinalRows = [R || R <- Rows, R /= [[]]],
-    {ColNames, ColTypes, FinalRows}.
+    {ColNames, ColTypes, Rows}.
 
 %%%===================================================================
 %%% Unit tests


### PR DESCRIPTION
If you query Riak TS with a statement that returns a single column and the data is a single row with a null value, the row will be filtered out. Example query:

```
select temperature from GeoHash882836005 where user = 'user2' and geohash = 'hash1' and (time > 1443805999999 and (time < 1443806900001))
```

We shouldn't be filtering out empty rows.

@hmmr - could you review as well? Thanks.
