### PR TITLE
RTS-1466: Reduce the limits on warn_object_size and max_object_size

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -385,14 +385,14 @@
 %% warning in the logs.
 {mapping, "object.size.warning_threshold", "riak_kv.warn_object_size", [
   {datatype, bytesize},
-  {default, "5MB"}
+  {default, "50KB"}
 ]}.
 
 %% @doc Writing an object bigger than this will send a failure to the
 %% client.
 {mapping, "object.size.maximum", "riak_kv.max_object_size", [
   {datatype, bytesize},
-  {default, "50MB"}
+  {default, "500KB"}
 ]}.
 
 %% @doc Writing an object with more than this number of siblings will

--- a/test/riak_kv_schema_tests.erl
+++ b/test/riak_kv_schema_tests.erl
@@ -73,8 +73,8 @@ basic_schema_test() ->
     cuttlefish_unit:assert_not_configured(Config, "riak_kv.multi_backend"),
 
     cuttlefish_unit:assert_config(Config, "riak_kv.secure_referer_check", true),
-    cuttlefish_unit:assert_config(Config, "riak_kv.warn_object_size", 5242880),
-    cuttlefish_unit:assert_config(Config, "riak_kv.max_object_size", 52428800),
+    cuttlefish_unit:assert_config(Config, "riak_kv.warn_object_size", 51200),
+    cuttlefish_unit:assert_config(Config, "riak_kv.max_object_size", 512000),
     cuttlefish_unit:assert_config(Config, "riak_kv.warn_siblings", 25),
     cuttlefish_unit:assert_config(Config, "riak_kv.max_siblings", 100),
 
@@ -263,8 +263,8 @@ multi_backend_test() ->
     cuttlefish_unit:assert_not_configured(Config, "riak_kv.memory_backend.ttl"),
 
     cuttlefish_unit:assert_config(Config, "riak_kv.secure_referer_check", true),
-    cuttlefish_unit:assert_config(Config, "riak_kv.warn_object_size", 5242880),
-    cuttlefish_unit:assert_config(Config, "riak_kv.max_object_size", 52428800),
+    cuttlefish_unit:assert_config(Config, "riak_kv.warn_object_size", 51200),
+    cuttlefish_unit:assert_config(Config, "riak_kv.max_object_size", 512000),
     cuttlefish_unit:assert_config(Config, "riak_kv.warn_siblings", 25),
     cuttlefish_unit:assert_config(Config, "riak_kv.max_siblings", 100),
 


### PR DESCRIPTION
https://bashoeng.atlassian.net/browse/RTS-1466

Basically this is a port of https://github.com/basho/riak_kv/blob/develop/src/riak_kv_vnode.erl#L2338-L2353 to write-once.

Test: https://github.com/basho/riak_test/pull/1218