### PR TITLE
Use a macro for the param record name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tags
 erln8.config
 .idea
 riak_kv.iml
+deps

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -217,25 +217,25 @@ do_describe(?DDL{fields = FieldSpecs,
 %% the following two functions are identical, for the way fields and
 %% keys are represented as of 2015-12-18; duplication here is a hint
 %% of things to come.
--spec column_pk_position_or_blank(binary(), [#param_v1{}]) -> integer() | [].
+-spec column_pk_position_or_blank(binary(), [?PARAM{}]) -> integer() | [].
 column_pk_position_or_blank(Col, KSpec) ->
     count_to_position(Col, KSpec, 1).
 
--spec column_lk_position_or_blank(binary(), [#param_v1{}]) -> integer() | [].
+-spec column_lk_position_or_blank(binary(), [?PARAM{}]) -> integer() | [].
 column_lk_position_or_blank(Col, KSpec) ->
     count_to_position(Col, KSpec, 1).
 
 %% Extract the quantum column information, if it exists in the table definition
 %% and put in two additional columns
--spec columns_quantum_or_blank(Col :: binary(), PKSpec :: [#param_v1{}|#hash_fn_v1{}]) ->
+-spec columns_quantum_or_blank(Col :: binary(), PKSpec :: [?PARAM{}|#hash_fn_v1{}]) ->
       [binary() | []].
-columns_quantum_or_blank(Col, #hash_fn_v1{args = [#param_v1{name = [Col]}, Interval, Unit]}) ->
+columns_quantum_or_blank(Col, #hash_fn_v1{args = [?PARAM{name = [Col]}, Interval, Unit]}) ->
     [Interval, list_to_binary(io_lib:format("~p", [Unit]))];
 columns_quantum_or_blank(_Col, _PKSpec) ->
     [[], []].
 
 %% Find the field associated with the quantum, if there is one
--spec find_quantum_field([#param_v1{}|#hash_fn_v1{}]) -> [] | #hash_fn_v1{}.
+-spec find_quantum_field([?PARAM{}|#hash_fn_v1{}]) -> [] | #hash_fn_v1{}.
 find_quantum_field([]) ->
     [];
 find_quantum_field([Q = #hash_fn_v1{}|_]) ->
@@ -245,9 +245,9 @@ find_quantum_field([_|T]) ->
 
 count_to_position(_, [], _) ->
     [];
-count_to_position(Col, [#param_v1{name = [Col]} | _], Pos) ->
+count_to_position(Col, [?PARAM{name = [Col]} | _], Pos) ->
     Pos;
-count_to_position(Col, [#hash_fn_v1{args = [#param_v1{name = [Col]} | _]} | _], Pos) ->
+count_to_position(Col, [#hash_fn_v1{args = [?PARAM{name = [Col]} | _]} | _], Pos) ->
     Pos;
 count_to_position(Col, [_ | Rest], Pos) ->
     count_to_position(Col, Rest, Pos + 1).

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -217,25 +217,25 @@ do_describe(?DDL{fields = FieldSpecs,
 %% the following two functions are identical, for the way fields and
 %% keys are represented as of 2015-12-18; duplication here is a hint
 %% of things to come.
--spec column_pk_position_or_blank(binary(), [?PARAM{}]) -> integer() | [].
+-spec column_pk_position_or_blank(binary(), [?SQL_PARAM{}]) -> integer() | [].
 column_pk_position_or_blank(Col, KSpec) ->
     count_to_position(Col, KSpec, 1).
 
--spec column_lk_position_or_blank(binary(), [?PARAM{}]) -> integer() | [].
+-spec column_lk_position_or_blank(binary(), [?SQL_PARAM{}]) -> integer() | [].
 column_lk_position_or_blank(Col, KSpec) ->
     count_to_position(Col, KSpec, 1).
 
 %% Extract the quantum column information, if it exists in the table definition
 %% and put in two additional columns
--spec columns_quantum_or_blank(Col :: binary(), PKSpec :: [?PARAM{}|#hash_fn_v1{}]) ->
+-spec columns_quantum_or_blank(Col :: binary(), PKSpec :: [?SQL_PARAM{}|#hash_fn_v1{}]) ->
       [binary() | []].
-columns_quantum_or_blank(Col, #hash_fn_v1{args = [?PARAM{name = [Col]}, Interval, Unit]}) ->
+columns_quantum_or_blank(Col, #hash_fn_v1{args = [?SQL_PARAM{name = [Col]}, Interval, Unit]}) ->
     [Interval, list_to_binary(io_lib:format("~p", [Unit]))];
 columns_quantum_or_blank(_Col, _PKSpec) ->
     [[], []].
 
 %% Find the field associated with the quantum, if there is one
--spec find_quantum_field([?PARAM{}|#hash_fn_v1{}]) -> [] | #hash_fn_v1{}.
+-spec find_quantum_field([?SQL_PARAM{}|#hash_fn_v1{}]) -> [] | #hash_fn_v1{}.
 find_quantum_field([]) ->
     [];
 find_quantum_field([Q = #hash_fn_v1{}|_]) ->
@@ -245,9 +245,9 @@ find_quantum_field([_|T]) ->
 
 count_to_position(_, [], _) ->
     [];
-count_to_position(Col, [?PARAM{name = [Col]} | _], Pos) ->
+count_to_position(Col, [?SQL_PARAM{name = [Col]} | _], Pos) ->
     Pos;
-count_to_position(Col, [#hash_fn_v1{args = [?PARAM{name = [Col]} | _]} | _], Pos) ->
+count_to_position(Col, [#hash_fn_v1{args = [?SQL_PARAM{name = [Col]} | _]} | _], Pos) ->
     Pos;
 count_to_position(Col, [_ | Rest], Pos) ->
     count_to_position(Col, Rest, Pos + 1).

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -490,7 +490,7 @@ find_quantum_field_index_in_key2([], _) ->
     notfound;
 find_quantum_field_index_in_key2([#hash_fn_v1{ mod = riak_ql_quanta,
                                                fn = quantum,
-                                               args = [#param_v1{name = [X]}, Y, Z] }|_], Index) ->
+                                               args = [?PARAM{name = [X]}, Y, Z] }|_], Index) ->
     {X,Y,Z,Index};
 find_quantum_field_index_in_key2([_|Tail], Index) ->
     find_quantum_field_index_in_key2(Tail, Index+1).
@@ -596,14 +596,14 @@ find_quantum_fields(?DDL{ partition_key = #key_v1{ ast = PKAST } }) ->
 %%
 quantum_fn_to_field_name(#hash_fn_v1{ mod = riak_ql_quanta,
                                       fn = quantum,
-                                      args = [#param_v1{name = [Name]}|_ ] }) ->
+                                      args = [?PARAM{name = [Name]}|_ ] }) ->
     Name.
 
 check_if_timeseries(?DDL{table = T, partition_key = PK, local_key = LK0} = DDL,
                     [W]) ->
     try
         #key_v1{ast = PartitionKeyAST} = PK,
-        PartitionFields = [X || #param_v1{name = X} <- PartitionKeyAST],
+        PartitionFields = [X || ?PARAM{name = X} <- PartitionKeyAST],
         LK = LK0#key_v1{ast = lists:sublist(LK0#key_v1.ast, length(PartitionKeyAST))},
         QuantumFieldName = quantum_field_name(DDL),
         StrippedW = strip(W, []),
@@ -818,7 +818,7 @@ rewrite2([], [], _Mod, Acc) ->
 rewrite2([], _W, _Mod, _Acc) ->
     %% the rewrite should have consumed all the passed in values
     {error, {invalid_rewrite, _W}};
-rewrite2([#param_v1{name = [FieldName]} | T], Where1, Mod, Acc) ->
+rewrite2([?PARAM{name = [FieldName]} | T], Where1, Mod, Acc) ->
     Type = Mod:get_field_type([FieldName]),
     case lists:keytake(FieldName, 2, Where1) of
         false                           ->
@@ -952,12 +952,12 @@ get_ddl(SQL) ->
 
 get_standard_pk() ->
     #key_v1{ast = [
-                   #param_v1{name = [<<"location">>]},
-                   #param_v1{name = [<<"user">>]},
+                   ?PARAM{name = [<<"location">>]},
+                   ?PARAM{name = [<<"user">>]},
                    #hash_fn_v1{mod = riak_ql_quanta,
                                fn = quantum,
                                args = [
-                                       #param_v1{name = [<<"time">>]},
+                                       ?PARAM{name = [<<"time">>]},
                                        15,
                                        s
                                       ],
@@ -967,9 +967,9 @@ get_standard_pk() ->
 
 get_standard_lk() ->
     #key_v1{ast = [
-                   #param_v1{name = [<<"location">>]},
-                   #param_v1{name = [<<"user">>]},
-                   #param_v1{name = [<<"time">>]}
+                   ?PARAM{name = [<<"location">>]},
+                   ?PARAM{name = [<<"user">>]},
+                   ?PARAM{name = [<<"time">>]}
                   ]}.
 
 %%
@@ -1016,8 +1016,8 @@ simple_rewrite_test() ->
     ?DDL{table = T} = get_standard_ddl(),
     Mod = riak_ql_ddl:make_module_name(T),
     LK  = #key_v1{ast = [
-                         #param_v1{name = [<<"geohash">>]},
-                         #param_v1{name = [<<"time">>]}
+                         ?PARAM{name = [<<"geohash">>]},
+                         ?PARAM{name = [<<"time">>]}
                         ]},
     W   = [
            {'=', <<"geohash">>, {word, "yardle"}},
@@ -1040,8 +1040,8 @@ simple_rewrite_fail_1_test() ->
     ?DDL{table = T} = get_standard_ddl(),
     Mod = riak_ql_ddl:make_module_name(T),
     LK  = #key_v1{ast = [
-                         #param_v1{name = [<<"geohash">>]},
-                         #param_v1{name = [<<"user">>]}
+                         ?PARAM{name = [<<"geohash">>]},
+                         ?PARAM{name = [<<"user">>]}
                         ]},
     W   = [
            {'=', <<"geohash">>, {"word", "yardle"}}
@@ -1055,8 +1055,8 @@ simple_rewrite_fail_2_test() ->
     ?DDL{table = T} = get_standard_ddl(),
     Mod = riak_ql_ddl:make_module_name(T),
     LK  = #key_v1{ast = [
-                         #param_v1{name = [<<"geohash">>]},
-                         #param_v1{name = [<<"user">>]}
+                         ?PARAM{name = [<<"geohash">>]},
+                         ?PARAM{name = [<<"user">>]}
                         ]},
     W   = [
            {'=', <<"user">>, {"word", "yardle"}}
@@ -1070,9 +1070,9 @@ simple_rewrite_fail_3_test() ->
     ?DDL{table = T} = get_standard_ddl(),
     Mod = riak_ql_ddl:make_module_name(T),
     LK  = #key_v1{ast = [
-                         #param_v1{name = [<<"geohash">>]},
-                         #param_v1{name = [<<"user">>]},
-                         #param_v1{name = [<<"temperature">>]}
+                         ?PARAM{name = [<<"geohash">>]},
+                         ?PARAM{name = [<<"user">>]},
+                         ?PARAM{name = [<<"temperature">>]}
                         ]},
     W   = [
            {'=', <<"geohash">>, {"word", "yardle"}}

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -490,7 +490,7 @@ find_quantum_field_index_in_key2([], _) ->
     notfound;
 find_quantum_field_index_in_key2([#hash_fn_v1{ mod = riak_ql_quanta,
                                                fn = quantum,
-                                               args = [?PARAM{name = [X]}, Y, Z] }|_], Index) ->
+                                               args = [?SQL_PARAM{name = [X]}, Y, Z] }|_], Index) ->
     {X,Y,Z,Index};
 find_quantum_field_index_in_key2([_|Tail], Index) ->
     find_quantum_field_index_in_key2(Tail, Index+1).
@@ -596,14 +596,14 @@ find_quantum_fields(?DDL{ partition_key = #key_v1{ ast = PKAST } }) ->
 %%
 quantum_fn_to_field_name(#hash_fn_v1{ mod = riak_ql_quanta,
                                       fn = quantum,
-                                      args = [?PARAM{name = [Name]}|_ ] }) ->
+                                      args = [?SQL_PARAM{name = [Name]}|_ ] }) ->
     Name.
 
 check_if_timeseries(?DDL{table = T, partition_key = PK, local_key = LK0} = DDL,
                     [W]) ->
     try
         #key_v1{ast = PartitionKeyAST} = PK,
-        PartitionFields = [X || ?PARAM{name = X} <- PartitionKeyAST],
+        PartitionFields = [X || ?SQL_PARAM{name = X} <- PartitionKeyAST],
         LK = LK0#key_v1{ast = lists:sublist(LK0#key_v1.ast, length(PartitionKeyAST))},
         QuantumFieldName = quantum_field_name(DDL),
         StrippedW = strip(W, []),
@@ -818,7 +818,7 @@ rewrite2([], [], _Mod, Acc) ->
 rewrite2([], _W, _Mod, _Acc) ->
     %% the rewrite should have consumed all the passed in values
     {error, {invalid_rewrite, _W}};
-rewrite2([?PARAM{name = [FieldName]} | T], Where1, Mod, Acc) ->
+rewrite2([?SQL_PARAM{name = [FieldName]} | T], Where1, Mod, Acc) ->
     Type = Mod:get_field_type([FieldName]),
     case lists:keytake(FieldName, 2, Where1) of
         false                           ->
@@ -952,12 +952,12 @@ get_ddl(SQL) ->
 
 get_standard_pk() ->
     #key_v1{ast = [
-                   ?PARAM{name = [<<"location">>]},
-                   ?PARAM{name = [<<"user">>]},
+                   ?SQL_PARAM{name = [<<"location">>]},
+                   ?SQL_PARAM{name = [<<"user">>]},
                    #hash_fn_v1{mod = riak_ql_quanta,
                                fn = quantum,
                                args = [
-                                       ?PARAM{name = [<<"time">>]},
+                                       ?SQL_PARAM{name = [<<"time">>]},
                                        15,
                                        s
                                       ],
@@ -967,9 +967,9 @@ get_standard_pk() ->
 
 get_standard_lk() ->
     #key_v1{ast = [
-                   ?PARAM{name = [<<"location">>]},
-                   ?PARAM{name = [<<"user">>]},
-                   ?PARAM{name = [<<"time">>]}
+                   ?SQL_PARAM{name = [<<"location">>]},
+                   ?SQL_PARAM{name = [<<"user">>]},
+                   ?SQL_PARAM{name = [<<"time">>]}
                   ]}.
 
 %%
@@ -1016,8 +1016,8 @@ simple_rewrite_test() ->
     ?DDL{table = T} = get_standard_ddl(),
     Mod = riak_ql_ddl:make_module_name(T),
     LK  = #key_v1{ast = [
-                         ?PARAM{name = [<<"geohash">>]},
-                         ?PARAM{name = [<<"time">>]}
+                         ?SQL_PARAM{name = [<<"geohash">>]},
+                         ?SQL_PARAM{name = [<<"time">>]}
                         ]},
     W   = [
            {'=', <<"geohash">>, {word, "yardle"}},
@@ -1040,8 +1040,8 @@ simple_rewrite_fail_1_test() ->
     ?DDL{table = T} = get_standard_ddl(),
     Mod = riak_ql_ddl:make_module_name(T),
     LK  = #key_v1{ast = [
-                         ?PARAM{name = [<<"geohash">>]},
-                         ?PARAM{name = [<<"user">>]}
+                         ?SQL_PARAM{name = [<<"geohash">>]},
+                         ?SQL_PARAM{name = [<<"user">>]}
                         ]},
     W   = [
            {'=', <<"geohash">>, {"word", "yardle"}}
@@ -1055,8 +1055,8 @@ simple_rewrite_fail_2_test() ->
     ?DDL{table = T} = get_standard_ddl(),
     Mod = riak_ql_ddl:make_module_name(T),
     LK  = #key_v1{ast = [
-                         ?PARAM{name = [<<"geohash">>]},
-                         ?PARAM{name = [<<"user">>]}
+                         ?SQL_PARAM{name = [<<"geohash">>]},
+                         ?SQL_PARAM{name = [<<"user">>]}
                         ]},
     W   = [
            {'=', <<"user">>, {"word", "yardle"}}
@@ -1070,9 +1070,9 @@ simple_rewrite_fail_3_test() ->
     ?DDL{table = T} = get_standard_ddl(),
     Mod = riak_ql_ddl:make_module_name(T),
     LK  = #key_v1{ast = [
-                         ?PARAM{name = [<<"geohash">>]},
-                         ?PARAM{name = [<<"user">>]},
-                         ?PARAM{name = [<<"temperature">>]}
+                         ?SQL_PARAM{name = [<<"geohash">>]},
+                         ?SQL_PARAM{name = [<<"user">>]},
+                         ?SQL_PARAM{name = [<<"temperature">>]}
                         ]},
     W   = [
            {'=', <<"geohash">>, {"word", "yardle"}}

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -379,7 +379,7 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
         {ok, ReqId} ->
             ColumnInfo =
                 [Mod:get_field_type(N)
-                 || ?PARAM{name = N} <- DDL?DDL.local_key#key_v1.ast],
+                 || ?SQL_PARAM{name = N} <- DDL?DDL.local_key#key_v1.ast],
             {reply, {stream, ReqId}, State#state{req = Req, req_ctx = ReqId,
                                                  column_info = ColumnInfo}};
         {error, Reason} ->

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -379,7 +379,7 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
         {ok, ReqId} ->
             ColumnInfo =
                 [Mod:get_field_type(N)
-                 || #param_v1{name = N} <- DDL?DDL.local_key#key_v1.ast],
+                 || ?PARAM{name = N} <- DDL?DDL.local_key#key_v1.ast],
             {reply, {stream, ReqId}, State#state{req = Req, req_ctx = ReqId,
                                                  column_info = ColumnInfo}};
         {error, Reason} ->

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -366,7 +366,7 @@ try_compile_ddl(DDL) ->
 make_ts_keys(CompoundKey, DDL = ?DDL{local_key = #key_v1{ast = LKAst},
                                      fields = Fields}, Mod) ->
     %% 1. use elements in Key to form a complete data record:
-    KeyFields = [F || ?PARAM{name = [F]} <- LKAst],
+    KeyFields = [F || ?SQL_PARAM{name = [F]} <- LKAst],
     AllFields = [F || #riak_field_v1{name = F} <- Fields],
     Got = length(CompoundKey),
     Need = length(KeyFields),
@@ -405,7 +405,7 @@ encode_typeval_key(TypeVals) ->
 lk_to_pk(LKVals, DDL = ?DDL{local_key = #key_v1{ast = LKAst},
                         fields = Fields}, Mod)
   when is_tuple(LKVals) andalso size(LKVals) == length(LKAst) ->
-    KeyFields = [F || ?PARAM{name = [F]} <- LKAst],
+    KeyFields = [F || ?SQL_PARAM{name = [F]} <- LKAst],
     AllFields = [F || #riak_field_v1{name = F} <- Fields],
     DummyObject = build_dummy_object_from_keyed_values(
                     lists:zip(KeyFields, tuple_to_list(LKVals)), AllFields),
@@ -638,7 +638,7 @@ extract_time_boundaries(FieldName, WhereList) ->
 identify_quantum_field(#key_v1{ast = KeyList}) ->
     HashFn = find_hash_fn(KeyList),
     P_V1 = hd(HashFn#hash_fn_v1.args),
-    hd(P_V1?PARAM.name).
+    hd(P_V1?SQL_PARAM.name).
 
 find_hash_fn([]) ->
     throw(wtf);

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -366,7 +366,7 @@ try_compile_ddl(DDL) ->
 make_ts_keys(CompoundKey, DDL = ?DDL{local_key = #key_v1{ast = LKAst},
                                      fields = Fields}, Mod) ->
     %% 1. use elements in Key to form a complete data record:
-    KeyFields = [F || #param_v1{name = [F]} <- LKAst],
+    KeyFields = [F || ?PARAM{name = [F]} <- LKAst],
     AllFields = [F || #riak_field_v1{name = F} <- Fields],
     Got = length(CompoundKey),
     Need = length(KeyFields),
@@ -405,7 +405,7 @@ encode_typeval_key(TypeVals) ->
 lk_to_pk(LKVals, DDL = ?DDL{local_key = #key_v1{ast = LKAst},
                         fields = Fields}, Mod)
   when is_tuple(LKVals) andalso size(LKVals) == length(LKAst) ->
-    KeyFields = [F || #param_v1{name = [F]} <- LKAst],
+    KeyFields = [F || ?PARAM{name = [F]} <- LKAst],
     AllFields = [F || #riak_field_v1{name = F} <- Fields],
     DummyObject = build_dummy_object_from_keyed_values(
                     lists:zip(KeyFields, tuple_to_list(LKVals)), AllFields),
@@ -638,7 +638,7 @@ extract_time_boundaries(FieldName, WhereList) ->
 identify_quantum_field(#key_v1{ast = KeyList}) ->
     HashFn = find_hash_fn(KeyList),
     P_V1 = hd(HashFn#hash_fn_v1.args),
-    hd(P_V1#param_v1.name).
+    hd(P_V1?PARAM.name).
 
 find_hash_fn([]) ->
     throw(wtf);

--- a/src/riak_kv_wm_timeseries.erl
+++ b/src/riak_kv_wm_timeseries.erl
@@ -363,7 +363,7 @@ convert_field(T, F, timestamp, V) ->
 
 ensure_lk_order_and_strip(LK, FVList) ->
     %% exclude fields not in LK
-    [V || V <- [proplists:get_value(F, FVList) || ?PARAM{name = F} <- LK],
+    [V || V <- [proplists:get_value(F, FVList) || ?SQL_PARAM{name = F} <- LK],
           V /= undefined].
 
 

--- a/src/riak_kv_wm_timeseries.erl
+++ b/src/riak_kv_wm_timeseries.erl
@@ -363,7 +363,7 @@ convert_field(T, F, timestamp, V) ->
 
 ensure_lk_order_and_strip(LK, FVList) ->
     %% exclude fields not in LK
-    [V || V <- [proplists:get_value(F, FVList) || #param_v1{name = F} <- LK],
+    [V || V <- [proplists:get_value(F, FVList) || ?PARAM{name = F} <- LK],
           V /= undefined].
 
 

--- a/src/riak_kv_wm_ts_util.erl
+++ b/src/riak_kv_wm_ts_util.erl
@@ -123,7 +123,7 @@ local_key(Mod) ->
 ddl_local_key(?DDL{local_key = #key_v1{ast = Ast}}) ->
     [ param_name(P) || P <- Ast].
 
-param_name(?PARAM{name=[Name]}) ->
+param_name(?SQL_PARAM{name=[Name]}) ->
     Name.
 
 local_key_fields_and_types(Mod) ->

--- a/src/riak_kv_wm_ts_util.erl
+++ b/src/riak_kv_wm_ts_util.erl
@@ -123,7 +123,7 @@ local_key(Mod) ->
 ddl_local_key(?DDL{local_key = #key_v1{ast = Ast}}) ->
     [ param_name(P) || P <- Ast].
 
-param_name(#param_v1{name=[Name]}) ->
+param_name(?PARAM{name=[Name]}) ->
     Name.
 
 local_key_fields_and_types(Mod) ->


### PR DESCRIPTION
Like ?DDL, so that version changes in the record name do not affect the rest of the code.

This is in advance of the DDL upgrade and down work, to ease changes in so I don't have to merge whenever a function head is modified.
