### PR TITLE
Dependency updates

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,9 +25,9 @@
                   ]}.
 
 {deps, [
-        {sidejob, ".*", {git, "git://github.com/basho/sidejob.git", {tag, "2.0.0"}}},
+        {sidejob, ".*", {git, "git://github.com/basho/sidejob.git", {tag, "2.0.1"}}},
         {erlang_js, ".*", {git, "git://github.com/basho/erlang_js.git", {tag, "1.3.0"}}},
-        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {tag, "1.7.4"}}},
+        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {tag, "2.0.3"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", {tag, "0.78"}}},
         {sext, ".*", {git, "git://github.com/basho/sext.git", {tag, "1.1p3"}}},
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {branch, "develop-2.2"}}},


### PR DESCRIPTION
Bumped bitcask dependency to 2.0.3.   Sidejob bump is needed for Yokozuna.
