### PR TITLE
Streaming Queries

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -20,3 +20,4 @@ Unknown types:
   mochijson2:json_value/0
   riak_dt:operation/0
   riak_dt:value/0
+The pattern {'reqid', ReqId} can never match the type {'error',_}

--- a/include/riak_kv_ts.hrl
+++ b/include/riak_kv_ts.hrl
@@ -60,7 +60,8 @@
           is_executable = false :: boolean(),
           type          = sql   :: sql | timeseries,
           cover_context = undefined :: term(), %% for parallel queries
-          local_key                            %% prolly a mistake to put this here - should be in DDL
+          local_key,                           %% prolly a mistake to put this here - should be in DDL
+          stream :: boolean()          
         }).
 
 -record(riak_sql_describe_v1,

--- a/src/riak_kv_pb_ts.erl
+++ b/src/riak_kv_pb_ts.erl
@@ -48,8 +48,6 @@ decode(Code, Bin) when Code >= 90, Code =< 103 ->
     Msg = riak_pb_codec:decode(Code, Bin),
     case Msg of
         #tsqueryreq{query = Q, cover_context = Cover, stream = Stream} ->
-            %% FIXME this function can return {ok, Error} which is not allowed
-            %% according to the spec
             riak_kv_ts_svc:decode_query_common(Q, Cover, Stream);
         #tsgetreq{table = Table}->
             {ok, Msg, {riak_kv_ts_api:api_call_to_perm(get), Table}};

--- a/src/riak_kv_pb_ts.erl
+++ b/src/riak_kv_pb_ts.erl
@@ -47,8 +47,10 @@ init() ->
 decode(Code, Bin) when Code >= 90, Code =< 103 ->
     Msg = riak_pb_codec:decode(Code, Bin),
     case Msg of
-        #tsqueryreq{query = Q, cover_context = Cover} ->
-            riak_kv_ts_svc:decode_query_common(Q, Cover);
+        #tsqueryreq{query = Q, cover_context = Cover, stream = Stream} ->
+            %% FIXME this function can return {ok, Error} which is not allowed
+            %% according to the spec
+            riak_kv_ts_svc:decode_query_common(Q, Cover, Stream);
         #tsgetreq{table = Table}->
             {ok, Msg, {riak_kv_ts_api:api_call_to_perm(get), Table}};
         #tsputreq{table = Table} ->

--- a/src/riak_kv_pb_ts.erl
+++ b/src/riak_kv_pb_ts.erl
@@ -86,7 +86,6 @@ encode_response({reply, {tsgetresp, {CNames, CTypes, Rows}}, State}) ->
     R = riak_pb_ts_codec:encode_rows(CTypes, Rows),
     Encoded = #tsgetresp{columns = C, rows = R},
     {reply, Encoded, State};
-
 encode_response({reply, {tscoverageresp, Entries}, State}) ->
     Encoded = #tscoverageresp{entries = riak_pb_ts_codec:encode_cover_list(Entries)},
     {reply, Encoded, State};

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -275,8 +275,12 @@ maybe_await_query_results(false, _) ->
 %% message.
 format_query_syntax_errors(Errors) ->
     iolist_to_binary(
-        [["\n", riak_ql_ddl:syntax_error_to_msg(E)] || E <- Errors]).
+        [["\n", syntax_error_to_msg(E)] || E <- Errors]).
 
