### PR TITLE
RTS-1391: qry:do_explain: correctly spell column type as 'sint64' not 'integer'

### DIFF
--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -467,12 +467,12 @@ explain_query_test() ->
     ?assert(meck:validate(riak_core_claimant)),
     Res = do_explain(DDL, Select),
     ExpectedRows =
-        [[1,"dev1@127.0.0.1/0, dev1@127.0.0.1/1, dev1@127.0.0.1/1",
-            "c = 'hola', b = 1",false,"c = 'hola', b = 1000",false,
-            "(((d = 15) OR ((e = true) AND (f = 'adios'))) AND (a = 319))"],
-        [2,"dev1@127.0.0.1/0, dev1@127.0.0.1/1, dev1@127.0.0.1/1",
-            "c = 'hola', b = 1000",false,"c = 'hola', b = 2000",false,
-            "(((d = 15) OR ((e = true) AND (f = 'adios'))) AND (a = 319))"]],
+        [[1,<<"dev1@127.0.0.1/0, dev1@127.0.0.1/1, dev1@127.0.0.1/1">>,
+            <<"c = 'hola', b = 1">>,false,<<"c = 'hola', b = 1000">>,false,
+            <<"(((d = 15) OR ((e = true) AND (f = 'adios'))) AND (a = 319))">>],
+        [2,<<"dev1@127.0.0.1/0, dev1@127.0.0.1/1, dev1@127.0.0.1/1">>,
+            <<"c = 'hola', b = 1000">>,false,<<"c = 'hola', b = 2000">>,false,
+            <<"(((d = 15) OR ((e = true) AND (f = 'adios'))) AND (a = 319))">>]],
     ?assertMatch(
         {ok, {_, _, ExpectedRows}},
         Res),

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -356,7 +356,7 @@ do_explain(DDL, Select) ->
         <<"Is End Inclusive?">>,
         <<"Filter">>],
     ColumnTypes = [
-        integer,
+        sint64,
         varchar,
         varchar,
         boolean,

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -474,7 +474,13 @@ explain_sub_query(Index, NVal, ?SQL_SELECT{'FROM' = Table,
     EndKey2 = string:join([key_to_string(Key) || Key <- EndKey1], ", "),
     StartInclusive = lists:keymember(start_inclusive, 1, StartKey1),
     EndInclusive = lists:keymember(end_inclusive, 1, EndKey1),
-    [Index, Coverage, StartKey2, StartInclusive, EndKey2, EndInclusive, filter_to_string(Filter)].
+    [Index,
+     list_to_binary(Coverage),
+     list_to_binary(StartKey2),
+     StartInclusive,
+     list_to_binary(EndKey2),
+     EndInclusive,
+     list_to_binary(filter_to_string(Filter))].
 
 %%
 format_coverage(Table, CoverKey, NVal) ->


### PR DESCRIPTION
RTS-1391

In `riak_kv_qry:explain`, the integer type for column "Subquery" was misspelled as `integer`, which causes a function_clause error in `riak_pb_ts_codec:encode_field_type/1` when it fails to match here: https://github.com/basho/riak_pb/blob/develop/src/riak_pb_ts_codec.erl#L70.

**Update:** Note that the bug is only triggered when the client uses the old PB encoding method (instead of TTB), as is the case with the Python client. This explains why it has gone undetected (the relevant r_t module, ts_simple_explain_query passes both with and without the fix).
