### PR TITLE
Use requested bucket and key in preflist endpoint

### DIFF
--- a/src/riak_kv_wm_preflist.erl
+++ b/src/riak_kv_wm_preflist.erl
@@ -93,7 +93,16 @@ service_available(RD, Ctx0=#ctx{riak=RiakProps}) ->
     case riak_kv_wm_utils:get_riak_client(RiakProps,
                                           riak_kv_wm_utils:get_client_id(RD)) of
         {ok, C} ->
-            {true, RD, Ctx#ctx { client=C }};
+            {true, RD, Ctx#ctx { 
+                         bucket=case wrq:path_info(bucket, RD) of
+                             undefined -> undefined;
+                             B -> list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, B))
+                         end,
+                         key=case wrq:path_info(key, RD) of
+                             undefined -> undefined;
+                             K -> list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, K))
+                         end,
+                         client=C }};
         Error ->
             {false,
              wrq:set_resp_body(


### PR DESCRIPTION
The endpoint /buckets/bucketname/keys/keyname/preflist always returned the same preflist because the bucket and key in the URI were ignored. 

Extract them from the request during the service_available check as is done in other riak_kv_wm_ modules
