### PR TITLE
quanta: don't generate m, y units for prop_quanta_bounded_test

### DIFF
--- a/src/riak_kv_quanta.erl
+++ b/src/riak_kv_quanta.erl
@@ -246,10 +246,10 @@ year_gen() ->
     {choose(1, 40), y}.
 
 quanta_gen() ->
-    oneof([month_gen(),
-           year_gen(),
-           {choose(1,2000), h},
-           {choose(1, 60), m}]).
+    oneof([{choose(1, 2000), d},
+           {choose(1,   24), h},
+           {choose(1,   60), m},
+           {choose(1,   60), s}]).
 
 -endif.
 


### PR DESCRIPTION
Even though jam allows for date/time arithmetics on a wider range of time
units, only `d`, `h`, `m`, and `s` are valid units in qunatum spec. It makes sense,
then, to limit the eqc testing to those -- especially given the fact that
this test fails for certain values of date expressed in months:

```
​ ​ module 'riak_kv_quanta'
​   [...]​
​ ​  riak_kv_quanta: ​  ​prop_quanta_bounded_test.....................Failed! After 19​​ tests.
​ ​{{2000,4,30},{17,36,46},{52,mo}}
​ ​Shrinking xxxxxxxxxxxxxxxxx..x..xx.xxx.xxxxxxxxxxxxxxx(6 times)
​ ​{{1972,4,30},{0,0,1},{7,mo}}
​ ​*failed*
```
