### PR TITLE
RTS-1262: Rename the TS permissions

### DIFF
--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -46,15 +46,15 @@
 -include("riak_kv_ts.hrl").
 
 %% external API calls enumerated
--type query_api_call() :: query_create_table | query_select | query_describe | query_insert | query_show_tables.
+-type query_api_call() :: create_table | query_select | describe_table | query_insert | show_tables.
 -type api_call() :: get | put | delete | list_keys | coverage | query_api_call().
 -export_type([query_api_call/0, api_call/0]).
 
 -spec api_call_from_sql_type(riak_kv_qry:query_type()) -> query_api_call().
-api_call_from_sql_type(ddl)         -> query_create_table;
+api_call_from_sql_type(ddl)         -> create_table;
 api_call_from_sql_type(select)      -> query_select;
-api_call_from_sql_type(describe)    -> query_describe;
-api_call_from_sql_type(show_tables) -> query_show_tables;
+api_call_from_sql_type(describe)    -> describe_table;
+api_call_from_sql_type(show_tables) -> show_tables;
 api_call_from_sql_type(insert)      -> query_insert.
 
 -spec api_call_to_perm(api_call()) -> string().
@@ -68,23 +68,23 @@ api_call_to_perm(list_keys) ->
     "riak_ts.list_keys";
 api_call_to_perm(coverage) ->
     "riak_ts.coverage";
-api_call_to_perm(query_create_table) ->
-    "riak_ts.query_create_table";
+api_call_to_perm(create_table) ->
+    "riak_ts.create_table";
 api_call_to_perm(query_select) ->
     "riak_ts.query_select";
-api_call_to_perm(query_describe) ->
-    "riak_ts.query_describe";
+api_call_to_perm(describe_table) ->
+    "riak_ts.describe_table";
 %% INSERT query is a put, so let's call it that
 api_call_to_perm(query_insert) ->
     api_call_to_perm(put);
-api_call_to_perm(query_show_tables) ->
-    "riak_ts.query_show_tables".
+api_call_to_perm(show_tables) ->
+    "riak_ts.show_tables".
 
 %%
 -spec api_calls() -> [api_call()].
 api_calls() ->
-    [query_create_table, query_select, query_describe, query_insert,
-     query_show_tables, get, put, delete, list_keys, coverage].
+    [create_table, query_select, describe_table, query_insert,
+     show_tables, get, put, delete, list_keys, coverage].
 
 
 -spec query(string() | riak_kv_qry:sql_query_type_record(), ?DDL{}) ->


### PR DESCRIPTION
@ph07 would like the permission names for TS to be a bit more human-readable.  Therefore he's proposed these changes:
- `riak_ts.query_create_table` -> `riak_ts.create_table`
  -`riak_ts.query_describe` -> `riak_ts.describe_table`
- `riak_ts.query_show_tables` -> `riak_ts.show_tables`

Jira: https://bashoeng.atlassian.net/browse/RTS-1262
