### PR TITLE
Bugfix/listkeys filters

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -702,7 +702,7 @@ stream_list_keys(Input, Timeout, KeyConvFn, Client, {?MODULE, [Node, _ClientId]}
                                                          [Bucket,
                                                           FilterExprs,
                                                           Timeout,
-							  KeyConvFn]]),
+                                                          KeyConvFn]]),
                     {ok, ReqId}
             end;
         Bucket ->
@@ -711,7 +711,7 @@ stream_list_keys(Input, Timeout, KeyConvFn, Client, {?MODULE, [Node, _ClientId]}
                                                  [Bucket,
                                                   none,
                                                   Timeout,
-						  KeyConvFn]]),
+                                                  KeyConvFn]]),
             {ok, ReqId}
     end.
 

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -30,7 +30,7 @@
 -export([delete/3,delete/4,delete/5]).
 -export([delete_vclock/4,delete_vclock/5,delete_vclock/6]).
 -export([list_keys/2,list_keys/3,list_keys/4]).
--export([stream_list_keys/2,stream_list_keys/3,stream_list_keys/4]).
+-export([stream_list_keys/2,stream_list_keys/3,stream_list_keys/4,stream_list_keys/5]).
 -export([filter_buckets/2]).
 -export([filter_keys/3,filter_keys/4]).
 -export([list_buckets/1,list_buckets/2,list_buckets/3, list_buckets/4]).
@@ -646,7 +646,12 @@ list_keys(Bucket, Filter, Timeout0, {?MODULE, [Node, _ClientId]}) ->
         end,
     Me = self(),
     ReqId = mk_reqid(),
-    riak_kv_keys_fsm_sup:start_keys_fsm(Node, [{raw, ReqId, Me}, [Bucket, Filter, Timeout]]),
+
+    %% Add no-op conversion function here so that riak_kv_keys_fsm has
+    %% a valid argument list for all invocations, including non-TS calls
+
+    KeyConvFn = fun(Key) -> Key end,
+    riak_kv_keys_fsm_sup:start_keys_fsm(Node, [{raw, ReqId, Me}, [Bucket, Filter, Timeout, KeyConvFn]]),
     wait_for_listkeys(ReqId).
 
 stream_list_keys(Bucket, {?MODULE, [_Node, _ClientId]}=THIS) ->
@@ -654,12 +659,21 @@ stream_list_keys(Bucket, {?MODULE, [_Node, _ClientId]}=THIS) ->
 
 stream_list_keys(Bucket, undefined, {?MODULE, [_Node, _ClientId]}=THIS) ->
     stream_list_keys(Bucket, ?DEFAULT_TIMEOUT, THIS);
+
+%% Stream_list_keys with no key conversion function uses a no-op
+%% conversion
+
 stream_list_keys(Bucket, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    KeyConvFn = fun(Key) -> Key end,
+    stream_list_keys(Bucket, Timeout, KeyConvFn, THIS).
+
+stream_list_keys(Bucket, Timeout, KeyConvFn, {?MODULE, [_Node, _ClientId]}=THIS) ->
     Me = self(),
-    stream_list_keys(Bucket, Timeout, Me, THIS).
+    stream_list_keys(Bucket, Timeout, KeyConvFn, Me, THIS).
 
 %% @spec stream_list_keys(riak_object:bucket(),
 %%                        TimeoutMillisecs :: integer(),
+%%                        KeyConvFn :: function(),
 %%                        Client :: pid(),
 %%                        riak_client()) ->
 %%       {ok, ReqId :: term()}
@@ -671,7 +685,7 @@ stream_list_keys(Bucket, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
 %%      and a final {ReqId, done} message.
 %%      None of the Keys lists will be larger than the number of
 %%      keys in Bucket on any single vnode.
-stream_list_keys(Input, Timeout, Client, {?MODULE, [Node, _ClientId]}) when is_pid(Client) ->
+stream_list_keys(Input, Timeout, KeyConvFn, Client, {?MODULE, [Node, _ClientId]}) when is_pid(Client) ->
     ReqId = mk_reqid(),
     case Input of
         %% buckets with bucket types are also a 2-tuple, so be careful not to
@@ -687,7 +701,8 @@ stream_list_keys(Input, Timeout, Client, {?MODULE, [Node, _ClientId]}) when is_p
                                                           Client},
                                                          [Bucket,
                                                           FilterExprs,
-                                                          Timeout]]),
+                                                          Timeout,
+							  KeyConvFn]]),
                     {ok, ReqId}
             end;
         Bucket ->
