### PR TITLE
Fix security permissions for the Riak TS PB API

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -227,6 +227,10 @@ start(_Type, _StartArgs) ->
             ]
             ++ [{health_check, {?MODULE, check_kv_health, []}} || HealthCheckOn]),
 
+            riak_core:register(riak_ts, [
+                {permissions, riak_kv_ts_api:api_calls()}
+            ]),
+
             ok = riak_api_pb_service:register(?SERVICES),
 
             %% Add routes to webmachine

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -28,6 +28,7 @@
 -export([
          api_call_from_sql_type/1,
          api_call_to_perm/1,
+         api_calls/0,
          put_data/2, put_data/3,
          get_data/2, get_data/3, get_data/4,
          delete_data/2, delete_data/3, delete_data/4, delete_data/5,
@@ -72,6 +73,12 @@ api_call_to_perm(query_select) ->
     "riak_ts.query_select";
 api_call_to_perm(query_describe) ->
     "riak_ts.query_describe".
+
+%%
+-spec api_calls() -> [api_call()].
+api_calls() ->
+    [query_create_table, query_select, query_describe, query_insert,
+     get, put, delete, listkeys, coverage].
 
 
 -spec query(string() | riak_kv_qry:sql_query_type_record(), ?DDL{}) ->

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -105,11 +105,13 @@ decode_query(#tsinterpolation{base = BaseQuery}, Cover) ->
             {error, Other}
     end.
 
+
 decode_query_permissions(QryType, {DDL = ?DDL{}, _WithProps}) ->
     decode_query_permissions(QryType, DDL);
 decode_query_permissions(QryType, Qry) ->
-    {riak_kv_ts_api:api_call_from_sql_type(QryType),
-     riak_kv_ts_util:queried_table(Qry)}.
+    SqlType = riak_kv_ts_api:api_call_from_sql_type(QryType),
+    Perm = riak_kv_ts_api:api_call_to_perm(SqlType),
+    {Perm, riak_kv_ts_util:queried_table(Qry)}.
 
 
 -spec process(atom() | ts_requests() | ts_query_types(), #state{}) ->


### PR DESCRIPTION
Register permissions with riak_core.

Return permissions for the decoded messages in the correct format, a string not an atom.

Common tests https://github.com/basho/riak_test/pull/1083

@javajolt @macintux @gordonguthrie @hmmr could one of you please review?
