### PR TITLE
supply lk2pk key conv fun for index_fsm init, to fix 2i listing

### DIFF
--- a/src/riak_kv_index_fsm.erl
+++ b/src/riak_kv_index_fsm.erl
@@ -108,6 +108,11 @@ init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout, MaxResults, PgSort0]) 
 init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout, MaxResults, PgSort0, VNodeTarget]) ->
     init(From, [Bucket, ItemFilter, Query, Timeout, MaxResults, PgSort0, VNodeTarget, riak_core_coverage_plan]);
 init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout, MaxResults, PgSort0, VNodeTarget, PlannerMod]) ->
+    init(From, [Bucket, ItemFilter, Query, Timeout, MaxResults, PgSort0, VNodeTarget, PlannerMod, fun(X) -> X end]);
+%% The KeyConvFn is needed to infer the PK from LK in TS keys, and use
+%% that to correctly create the coverage plan.  For details, see
+%% github/riak_kv/pulls/1404
+init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout, MaxResults, PgSort0, VNodeTarget, PlannerMod, KeyConvFn]) ->
     %% Get the bucket n_val for use in creating a coverage plan
     BucketProps = riak_core_bucket:get_bucket(Bucket),
     NVal = proplists:get_value(n_val, BucketProps),
@@ -125,8 +130,22 @@ init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout, MaxResults, PgSort0, V
 
     %% Note riak_core_coverage_fsm now expects a plan function, not a mod, to be returned
 
-    {Req, VNodeTarget, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout, fun PlannerMod:create_plan/6,
+    CreatePlanFn =
+        fun(Target, NValArg, PVC, ReqId, Service, Request) ->
+                create_plan(PlannerMod, Target, NValArg, PVC, ReqId, Service, Request, KeyConvFn)
+        end,
+
+    {Req, VNodeTarget, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout, CreatePlanFn,
      #state{from=From, max_results=MaxResults, pagination_sort=PgSort}}.
+
+create_plan(PlannerMod, Target, NVal, PVC, ReqId, Service, Request, KeyConvFn) ->
+    CoveragePlan = PlannerMod:create_plan(Target, NVal, PVC, ReqId, Service, Request),
+    case CoveragePlan of
+        {error, Reason} ->
+            {error, Reason};
+        {CoverageVNodes, FilterVNodes} ->
+            {CoverageVNodes, [{key_conv_fn, KeyConvFn} | FilterVNodes]}
+    end.
 
 plan(CoverageVNodes, State = #state{pagination_sort=true}) ->
     {ok, State#state{merge_sort_buffer=sms:new(CoverageVNodes)}};

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -339,7 +339,7 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
     %% hash of the partition key, not the local key, when folding over
     %% keys in the backend.
 
-    KeyConvFn = 
+    KeyConvFn =
         fun(Key) when is_binary(Key) ->
                 riak_kv_ts_util:row_to_key(sext:decode(Key), DDL, Mod);
            (Key) ->
@@ -352,9 +352,8 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
                 %% Nonetheless, we log an error in case this branch is
                 %% ever exercised
 
-                lager:error("Key conversion function " ++ 
-                                "(from riak_kv_ts_svc:sub_tslistkeysreq/4) " ++
-                                "encountered a non-binary object key: ~p~n", [Key]),
+                lager:error("Key conversion function "
+                            "encountered a non-binary object key: ~p", [Key]),
                 Key
         end,
 


### PR DESCRIPTION
As detailed by @erikleitch in a3076a22b8, the coverage plan for list_keys operation in TS was computed incorrectly because it must use PK and not LK. The proposed fix used a function to derive PK from the LK (immediately available in TS object being iterated), passed to the call site of `riak_kv_coverage_filter:build_filter` (and further to `:build_preflist_fun`) from the caller of `riak_client:list_keys`.

Because index_fsm facilities (as well as keys_fsm and bucket_fsm) are shared between TS and standard riak, and because 2i functionality is not enabled in TS, the fix by Erik was OK for the TS uses but intrusive enough to subtly break things for standard riak operations.

Following up and complementing this work, this commit:
1. unbreaks 2i list_keys by supplying an identity fun for the non-TS uses of index_fsm;
2. creates the key conversion function to build the correct coverage plan in queries with pre-ordered coverage contexts (possibly fixing the sporadic failures of ts_cluster_coverage).
