### PR TITLE
Address select exception at quantum boundaries

### DIFF
--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -70,8 +70,7 @@
 
 -define(
     E_TSMSG_LOWER_AND_UPPER_BOUNDS_ARE_EQUAL_WHEN_NO_EQUALS_OPERATOR,
-    <<"The upper and lower boundaries are equal but the query uses the greater and less than operators.  ",
-      "Change the bounds time or use the greater/less than or equals to on either side.">>
+    <<"The upper and lower boundaries are equal or adjacent and the comparison makes no sense.">>
 ).
 
 -define(

--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -70,7 +70,7 @@
 
 -define(
     E_TSMSG_LOWER_AND_UPPER_BOUNDS_ARE_EQUAL_WHEN_NO_EQUALS_OPERATOR,
-    <<"The upper and lower boundaries are equal or adjacent and the comparison makes no sense.">>
+    <<"The upper and lower boundaries are equal or adjacent. No results are possible.">>
 ).
 
 -define(


### PR DESCRIPTION
Addresses #1472 (RIAK-2782). `riak_test` to follow.

1.4.0 shipped with a exception on selecting at quantum boundaries that was exacerbated by the new time parsing and not-entirely-intuitive handling of reduced accuracy times.

`select * from foo where time > '2016-01-01 05' and time < '2016-01-01 06'` e.g. seems like a reasonable query but in effect both time values are the same.
