### PR TITLE
Allow ISO 8601 strings as timestamps for select and insert

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,6 +36,6 @@
         {riak_dt,          ".*", {git, "git://github.com/basho/riak_dt.git",           {tag,    "2.1.2"}}},
         {msgpack,          ".*", {git, "git://github.com/msgpack/msgpack-erlang.git",  {tag,    "0.3.5"}}},
         {riak_ql,          ".*", {git, "git://github.com/basho/riak_ql.git",           {branch, "develop"}}},
-        {jam,          ".*", {git, "git://github.com/basho/jam.git",           {branch, "master"}}},
+        {jam,          ".*", {git, "git://github.com/basho/jam.git",           {branch, "develop"}}},
         {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag,    "0.1.2"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -36,5 +36,6 @@
         {riak_dt,          ".*", {git, "git://github.com/basho/riak_dt.git",           {tag,    "2.1.2"}}},
         {msgpack,          ".*", {git, "git://github.com/msgpack/msgpack-erlang.git",  {tag,    "0.3.5"}}},
         {riak_ql,          ".*", {git, "git://github.com/basho/riak_ql.git",           {branch, "develop"}}},
+        {jam,          ".*", {git, "git://github.com/basho/jam.git",           {branch, "master"}}},
         {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag,    "0.1.2"}}}
        ]}.

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -86,7 +86,8 @@ decode_query_common(Q, Cover) ->
     end.
 
 -spec decode_query(Query::#tsinterpolation{}, Cover::term()) ->
-    {error, _} | {ok, ts_query_types()}.
+    {error, _} | {ddl, {ok, {?DDL{}, proplists:proplist()}}}
+               | {ts_query_types(), riak_kv_qry:sql_query_type_record()}.
 decode_query(#tsinterpolation{}, Cover)
   when not (Cover == undefined orelse is_binary(Cover)) ->
     {error, bad_coverage_context};

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -86,7 +86,7 @@ decode_query_common(Q, Cover) ->
     end.
 
 -spec decode_query(Query::#tsinterpolation{}, Cover::term()) ->
-    {error, _} | {ok, ts_query_types()}.
+    {error, _} | {atom(), {ok, ts_query_types()}}.
 decode_query(#tsinterpolation{}, Cover)
   when not (Cover == undefined orelse is_binary(Cover)) ->
     {error, bad_coverage_context};

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -153,7 +153,7 @@ timestamp_to_epoch(Str) ->
                    jam:compile(
                      jam_iso8601:parse(Str), ProcessOptions)
                   ), second),
-    jam:to_epoch(Datetime, 1000).
+    jam:to_epoch(Datetime, 3).
 
 %% Useful key extractors for functions (e.g., in get or delete code
 %% paths) which are agnostic to whether they are dealing with TS or

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -146,11 +146,14 @@ timestamp_to_epoch(Str) ->
         [
          {default_timezone,
           riak_core_metadata:get({riak_core, timezone},
-                                 string, [{default, "+00"}])},
-         {target_accuracy, second}
+                                 string, [{default, "+00"}])}
         ],
-    {_, DT} = jam:normalize(jam:process(jam_iso8601:parse(Str), ProcessOptions)),
-    jam:to_epoch(DT, 1000).
+    Datetime = jam:expand(
+                 jam:normalize(
+                   jam:compile(
+                     jam_iso8601:parse(Str), ProcessOptions)
+                  ), second),
+    jam:to_epoch(Datetime, 1000).
 
 %% Useful key extractors for functions (e.g., in get or delete code
 %% paths) which are agnostic to whether they are dealing with TS or

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -116,7 +116,7 @@ build_sql_record_int(insert, SQL, _Cover) ->
         false ->
             {error, <<"Must provide exactly one table name">>}
     end;
