### PR TITLE
new convenience fun riak_kv_ts_svc:lk_to_pk/3

### DIFF
--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -163,7 +163,7 @@ make_key_conversion_fun(Table) ->
     Mod = riak_ql_ddl:make_module_name(Table),
     DDL = Mod:get_ddl(),
     fun(Key) when is_binary(Key) ->
-            riak_kv_ts_util:row_to_key(sext:decode(Key), DDL, Mod);
+            riak_kv_ts_util:lk_to_pk(sext:decode(Key), DDL, Mod);
        (Key) ->
             lager:error("Key conversion function "
                         "encountered a non-binary object key: ~p", [Key]),

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -341,7 +341,7 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
 
     KeyConvFn =
         fun(Key) when is_binary(Key) ->
-                riak_kv_ts_util:row_to_key(sext:decode(Key), DDL, Mod);
+                riak_kv_ts_util:lk_to_pk(sext:decode(Key), DDL, Mod);
            (Key) ->
                 %% Key read from leveldb should always be binary.
                 %% This clause is just to keep dialyzer quiet


### PR DESCRIPTION
to use in key conversion function for proper coverage plan calculation
instead of ts_util:row_to_key, in list_keys code path. Specifically,
this is 01725aa15c done right.

As its argument, the old key conversion function (row_to_key) used to take
the LK values while it logically treated the argument as a list of _all_
values of a TS record. For the (common) case where key fields all appear
at the beginning of DDL, and they do so in the order they are defined,
row_to_key happens to work. It will break, however, when that condition
does not hold.

To fix this, we now use a newly written function lk_to_pk, which does
what its name suggests, and which is a pared down version of make_ts_keys.
