### PR TITLE
RTS-1307: Add Coverage Plan column to EXPLAIN command

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -47,6 +47,7 @@
 -export([ensemble/1]).
 -export([get_cover/3, get_cover/4, get_cover/5, replace_cover/6, replace_cover/7]).
 -export([vnode_target/1]).
+-export([ring_size/0]).
 
 -include_lib("riak_core/include/riak_core_vnode.hrl").
 

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -467,10 +467,10 @@ explain_query_test() ->
     ?assert(meck:validate(riak_core_claimant)),
     Res = do_explain(DDL, Select),
     ExpectedRows =
-        [[1,"dev1@127.0.0.1:0, dev1@127.0.0.1:1, dev1@127.0.0.1:1",
+        [[1,"dev1@127.0.0.1/0, dev1@127.0.0.1/1, dev1@127.0.0.1/1",
             "c = 'hola', b = 1",false,"c = 'hola', b = 1000",false,
             "(((d = 15) OR ((e = true) AND (f = 'adios'))) AND (a = 319))"],
-        [2,"dev1@127.0.0.1:0, dev1@127.0.0.1:1, dev1@127.0.0.1:1",
+        [2,"dev1@127.0.0.1/0, dev1@127.0.0.1/1, dev1@127.0.0.1/1",
             "c = 'hola', b = 1000",false,"c = 'hola', b = 2000",false,
             "(((d = 15) OR ((e = true) AND (f = 'adios'))) AND (a = 319))"]],
     ?assertMatch(

--- a/src/riak_kv_qry_coverage_plan.erl
+++ b/src/riak_kv_qry_coverage_plan.erl
@@ -23,10 +23,11 @@
 -module(riak_kv_qry_coverage_plan).
 
 -export([
+         cover_to_proplist/1,
          create_plan/5,
          create_plan/6,
-         replace_chunk/7,
-         cover_to_proplist/1
+         make_key/3,
+         replace_chunk/7
         ]).
 
 -include("riak_kv_ts.hrl").

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -488,7 +488,7 @@ format_coverage(Table, CoverKey, NVal) ->
             Number = Key bsr (160-Exponent),
             lists:flatten(io_lib:format("~s/~b", [Node, Number]))
         end, Coverage),
-    string:join(VNodes, ", ").
+    string:join(lists:sort(VNodes), ", ").
 
 %%
 key_element_to_string(V) when is_binary(V) -> binary_to_list(V);

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -486,7 +486,7 @@ format_coverage(Table, CoverKey, NVal) ->
         fun({{Key, Node}, _}) ->
             Exponent = trunc(math:log(RingSize)/math:log(2)),
             Number = Key bsr (160-Exponent),
-            lists:flatten(io_lib:format("~s:~b", [Node, Number]))
+            lists:flatten(io_lib:format("~s/~b", [Node, Number]))
         end, Coverage),
     string:join(VNodes, ", ").
 

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -435,10 +435,18 @@ explain_query(QueryString) ->
 %% string.
 %%
 %% Have a flexible API because it is a debugging function.
-explain_query(DDL, ?SQL_SELECT{} = Select) ->
+explain_query(DDL, ?SQL_SELECT{'FROM' = Table} = Select) ->
+    Props = riak_core_bucket_type:get(Table),
+    NVal = proplists:get_value(n_val, Props),
     case riak_kv_qry_compiler:compile(DDL, Select, 10000) of
         {ok, SubQueries} ->
-            {_Total, Rows} = lists:foldl(fun index_subquery/2, {1,[]}, SubQueries),
+            {_Total, Rows} =
+                lists:foldl(
+                    fun(SQ, {Idx, Acc}) ->
+                        Row = explain_sub_query(Idx, NVal, SQ),
+                        {Idx + 1, [Row | Acc]}
+                    end,
+                    {1,[]}, SubQueries),
             lists:reverse(Rows);
         Error ->
             Error
@@ -448,17 +456,17 @@ explain_query(DDL, QueryString) ->
     explain_query(DDL, Select).
 
 %%
-index_subquery(SQ, {Idx, Acc}) ->
-    Row = explain_sub_query(Idx, SQ),
-    {Idx + 1, [Row | Acc]}.
-
-%%
 explain_compile_query(QueryString) ->
     {ok, Q} = riak_ql_parser:parse(riak_ql_lexer:get_tokens(QueryString)),
     build_sql_record(select, Q, undefined).
 
 %%
-explain_sub_query(Index, ?SQL_SELECT{ 'WHERE' = SubQueryWhere }) ->
+explain_sub_query(Index, NVal, ?SQL_SELECT{'FROM' = Table,
+                                           'WHERE' = SubQueryWhere,
+                                           helper_mod = HelperMod,
+                                           partition_key = PartitionKey}) ->
+    CoverKey = riak_kv_qry_coverage_plan:make_key(HelperMod, PartitionKey, SubQueryWhere),
+    Coverage = format_coverage(Table, CoverKey, NVal),
     {_, StartKey1} = lists:keyfind(startkey, 1, SubQueryWhere),
     {_, EndKey1} = lists:keyfind(endkey, 1, SubQueryWhere),
     {_, Filter} = lists:keyfind(filter, 1, SubQueryWhere),
@@ -466,7 +474,21 @@ explain_sub_query(Index, ?SQL_SELECT{ 'WHERE' = SubQueryWhere }) ->
     EndKey2 = string:join([key_to_string(Key) || Key <- EndKey1], ", "),
     StartInclusive = lists:keymember(start_inclusive, 1, StartKey1),
     EndInclusive = lists:keymember(end_inclusive, 1, EndKey1),
-    [Index, StartKey2, StartInclusive, EndKey2, EndInclusive, filter_to_string(Filter)].
+    [Index, Coverage, StartKey2, StartInclusive, EndKey2, EndInclusive, filter_to_string(Filter)].
+
+%%
+format_coverage(Table, CoverKey, NVal) ->
+    Bucket = table_to_bucket(Table),
+    DocIdx = riak_core_util:chash_key({Bucket, CoverKey}),
+    Coverage = riak_core_apl:get_primary_apl(DocIdx, NVal, riak_kv),
+    RingSize = riak_client:ring_size(),
+    VNodes = lists:map(
+        fun({{Key, Node}, _}) ->
+            Exponent = trunc(math:log(RingSize)/math:log(2)),
+            Number = Key bsr (160-Exponent),
+            lists:flatten(io_lib:format("~s:~b", [Node, Number]))
+        end, Coverage),
+    string:join(VNodes, ", ").
 
 %%
 key_element_to_string(V) when is_binary(V) -> binary_to_list(V);


### PR DESCRIPTION
Due to scheduling constraints this more complicated column was excluded from the initial implementation.  Now, with lots of help from @macintux, it's become a reality.
