### PR TITLE
Rework backend_test_util:standard_test/2

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -857,14 +857,14 @@ finalize_upgrade(Dir) ->
 simple_test_() ->
     ?assertCmd("rm -rf test/bitcask-backend"),
     application:set_env(bitcask, data_root, ""),
-    backend_test_util:standard_test(?MODULE,
-                                    [{data_root, "test/bitcask-backend"}]).
+    backend_test_util:standard_test_gen(?MODULE,
+                                        [{data_root, "test/bitcask-backend"}]).
 
 custom_config_test_() ->
     ?assertCmd("rm -rf test/bitcask-backend"),
     application:set_env(bitcask, data_root, ""),
-    backend_test_util:standard_test(?MODULE,
-                                    [{data_root, "test/bitcask-backend"}]).
+    backend_test_util:standard_test_gen(?MODULE,
+                                        [{data_root, "test/bitcask-backend"}]).
 
 startup_data_dir_test() ->
     os:cmd("rm -rf test/bitcask-backend/*"),

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -922,12 +922,12 @@ to_md_key(Key) ->
 simple_test_() ->
     ?assertCmd("rm -rf test/eleveldb-backend"),
     application:set_env(eleveldb, data_root, "test/eleveldb-backend"),
-    backend_test_util:standard_test(?MODULE, []).
+    backend_test_util:standard_test_gen(?MODULE, []).
 
 custom_config_test_() ->
     ?assertCmd("rm -rf test/eleveldb-backend"),
     application:set_env(eleveldb, data_root, ""),
-    backend_test_util:standard_test(?MODULE, [{data_root, "test/eleveldb-backend"}]).
+    backend_test_util:standard_test_gen(?MODULE, [{data_root, "test/eleveldb-backend"}]).
 
 retry_test_() ->
     {spawn, [fun retry/0, fun retry_fail/0]}.

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -721,7 +721,7 @@ object_size(Object) ->
 
 simple_test_() ->
     Config = [{test, true}, {test_table_opts, [public]}],
-    backend_test_util:standard_test(?MODULE, Config).
+    backend_test_util:standard_test_gen(?MODULE, Config).
 
 ttl_test_() ->
     Config = [{ttl, 15}],

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -651,7 +651,7 @@ multi_backend_test_() ->
 
                        %% Run the standard backend test...
                        Config = sample_config(),
-                       backend_test_util:standard_test(?MODULE, Config)
+                       backend_test_util:standard_test_fun(?MODULE, Config)
                end
               }
       end,

--- a/src/riak_kv_multi_prefix_backend.erl
+++ b/src/riak_kv_multi_prefix_backend.erl
@@ -703,7 +703,7 @@ backend_can_index_reformat(Mod, ModState) ->
 
 %%                        %% Run the standard backend test...
 %%                        Config = sample_config(),
-%%                        backend_test_util:standard_test(?MODULE, Config)
+%%                        backend_test_util:standard_test_fun(?MODULE, Config)
 %%                end
 %%               }
 %%       end,

--- a/src/riak_kv_yessir_backend.erl
+++ b/src/riak_kv_yessir_backend.erl
@@ -473,7 +473,7 @@ t0_number1(_BucketSuffix, Bucket, Key) ->
 -ifdef(TEST).
 simple_test() ->
    Config = [],
-   backend_test_util:standard_test(?MODULE, Config).
+   backend_test_util:standard_test_fun(?MODULE, Config).
 
 -ifdef(EQC).
 eqc_test() ->

--- a/test/backend_test_util.erl
+++ b/test/backend_test_util.erl
@@ -25,13 +25,14 @@
 -include_lib("eunit/include/eunit.hrl").
 -compile(export_all).
 
-standard_test(BackendMod, Config) ->
+standard_test_gen(BackendMod, Config) ->
     {"Basic Backend",
-     fun() ->
-             {Mod, State} = setup({BackendMod, Config}),
-             State2 = basic_store_and_fetch(Mod, State),
-             cleanup({Mod, State2})
-     end}.
+     fun() -> standard_test_fun(BackendMod, Config) end}.
+
+standard_test_fun(BackendMod, Config) ->
+    {Mod, State} = setup({BackendMod, Config}),
+    State2 = basic_store_and_fetch(Mod, State),
+    cleanup({Mod, State2}).
 
 make_test_bucket(Backend, Suffix) ->
     try


### PR DESCRIPTION
At some call points, this function was expected to run a test. At others
it was expected to generate a test.

Now there are two functions: `standard_test_gen/2` and `standard_test_fun/2`.
All call points, even ones that do not actually run today, have been
updated appropriately.