-build_sql_record(show_tables, _SQL, _Cover) ->
+build_sql_record_int(show_tables, _SQL, _Cover) ->
     {ok, #riak_sql_show_tables_v1{}}.
 
 convert_where_timestamps(_Mod, []) ->

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -45,6 +45,10 @@
 -export([explain_query/1, explain_query/2]).
 -export([explain_query_print/1]).
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+-endif.
 
 %% NOTE on table_to_bucket/1: Clients will work with table
 %% names. Those names map to a bucket type/bucket name tuple in Riak,
@@ -65,8 +69,16 @@ sql_record_to_tuple(?SQL_SELECT{'FROM'   = From,
                                 'WHERE'  = Where}) ->
     {From, Select, Where}.
 
+build_sql_record(Command, SQL, Cover) ->
+    try build_sql_record_int(Command, SQL, Cover) of
+        Return -> Return
+    catch
+        throw:Atom ->
+            {error, Atom}
+    end.
+
 %% Convert the proplist obtained from the QL parser
-build_sql_record(select, SQL, Cover) ->
+build_sql_record_int(select, SQL, Cover) ->
     T = proplists:get_value(tables, SQL),
     F = proplists:get_value(fields, SQL),
     L = proplists:get_value(limit, SQL),
@@ -85,10 +97,10 @@ build_sql_record(select, SQL, Cover) ->
         false ->
             {error, <<"Must provide exactly one table name">>}
     end;
-build_sql_record(describe, SQL, _Cover) ->
+build_sql_record_int(describe, SQL, _Cover) ->
     D = proplists:get_value(identifier, SQL),
     {ok, #riak_sql_describe_v1{'DESCRIBE' = D}};
-build_sql_record(insert, SQL, _Cover) ->
+build_sql_record_int(insert, SQL, _Cover) ->
     T = proplists:get_value(table, SQL),
     case is_binary(T) of
         true ->
@@ -113,15 +125,45 @@ convert_where_timestamps(Mod, Where) ->
 replace_ast_timestamps(Mod, {Op, Item1, Item2}) when is_tuple(Item1) andalso is_tuple(Item2) ->
     {Op, replace_ast_timestamps(Mod, Item1), replace_ast_timestamps(Mod, Item2)};
 replace_ast_timestamps(Mod, {Op, FieldName, {binary, Value}}) ->
-    {Op, FieldName, maybe_convert_to_epoch(catch Mod:get_field_type([FieldName]), Value)};
+    {Op, FieldName, maybe_convert_to_epoch(catch Mod:get_field_type([FieldName]), Value, Op)};
 replace_ast_timestamps(_Mod, {Op, Item1, Item2}) ->
     {Op, Item1, Item2}.
 
-maybe_convert_to_epoch({'EXIT', _}, Value) ->
+maybe_convert_to_epoch({'EXIT', _}, Value, _Op) ->
     {binary, Value};
-maybe_convert_to_epoch(timestamp, Value) ->
-    {integer, timestamp_to_epoch(Value)};
-maybe_convert_to_epoch(_Type, Value) ->
+maybe_convert_to_epoch(timestamp, Value, '>') ->
+    %% For strictly greater than, we increment any incomplete
+    %% date/time strings by one "unit", where the unit is the least
+    %% significant value provided by the user. "2016" becomes
+    %% "2017". "2016-07-05T11" becomes "2016-07-05T12".
+    Normal = timestamp_to_normalized(Value),
+    Epoch = case jam:is_complete(Normal) of
+                true ->
+                    to_epoch(Normal, 3);
+                false ->
+                    to_epoch(jam:expand(jam:increment(Normal, 1), second), 3)
+            end,
+    case is_atom(Epoch) of
+        true ->
+            throw(Epoch);
+        false ->
+            {integer, Epoch}
+    end;
+maybe_convert_to_epoch(timestamp, Value, _Op) ->
+    Normal = timestamp_to_normalized(Value),
+    Epoch = case jam:is_complete(Normal) of
+                true ->
+                    to_epoch(Normal, 3);
+                false ->
+                    to_epoch(jam:expand(Normal, second), 3)
+            end,
+    case is_atom(Epoch) of
+        true ->
+            throw(Epoch);
+        false ->
+            {integer, Epoch}
+    end;
+maybe_convert_to_epoch(_Type, Value, _Op) ->
     {binary, Value}.
 
 %% I haven't investigated why the values are a nested list
@@ -141,12 +183,40 @@ convert_insert_timestamps(Mod, Fields, [Values]) ->
                        Value
                end, Values)].
 
