### PR TITLE
Handle the case with no fsm_limit being specified

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -57,7 +57,11 @@ start(_Type, _StartArgs) ->
                         %% then we're pretty much guaranteed to never exceed that:
                         erlang:system_info(process_limit);
                     Limit when is_integer(Limit) ->
-                        Limit
+                        Limit;
+                    BadValue ->
+                        lager:critical("Bad value provided for riak_kv.fsm_limit - ~p. "
+                                       "Must be an integer or 'undefined'", [BadValue]),
+                        throw({error, bad_fsm_limit})
                 end,
 
     sidejob:new_resource(riak_kv_put_fsm_sj, sidejob_supervisor, FSM_Limit),


### PR DESCRIPTION
Prior to #1420, an fsm_limit setting of `undefined` meant that overload
protection would be disabled. Since those code paths have been removed,
we had originally figured that everyone would have to specify an FSM
limit now.

However, this wouldn't be terribly friendly to anyone with an existing
cluster set up that had disabled overload protection. To smooth over
this transition and still allow existing config to work, we once again
allow a setting of `undefined` to mean that there's no limit.

There is no option in sidejob to allow us to specify "no limit", but by
setting the limit to the maximum process limit on the node, we can
pretty much guarantee that the limit will never get hit, making it all
effectively unlimited.
