### PR TITLE
Revert build/upgrade prioritization

### DIFF
--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -555,7 +555,7 @@ check_lock_type(Type, State) ->
         build->
             do_get_build_token(State);
         upgrade ->
-            maybe_get_upgrade_token(State);
+            do_get_build_token(State);
         _ ->
             {ok, State}
     end.
@@ -567,25 +567,6 @@ do_get_build_token(State=#state{build_tokens=Tokens}) ->
        true ->
             build_limit_reached
     end.
-
--spec maybe_get_upgrade_token(state()) -> build_limit_reached | {ok, state()}.
-maybe_get_upgrade_token(State=#state{trees_version=VTrees}) ->
-    Indexes = [Idx || {Idx, Version} <- VTrees, Version /= legacy],
-    check_built_upgraded_trees(Indexes, State).
-
--spec check_built_upgraded_trees(list(), state()) -> build_limit_reached | {ok, state()}.
-check_built_upgraded_trees(Indexes, State=#state{trees=Trees}) ->
-    TreePids = [element(2,orddict:find(Index, Trees)) || Index <- Indexes],
-    case lists:all(fun check_built/1, TreePids) of
-        true ->
-            do_get_build_token(State);
-        _ -> 
-            build_limit_reached
-    end.
-
--spec check_built(pid()) -> boolean().
-check_built(Pid) ->
-    riak_kv_index_hashtree:built(Pid).
 
 -spec maybe_release_lock(reference(), state()) -> state().
 maybe_release_lock(Ref, State) ->

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -63,8 +63,7 @@
          destroy/1,
          index_2i_n/0,
          get_trees/1,
-         get_version/1,
-         built/1]).
+         get_version/1]).
 
 -export([poke/1,
          get_build_time/1]).
@@ -223,11 +222,6 @@ get_lock(Tree, Type, Version, Pid) ->
 get_version(Tree) ->
     gen_server:call(Tree, get_version, infinity).
 
-%% @doc Return a boolean of trees build status
--spec built(pid()) -> boolean().
-built(Tree) ->
-    gen_server:call(Tree, built, infinity).
-
 %% @doc Acquire the lock and return the version for the specified index_hashtree if not already
 %%      locked.
 -spec get_lock_and_version(pid(), any()) -> {ok | not_built | already_locked, version()}.
@@ -333,11 +327,6 @@ handle_call({get_lock, Type, Version, Pid}, _From, State) ->
 
 handle_call(get_version, _From, State=#state{version=Version}) ->
     {reply, Version, State};
-
-handle_call(built, _From, State=#state{built=true}) ->
-    {reply, true, State};
-handle_call(built, _From, State) ->
-    {reply, false, State};
 
 handle_call({insert, Items, Options}, _From, State) ->
     State2 = do_insert(Items, Options, State),


### PR DESCRIPTION
This reverts commit: b74ba9d00dda0f801a1fc9201c0e70d64d96b24d

This change results in slower upgrades to version 0 of AAE hashing which caused many tests to fail. The failures look to be due to existing bugs in riak_kv_entropy_manager handling of the exchange and tree queue. I am in process of refactoring the entropy_manager, index_hashtree, and exchange_fsm and would like to roll this prioritization into that work.

I'm tired of the entropy_manager and fighting bugs that are an issue with the architecture of the manager. I will follow up with an RFC for how i'd like to change this subsystem