+get_default_timezone(Default) ->
+    try
+        riak_core_metadata:get({riak_core, timezone},
+                               string, [{default, Default}])
+            of
+        Value ->
+            Value
+    catch
+        _:_ -> Default
+    end.
+
+timestamp_to_normalized(Str) ->
+    ProcessOptions =
+        [
+         {default_timezone, get_default_timezone("+00")}
+        ],
+    Normal = jam:normalize(
+               jam:compile(
+                 jam_iso8601:parse(Str), ProcessOptions)
+              ),
+    case Normal of
+        undefined ->
+            throw(<<"Invalid date/time string">>);
+        _ ->
+            Normal
+    end.
+
+to_epoch(Normalized, Exponent) ->
+    jam:to_epoch(Normalized, Exponent).
+
 timestamp_to_epoch(Str) ->
     ProcessOptions =
         [
-         {default_timezone,
-          riak_core_metadata:get({riak_core, timezone},
-                                 string, [{default, "+00"}])}
+         {default_timezone, get_default_timezone("+00")}
         ],
     Datetime = jam:expand(
                  jam:normalize(
@@ -593,7 +663,6 @@ flat_format(Format, Args) ->
 %%%
 
 -ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
 
 helper_compile_def_to_module(SQL) ->
     Lexed = riak_ql_lexer:get_tokens(SQL),
@@ -694,5 +763,78 @@ validate_rows_bad_2_test() ->
         [1, 3, 4],
         validate_rows(Mod, [{}, {<<"f">>, <<"s">>, 11}, {a, <<"s">>, 12}, {"hithere"}])
     ).
+
+bad_timestamp_test() ->
+    BadFormat = "20151T10",
+    BadQuery = lists:flatten(
+                 io_lib:format("select * from table1 "
+                               "where b > '~s' and "
+                               " b < '20151013T20:00:00'", [BadFormat])),
+    {_DDL, _Mod} = helper_compile_def_to_module(
+        "CREATE TABLE table1 ("
+        "a SINT64 NOT NULL, "
+        "b TIMESTAMP NOT NULL, "
+        "c SINT64 NOT NULL, "
+        "PRIMARY KEY((a, quantum(b, 15, 's')), a, b))"),
+    Lexed = riak_ql_lexer:get_tokens(BadQuery),
+    {ok, Q} = riak_ql_parser:parse(Lexed),
+    ?assertMatch({error, <<"Invalid date/time string">>},
+                 build_sql_record(select, Q, undefined)).
+
+good_timestamp_test() ->
+    GoodQuery = "select * from table1 "
+        " where b > '20151013T18:30' and "
+        " b < '20151013T20:00:00' ",
+    {_DDL, _Mod} = helper_compile_def_to_module(
+        "CREATE TABLE table1 ("
+        "a SINT64 NOT NULL, "
+        "b TIMESTAMP NOT NULL, "
+        "c SINT64 NOT NULL, "
+        "PRIMARY KEY((a, quantum(b, 15, 's')), a, b))"),
+    Lexed = riak_ql_lexer:get_tokens(GoodQuery),
+    {ok, Q} = riak_ql_parser:parse(Lexed),
+    {ok, Select} = build_sql_record(select, Q, undefined),
+    Where = Select?SQL_SELECT.'WHERE',
+    %% Navigate the tree looking for integer values for b
+    %% comparisons. Verify that we find both (hence `2' as our
+    %% equality)
+    ?assertEqual(2,
+                 check_integer_timestamps(
+                   hd(Where),
+                   %% The first value, the lower bound, is
+                   %% 20151013T18:31:00 because of the
+                   %% incomplete datetime string
+                   1444761060000,
+                   1444766400000)).
+
+check_integer_timestamps({_Op, A, B}, Lower, Upper) when is_tuple(A), is_tuple(B) ->
+    check_integer_timestamps(A, Lower, Upper) +
+        check_integer_timestamps(B, Lower, Upper);
+check_integer_timestamps({'<', <<"b">>, Compare}, _Lower, Upper) ->
+    ?assertEqual({integer, Upper}, Compare),
+    1;
+check_integer_timestamps({'>', <<"b">>, Compare}, Lower, _Upper) ->
+    ?assertEqual({integer, Lower}, Compare),
+    1;
+check_integer_timestamps(_, _, _) ->
+    0.
+
+timestamp_parsing_test() ->
+    BadFormat = "20151T10",
+    BadQuery = lists:flatten(
+                 io_lib:format("select * from table1 "
+                               "where b > '~s' and "
+                               " b < '201510T20:00:00'", [BadFormat])),
+    {_DDL, Mod} = helper_compile_def_to_module(
+        "CREATE TABLE table1 ("
+        "a SINT64 NOT NULL, "
+        "b TIMESTAMP NOT NULL, "
+        "c SINT64 NOT NULL, "
+        "PRIMARY KEY((a, quantum(b, 15, 's')), a, b))"),
+    ?assertEqual(timestamp, Mod:get_field_type([<<"b">>])),
+    Lexed = riak_ql_lexer:get_tokens(BadQuery),
+    {ok, Q} = riak_ql_parser:parse(Lexed),
+    ?assertMatch({error, <<"Invalid date/time string">>},
+                 build_sql_record(select, Q, undefined)).
 
 -endif.

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -71,9 +71,9 @@ build_sql_record(select, SQL, Cover) ->
     F = proplists:get_value(fields, SQL),
     L = proplists:get_value(limit, SQL),
     W = proplists:get_value(where, SQL),
-    Mod = riak_ql_ddl:make_module_name(T),
     case is_binary(T) of
         true ->
+            Mod = riak_ql_ddl:make_module_name(T),
             {ok,
              ?SQL_SELECT{'SELECT'   = #riak_sel_clause_v1{clause = F},
                          'FROM'     = T,


### PR DESCRIPTION
Ready for review. Requires https://github.com/basho/riak-erlang-client/pull/303 and https://github.com/basho/riak_shell/pull/43 for testing
