### PR TITLE
Bump bitcask up to the develop branch

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -27,7 +27,7 @@
 {deps, [
         {sidejob, ".*", {git, "git://github.com/basho/sidejob.git", {tag, "2.0.1"}}},
         {erlang_js, ".*", {git, "git://github.com/basho/erlang_js.git", {tag, "1.3.0"}}},
-        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {tag, "2.0.3"}}},
+        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {branch, "develop"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", {tag, "0.78"}}},
         {sext, ".*", {git, "git://github.com/basho/sext.git", {tag, "1.1p3"}}},
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {branch, "develop-2.2"}}},


### PR DESCRIPTION
This is needed to pull in the switch over to the cuttlefish develop branch. Other than that it's the same version of bitcask that we were previously using from the tag.
