### PR TITLE
Add object lager sink

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -29,6 +29,7 @@ Unknown functions:
   yz_kv:index/3
   yz_kv:index_binary/5
   yz_kv:should_handoff/1
+  object:warning/2
 Unknown types:
   base64:ascii_binary/0
   mochijson2:json_object/0

--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,7 @@
 {edoc_opts, [{preprocess, true}]}.
 {erl_opts, [warnings_as_errors,
             {parse_transform, lager_transform},
+            {lager_extra_sinks, [object]},
             {src_dirs, ["src", "priv/tracers"]},
             {platform_define, "^[0-9]+", namespaced_types},
             {platform_define, "^[0-9]+", set_env_options},

--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,8 @@
 {xref_checks, []}.
 %% XXX yz_kv is here becase Ryan has not yet made a generic hook interface for object modification
 %% XXX yz_stat is here for similar reasons -- we do not yet support dynamic stat hooks
-{xref_queries, [{"(XC - UC) || (XU - X - B - \"(cluster_info|dtrace|yz_kv|yz_stat)\" : Mod)", []}]}.
+%% XXX object is here because it's a new Lager sync
+{xref_queries, [{"(XC - UC) || (XU - X - B - \"(cluster_info|dtrace|yz_kv|yz_stat|object)\" : Mod)", []}]}.
 
 {erl_first_files, [
                    "src/riak_kv_backend.erl"

--- a/src/riak_kv_get_core.erl
+++ b/src/riak_kv_get_core.erl
@@ -310,7 +310,7 @@ maybe_log_old_vclock(Results) ->
                         [] ->
                             ok;
                         _ ->
-                            lager:warning("Bucket: ~p Key: ~p should be rewritten to guarantee
+                            object:warning("Bucket: ~p Key: ~p should be rewritten to guarantee
                               compatability with AAE version 0",
                                 [riak_object:bucket(R1),riak_object:key(R1)])
                     end


### PR DESCRIPTION
Also add a version entry into riak_kv_entropy_manager ets table so we
don't need to serialize get_version requests on the managers msgq.
