### PR TITLE
Always drop dots from CRDTs, not just on merge [JIRA: RIAK-2987]

### DIFF
--- a/src/riak_kv_crdt.erl
+++ b/src/riak_kv_crdt.erl
@@ -398,7 +398,7 @@ meta(undefined, ?CRDT{ctype=CType}) ->
     M3 = dict:store(?MD_VTAG, riak_kv_util:make_vtag(Now), M2),
     dict:store(?MD_CTYPE, CType, M3);
 meta(Meta, _CRDT) ->
-    Meta.
+    drop_the_dot(Meta).
 
 %% Just a simple take the largest for meta values based on last mod
 merge_meta(CType, Meta1, Meta2) ->


### PR DESCRIPTION
Prior to this change, the first write of a new CRDT would end up with a dot in its metadata, since dots were only being dropped on merge. This could potentially lead to sibling CRDTs on disk, since our merge code assumes CRDTs will never have dots.

Although we should never have sibling values for CRDTs present on disk, this bug did not normally cause problems, because using the `fetch_type` client functions would still cause the values to be merged prior to returning them to the client. However, doing a basic `get` could cause the siblings to be exposed to the client directly.

This was the issue that has been causing the `test_hll` test to intermittently fail. The issue can be consistently reproduced using the new `verify_no_datatype_siblings` test, and applying this fix causes that test to pass.

Adding the new call to `drop_the_dot` is needed in order to fix this issue, but removing the old makes no difference for new data, and would be more efficient. However, if we remove the old call then we will run into problems with existing CRDTs on disk that already have dots present, so I'm leaving the old call in place to deal with any such scenarios.
