### PR TITLE
Error handling for invalid CoverageContext

### DIFF
--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -832,15 +832,13 @@ unwrap_cover(undefined) ->
     {ok, {undefined, undefined}};
 unwrap_cover(<<>>) ->
     {ok, {undefined, undefined}};
-unwrap_cover(Cover) ->
+unwrap_cover(Cover) when is_binary(Cover) ->
     case catch riak_kv_pb_coverage:checksum_binary_to_term(Cover) of
         {ok, {OpaqueContext, {FieldName, RangeTuple}}} ->
             {riak_kv_pb_coverage:term_to_checksum_binary(OpaqueContext),
              {FieldName, RangeTuple}};
         {error, invalid_checksum} ->
-            {error, invalid_coverage_context_checksum};
-        {'EXIT', _} ->
-            {error, bad_coverage_context}
+            {error, invalid_coverage_context_checksum}
     end.
 
 update_where_for_cover(Where, undefined) ->
@@ -2236,12 +2234,6 @@ doctored_coverage_context_test() ->
     {ok, Q} = get_query(?TINY_SQL, term_to_binary({NotACheckSum, OfThisTerm})),
     ?assertEqual(
        {error, invalid_coverage_context_checksum},
-       compile(get_ddl(?TINY_DDL), Q, 100)).
-
-outright_bad_coverage_context_test() ->
-    {ok, Q} = get_query(?TINY_SQL, not_a_binary),
-    ?assertEqual(
-       {error, bad_coverage_context},
        compile(get_ddl(?TINY_DDL), Q, 100)).
 
 -endif.

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -830,8 +830,6 @@ rewrite2([#param_v1{name = [FieldName]} | T], Where1, Mod, Acc) ->
 %% Functions to assist with coverage chunks that redefine quanta ranges
 unwrap_cover(undefined) ->
     {ok, {undefined, undefined}};
-unwrap_cover(<<>>) ->
-    {ok, {undefined, undefined}};
 unwrap_cover(Cover) when is_binary(Cover) ->
     case catch riak_kv_pb_coverage:checksum_binary_to_term(Cover) of
         {ok, {OpaqueContext, {FieldName, RangeTuple}}} ->
@@ -2225,15 +2223,12 @@ negate_an_aggregation_function_test() ->
         finalise_aggregate(Select, [3])
       ).
 
--define(TINY_DDL, "create table t (a timestamp not null, primary key ((quantum(a,1,d)), a))").
--define(TINY_SQL, "select a from t where a>0 and a<2").
-
-doctored_coverage_context_test() ->
+coverage_context_not_a_tuple_or_invalid_checksum_test() ->
     NotACheckSum = 34,
     OfThisTerm = <<"f,a,f,a">>,
-    {ok, Q} = get_query(?TINY_SQL, term_to_binary({NotACheckSum, OfThisTerm})),
+    {ok, Q} = get_query("select a from t where a>0 and a<2", term_to_binary({NotACheckSum, OfThisTerm})),
     ?assertEqual(
        {error, invalid_coverage_context_checksum},
-       compile(get_ddl(?TINY_DDL), Q, 100)).
+       compile(get_ddl("create table t (a timestamp not null, primary key ((quantum(a,1,d)), a))"), Q, 100)).
 
 -endif.

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -440,6 +440,10 @@ sub_tsqueryreq(_Mod, DDL = ?DDL{table = Table}, SQL, State) ->
         %% these come from riak_kv_qry_compiler, even though the query is a valid SQL.
         {error, {_DDLCompilerErrType, DDLCompilerErrDesc}} when is_atom(_DDLCompilerErrType) ->
             {reply, make_rpberrresp(?E_SUBMIT, DDLCompilerErrDesc), State};
+        {error, invalid_coverage_context_checksum} ->
+            {reply, make_rpberrresp(?E_SUBMIT, "Query coverage context fails checksum"), State};
+        {error, bad_coverage_context} ->
+            {reply, make_rpberrresp(?E_SUBMIT, "Bad coverage context"), State};
 
         {error, Reason} ->
             {reply, make_rpberrresp(?E_SUBMIT, Reason), State}

--- a/src/riak_kv_wm_timeseries_query.erl
+++ b/src/riak_kv_wm_timeseries_query.erl
@@ -210,6 +210,10 @@ process_post(RD, #ctx{sql_type = QueryType,
             %% the eleveldb process did manage to send us a timeout
             %% response
             riak_kv_wm_ts_util:handle_error(backend_timeout, RD, Ctx);
+        {error, invalid_coverage_context_checksum} ->
+            riak_kv_wm_ts_util:handle_error({parameter_error, "Query coverage context fails checksum"}, RD, Ctx);
+        {error, bad_coverage_context} ->
+            riak_kv_wm_ts_util:handle_error({parameter_error, "Bad coverage context"}, RD, Ctx);
         {error, Reason} ->
             riak_kv_wm_ts_util:handle_error({query_exec_error, QueryType, Table, Reason}, RD, Ctx)
     end.


### PR DESCRIPTION
Addresses https://github.com/basho/riak_kv/issues/1411 (the issue is now closed by @lukebakken by sanitizing the parameter in question on the client side; this PR does the same on the server side, for the great good).

Now, instead of crashing with a `badarg`, bad (non-binary) and doctored (failing an internal CRC check in https://github.com/basho/riak_kv/blob/riak_ts-develop/src/riak_kv_pb_coverage.erl#L108) values are properly diagnosed and reported.
