### PR TITLE
Add force update flag and rename `undefined` version to `legacy`

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -202,8 +202,8 @@ start(_Type, _StartArgs) ->
                                           disabled),
 
             riak_core_capability:register({riak_kv, object_hash_version},
-                                          [0, undefined],
-                                          undefined),
+                                          [0, legacy],
+                                          legacy),
 
             HealthCheckOn = app_helper:get_env(riak_kv, enable_health_checks, false),
             %% Go ahead and mark the riak_kv service as up in the node watcher.

--- a/src/riak_kv_get_core.erl
+++ b/src/riak_kv_get_core.erl
@@ -291,11 +291,10 @@ num_pr(GetCore = #getcore{num_pok=NumPOK, idx_type=IdxType}, Idx) ->
 %% @private Print a warning if objects are not equal. Only called on case of no read-repair
 %% This situation could happen with pre 2.1 vclocks in very rare cases. Fixing the object
 %% requires the user to rewrite the object in 2.1+ of Riak. Logic is enabled when capabilities
-%% returns a version(all nodes at least 2.2) and the entropy_manager does not yet have a
-%% defined version.
+%% returns a version(all nodes at least 2.2) and the entropy_manager is not yet version 0
 maybe_log_old_vclock(Results) ->
-    case riak_core_capability:get({riak_kv, object_hash_version}, undefined) of
-        undefined ->
+    case riak_core_capability:get({riak_kv, object_hash_version}, legacy) of
+        legacy ->
             ok;
         0 ->
             Version = riak_kv_entropy_manager:get_version(),

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -528,10 +528,13 @@ check_upgrade_opts(Opts, _) ->
 
 -spec check_upgrade_env() -> boolean().
 check_upgrade_env() ->
-    case application:get_env(riak_kv, force_hashtree_upgrade) of
-        {ok, true} ->
+    case application:get_env(riak_kv, force_hashtree_upgrade, false) of
+        true ->
             true;
-        _ ->
+        false ->
+            false;
+        Value ->
+            lager:error("Unsupported non-boolean value for environment variable force_hashtree_upgrade ~p",[Value]),
             false
     end.
 

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -509,22 +509,27 @@ determine_data_root() ->
 %%      looking for versioned AAE directory.
 -spec determine_version(undefined | list(), non_neg_integer(), list()) -> undefined | non_neg_integer().
 determine_version(Root, Index, Opts) ->
-    case lists:member(upgrade, Opts) of
-        true ->
-            riak_core_capability:get({riak_kv, object_hash_version}, undefined);
-        false ->
-            case riak_core_capability:get({riak_kv, object_hash_version}, undefined) of
-                V when is_integer(V) ->
-                    %% Check if the v[Version]/Index dir exists
-                    case filelib:is_dir(filename:join(filename:join(Root, "v" ++ integer_to_list(V)),integer_to_list(Index))) of
-                        true ->
-                            V;
-                        false ->
-                            undefined
-                    end;
-                _ ->
-                    undefined
-            end
+    case application:get_env(riak_kv, force_hashtree_upgrade)
+        {ok, true} -> 
+            0;
+         _ ->
+            case lists:member(upgrade, Opts) of
+                true ->
+                   riak_core_capability:get({riak_kv, object_hash_version}, undefined);
+               false ->
+                   case riak_core_capability:get({riak_kv, object_hash_version}, undefined) of
+                       V when is_integer(V) ->
+                           %% Check if the v[Version]/Index dir exists
+                           case filelib:is_dir(filename:join(filename:join(Root, "v" ++ integer_to_list(V)),integer_to_list(Index))) of
+                               true ->
+                                   V;
+                               false ->
+                                   undefined
+                           end;
+                       _ ->
+                           undefined
+                   end
+           end
     end.
 
 %% @doc Init the trees.

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -509,7 +509,7 @@ determine_data_root() ->
 %%      looking for versioned AAE directory.
 -spec determine_version(undefined | list(), non_neg_integer(), list()) -> undefined | non_neg_integer().
 determine_version(Root, Index, Opts) ->
-    case application:get_env(riak_kv, force_hashtree_upgrade)
+    case application:get_env(riak_kv, force_hashtree_upgrade) of
         {ok, true} -> 
             0;
          _ ->

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -75,7 +75,7 @@
 -type riak_object_t2b() :: binary().
 -type hashtree() :: hashtree:hashtree().
 -type update_callback() :: fun(() -> term()).
--type version() :: undefined | non_neg_integer().
+-type version() :: legacy | non_neg_integer().
 
 -record(state, {index,
                 vnode_pid,
@@ -86,7 +86,7 @@
                 build_time,
                 trees,
                 use_2i = false :: boolean(),
-                version :: version()}).
+                version = legacy :: version()}).
 
 -type state() :: #state{}.
 
@@ -145,7 +145,7 @@ async_delete(Items=[{_Id, _Key}|_], Tree) ->
 %% @doc Called by the entropy manager to finish the process used to acquire
 %%      remote vnode locks when starting an exchange. For more details,
 %%      see {@link riak_kv_entropy_manager:start_exchange_remote/3}
--spec start_exchange_remote(pid(), non_neg_integer(), term(), index_n(), pid()) -> ok.
+-spec start_exchange_remote(pid(), version(), term(), index_n(), pid()) -> ok.
 start_exchange_remote(FsmPid, Version, From, IndexN, Tree) ->
     gen_server:cast(Tree, {start_exchange_remote, FsmPid, Version, From, IndexN}).
 
