### PR TITLE
Refactor riak_kv_qry_worker

### DIFF
--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -168,7 +168,6 @@ make_key_conversion_fun(Table) ->
             Key
     end.
 
-
 decode_results([]) ->
     [];
 decode_results([{_,V}|Tail]) when is_binary(V) ->
@@ -223,14 +222,14 @@ add_subquery_result(SubQId, Chunk, #state{ sub_qrys = SubQs} = State) ->
 %%
 run_select_on_chunk(SubQId, Chunk, #state{ qry = Query,
                                            result = QueryResult1 }) ->
-  DecodedChunk = decode_results(lists:flatten(Chunk)),
-  SelClause = sql_select_clause(Query),
-  case sql_select_calc_type(Query) of
-      rows ->
-          run_select_on_rows_chunk(SubQId, SelClause, DecodedChunk, QueryResult1);
-      aggregate ->
-          run_select_on_aggregate_chunk(SelClause, DecodedChunk, QueryResult1)
-  end.
+    DecodedChunk = decode_results(lists:flatten(Chunk)),
+    SelClause = sql_select_clause(Query),
+    case sql_select_calc_type(Query) of
+        rows ->
+            run_select_on_rows_chunk(SubQId, SelClause, DecodedChunk, QueryResult1);
+        aggregate ->
+            run_select_on_aggregate_chunk(SelClause, DecodedChunk, QueryResult1)
+    end.
 
 %% Run the selection clause on results that accumulate rows
 run_select_on_rows_chunk(SubQId, SelClause, DecodedChunk, QueryResult1) ->
@@ -254,10 +253,9 @@ cancel_error_query(Error, #state{ receiver_pid = ReceiverPid}) ->
     new_state().
 
 %%
-subqueries_done(QId,
-                #state{qid          = QId,
-                       receiver_pid = ReceiverPid,
-                       sub_qrys     = SubQQ} = State) ->
+subqueries_done(QId, #state{qid          = QId,
+                            receiver_pid = ReceiverPid,
+                            sub_qrys     = SubQQ} = State) ->
     case SubQQ of
         [] ->
             QueryResult2 = prepare_final_results(State),


### PR DESCRIPTION
Refactor of `riak_kv_qry_worker`.
- Remove the unused `#state.status` field that was written to but never checked.
- Remove the unused `#state.name` field that was written to but never checked. This is the registered name for the process and available from it's process info.
- Functions to extract data from the `?SQL_SELECT` records to clean up function headers.
- Extract code into it new functions e.g. in case statement bodies.
#### Motivation

Remove cruft and prepare for all the changes that will arrive for temporary tables and streaming queries.

There are more changes in this style in the streaming queries WIP https://github.com/basho/riak_kv/pull/1415.
