### PR TITLE
Add logic to skip upgrading a tree if already upgraded trees are not yet built

### DIFF
--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -582,7 +582,7 @@ maybe_get_build_token(State=#state{trees_version=VTrees}) ->
 
 -spec check_built_upgraded_trees(list(), state()) -> build_limit_reached | {ok, state()}.
 check_built_upgraded_trees(Indexes, State=#state{trees=Trees}) ->
-    TreePids = [element(2,orddict:find(Index, Trees)) || Index <- Indexes]
+    TreePids = [element(2,orddict:find(Index, Trees)) || Index <- Indexes],
     case lists:all(fun check_built/1, TreePids) of
         true ->
             do_get_build_token(State);

--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -570,15 +570,8 @@ do_get_build_token(State=#state{build_tokens=Tokens}) ->
 
 -spec maybe_get_upgrade_token(state()) -> build_limit_reached | {ok, state()}.
 maybe_get_upgrade_token(State=#state{trees_version=VTrees}) ->
-    case [Idx || {Idx, Version} <- VTrees, Version /= legacy] of
-        %% All legacy trees, allow build token
-        [] ->
-            do_get_build_token(State);
-        %% Some trees upgraded. Confirm the upgraded trees are built
-        %% before allowing another build token for an upgrade
-        Indexes ->
-            check_built_upgraded_trees(Indexes, State)
-    end.
+    Indexes = [Idx || {Idx, Version} <- VTrees, Version /= legacy],
+    check_built_upgraded_trees(Indexes, State).
 
 -spec check_built_upgraded_trees(list(), state()) -> build_limit_reached | {ok, state()}.
 check_built_upgraded_trees(Indexes, State=#state{trees=Trees}) ->

--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -568,8 +568,8 @@ do_get_build_token(State=#state{build_tokens=Tokens}) ->
             build_limit_reached
     end.
 
--spec maybe_get_build_token(state()) -> build_limit_reached | {ok, state()}.
-maybe_get_build_token(State=#state{trees_version=VTrees}) ->
+-spec maybe_get_upgrade_token(state()) -> build_limit_reached | {ok, state()}.
+maybe_get_upgrade_token(State=#state{trees_version=VTrees}) ->
     case [Idx || {Idx, Version} <- VTrees, Version /= legacy] of
         %% All legacy trees, allow build token
         [] ->

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -336,7 +336,7 @@ handle_call(get_version, _From, State=#state{version=Version}) ->
 
 handle_call(built, _From, State=#state{built=true}) ->
     {reply, true, State};
-handle_call(get_built, _From, State) ->
+handle_call(built, _From, State) ->
     {reply, false, State};
 
 handle_call({insert, Items, Options}, _From, State) ->

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -63,7 +63,8 @@
          destroy/1,
          index_2i_n/0,
          get_trees/1,
-         get_version/1]).
+         get_version/1,
+         built/1).
 
 -export([poke/1,
          get_build_time/1]).
@@ -222,6 +223,11 @@ get_lock(Tree, Type, Version, Pid) ->
 get_version(Tree) ->
     gen_server:call(Tree, get_version, infinity).
 
+%% @doc Return a boolean of trees build status
+-spec built(pid()) -> boolean().
+built(Tree) ->
+    gen_server:call(Tree, built, infinity).
+
 %% @doc Acquire the lock and return the version for the specified index_hashtree if not already
 %%      locked.
 -spec get_lock_and_version(pid(), any()) -> {ok | not_built | already_locked, version()}.
@@ -327,6 +333,11 @@ handle_call({get_lock, Type, Version, Pid}, _From, State) ->
 
 handle_call(get_version, _From, State=#state{version=Version}) ->
     {reply, Version, State};
+
+handle_call(built, _From, State=#state{built=true}) ->
+    {reply, true, State};
+handle_call(get_built, _From, State) ->
+    {reply, false, State};
 
 handle_call({insert, Items, Options}, _From, State) ->
     State2 = do_insert(Items, Options, State),

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -64,7 +64,7 @@
          index_2i_n/0,
          get_trees/1,
          get_version/1,
-         built/1).
+         built/1]).
 
 -export([poke/1,
          get_build_time/1]).


### PR DESCRIPTION
This fixes an issue where, if a user gets an unlucky queue, all trees will upgrade before doing any builds. This leads to unavailable AAE for a period of time.
