### PR TITLE
Recognize TS data arriving via handoff

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -2390,15 +2390,9 @@ encode_and_put_no_sib_check(Obj, Mod, Bucket, Key, IndexSpecs, ModState,
                     %% identify them and unencode the key.
                     %%
                     %% Not the ideal solution but sufficient.
-                    PutRet = case timeseries_data(Key, Obj) of
-                                 true ->
-                                     RawKey = sext:decode(Key),
-                                     Mod:put(Bucket, RawKey, IndexSpecs, EncodedVal,
-                                             ModState);
-                                 false ->
-                                     Mod:put(Bucket, Key, IndexSpecs, EncodedVal,
-                                             ModState)
-                             end,
+                    PutKey = maybe_timeseries_key(Key, Obj),
+                    PutRet = Mod:put(Bucket, PutKey, IndexSpecs, EncodedVal,
+                                     ModState),
                     {PutRet, EncodedVal}
             end
     end.
@@ -2409,12 +2403,17 @@ encode_and_put_no_sib_check(Obj, Mod, Bucket, Key, IndexSpecs, ModState,
 %% The binary pattern match is quick and easy: does this look like a
 %% sext-encoded tuple?
 %%
-%% Only if that is true do we examine the object for DDL metadata.
-timeseries_data(<<16,0,0,0, _Rest/binary>>, Object) ->
-    {IsTs, _Ver} = riak_object:is_ts(Object),
-    IsTs;
-timeseries_data(_, _) ->
-    false.
+%% Only if that is true do we examine the object for DDL metadata and
+%% decode the key if this is TS.
+maybe_timeseries_key(<<16,0,0,0, _Rest/binary>>=Key, Object) ->
+    case riak_object:is_ts(Object) of
+        {true, _Version} ->
+            sext:decode(Key);
+        false ->
+            Key
+    end;
+maybe_timeseries_key(Key, _Object) ->
+    Key.
 
 uses_r_object(Mod, ModState, Bucket) ->
     {ok, Capabilities} = Mod:capabilities(Bucket, ModState),


### PR DESCRIPTION
Currently, TS data that arrives via handoff is not stored under a recognizable key.

The key is sext-encoded twice: once as pulled from disk on the sending side, then again when sent to the backend on the receiving side.

This patch addresses that problem, although it deserves more thought for the next major release.
