### PR TITLE
Replace msgpack encoding with ttb

### DIFF
--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -510,8 +510,7 @@ range_scan(FoldIndexFun, Buffer, Opts, #state{fold_opts=_FoldOpts,
     Options = [
                {start_key,   StartKey2},
                {end_key,     EndKey2},
-               {fold_method, streaming},
-               {encoding,    msgpack} | range_scan_additional_options(W)
+               {fold_method, streaming} | range_scan_additional_options(W)
               ],
     KeyFolder = fun() ->
                         Vals = eleveldb:fold(Ref, FoldFun, [], Options),

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -135,7 +135,7 @@ put_data_to_partitions(Data, Bucket, BucketProps, DDL, Mod) ->
     CappedBatchSize = app_helper:get_env(riak_kv, timeseries_max_batch_size,
                                          1024 * 1024),
     EncodeFn =
-        fun(O) -> riak_object:to_binary(v1, O, msgpack) end,
+        fun(O) -> riak_object:to_binary(v1, O, erlang) end,
 
     {ReqIds, FailReqs} =
         lists:foldl(

--- a/src/riak_kv_w1c_worker.erl
+++ b/src/riak_kv_w1c_worker.erl
@@ -475,7 +475,7 @@ kv_or_ts_details(RObj, {ok, LocalKey}) ->
     MD1 = dict:erase(?MD_TS_LOCAL_KEY, MD),
     RObj1 = riak_object:update_metadata(RObj, MD1),
     {RObj1, {riak_object:key(RObj), LocalKey},
-     fun(O) -> riak_object:to_binary(v1, O, msgpack) end};
+     fun(O) -> riak_object:to_binary(v1, O, erlang) end};
 kv_or_ts_details(RObj, error) ->
     {RObj, riak_object:key(RObj), fun(O) -> riak_object:to_binary(v1, O) end}.
 

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -95,7 +95,7 @@
 -export([to_json/1, from_json/1]).
 -export([index_data/1, diff_index_data/2]).
 -export([index_specs/1, diff_index_specs/2]).
--export([to_binary/2, to_binary/3, from_binary/3, from_binary/4, to_binary_version/4, binary_version/1]).
+-export([to_binary/2, to_binary/3, from_binary/3, to_binary_version/4, binary_version/1]).
 -export([set_contents/2, set_vclock/2]). %% INTERNAL, only for riak_*
 -export([is_robject/1]).
 -export([update_last_modified/1, update_last_modified/2]).
@@ -955,14 +955,6 @@ binary_version(<<?MAGIC:8/integer, 1:8/integer, _/binary>>) -> v1.
 %% @doc Convert binary object to riak object
 -spec from_binary(bucket(),key(),binary()) ->
     riak_object() | {error, 'bad_object_format'}.
--spec from_binary(bucket(),key(),binary(),encoding()) ->
-    riak_object() | {error, 'bad_object_format'}.
-
-%% Keep deprecated interface around, because I have a feeling someone
-%% will still try to use it
-
-from_binary(B,K,ObjTerm, _Enc) ->
-    from_binary(B, K, ObjTerm).
 
 from_binary(_B,_K,<<131, _Rest/binary>>=ObjTerm) ->
     binary_to_term(ObjTerm);
@@ -1509,14 +1501,10 @@ packObj_test() ->
     Obj = riak_object:new(<<"bucket">>, <<"key">>, [{<<"field1">>, 1}, {<<"field2">>, 2.123}]),
     PackedErl = riak_object:to_binary(v1, Obj, erlang),
     PackedMsg = riak_object:to_binary(v1, Obj, msgpack),
-    ObjErl = riak_object:from_binary(<<"bucket">>, <<"key">>, PackedErl, erlang),
-    ObjMsg = riak_object:from_binary(<<"bucket">>, <<"key">>, PackedMsg, msgpack),
-    ObjErl2 = riak_object:from_binary(<<"bucket">>, <<"key">>, PackedErl),
-    ObjMsg2 = riak_object:from_binary(<<"bucket">>, <<"key">>, PackedMsg),
+    ObjErl = riak_object:from_binary(<<"bucket">>, <<"key">>, PackedErl),
+    ObjMsg = riak_object:from_binary(<<"bucket">>, <<"key">>, PackedMsg),
     ?assertEqual(Obj, ObjErl),
-    ?assertEqual(Obj, ObjMsg),
-    ?assertEqual(Obj, ObjErl2),
-    ?assertEqual(Obj, ObjMsg2).
+    ?assertEqual(Obj, ObjMsg).
 
 dotted_values_reconcile() ->
     {B, K} = {<<"b">>, <<"k">>},


### PR DESCRIPTION
## **Overview**

This is one of two related PRs to replace msgpack with ttb as the default on-disk encoding format for TS.   The other is https://github.com/basho/eleveldb/pull/223.

Msgpack was originally chosen as the encoding format because in early TS development (before the query pipeline was even written), micro-benchmarking of decoding riak objects in C++ for secondary filtering found that msgpack was significantly faster than naive implementation of the ei decoding library for ttb.  In the context of the end-to-end query pipeline, however, that decoding in C++ represents less than 10% of the total query latency.  Far and away the largest contribution to the latency is converting encoded records back to erlang terms in riak_kv_qry:decode_results() when they are returned to riak from eleveldb.  In this context, the `binary_to_term` BIF is _significantly_ more efficient than our implementation of msgpack decoding -- up to 30% faster for queries of 100K rows, and increasing with the size of the query.  

You can find more discussion of the original micro-benchmarks, the query pipeline, and performance testing of this branch at https://github.com/basho/internal_wiki/wiki/Performance-Improvements-for-Riak#ts1.5.

The purpose of these PRs is to improve query performance by replacing msgpack with ttb encoding as the default on-disk format for TS data.
## **Changes in this repo**

`src/riak_kv_eleveldb_backend.erl` For backwards compatibility, the accompanying eleveldb PR changes the eleveldb fold to allow either msgpack or ttb-encoded data, and determines which encoding has been used on the fly for each key.  This removes the need to specify an encoding format when initiating the fold from erlang.  The `{encoding, type}` tuple has therefore been removed from the options (but will simply be ignored if it is specified, so that the eleveldb code will continue to work even if riak_kv is subsequently downgraded).

`src/riak_kv_ts_api.erl` Encode function in `put_data_to_partitions` has been changed to default to `erlang` encoding, aka ttb.

`src/riak_kv_w1c_worker.erl` Similarly, `kv_or_ts_details` has been changed to return an encoding function that uses `erlang` encoding instead of `msgpack`

`src/riak_object.erl` This was a holdover from long ago (prior to TS1.0 release), when riak_object:from_binary had to be told how to decode a msgpack-encoded record secretly masquerading as a normal riak object.  We changed the encoding flag to indicate the encoding type so that this dangerous situation was no longer needed, but left the deprecated interface lying around.  It's not used by any code today, and is confusing, and I'm therefore removing it.
## **Compatibility**

**Backwards Compatibility** `riak_object:from_binary` has always used the encoding flag written with each data record to switch on encoding type and decode accordingly.  Data written previously with the msgpack flag will therefore continue to be correctly decoded -- customers upgrading to TS1.5 will not have to do anything special to process data written in msgpack format by earlier versions of TS.  Interleaved data written in either format are seamlessly processed by eleveldb, and this is part of the coverage of unit tests included with the eleveldb PR.

**Downgrade Compatibility** In these PRs, the existing TTB encoding flag (used for normal KV objects) has been reused for TS records -- no new encoding flag has been created.  That means that if data are written in the new format (TTB encoding) and riak is subsequently downgraded to TS1.4, both msgpack and ttb-encoded data will be correctly decoded by earlier versions of TS.  _Caveat:_ If downgrading from TS1.5, a patched version of eleveldb will be required, so that records written in TTB format are not ignored by the eleveldb fold.  TS1.5 eleveldb can simply be used with downgraded versions of RiakTS.

Although the encoding flag has been removed from the streaming fold options, the TS1.5 version of eleveldb will simply ignore the parameter if specified, so downgrading to earlier versions of TS will not cause an error.
