### PR TITLE
get_fsm: treat a timeout value of 0 as infinity

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -1077,7 +1077,12 @@ recv_timeout(Options) ->
         undefined ->
             %% If no reply timeout given, use the FSM timeout + 100ms to give it a chance
             %% to respond.
-            proplists:get_value(timeout, Options, ?DEFAULT_TIMEOUT) + 100;
+            case proplists:get_value(timeout, Options, ?DEFAULT_TIMEOUT) of
+                infinity ->
+                    infinity;
+                Finity ->
+                    Finity + 100
+            end;
         Timeout ->
             %% Otherwise use the directly supplied timeout.
             Timeout


### PR DESCRIPTION
RTS-1328 (#1464)

When a client calls a `get` with a value of 0 for its `Timeout` parameter, get_fsm treats that value literally and immediately triggers a timeout (https://github.com/basho/riak_kv/blob/riak_ts-develop/src/riak_kv_get_fsm.erl#L544). One can argue that this is indeed expected behaviour, but the FSM still manages to serve some `get`s (which becomes possible under certain racy conditions between state changes and message passing to self), and that can be really confusing for the client.

This PR explicitly treats the case of `Timeout = 0` the same as `Timeout = infinity`, for the `get` API call.
