### PR TITLE
Refactored riak_kv_pb_index and riak_kv_pb_bucket (version 2)

### DIFF
--- a/src/riak_kv_pb_bucket.erl
+++ b/src/riak_kv_pb_bucket.erl
@@ -66,89 +66,86 @@ init() ->
 %% @doc decode/2 callback. Decodes an incoming message.
 decode(Code, Bin) ->
     Msg = riak_pb_codec:decode(Code, Bin),
-    case Msg of
-        rpblistbucketsreq ->
-            %% backwards compat
-            {ok, Msg, {"riak_kv.list_buckets", <<"default">>}};
-        #rpblistbucketsreq{} ->
-            Type = case Msg#rpblistbucketsreq.type of
-                       undefined ->
-                           <<"default">>;
-                       T ->
-                           T
-                   end,
-            {ok, Msg, {"riak_kv.list_buckets", Type}};
-        #rpblistkeysreq{} ->
-            Type = case Msg#rpblistkeysreq.type of
-                       undefined ->
-                           <<"default">>;
-                       T ->
-                           T
-                   end,
-            {ok, Msg, {"riak_kv.list_keys", {Type,
-                                                Msg#rpblistkeysreq.bucket}}}
-    end.
+    handle_decoded(Msg).
+
+handle_decoded(rpblistbucketsreq = Msg) ->
+    %% backwards compat
+    {ok, Msg, {"riak_kv.list_buckets", <<"default">>}};
+handle_decoded(#rpblistbucketsreq{} = Msg) ->
+    Type = convert_type(Msg#rpblistbucketsreq.type),
+    {ok, Msg, {"riak_kv.list_buckets", Type}};
+handle_decoded(#rpblistkeysreq{} = Msg) ->
+    Type = convert_type(Msg#rpblistkeysreq.type),
+    {ok, Msg, {"riak_kv.list_keys", {Type,
+                                     Msg#rpblistkeysreq.bucket}}}.
 
 %% @doc encode/1 callback. Encodes an outgoing response message.
 encode(Message) ->
     {ok, riak_pb_codec:encode(Message)}.
 
-%% @doc process/2 callback. Handles an incoming request message.
-process(#rpblistbucketsreq{type = Type, timeout = T, stream = S} = Req, State) ->
-    Class = case S of
-        true ->
-            {riak_kv, stream_list_buckets};
-        _ ->
-            {riak_kv, list_buckets}
-    end,
-    Accept = riak_core_util:job_class_enabled(Class),
-    _ = riak_core_util:report_job_request_disposition(
-            Accept, Class, ?MODULE, process, ?LINE, protobuf),
-    case Accept of
-        true ->
-            case check_bucket_type(Type) of
-                {ok, GoodType} ->
-                    do_list_buckets(GoodType, T, S, Req, State);
-                error ->
-                    {error,
-                        {format, "No bucket-type named '~s'", [Type]}, State}
-            end;
-        _ ->
-            {error,
-                riak_core_util:job_class_disabled_message(binary, Class),
-                State}
-    end;
 
 %% this should remain for backwards compatibility
 process(rpblistbucketsreq, State) ->
     process(#rpblistbucketsreq{}, State);
 
-%% Start streaming in list keys
-process(#rpblistkeysreq{type = Type, bucket = B, timeout = T} = Req,
-        #state{client = Client} = State) ->
-    % at present list-keys always streams
-    Class = {riak_kv, stream_list_keys},
+%% @doc process/2 callback. Handles an incoming request message.
+process(Req, State) ->
+    {Class, Listing} = determine_class_and_listing(Req),
+    Accept = determine_accept_and_report_job_disposition(Class),
+    case {Accept, Listing} of
+        {true, buckets} ->
+            maybe_do_list_buckets(Req, State);
+        {true, keys} ->
+            %% at present list-keys always streams
+            %% Start streaming in list keys
+            maybe_stream_list_keys(Req, State);
+        {false, _} ->
+            error_accept(Class, State)
+    end.
+
+
+determine_accept_and_report_job_disposition(Class) ->
     Accept = riak_core_util:job_class_enabled(Class),
     _ = riak_core_util:report_job_request_disposition(
-            Accept, Class, ?MODULE, process, ?LINE, protobuf),
-    case Accept of
-        true ->
-            %% stream_list_keys results will be processed by process_stream/3
-            case check_bucket_type(Type) of
-                {ok, GoodType} ->
-                    Bucket = maybe_create_bucket_type(GoodType, B),
-                    {ok, ReqId} = Client:stream_list_keys(Bucket, T),
-                    {reply, {stream, ReqId},
-                        State#state{req = Req, req_ctx = ReqId}};
-                error ->
-                    {error,
-                        {format, "No bucket-type named '~s'", [Type]}, State}
-            end;
-        _ ->
-            {error,
-                riak_core_util:job_class_disabled_message(binary, Class),
-                State}
+        Accept, Class, ?MODULE, process, ?LINE, protobuf),
+    Accept.
+
+determine_class_and_listing(#rpblistbucketsreq{stream = true}) ->
+    {{riak_kv, stream_list_buckets}, buckets};
+determine_class_and_listing(#rpblistbucketsreq{stream = false}) ->
+    {{riak_kv, list_buckets}, buckets};
+determine_class_and_listing(#rpblistkeysreq{}) ->
+    {{riak_kv, stream_list_keys}, keys}.
+
+maybe_stream_list_keys(#rpblistkeysreq{type = Type, bucket = B, timeout = T} = Req,
+                       #state{client = Client} = State) ->
+    case check_bucket_type(Type) of
+        {ok, GoodType} ->
+            Bucket = maybe_create_bucket_type(GoodType, B),
+            {ok, ReqId} = Client:stream_list_keys(Bucket, T),
+            {reply, {stream, ReqId},
+             State#state{req = Req, req_ctx = ReqId}};
+        error ->
+            error_no_bucket_type(Type, State)
     end.
+
+error_no_bucket_type(Type, State) ->
+    {error,
+     {format, "No bucket-type named '~s'", [Type]}, State}.
+
+error_accept(Class, State) ->
+    {error,
+     riak_core_util:job_class_disabled_message(binary, Class),
+     State}.
+
+maybe_do_list_buckets(#rpblistbucketsreq{type = Type, timeout = T, stream = S} = Req, State) ->
+    case check_bucket_type(Type) of
+        {ok, GoodType} ->
+            do_list_buckets(GoodType, T, S, Req, State);
+        error ->
+            error_no_bucket_type(Type, State)
+    end.
+
 
 %% @doc process_stream/3 callback. Handles streaming keys messages and
 %% streaming buckets.
@@ -232,3 +229,9 @@ bucket_type(undefined, B) ->
     {<<"default">>, B};
 bucket_type(T, B) ->
     {T, B}.
+
+
+convert_type(undefined) ->
+    <<"default">>;
+convert_type(T) ->
+    T.

--- a/src/riak_kv_pb_bucket.erl
+++ b/src/riak_kv_pb_bucket.erl
@@ -86,7 +86,7 @@ encode(Message) ->
 
 %% this should remain for backwards compatibility
 process(rpblistbucketsreq, State) ->
-    process(#rpblistbucketsreq{}, State);
+    process(#rpblistbucketsreq{stream = false}, State);
 
 %% @doc process/2 callback. Handles an incoming request message.
 process(Req, State) ->

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -73,29 +73,29 @@ validate_request(#rpbindexreq{qtype = range, range_min = Min, range_max = Max})
 validate_request(#rpbindexreq{term_regex = TermRe} = Req) ->
     {ValRe, ValErr} = ensure_compiled_re(TermRe),
     case ValRe of
-      error ->
-          {error, {format, "Invalid term regular expression ~p : ~p", [TermRe, ValErr]}};
-      _ ->
-        validate_query(Req)
+        error ->
+            {error, {format, "Invalid term regular expression ~p : ~p", [TermRe, ValErr]}};
+        _ ->
+            validate_query(Req)
     end.
 
 validate_query(Req) ->
-  Query = riak_index:to_index_query(query_params(Req)),
-  case Query of
-    {ok, ?KV_INDEX_Q{start_term = Start, term_regex = Re}} when is_integer(Start)
-                                                                andalso Re =/= undefined ->
-      {error, "Can not use term regular expression in integer query"};
-    _ ->
-      Query
-  end.
+    Query = riak_index:to_index_query(query_params(Req)),
+    case Query of
+        {ok, ?KV_INDEX_Q{start_term = Start, term_regex = Re}} when is_integer(Start)
+                                                                    andalso Re =/= undefined ->
+            {error, "Can not use term regular expression in integer query"};
+        _ ->
+            Query
+    end.
 
 ensure_compiled_re(TermRe) ->
-  case TermRe of
-      undefined ->
-        {undefined, undefined};
-      _ ->
-        re:compile(TermRe)
-  end.
+    case TermRe of
+        undefined ->
+            {undefined, undefined};
+        _ ->
+            re:compile(TermRe)
+    end.
 
 %% @doc process/2 callback. Handles an incoming request message.
 process(#rpbindexreq{stream = S} = Req, State) ->
@@ -110,21 +110,21 @@ process(#rpbindexreq{stream = S} = Req, State) ->
             Accept, Class, ?MODULE, process, ?LINE, protobuf),
     case Accept of
         true ->
-          validate_request_and_maybe_perform_query(Req, State);
+            validate_request_and_maybe_perform_query(Req, State);
         false ->
-          error_accept(Class, State)
+            error_accept(Class, State)
     end.
 
 validate_request_and_maybe_perform_query(Req, State) ->
-  case validate_request(Req) of
-    {error, Err} ->
-      {error, Err, State};
-    QueryVal ->
-      maybe_perform_query(QueryVal, Req, State)
-  end.
+    case validate_request(Req) of
+        {error, Err} ->
+            {error, Err, State};
+        QueryVal ->
+            maybe_perform_query(QueryVal, Req, State)
+    end.
 
 error_accept(Class, State) ->
-  {error, riak_core_util:job_class_disabled_message(binary, Class), State}.
+    {error, riak_core_util:job_class_disabled_message(binary, Class), State}.
 
 maybe_perform_query({ok, Query}, Req=#rpbindexreq{stream=true}, State) ->
     #rpbindexreq{type=T, bucket=B, max_results=MaxResults, timeout=Timeout,
@@ -152,9 +152,9 @@ maybe_perform_query({ok, Query}, Req, State) ->
     handle_query_results(ReturnTerms, MaxResults, QueryResult , State).
 
 maybe_pgsort(undefined, PgSort0) ->
-  PgSort0;
+    PgSort0;
 maybe_pgsort(_, _) ->
-  true.
+    true.
 
 
 handle_query_results(_, _, {error, Reason}, State) ->

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -56,52 +56,54 @@ init() ->
 
 %% @doc decode/2 callback. Decodes an incoming message.
 decode(Code, Bin) ->
-    Msg = riak_pb_codec:decode(Code, Bin),
-    case Msg of
-        #rpbindexreq{type=T, bucket=B} ->
-            Bucket = bucket_type(T, B),
-            {ok, Msg, {"riak_kv.index", Bucket}}
-    end.
+    #rpbindexreq{type=T, bucket=B} = Msg = riak_pb_codec:decode(Code, Bin),
+    Bucket = bucket_type(T, B),
+    {ok, Msg, {"riak_kv.index", Bucket}}.
 
 %% @doc encode/1 callback. Encodes an outgoing response message.
 encode(Message) ->
     {ok, riak_pb_codec:encode(Message)}.
 
-validate_request(#rpbindexreq{qtype=QType, key=SKey,
-                              range_min=Min, range_max=Max,
-                              term_regex=TermRe} = Req) ->
-    {ValRe, ValErr} = case TermRe of
-        undefined ->
-            {undefined, undefined};
-        _ ->
-            re:compile(TermRe)
-    end,
 
-    if
-        QType == eq andalso not is_binary(SKey) ->
-            {error, {format, "Invalid equality query ~p", [SKey]}};
-        QType == range andalso not(is_binary(Min) andalso is_binary(Max)) ->
-            {error, {format, "Invalid range query: ~p -> ~p", [Min, Max]}};
-        ValRe =:= error ->
-            {error, {format, "Invalid term regular expression ~p : ~p",
-                     [TermRe, ValErr]}};
-        true ->
-            Query = riak_index:to_index_query(query_params(Req)),
-            case Query of
-                {ok, ?KV_INDEX_Q{start_term=Start, term_regex=Re}} when is_integer(Start)
-                       andalso Re =/= undefined ->
-                    {error, "Can not use term regular expression in integer query"};
-                _ ->
-                    Query
-            end
+validate_request(#rpbindexreq{qtype = eq, key = SKey}) when not is_binary(SKey) ->
+    {error, {format, "Invalid equality query ~p", [SKey]}};
+validate_request(#rpbindexreq{qtype = range, range_min = Min, range_max = Max})
+    when not is_binary(Min); not is_binary(Max) ->
+    {error, {format, "Invalid range query: ~p -> ~p", [Min, Max]}};
+validate_request(#rpbindexreq{term_regex = TermRe} = Req) ->
+    {ValRe, ValErr} = ensure_compiled_re(TermRe),
+    case ValRe of
+      error ->
+          {error, {format, "Invalid term regular expression ~p : ~p",
+                   [TermRe, ValErr]}};
+      _ ->
+        validate_query(Req)
     end.
+
+validate_query(Req) ->
+  Query = riak_index:to_index_query(query_params(Req)),
+  case Query of
+    {ok, ?KV_INDEX_Q{start_term = Start, term_regex = Re}} when is_integer(Start)
+                                                                andalso Re =/= undefined ->
+      {error, "Can not use term regular expression in integer query"};
+    _ ->
+      Query
+  end.
+
+ensure_compiled_re(TermRe) ->
+  case TermRe of
+      undefined ->
+        {undefined, undefined};
+      _ ->
+        re:compile(TermRe)
+  end.
 
 %% @doc process/2 callback. Handles an incoming request message.
 process(#rpbindexreq{stream = S} = Req, State) ->
     Class = case S of
         true ->
             {riak_kv, stream_secondary_index};
-        _ ->
+        false ->
             {riak_kv, secondary_index}
     end,
     Accept = riak_core_util:job_class_enabled(Class),
@@ -109,17 +111,23 @@ process(#rpbindexreq{stream = S} = Req, State) ->
             Accept, Class, ?MODULE, process, ?LINE, protobuf),
     case Accept of
         true ->
-            case validate_request(Req) of
-                {error, Err} ->
-                    {error, Err, State};
-                QueryVal ->
-                    maybe_perform_query(QueryVal, Req, State)
-            end;
-        _ ->
-            {error,
-                riak_core_util:job_class_disabled_message(binary, Class),
-                State}
+          validate_request_and_maybe_perform_query(Req, State);
+        false ->
+          error_accept(Class, State)
     end.
+
+validate_request_and_maybe_perform_query(Req, State) ->
+  case validate_request(Req) of
+    {error, Err} ->
+      {error, Err, State};
+    QueryVal ->
+      maybe_perform_query(QueryVal, Req, State)
+  end.
+
+error_accept(Class, State) ->
+  {error,
+   riak_core_util:job_class_disabled_message(binary, Class),
+   State}.
 
 maybe_perform_query({ok, Query}, Req=#rpbindexreq{stream=true}, State) ->
     #rpbindexreq{type=T, bucket=B, max_results=MaxResults, timeout=Timeout,
@@ -127,10 +135,7 @@ maybe_perform_query({ok, Query}, Req=#rpbindexreq{stream=true}, State) ->
     #state{client=Client} = State,
     Bucket = maybe_bucket_type(T, B),
     %% Special case: a continuation implies pagination even if no max_results
-    PgSort = case Continuation of
-                 undefined -> PgSort0;
-                 _ -> true
-             end,
+    PgSort = maybe_pgsort(Continuation, PgSort0),
     Opts0 = [{max_results, MaxResults}] ++ [{pagination_sort, PgSort} || PgSort /= undefined],
     Opts = riak_index:add_timeout_opt(Timeout, Opts0),
     {ok, ReqId, _FSMPid} = Client:stream_get_index(Bucket, Query, Opts),
@@ -142,15 +147,17 @@ maybe_perform_query({ok, Query}, Req, State) ->
                  pagination_sort=PgSort0, continuation=Continuation} = Req,
     #state{client=Client} = State,
     Bucket = maybe_bucket_type(T, B),
-    PgSort = case Continuation of
-                 undefined -> PgSort0;
-                 _ -> true
-             end,
+    PgSort = maybe_pgsort(Continuation,PgSort0),
     Opts0 = [{max_results, MaxResults}] ++ [{pagination_sort, PgSort} || PgSort /= undefined],
     Opts = riak_index:add_timeout_opt(Timeout, Opts0),
     ReturnTerms =  riak_index:return_terms(ReturnTerms0, Query),
     QueryResult = Client:get_index(Bucket, Query, Opts),
     handle_query_results(ReturnTerms, MaxResults, QueryResult , State).
+
+maybe_pgsort(undefined, PgSort0) ->
+  PgSort0;
+maybe_pgsort(_, _) ->
+  true.
 
 
 handle_query_results(_, _, {error, Reason}, State) ->

--- a/src/riak_kv_pb_index.erl
+++ b/src/riak_kv_pb_index.erl
@@ -74,8 +74,7 @@ validate_request(#rpbindexreq{term_regex = TermRe} = Req) ->
     {ValRe, ValErr} = ensure_compiled_re(TermRe),
     case ValRe of
       error ->
-          {error, {format, "Invalid term regular expression ~p : ~p",
-                   [TermRe, ValErr]}};
+          {error, {format, "Invalid term regular expression ~p : ~p", [TermRe, ValErr]}};
       _ ->
         validate_query(Req)
     end.
@@ -125,9 +124,7 @@ validate_request_and_maybe_perform_query(Req, State) ->
   end.
 
 error_accept(Class, State) ->
-  {error,
-   riak_core_util:job_class_disabled_message(binary, Class),
-   State}.
+  {error, riak_core_util:job_class_disabled_message(binary, Class), State}.
 
 maybe_perform_query({ok, Query}, Req=#rpbindexreq{stream=true}, State) ->
     #rpbindexreq{type=T, bucket=B, max_results=MaxResults, timeout=Timeout,


### PR DESCRIPTION
This is an updated version of #1468. See that PR for more info and review comments. I would have added commits directly there, but the branch there was from a fork of riak_kv set up by @lehoff, so I couldn't commit directly to it. Original PR summary for reference:

> Refactored `riak_kv_pb_index` and `riak_kv_pb_bucket`
> 
> Refactored to reduce code duplication and increase clarity.