+syntax_error_to_msg({aggregate_in_stream_query, Message}) when is_binary(Message) ->
+    Message;
+syntax_error_to_msg(E) ->
+    riak_ql_ddl:syntax_error_to_msg(E).
 
 -spec empty_result() -> query_tabular_result().
 empty_result() ->

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -303,7 +303,7 @@ describe_table_columns_test() ->
             " f, s, t))")),
     Res = do_describe(DDL),
     ?assertMatch(
-       {ok, {_, _,
+       {result_set, {_, _,
              [[<<"f">>, <<"varchar">>,   false, 1,  1],
               [<<"s">>, <<"varchar">>,   false, 2,  2],
               [<<"t">>, <<"timestamp">>, false, 3,  3],

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -158,7 +158,8 @@ my_mapfoldl(F, Accu0, [Hd|Tail]) ->
 my_mapfoldl(F, Accu, []) when is_function(F, 2) -> {[],Accu}.
 
 %%
-compile_select_clause(DDL, ?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{ clause = Sel } } = Q) ->
+compile_select_clause(DDL, ?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{ clause = Sel },
+                                       stream = Stream } = Q) ->
     CompileColFn =
         fun(ColX, AccX) ->
             select_column_clause_folder(DDL, ColX, AccX)
@@ -170,9 +171,9 @@ compile_select_clause(DDL, ?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{ clause = 
     %% iterate from the right so we can append to the head of lists
     {ResultTypeSet, Q2} = lists:foldl(CompileColFn, Acc, Sel),
 
-    {ColTypes, Errors} = my_mapfoldl(
-        fun(ColASTX, Errors) ->
-            infer_col_type(DDL, ColASTX, Errors)
+    {ColTypes, Errors1} = my_mapfoldl(
+        fun(ColASTX, ErrorsX) ->
+            infer_col_type(DDL, ColASTX, ErrorsX)
         end, [], Sel),
 
     case sets:is_element(aggregate, ResultTypeSet) of
@@ -186,14 +187,24 @@ compile_select_clause(DDL, ?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{ clause = 
                    initial_state = [],
                    col_names = get_col_names(DDL, Q) }
     end,
-    case Errors of
+    Errors2 = validate_stream_query(Stream, Q3, Errors1),
+    case Errors2 of
       [] ->
           {ok, Q3#riak_sel_clause_v1{
               col_names = get_col_names(DDL, Q),
               col_return_types = lists:flatten(ColTypes) }};
       [_|_] ->
-          {error, {invalid_query, riak_kv_qry:format_query_syntax_errors(lists:reverse(Errors))}}
+          {error, {invalid_query,
+                riak_kv_qry:format_query_syntax_errors(lists:reverse(Errors2))}}
     end.
+
+%% Queries that have been requested with the stream API cannot contain
+%% aggregates because the result set cannot be returned until all rows have been
+%% processed.
+validate_stream_query(true, #riak_sel_clause_v1{ calc_type = aggregate }, Errors) ->
+    [{aggregate_in_stream_query, ?E_AGGREGATE_IN_STREAM_QUERY} | Errors];
+validate_stream_query(_, _, Errors) ->
+    Errors.
 
 %%
 -spec get_col_names(?DDL{}, ?SQL_SELECT{}) -> [binary()].

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -893,7 +893,7 @@ is_query_valid(?DDL{table = Table} = DDL, Q) ->
 get_query(String) ->
     Lexed = riak_ql_lexer:get_tokens(String),
     {ok, Q} = riak_ql_parser:parse(Lexed),
-    riak_kv_ts_util:build_sql_record(select, Q, undefined).
+    riak_kv_ts_util:build_sql_record(select, Q, undefined, false).
 
 get_long_ddl() ->
     SQL = "CREATE TABLE GeoCheckin " ++

--- a/src/riak_kv_qry_queue.erl
+++ b/src/riak_kv_qry_queue.erl
@@ -210,35 +210,40 @@ do_blocking_pop_2_test() ->
 
 % reply to a waiting worker with the pushed query
 do_push_query_1_test() ->
-    Ref = make_ref(),
+    ReqId = mk_reqid(),
     State = #state{
-        reply_fn = fun(test_from, test_query) -> put(Ref, Ref) end
+        reply_fn = fun(test_from, test_query) -> put(ReqId, ReqId) end
     },
     ?assertEqual(
         do_push_query(
+            ReqId,
             test_query,
             State#state{ waiting_workers = ?Q(test_from) }),
-        {reply, ok, State}
+        {reply, {ok,ReqId}, State}
     ),
     % test that the reply function was called
     ?assertEqual(
-        Ref,
-        get(Ref)
+        ReqId,
+        get(ReqId)
     ).
 
 % no worker is waiting so queue the query
 do_push_query_2_test() ->
+    ReqId = mk_reqid(),
     ?assertEqual(
         do_push_query(
+            ReqId,
             test_query,
             #state{}),
-        {reply, ok, #state{ queued_qrys = ?Q(test_query) }}
+        {reply, {ok,ReqId}, #state{ queued_qrys = ?Q(test_query) }}
     ).
 
 % no worker is waiting so queue the query with other queries queued
 do_push_query_3_test() ->
-    {reply, ok, State} =
+    ReqId = mk_reqid(),
+    {reply, {ok,ReqId}, State} =
         do_push_query(
+            ReqId,
             test_query_3,
             #state{ max_q_len = 3, queued_qrys = ?Q([test_query_2,test_query_1]) }),
     ?assertEqual(
@@ -251,7 +256,7 @@ do_push_query_4_test() ->
     State = #state{ max_q_len = 1, queued_qrys = ?Q([test_query_1]) },
     ?assertEqual(
         {reply, {error, overload}, State},
-        do_push_query(test_query_3, State)
+        do_push_query(mk_reqid(), test_query_3, State)
     ).
 
 -endif.

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -51,7 +51,7 @@
 
 -record(state, {
           qry           = none                :: none | ?SQL_SELECT{},
-          qid           = undefined           :: undefined | {node(), non_neg_integer()},
+          qid           = undefined           :: undefined | non_neg_integer(),
           sub_qrys      = []                  :: [integer()],
           receiver_pid                        :: pid(),
           result        = []                  :: [{non_neg_integer(), list()}] | [{binary(), term()}],
@@ -230,12 +230,12 @@ maybe_stream_chunk_to_client(QueryResult, #state{ qry = Query } = State) ->
     end.
 
 %%
-stream_chunk_to_client(Chunk, #state{ receiver_pid = Pid, qid = {_,QID} }) ->
-    Pid ! {QID, {self(), x_monitor}, {rows, Chunk}},
+stream_chunk_to_client(Chunk, #state{ receiver_pid = Pid, qid = QID }) ->
+    Pid ! {QID, self(), {rows, Chunk}},
     ok.
 
 %%
-stream_done_to_client(#state{ receiver_pid = Pid, qid = {_,QID} }) ->
+stream_done_to_client(#state{ receiver_pid = Pid, qid = QID }) ->
     Pid ! {QID, done},
     ok.
 

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -75,7 +75,8 @@ api_call_to_perm(query_describe) ->
 
 
 -spec query(string() | riak_kv_qry:sql_query_type_record(), ?DDL{}) ->
-                   {ok, riak_kv_qry:query_tabular_result()} |
+                   {result_set, riak_kv_qry:query_tabular_result()} |
+                   {reqid, integer()} |
                    {error, term()}.
 query(QueryStringOrSQL, DDL) ->
     riak_kv_qry:submit(QueryStringOrSQL, DDL).

--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -89,7 +89,12 @@
 ).
 
 -define(
-   E_TOO_MANY_SUBQUERIES(N),
-   iolist_to_binary(
-     ["Too many subqueries (",integer_to_list(N),")"])
+    E_TOO_MANY_SUBQUERIES(N),
+    iolist_to_binary(
+      ["Too many subqueries (",integer_to_list(N),")"])
+).
+
+-define(
+    E_AGGREGATE_IN_STREAM_QUERY,
+    <<"Aggregate functions are not allowed in streamed queries.">>
 ).

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -206,7 +206,7 @@ process_stream_query({rows, SubQueryId, {ColNames, ColTypes, Rows}}, State) ->
       {column_types, ColTypes},
       {done, false},
       {rows, [list_to_tuple(R) || R <- Rows]},
-      {sub_query_id, SubQueryId}
+      {continuation, <<SubQueryId:32>>}
     ]},
     {reply, Response, State};
 process_stream_query({error, Error}, _) ->

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -104,29 +104,8 @@ decode_query(#tsinterpolation{base = BaseQuery}, Cover, Stream) ->
         {QryType, SQL} ->
             {ok, SqlRecord} =
                 riak_kv_ts_util:build_sql_record(QryType, SQL, Cover, Stream),
-            case validate_streamable_query(Stream, SqlRecord) of
-                ok ->
-                    {QryType, SqlRecord};
-                {error, _} = Error ->
-                    Error
-            end
+            {QryType, SqlRecord}
     end.
-
-%% if steaming is requested then check that the query is not using features
-%% that prevent streaming.
-validate_streamable_query(false, _) ->
-    ok;
-validate_streamable_query(true, SqlRecord) ->
-    case sql_select_calc_type(SqlRecord) of
-        rows ->
-            ok;
-        aggregate ->
-            {error, {?E_QUERY_NOT_STREAMABLE, ""}} %% FIXME error message
-    end.
-
-%% Return the `calc_type' from a query.
-sql_select_calc_type(?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{calc_type = Type}}) ->
-    Type.
 
 %%
 decode_query_permissions(QryType, {DDL = ?DDL{}, _WithProps}) ->

--- a/src/riak_kv_ttb_ts.erl
+++ b/src/riak_kv_ttb_ts.erl
@@ -66,5 +66,5 @@ process(Request, State) ->
     riak_kv_ts_svc:process(Request, State).
 
 %% TS TTB messages do not support streaming yet
-process_stream(_, _, _) ->
-    {error, "Not Supported", #state{}}.
+process_stream(Chunk, ReqId, State) ->
+    riak_kv_ts_svc:process_stream(Chunk, ReqId, State).

--- a/src/riak_kv_ttb_ts.erl
+++ b/src/riak_kv_ttb_ts.erl
@@ -48,8 +48,8 @@ init() ->
 decode(?TTB_MSG_CODE, Bin) ->
     Msg = riak_ttb_codec:decode(Bin),
     case Msg of
-        #tsqueryreq{query = Q, cover_context = Cover} ->
-            riak_kv_ts_svc:decode_query_common(Q, Cover);
+        #tsqueryreq{query = Q, cover_context = Cover, stream = Stream} ->
+            riak_kv_ts_svc:decode_query_common(Q, Cover, Stream);
         #tsgetreq{table = Table}->
             {ok, Msg, {riak_kv_ts_api:api_call_to_perm(get), Table}};
         #tsputreq{table = Table} ->

--- a/src/riak_kv_wm_timeseries_query.erl
+++ b/src/riak_kv_wm_timeseries_query.erl
@@ -244,8 +244,10 @@ compile_query(QueryStr) ->
         {ddl, _DDL, _Props} = Res ->
             Res;
         {Type, Compiled} ->
+            Cover = undefined,
+            Stream = false,
             {ok, SQL} = riak_kv_ts_util:build_sql_record(
-                          Type, Compiled, undefined),
+                          Type, Compiled, Cover, Stream),
             {Type, SQL, undefined}
     end.
 

--- a/src/riak_kv_wm_timeseries_query.erl
+++ b/src/riak_kv_wm_timeseries_query.erl
@@ -197,7 +197,7 @@ process_post(RD, #ctx{sql_type = QueryType,
                       mod = Mod} = Ctx) ->
     DDL = Mod:get_ddl(), %% might be faster to store this earlier on
     case riak_kv_ts_api:query(SQL, DDL) of
-        {ok, Data} ->
+        {result_set, Data} ->
             {ColumnNames, _ColumnTypes, Rows} = Data,
             Json = to_json({ColumnNames, Rows}),
             {true, wrq:append_to_response_body(Json, RD), Ctx};


### PR DESCRIPTION
**Ready for Review, please do NOT merge**

PRs for streaming queries.
- https://github.com/basho/riak_kv/pull/1415
- https://github.com/basho/riak-erlang-client/pull/281
- https://github.com/basho/riak_test/pull/1072
#### Usage

``` erlang
9> f(Pid), {ok, Pid} = riakc_pb_socket:start_link("localhost", 10017).                            
{ok,<0.282.0>}
10>  riakc_ts:stream_query(Pid,"SELECT * FROM streamtable1 WHERE a = 1 AND b = 1 AND c > 0 AND c < 11").
{ok,99152938}
11> flush().                                                                                       
Shell got {99152938,
           {rows,<<0,0,0,1>>,
                 [<<"a">>,<<"b">>,<<"c">>],
                 [{1,1,1},
                  {1,1,2},
                  {1,1,3},
                  {1,1,4},
                  {1,1,5},
                  {1,1,6},
                  {1,1,7},
                  {1,1,8},
                  {1,1,9},
                  {1,1,10}]}}
Shell got {99152938,done}
```

Reference doc https://docs.google.com/document/d/1T-J_qymDfY5VAfk9PgPU7fYuAod2UlkaaWunEqodSKk/edit# (restricted access, sorry).
#### `riak_kv_qry`

If the query is to be streamed then `riak_kv_qry:submit/2` returns a tuple tagged with `reqid` meaning this is the request ID that will be referenced in future messages back to the client. `riak_kv_qry` returns immediately in this case.

If the result set is returned in one message then `riak_kv_qry` will block until the result is returned from the coordinator.
#### `riak_kv_qry_compiler`

Validations on what can be streamed. At the moment queries that cannot be streamed because the query needs the full result set before anything can be returned to the client will return an error.
#### `riak_kv_pb_ts`, `riak_kv_ttb_ts`

Pass the `stream` field from the request  into the decode function.
#### `riak_kv_qry_queue`

Use a integer for the query ID instead of `{node(),ref()}` so the query ID is consistent from the client and all the way through the backend. The ID is generated in the same way as the stream list keys ID.
#### `riak_kv_qry_worker`

A new, separate code path streaming query chunks to the client. The old path for accumulating rows and then returning them all at once is not changed too much.
#### `riak_kv_ts_svc`

Handle callbacks for streamed responses from the coordinator and pass the `Stream` flag around.
#### `riak_kv_ts_util`

Whether results should be streamed or returned in one message depends on the client call and not the SQL but it is very convenient to pass the flag around in the sql select record, so it is added here.
#### `riak_kv_wm_timeseries_query`

The HTTP API doesn't do streaming, updated to pass `false` for the `Stream` flag.
