### PR TITLE
converge permissions for INSERT query onto "riak_ts.put"

### DIFF
--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -64,7 +64,7 @@ api_call_to_perm(put) ->
 api_call_to_perm(delete) ->
     "riak_ts.delete";
 api_call_to_perm(listkeys) ->
-    "riak_ts.listkeys";
+    "riak_ts.list_keys";
 api_call_to_perm(coverage) ->
     "riak_ts.coverage";
 api_call_to_perm(query_create_table) ->

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -72,7 +72,10 @@ api_call_to_perm(query_create_table) ->
 api_call_to_perm(query_select) ->
     "riak_ts.query_select";
 api_call_to_perm(query_describe) ->
-    "riak_ts.query_describe".
+    "riak_ts.query_describe";
+%% INSERT query is a put, so let's cal it that
+api_call_to_perm(query_insert) ->
+    api_call_to_perm(put).
 
 %%
 -spec api_calls() -> [api_call()].


### PR DESCRIPTION
Because an INSERT query is essentially a batch put, the two API calls should be identified by a single permission atom (`"riak_ts.put"`).

@javajolt can deal with in a snap.
