### PR TITLE
Fix issue with mixed version

### DIFF
--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -336,10 +336,10 @@ handle_call({get_lock, Type, Pid}, _From, State) ->
     {reply, Reply, State2};
 %% To support compatibility with pre 2.2 nodes.
 handle_call({start_exchange_remote, FsmPid, Index, IndexN}, From, State) ->
-    {Type, Reply, State2} = do_start_exchange_remote(FsmPid, Index, IndexN, legacy),
+    {Type, Reply, State2} = do_start_exchange_remote(FsmPid, Index, IndexN, legacy, From, State),
     {Type, Reply, State2};
 handle_call({start_exchange_remote, FsmPid, Index, IndexN, Version}, From, State) ->
-    {Type, Reply, State2} = do_start_exchange_remote(FsmPid, Index, IndexN, Version),
+    {Type, Reply, State2} = do_start_exchange_remote(FsmPid, Index, IndexN, Version, From, State),
     {Type, Reply, State2};
 handle_call({cancel_exchange, Index}, _From, State) ->
     case lists:keyfind(Index, 1, State#state.exchanges) of
@@ -520,9 +520,9 @@ do_get_lock(Type, Pid, State=#state{locks=Locks}) ->
             end
     end.
 
--spec do_start_exchange_remote(pid(), index(), index_n(), version()) 
+-spec do_start_exchange_remote(pid(), index(), index_n(), version(), term(), state())
                   -> {reply|noreply, term(), state()}.
-do_start_exchange_remote(FsmPid, Index, IndexN, Version) ->
+do_start_exchange_remote(FsmPid, Index, IndexN, Version, From, State) ->
     case {enabled(),
           orddict:find(Index, State#state.trees)} of
         {false, _} ->

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -51,6 +51,7 @@
          hash_object/3,
          update/2,
          update/3,
+         start_exchange_remote/4,
          start_exchange_remote/5,
          delete/2,
          async_delete/2,
@@ -141,10 +142,12 @@ async_delete(Items, Tree) when Tree =:= undefined; Items =:= [] ->
 async_delete(Items=[{_Id, _Key}|_], Tree) ->
     catch gen_server:cast(Tree, {delete, Items}).
 
-%
 %% @doc Called by the entropy manager to finish the process used to acquire
 %%      remote vnode locks when starting an exchange. For more details,
 %%      see {@link riak_kv_entropy_manager:start_exchange_remote/3}
+-spec start_exchange_remote(pid(), term(), index_n(), pid()) -> ok.
+start_exchange_remote(FsmPid, From, IndexN, Tree) ->
+    start_exchange_remote(FsmPid, legacy, From, IndexN, Tree).
 -spec start_exchange_remote(pid(), version(), term(), index_n(), pid()) -> ok.
 start_exchange_remote(FsmPid, Version, From, IndexN, Tree) ->
     gen_server:cast(Tree, {start_exchange_remote, FsmPid, Version, From, IndexN}).

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -51,7 +51,6 @@
          hash_object/3,
          update/2,
          update/3,
-         start_exchange_remote/4,
          start_exchange_remote/5,
          delete/2,
          async_delete/2,
@@ -145,9 +144,6 @@ async_delete(Items=[{_Id, _Key}|_], Tree) ->
 %% @doc Called by the entropy manager to finish the process used to acquire
 %%      remote vnode locks when starting an exchange. For more details,
 %%      see {@link riak_kv_entropy_manager:start_exchange_remote/3}
--spec start_exchange_remote(pid(), term(), index_n(), pid()) -> ok.
-start_exchange_remote(FsmPid, From, IndexN, Tree) ->
-    start_exchange_remote(FsmPid, legacy, From, IndexN, Tree).
 -spec start_exchange_remote(pid(), version(), term(), index_n(), pid()) -> ok.
 start_exchange_remote(FsmPid, Version, From, IndexN, Tree) ->
     gen_server:cast(Tree, {start_exchange_remote, FsmPid, Version, From, IndexN}).


### PR DESCRIPTION
Specifically add support for aae exchanges if the upgraded nodes still
have legacy trees.