@@ -695,7 +710,8 @@ stream_list_keys(Input, Timeout, Client, {?MODULE, [Node, _ClientId]}) when is_p
                                                 [{raw, ReqId, Client},
                                                  [Bucket,
                                                   none,
-                                                  Timeout]]),
+                                                  Timeout,
+						  KeyConvFn]]),
             {ok, ReqId}
     end.
 

--- a/src/riak_kv_buckets_fsm.erl
+++ b/src/riak_kv_buckets_fsm.erl
@@ -69,8 +69,11 @@ init(From={_, _, ClientPid}, [ItemFilter, Timeout, Stream, BucketType]) ->
             [<<"other">>, ClientNode, PidStr]),
     %% Construct the bucket listing request
     Req = ?KV_LISTBUCKETS_REQ{item_filter=ItemFilter},
+
+    %% Note riak_core_coverage_fsm now expects a plan function, not a mod, to be returned
+
     {Req, allup, 1, 1, riak_kv, riak_kv_vnode_master, Timeout,
-     riak_core_coverage_plan, #state{from=From, stream=Stream, type=BucketType}}.
+     fun riak_core_coverage_plan:create_plan/6, #state{from=From, stream=Stream, type=BucketType}}.
 
 process_results(done, StateData) ->
     {done, StateData};

--- a/src/riak_kv_coverage_filter.erl
+++ b/src/riak_kv_coverage_filter.erl
@@ -73,8 +73,8 @@ build_filter(Bucket, ItemFilterInput, {_Hash, _Mask}=SubP, KeyConvFn) ->
             SubpartitionFun = build_subpartition_fun(Bucket, KeyConvFn),
             compose_sub_filter(SubP, SubpartitionFun);
         true -> % key and vnode filtering
-            SubpartitionFun = build_subpartition_fun(Bucket),
-            compose_sub_filter(SubP, SubpartitionFun, ItemFilter, KeyConvFn)
+            SubpartitionFun = build_subpartition_fun(Bucket, KeyConvFn),
+            compose_sub_filter(SubP, SubpartitionFun, ItemFilter)
     end;
 build_filter(Bucket, ItemFilterInput, FilterVNode, KeyConvFn) ->
     ItemFilter = build_item_filter(ItemFilterInput),

--- a/src/riak_kv_index_fsm.erl
+++ b/src/riak_kv_index_fsm.erl
@@ -125,8 +125,7 @@ init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout, MaxResults, PgSort0, V
 
     %% Note riak_core_coverage_fsm now expects a plan function, not a mod, to be returned
 
-    {Req, VNodeTarget, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout, fun PlannerMod:create_pl\
-an/6,
+    {Req, VNodeTarget, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout, fun PlannerMod:create_plan/6,
      #state{from=From, max_results=MaxResults, pagination_sort=PgSort}}.
 
 plan(CoverageVNodes, State = #state{pagination_sort=true}) ->

--- a/src/riak_kv_index_fsm.erl
+++ b/src/riak_kv_index_fsm.erl
@@ -122,7 +122,11 @@ init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout, MaxResults, PgSort0, V
     end,
     %% Construct the key listing request
     Req = req(Bucket, ItemFilter, Query),
-    {Req, VNodeTarget, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout, PlannerMod,
+
+    %% Note riak_core_coverage_fsm now expects a plan function, not a mod, to be returned
+
+    {Req, VNodeTarget, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout, fun PlannerMod:create_pl\
+an/6,
      #state{from=From, max_results=MaxResults, pagination_sort=PgSort}}.
 
 plan(CoverageVNodes, State = #state{pagination_sort=true}) ->

--- a/src/riak_kv_keys_fsm.erl
+++ b/src/riak_kv_keys_fsm.erl
@@ -78,7 +78,7 @@ req(Bucket, ItemFilter) ->
 %% the number of primary preflist vnodes the operation
 %% should cover, the service to use to check for available nodes,
 %% and the registered name to use to access the vnode master process.
-init(From={_, _, ClientPid}, [Bucket, ItemFilter, Timeout]) ->
+init(From={_, _, ClientPid}, [Bucket, ItemFilter, Timeout, KeyConvFn]) ->
     riak_core_dtrace:put_tag(io_lib:format("~p", [Bucket])),
     ClientNode = atom_to_list(node(ClientPid)),
     PidStr = pid_to_list(ClientPid),
@@ -94,9 +94,35 @@ init(From={_, _, ClientPid}, [Bucket, ItemFilter, Timeout]) ->
     NVal = proplists:get_value(n_val, BucketProps),
     %% Construct the key listing request
     Req = req(Bucket, ItemFilter),
-    {Req, all, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout,
-     riak_core_coverage_plan, #state{from=From}}.
 
+    %% CreatePlanFn for this module invokes
+    %% riak_kv_keys_fsm:create_plan with the passed KeyConvFn
+
+    CreatePlanFn =
+        fun(Target, NValArg, PVC, ReqId, Service, Request) ->
+                create_plan(Target, NValArg, PVC, ReqId, Service, Request, KeyConvFn)
+        end,
+
+    {Req, all, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout,
+     CreatePlanFn, #state{from=From}}.
+
+%% ------------------------------------------------------------ 
+%% Create coverage plan for this module.
+%%
+%% Calls riak_core_coverage_plan:create_plan, but adds a key
+%% conversion function to the returned vnode filter prop list
+%%
+%% This is required to build the key filter used in listkeys
+%% ------------------------------------------------------------
+
+create_plan(Target, NVal, PVC, ReqId, Service, Request, KeyConvFn) ->
+    CoveragePlan = riak_core_coverage_plan:create_plan(Target, NVal, PVC, ReqId, Service, Request),
+    case CoveragePlan of
+        {error, Reason} ->
+	    {error, Reason};
+	{CoverageVNodes, FilterVNodes} ->
+	    {CoverageVNodes, [{key_conv_fn, KeyConvFn} | FilterVNodes]}
+    end.
 
 process_results({From, Bucket, Keys},
                 StateData=#state{from={raw, ReqId, ClientPid}}) ->

--- a/src/riak_kv_keys_fsm.erl
+++ b/src/riak_kv_keys_fsm.erl
@@ -119,9 +119,9 @@ create_plan(Target, NVal, PVC, ReqId, Service, Request, KeyConvFn) ->
     CoveragePlan = riak_core_coverage_plan:create_plan(Target, NVal, PVC, ReqId, Service, Request),
     case CoveragePlan of
         {error, Reason} ->
-	    {error, Reason};
-	{CoverageVNodes, FilterVNodes} ->
-	    {CoverageVNodes, [{key_conv_fn, KeyConvFn} | FilterVNodes]}
+            {error, Reason};
+        {CoverageVNodes, FilterVNodes} ->
+            {CoverageVNodes, [{key_conv_fn, KeyConvFn} | FilterVNodes]}
     end.
 
 process_results({From, Bucket, Keys},

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -32,7 +32,6 @@
          get_data/2, get_data/3, get_data/4,
          delete_data/2, delete_data/3, delete_data/4, delete_data/5,
          query/2,
-         row_to_key/3,
          compile_to_per_quantum_queries/2  %% coverage
          %% To reassemble the broken-up queries into coverage entries
          %% for returning to pb or http clients (each needing to
@@ -170,7 +169,7 @@ put_data_to_partitions(Data, Bucket, BucketProps, DDL, Mod) ->
                             list(tuple(chash:index(), list(term()))).
 partition_data(Data, Bucket, BucketProps, DDL, Mod) ->
     PartitionTuples =
-        [ { riak_core_util:chash_key({Bucket, row_to_key(R, DDL, Mod)},
+        [ { riak_core_util:chash_key({Bucket, riak_kv_ts_util:row_to_key(R, DDL, Mod)},
                                      BucketProps), R } || R <- Data ],
     dict:to_list(
       lists:foldl(fun({Idx, R}, Dict) ->
@@ -178,10 +177,6 @@ partition_data(Data, Bucket, BucketProps, DDL, Mod) ->
                   end,
                   dict:new(),
                   PartitionTuples)).
-
-row_to_key(Row, DDL, Mod) ->
-    riak_kv_ts_util:encode_typeval_key(
-      riak_ql_ddl:get_partition_key(DDL, Row, Mod)).
 
 add_preflists(PartitionedData, NVal, UpNodes) ->
     lists:map(fun({Idx, Rows}) -> {Idx,

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -32,7 +32,8 @@
          get_data/2, get_data/3, get_data/4,
          delete_data/2, delete_data/3, delete_data/4, delete_data/5,
          query/2,
-         compile_to_per_quantum_queries/2  %% coverage
+	 row_to_key/3,
+         compile_to_per_quantum_queries/2,  %% coverage
          %% To reassemble the broken-up queries into coverage entries
          %% for returning to pb or http clients (each needing to
          %% convert and repackage entry details in their own way),

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -32,7 +32,7 @@
          get_data/2, get_data/3, get_data/4,
          delete_data/2, delete_data/3, delete_data/4, delete_data/5,
          query/2,
-	 row_to_key/3,
+         row_to_key/3,
          compile_to_per_quantum_queries/2  %% coverage
          %% To reassemble the broken-up queries into coverage entries
          %% for returning to pb or http clients (each needing to

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -33,7 +33,7 @@
          delete_data/2, delete_data/3, delete_data/4, delete_data/5,
          query/2,
 	 row_to_key/3,
-         compile_to_per_quantum_queries/2,  %% coverage
+         compile_to_per_quantum_queries/2  %% coverage
          %% To reassemble the broken-up queries into coverage entries
          %% for returning to pb or http clients (each needing to
          %% convert and repackage entry details in their own way),

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -344,10 +344,18 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
         fun(Key) when is_binary(Key) ->
                 riak_kv_ts_util:row_to_key(sext:decode(Key), DDL, Mod);
            (Key) ->
-                %% Key read from leveldb will always be binary.  This
-                %% clause is just to keep dialyzer quiet (dialyzer is
-                %% within his rights as we have no way to 'declare'
-                %% the type of Key)
+                %% Key read from leveldb should always be binary.
+                %% This clause is just to keep dialyzer quiet
+                %% (otherwise dialyzer will complain about no local
+                %% return, since we have no way to spec the type
+                %% of Key for an anonymous function).
+		%%
+		%% Nonetheless, we log an error in case this branch is
+		%% ever exercised
+
+		lager:error("Key conversion function " ++ 
+				"(from riak_kv_ts_svc:sub_tslistkeysreq/4) " ++
+				"encountered a non-binary object key: ~p~n", [Key]),
                 Key
         end,
 

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -349,13 +349,13 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
                 %% (otherwise dialyzer will complain about no local
                 %% return, since we have no way to spec the type
                 %% of Key for an anonymous function).
-		%%
-		%% Nonetheless, we log an error in case this branch is
-		%% ever exercised
+                %%
+                %% Nonetheless, we log an error in case this branch is
+                %% ever exercised
 
-		lager:error("Key conversion function " ++ 
-				"(from riak_kv_ts_svc:sub_tslistkeysreq/4) " ++
-				"encountered a non-binary object key: ~p~n", [Key]),
+                lager:error("Key conversion function " ++ 
+                                "(from riak_kv_ts_svc:sub_tslistkeysreq/4) " ++
+                                "encountered a non-binary object key: ~p~n", [Key]),
                 Key
         end,
 

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -341,15 +341,15 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
     %% keys in the backend.
 
     KeyConvFn = 
-	fun(Key) when is_binary(Key) ->
-		riak_kv_ts_api:row_to_key(sext:decode(Key), DDL, Mod);
-	   (Key) ->
-		%% Key read from leveldb will always be binary.  This
-		%% clause is just to keep dialyzer quiet (dialyzer is
-		%% within his rights as we have no way to 'declare'
-		%% the type of Key)
-		Key
-	end,
+        fun(Key) when is_binary(Key) ->
+                riak_kv_ts_api:row_to_key(sext:decode(Key), DDL, Mod);
+           (Key) ->
+                %% Key read from leveldb will always be binary.  This
+                %% clause is just to keep dialyzer quiet (dialyzer is
+                %% within his rights as we have no way to 'declare'
+                %% the type of Key)
+                Key
+        end,
 
     Result =
         riak_client:stream_list_keys(

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -342,7 +342,7 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
 
     KeyConvFn = 
         fun(Key) when is_binary(Key) ->
-                riak_kv_ts_api:row_to_key(sext:decode(Key), DDL, Mod);
+                riak_kv_ts_util:row_to_key(sext:decode(Key), DDL, Mod);
            (Key) ->
                 %% Key read from leveldb will always be binary.  This
                 %% clause is just to keep dialyzer quiet (dialyzer is

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -340,7 +340,7 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
 
     KeyConvFn =
         fun(Key) ->                
-                riak_kv_ts_svc:row_to_key(sext:decode(Key), DDL, Mod)
+                riak_kv_ts_api:row_to_key(sext:decode(Key), DDL, Mod)
         end,
 
     Result =

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -38,7 +38,8 @@
          sql_record_to_tuple/1,
          sql_to_cover/4,
          table_to_bucket/1,
-         validate_rows/2
+         validate_rows/2,
+         row_to_key/3
         ]).
 -export([explain_query/1, explain_query/2]).
 -export([explain_query_print/1]).
@@ -387,6 +388,9 @@ validate_rows(Mod, Rows) ->
 get_column_types(ColumnNames, Mod) ->
     [Mod:get_field_type([N]) || N <- ColumnNames].
 
+row_to_key(Row, DDL, Mod) ->
+    riak_kv_ts_util:encode_typeval_key(
+      riak_ql_ddl:get_partition_key(DDL, Row, Mod)).
 
 %% Result from riak_client:get_cover is a nested list of coverage plan
 %% because KV coverage requests are designed that way, but in our case

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -48,7 +48,7 @@
          overload_reply/1,
          get_backend_config/3,
          is_modfun_allowed/2,
-	 get_bucket_from_req/1]).
+         get_bucket_from_req/1]).
 
 -include_lib("riak_kv_vnode.hrl").
 

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1048,7 +1048,8 @@ handle_coverage_fold(FoldType, Bucket, ItemFilter, ResultFun,
                                   modstate      = ModState}) ->
     %% Construct the filter function
     FilterVNode = proplists:get_value(Index, FilterVNodes),
-    Filter = riak_kv_coverage_filter:build_filter(Bucket, ItemFilter, FilterVNode),
+    KeyConvFn   = proplists:get_value(key_conv_fn, FilterVNodes),
+    Filter = riak_kv_coverage_filter:build_filter(Bucket, ItemFilter, FilterVNode, KeyConvFn),
     BufferMod = riak_kv_fold_buffer,
     BufferSize = proplists:get_value(buffer_size, Opts0, DefaultBufSz),
     Buffer = BufferMod:new(BufferSize, ResultFun),


### PR DESCRIPTION
**Context**

stream_list_keys has always returned inconsistent results when used with TS data.  I've tracked this down to the coverage filter functions that are applied during the fold over keys on a vnode.  These filters check whether a key should be included, by checking if its hash falls within a specified hash range for a vnode.  These filters are applied to the storage keys in leveldb.  For TS, however, these filters need to be applied not to the storage key (which is the local key), but instead to the partition key, which can be derived from the local key by an appropriate transformation.

This PR addresses this inconsistency by changing the filter functions to use a key conversion function on the storage key prior to hashing. It is one of three PRs: riak_kv (https://github.com/basho/riak_kv/pull/1404), riak_core (https://github.com/basho/riak_core/pull/834) and riak_pipe (https://github.com/basho/riak_pipe/pull/105).  For reference, I include my diagram of the listkeys code path here:

 ![RiakTS Listkeys Path](https://gist.githubusercontent.com/erikleitch/8191db35b09bc8357df4/raw/69e7510c9233ecc3e35fd78a12807df6fab5514d/tslistkeys.png)

**Changes in this repo**
- **riak_kv_ts_svc.erl**<br>
  - sub_tslistkeysreq now constructs a key conversion
    function (KeyConvFn) when invoked, that takes the decoded object key, sext
    decodes it, and converts to a partition key, using riak_kv_ts_api:row_to_key with the
    Mod and DDL specific to the table for which listkeys has been invoked.  This is passed as an argument to riak_client:stream_list_keys
- **riak_kv_ts_api**<br>
  - row_to_key/3 exported because it is needed in sub_tslistkeysreq when building the key conversion function
- **riak_client**<br>
  - stream_list_keys/5 has been added, with KeyConvFn as 3rd arg, as 
    the function that all variants of stream_list_keys call down to.
    This calls riak_kv_keys_fsm_sup:start_keys_fsm with KeyConvFn as an
    extra argument in the fsm startup arg list
  - stream_list_keys/4, which in the riak_ee codebase was only called by sub_tslistkeysreq, has been modified to take KeyConvFn as its 3rd argument
  - the interfaces to stream_list_keys/2 and stream_list_keys/3, which are used  elsewhere in
    the riak_ee codebase, remain unchanged.  On invocation,
    they construct a no-op key conversion function and pass it into stream_list_keys/4
  - list_keys/4 has been modified to call start_keys_fsm with a no-op key conversion function, to ensure that list_keys also continues to work with this change
- **riak_kv_keys_fsm**<br>
  - init uses the KeyConvFn argument to construct a
    coverage plan function that returns a proplist including the key
    conversion function, in addition to the usual vnode filter list.  This will
    be needed later in riak_kv_vnode:handle_coverage_fold to construct the
    vnode filter function applied during the listkeys fold.
- **riak_kv_index_fsm.erl, riak_kv_buckets_fsm.erl**<br>
  - Because riak_core_coverage_fsm now expects a plan fn rather than a plan mod, init functions for these modules have also been modified to return a plan fun, so that we don't break range scans and bucket listing
- **riak_kv_vnode.erl**<br>
  - handle_coverage_fold has been modified to extract the key
    conversion function from the FilterVNodes proplist, and pass it into
    riak_kv_coverage_filter:build_filter, where it is used to construct an appropriate
    filter
- **riak_kv_coverage_filter.erl**<br>
  - build_filter/4 has been added to use an explicit key conversion function
  - build_filter/3 has been modified to pass a no-op key conversion function, to  preserve the functionality of other code that uses build_filter/3 directly
  - build_preflist_fun and build_subpartition_fun now take KeyConvFn as an extra argument, and use it to convert the key before hashing

**Notes**
- I have verified in manual testing that streaming list keys now works consistently for TS buckets (ie, the changes here do what they are intended to do)
- I have verified in manual testing that streaming list keys still works (and returns consistent results) for non-TS buckets (ie, the code changes here haven't broken listkeys for non-TS buckets, and incidentally that there isn't a separate problem with non-TS listkeys)
- I have verified in riak_test that verify_listkeys now passes (note that there is also a bugfix/listkeys_filters branch of riak_ee that can be used in riak_test to verify the changes)
- I still want to verify that stream_list_buckets works, but I haven't gotten to that yet
