### PR TITLE
Changed job control switches to be commented with default values

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -636,54 +636,62 @@
 {mapping, "cluster.job.riak_kv.list_buckets", "riak_core.job_accept_class", [
     merge,
     {datatype, {flag, enabled, disabled}},
-    {default, enabled}
+    {default, enabled},
+    {commented, enabled}
 ]}.
 
 %% @doc Whether to allow streaming list buckets.
 {mapping, "cluster.job.riak_kv.stream_list_buckets", "riak_core.job_accept_class", [
     merge,
     {datatype, {flag, enabled, disabled}},
-    {default, enabled}
+    {default, enabled},
+    {commented, enabled}
 ]}.
 
 %% @doc Whether to allow list keys.
 {mapping, "cluster.job.riak_kv.list_keys", "riak_core.job_accept_class", [
     merge,
     {datatype, {flag, enabled, disabled}},
-    {default, enabled}
+    {default, enabled},
+    {commented, enabled}
 ]}.
 
 %% @doc Whether to allow streaming list keys.
 {mapping, "cluster.job.riak_kv.stream_list_keys", "riak_core.job_accept_class", [
     merge,
     {datatype, {flag, enabled, disabled}},
-    {default, enabled}
+    {default, enabled},
+    {commented, enabled}
 ]}.
 
 %% @doc Whether to allow secondary index queries.
 {mapping, "cluster.job.riak_kv.secondary_index", "riak_core.job_accept_class", [
     merge,
     {datatype, {flag, enabled, disabled}},
-    {default, enabled}
+    {default, enabled},
+    {commented, enabled}
 ]}.
 
 %% @doc Whether to allow streaming secondary index queries.
 {mapping, "cluster.job.riak_kv.stream_secondary_index", "riak_core.job_accept_class", [
     merge,
     {datatype, {flag, enabled, disabled}},
-    {default, enabled}
+    {default, enabled},
+    {commented, enabled}
 ]}.
 
 %% @doc Whether to allow term-based map-reduce.
 {mapping, "cluster.job.riak_kv.map_reduce", "riak_core.job_accept_class", [
     merge,
     {datatype, {flag, enabled, disabled}},
-    {default, enabled}
+    {default, enabled},
+    {commented, enabled}
 ]}.
 
 %% @doc Whether to allow JavaScript map-reduce.
 {mapping, "cluster.job.riak_kv.map_reduce_js", "riak_core.job_accept_class", [
     merge,
     {datatype, {flag, enabled, disabled}},
-    {default, enabled}
+    {default, enabled},
+    {commented, enabled}
 ]}.


### PR DESCRIPTION
This PR changes the job control settings added in 2.2 so that they are commented with their associated default values.  Doing so reduces friction in the (unlikely) case that a new install is downgraded to a previous version.