@@ -292,7 +292,7 @@ init([Index, VNPid, Opts]) ->
                     %% easy downgrades where the new trees will be unable to be found by old code.
                     {filename:join(Root, "v" ++ integer_to_list(V)), V};
                 _ ->
-                    {Root, undefined}
+                    {Root, legacy}
             end,
             Path = filename:join(Path0, integer_to_list(Index)),
             monitor(process, VNPid),
@@ -507,7 +507,7 @@ determine_data_root() ->
 %%      then we immediately use version in capabilities. Otherwise check if capabilities
 %%      has flipped to a version yet and if it has, check if we've already upgraded by
 %%      looking for versioned AAE directory.
--spec determine_version(undefined | list(), non_neg_integer(), list()) -> undefined | non_neg_integer().
+-spec determine_version(undefined | list(), non_neg_integer(), list()) -> legacy | non_neg_integer().
 determine_version(Root, Index, Opts) ->
     case application:get_env(riak_kv, force_hashtree_upgrade) of
         {ok, true} -> 
@@ -515,19 +515,19 @@ determine_version(Root, Index, Opts) ->
          _ ->
             case lists:member(upgrade, Opts) of
                 true ->
-                   riak_core_capability:get({riak_kv, object_hash_version}, undefined);
+                   riak_core_capability:get({riak_kv, object_hash_version}, legacy);
                false ->
-                   case riak_core_capability:get({riak_kv, object_hash_version}, undefined) of
+                   case riak_core_capability:get({riak_kv, object_hash_version}, legacy) of
                        V when is_integer(V) ->
                            %% Check if the v[Version]/Index dir exists
                            case filelib:is_dir(filename:join(filename:join(Root, "v" ++ integer_to_list(V)),integer_to_list(Index))) of
                                true ->
                                    V;
                                false ->
-                                   undefined
+                                   legacy
                            end;
                        _ ->
-                           undefined
+                           legacy
                    end
            end
     end.
@@ -560,7 +560,7 @@ load_built(#state{trees=Trees}) ->
 %% Generate a hash value for a `riak_object'
 -spec hash_object({riak_object:bucket(), riak_object:key()},
                   riak_object_t2b() | riak_object:riak_object(),
-                  undefined | non_neg_integer()) -> binary().
+                  version()) -> binary().
 hash_object({Bucket, Key}, RObj0, Version) ->
     try
         RObj = case riak_object:is_robject(RObj0) of
@@ -688,7 +688,7 @@ do_new_tree(Id, State=#state{trees=Trees, path=Path}, MarkType) ->
 
 %% This function never uses the Type field. Unsure why it is part of the API. Maybe was meant to be used
 %% by the background manager which could manage tokens based on Type atom. Best guess...
--spec do_get_lock(any(), non_neg_integer(), pid(), state()) -> {not_built | ok | already_locked | bad_version, state()}.
+-spec do_get_lock(any(), version(), pid(), state()) -> {not_built | ok | already_locked | bad_version, state()}.
 do_get_lock(_, _, _, State) when State#state.built /= true ->
     lager:debug("Not built: ~p :: ~p", [State#state.index, State#state.built]),
     {not_built, State};
@@ -943,9 +943,9 @@ do_poke(State) ->
     State3.
 
 -spec maybe_upgrade(state()) -> state().
-maybe_upgrade(State=#state{lock=undefined, built=true, version=undefined, index=Index}) ->
+maybe_upgrade(State=#state{lock=undefined, built=true, version=legacy, index=Index}) ->
     case riak_kv_entropy_manager:get_pending_version() of
-        undefined ->
+        legacy ->
             State;
         0 ->
             case get_all_locks(upgrade, Index, self()) of

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -746,9 +746,9 @@ handle_command({upgrade_hashtree, Node}, _, State=#state{hashtrees=HT}) ->
                 _  ->
                     case {riak_kv_index_hashtree:get_version(HT),
                         riak_kv_entropy_manager:get_pending_version()} of
-                        {undefined, undefined} ->
+                        {legacy, legacy} ->
                             {reply, ok, State};
-                        {undefined, _} ->
+                        {legacy, _} ->
                             lager:notice("Destroying and upgrading index_hashtree for Index: ~p", [State#state.idx]),
                             _ = riak_kv_index_hashtree:destroy(HT),
                             riak_kv_entropy_info:clear_tree_build(State#state.idx),

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -645,12 +645,12 @@ hash(Obj=#r_object{}) ->
     case riak_kv_entropy_manager:get_version() of
         0 ->
             vclock_hash(Obj);
-        undefined ->
+        legacy ->
             legacy_hash(Obj)
     end.
 
 %% @doc calculates the canonical hash of a riak object depending on version
--spec hash(riak_object(), non_neg_integer() | undefined) -> binary().
+-spec hash(riak_object(), non_neg_integer() | legacy) -> binary().
 hash(Obj=#r_object{}, _Version=0) ->
     vclock_hash(Obj);
 hash(Obj=#r_object{}, _Version) ->

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -639,9 +639,9 @@ get_value(Object=#r_object{}) ->
 
 %% @doc calculates the canonical hash of a riak object
 %%      Old API which uses the version .
+%% DEPRECATED
 -spec hash(riak_object()) -> binary().
 hash(Obj=#r_object{}) ->
-    %% BRIAN What to do here needs more discussion(race condition due to tick, vnode startup, etc)
     case riak_kv_entropy_manager:get_version() of
         0 ->
             vclock_hash(Obj);


### PR DESCRIPTION
Rename AAE hashtree version from `undefined` to `legacy`.
Add public ETS table to handle partition version requests
