### PR TITLE
Handle case where there is no key_conv_fn defined

### DIFF
--- a/src/riak_kv_coverage_filter.erl
+++ b/src/riak_kv_coverage_filter.erl
@@ -66,6 +66,9 @@ build_filter(Bucket, ItemFilterInput, FilterVNode) ->
     build_filter(Bucket, ItemFilterInput, FilterVNode, KeyConvFn).
 
 -spec build_filter(bucket(), filter(), [index()]|subpartition(), function()) -> filter().
+build_filter(Bucket, ItemFilterInput, FilterVNode, undefined) ->
+    %% Generate an identity function for `KeyConvFn' and come back
+    build_filter(Bucket, ItemFilterInput, FilterVNode);
 build_filter(Bucket, ItemFilterInput, {_Hash, _Mask}=SubP, KeyConvFn) ->
     ItemFilter = build_item_filter(ItemFilterInput),
     if


### PR DESCRIPTION
`riak_kv_vnode:handle_coverage_fold/8` may not have a `key_conv_fn` option supplied, which results in a serious 2i failure without this fix.
