### PR TITLE
Remove redudant ack_execute option.

### DIFF
--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -335,8 +335,7 @@ prepare(timeout, StateData0 = #state{from = From, robj = RObj,
                     ?DTRACE(Trace, ?C_PUT_FSM_PREPARE, [1],
                             ["prepare", atom2list(CoordNode)]),
                     try
-                        {UseAckP, Options2} = make_ack_options(
-                                               [{ack_execute, self()}|Options]),
+                        {UseAckP, Options2} = make_ack_options(Options),
                         MiddleMan = spawn_coordinator_proc(
                                       CoordNode, riak_kv_put_fsm, start_link,
                                       [From,RObj,Options2]),


### PR DESCRIPTION
The ack_execute option is already added by make_ack_options when the
corresponding capability exists. Adding the option here is redundant and
causes unnecessary acks to be sent.
