### PR TITLE
consistently spell 'list_keys' atom

### DIFF
--- a/src/riak_kv_pb_ts.erl
+++ b/src/riak_kv_pb_ts.erl
@@ -56,7 +56,7 @@ decode(Code, Bin) when Code >= 90, Code =< 103 ->
         #tsdelreq{table = Table} ->
             {ok, Msg, {riak_kv_ts_api:api_call_to_perm(delete), Table}};
         #tslistkeysreq{table = Table} ->
-            {ok, Msg, {riak_kv_ts_api:api_call_to_perm(listkeys), Table}};
+            {ok, Msg, {riak_kv_ts_api:api_call_to_perm(list_keys), Table}};
         #tscoveragereq{table = Table} ->
             {ok, Msg, {riak_kv_ts_api:api_call_to_perm(coverage), Table}}
     end.

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -64,7 +64,7 @@ api_call_to_perm(put) ->
 api_call_to_perm(delete) ->
     "riak_ts.delete";
 api_call_to_perm(listkeys) ->
-    "riak_ts.listkeys";
+    "riak_ts.list_keys";
 api_call_to_perm(coverage) ->
     "riak_ts.coverage";
 api_call_to_perm(query_create_table) ->

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -72,7 +72,10 @@ api_call_to_perm(query_create_table) ->
 api_call_to_perm(query_select) ->
     "riak_ts.query_select";
 api_call_to_perm(query_describe) ->
-    "riak_ts.query_describe".
+    "riak_ts.query_describe";
+%% INSERT query is a put, so let's cal it that
+api_call_to_perm(query_insert) ->
+    api_call_to_perm(put).
 
 %%
 -spec api_calls() -> [api_call()].

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -47,7 +47,7 @@
 
 %% external API calls enumerated
 -type query_api_call() :: query_create_table | query_select | query_describe | query_insert.
--type api_call() :: get | put | delete | listkeys | coverage | query_api_call().
+-type api_call() :: get | put | delete | list_keys | coverage | query_api_call().
 -export_type([query_api_call/0, api_call/0]).
 
 -spec api_call_from_sql_type(riak_kv_qry:query_type()) -> query_api_call().
@@ -63,7 +63,7 @@ api_call_to_perm(put) ->
     "riak_ts.put";
 api_call_to_perm(delete) ->
     "riak_ts.delete";
-api_call_to_perm(listkeys) ->
+api_call_to_perm(list_keys) ->
     "riak_ts.list_keys";
 api_call_to_perm(coverage) ->
     "riak_ts.coverage";
@@ -81,7 +81,7 @@ api_call_to_perm(query_insert) ->
 -spec api_calls() -> [api_call()].
 api_calls() ->
     [query_create_table, query_select, query_describe, query_insert,
-     get, put, delete, listkeys, coverage].
+     get, put, delete, list_keys, coverage].
 
 
 -spec query(string() | riak_kv_qry:sql_query_type_record(), ?DDL{}) ->

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -332,7 +332,7 @@ sub_tsdelreq(Mod, _DDL, #tsdelreq{table = Table,
 
 
 %% -----------
-%% listkeys
+%% list_keys
 %% -----------
 
 sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,

--- a/src/riak_kv_wm_timeseries_listkeys.erl
+++ b/src/riak_kv_wm_timeseries_listkeys.erl
@@ -88,7 +88,7 @@ service_available(RD, Ctx) ->
     end.
 
 is_authorized(RD, #ctx{table = Table} = Ctx) ->
-    case riak_kv_wm_ts_util:authorize(listkeys, Table, RD) of
+    case riak_kv_wm_ts_util:authorize(list_keys, Table, RD) of
         ok ->
             {true, RD, Ctx};
         {error, ErrorMsg} ->


### PR DESCRIPTION
This PR only concerns with the spelling of this atom as an argument to `riak_kv_ts_api:api_call_to_perm/1`.
