### PR TITLE
TS Insert NULL support

### DIFF
--- a/include/riak_kv_ts.hrl
+++ b/include/riak_kv_ts.hrl
@@ -32,8 +32,6 @@
 -define(SQL_SELECT, #riak_select_v2).
 -define(SQL_SELECT_RECORD_NAME, riak_select_v2).
 
--define(SQL_NULL, []).
-
 %% the result type of a query, rows means to return all matching rows, aggregate
 %% returns one row calculated from the result set for the query.
 -type select_result_type() :: rows | aggregate | group_by.

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -412,7 +412,7 @@ describe_table_columns_no_quantum_test() ->
                 " t timestamp not null,"
                 " w sint64    not null,"
                 " p double,"
-                " PRIMARY KEY (f, s, t))")),
+                " PRIMARY KEY ((f, s, t), f, s, t))")),
     Res = do_describe(DDL),
     ?assertMatch(
         {ok, {_, _,

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -202,6 +202,8 @@ make_insert_row([], _Positions, Row, _FieldTypes) ->
     %% Out of entries in the value - row is populated with default values
     %% so if we run out of data for implicit/explicit fieldnames can just return
     {ok, Row};
+make_insert_row([{identifier, _Identifier} | _Values], _Positions, _Row, _FieldTypes) ->
+    {error, identifier_unexpected};
 make_insert_row([TypedVal | Values], [Pos | Positions], Row, FieldTypes) ->
     %% Note the Type in TypedVal = {Type, _} is what the value was
     %% parsed into, while its counterpart in FieldTypes is what DDL
@@ -561,6 +563,22 @@ validate_xlate_insert_to_putdata_too_many_values_test() ->
               [{integer, 8}, {binary, <<"scat">>}, {float, 7.65}, {binary, <<"yolo!">>}]],
     Positions = [3, 1, 2, 4],
     Result = xlate_insert_to_putdata(Values, Positions, Empty, [double, varchar, varchar, binary]),
+    ?assertEqual(
+        {error,{too_many_insert_values, [1]}},
+        Result
+    ).
+
+validate_xlate_insert_to_putdata_unexpected_identifier_test() ->
+    Empty = list_to_tuple(lists:duplicate(4, undefined)),
+    Values = [[{integer, 4}, {identifier, <<"babs">>}, {float, 5.67}, {binary, <<"bingo">>}, {integer, 7}],
+              [{integer, 8}, {binary, <<"scat">>}, {float, 7.65}, {binary, <<"yolo!">>}]],
+    Positions = [3, 1, 2, 4],
+    Result = xlate_insert_to_putdata(Values, Positions, Empty, [double, varchar, varchar, binary]),
+    %% TODO: the error for an insert which may span multiple rows  currently
+    %% only supports a single reason due to levels above and below, most
+    %% constraining being the translation of too_many_insert_values into the
+    %% human-readable message:
+    %% {error,{1003,<<"Invalid data found at row index(es) 1">>}}
     ?assertEqual(
         {error,{too_many_insert_values, [1]}},
         Result

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -192,7 +192,8 @@ xlate_insert_to_putdata(Values, Positions, Empty, FieldTypes) ->
 
 -spec make_insert_row([riak_ql_ddl:data_value()], [pos_integer()], tuple(),
                       [riak_ql_ddl:simple_field_type()]) ->
-                      {ok, tuple()} | {error, string()}.
+                      {ok, tuple()} | {error, string()} |
+                      {error, {atom(), string()}}.
 make_insert_row(Vals, _Positions, Row, _FieldTypes)
   when length(Vals) > size(Row) ->
     %% diagnose too_many_values before eventual timestamp conversion
@@ -202,8 +203,8 @@ make_insert_row([], _Positions, Row, _FieldTypes) ->
     %% Out of entries in the value - row is populated with default values
     %% so if we run out of data for implicit/explicit fieldnames can just return
     {ok, Row};
-make_insert_row([{identifier, _Identifier} | _Values], _Positions, _Row, _FieldTypes) ->
-    {error, identifier_unexpected};
+make_insert_row([{identifier, Identifier} | _Values], _Positions, _Row, _FieldTypes) ->
+    {error, {identifier_unexpected, Identifier}};
 make_insert_row([TypedVal | Values], [Pos | Positions], Row, FieldTypes) ->
     %% Note the Type in TypedVal = {Type, _} is what the value was
     %% parsed into, while its counterpart in FieldTypes is what DDL

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -459,6 +459,8 @@ sub_tsqueryreq(_Mod, DDL = ?DDL{table = Table}, SQL, State) ->
             {reply, make_too_many_insert_values_resp(BadRowIdxs), State};
         {error, {undefined_fields, BadFields}} ->
             {reply, make_undefined_field_in_insert_resp(BadFields), State};
+        {error, {identifier_unexpected, Identifier}} ->
+            {reply, make_identifier_unexpected_resp(Identifier), State};
 
         %% these come from riak_kv_qry_compiler, even though the query is a valid SQL.
         {error, {_DDLCompilerErrType, DDLCompilerErrDesc}} when is_atom(_DDLCompilerErrType) ->
@@ -563,6 +565,11 @@ make_undefined_field_in_insert_resp(BadFields) ->
     make_rpberrresp(
       ?E_BAD_QUERY,
       flat_format("undefined fields: ~s", [string:join(BadFields, ", ")])).
+
+make_identifier_unexpected_resp(Identifier) ->
+    make_rpberrresp(
+        ?E_BAD_QUERY,
+        flat_format("unexpected identifer: ~s", [Identifier])).
 
 make_failed_put_resp(ErrorCount) ->
     make_rpberrresp(

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -112,15 +112,20 @@ build_sql_record_int(describe, SQL, _Cover) ->
     {ok, #riak_sql_describe_v1{'DESCRIBE' = D}};
 
 build_sql_record_int(insert, SQL, _Cover) ->
-    T = proplists:get_value(table, SQL),
-    case is_binary(T) of
+    Table = proplists:get_value(table, SQL),
+    case is_binary(Table) of
         true ->
-            Mod = riak_ql_ddl:make_module_name(T),
-            %% If columns are not specified, all columns are implied
-            F = riak_ql_ddl:insert_sql_columns(Mod, proplists:get_value(fields, SQL, [])),
-            V = proplists:get_value(values, SQL),
+            %% To support non- and partial specification of columns, the DDL
+            %% Module, Fields specified in the query, and Values specified in
+            %% the query are sent to the riak_ql_ddl module to flesh out the
+            %% missing or partially specified column to value mappings.
+            Mod = riak_ql_ddl:make_module_name(Table),
+            FieldsInQuery = proplists:get_value(fields, SQL, []),
+            ValuesInQuery = proplists:get_value(values, SQL),
+            {Fields, Values} = riak_ql_ddl:insert_sql_columns(Mod, FieldsInQuery, ValuesInQuery),
+
             %% In order to convert timestamps given as strings, rather
-            %% than doing this here, we pass V (Values) as is and
+            %% than doing this here, we pass Values as is and
             %% relegate the timestamp conversion to
             %% riak_kv_qry:do_insert. The conversion will take place
             %% after checking for too many values wrt the number of
@@ -128,9 +133,9 @@ build_sql_record_int(insert, SQL, _Cover) ->
             %% twice as the timestamp conversion code needs to have
             %% the Types available (and check that length(Types) ==
             %% length(Values)).
-            {ok, #riak_sql_insert_v1{'INSERT'   = T,
-                                     fields     = F,
-                                     values     = V,
+            {ok, #riak_sql_insert_v1{'INSERT'   = Table,
+                                     fields     = Fields,
+                                     values     = Values,
                                      helper_mod = Mod
                                     }};
         false ->


### PR DESCRIPTION
depends on:
- https://github.com/basho/riak_ql/pull/144

does:
- for Riak TS insert support for NULL values, implicitly and explicitly, changed call site to riak_ql_ddl:insert_sql_columns/3 to allow the ddl module to flesh out fields and values not specified in the query.
