### PR TITLE
Bugfix: do not match dead process IDs in compilation table

### DIFF
--- a/src/riak_kv_compile_tab.erl
+++ b/src/riak_kv_compile_tab.erl
@@ -45,7 +45,7 @@
          S == failed orelse
          S == retrying)).
 
-%% 
+%%
 -spec new(file:name()) ->
          {ok, dets:tab_name(), dets:tab_name()} | error.
 new(FileDir) ->
@@ -145,20 +145,38 @@ get_all_table_names() ->
     Tables = [DDL || [DDL] <- Matches],
     lists:usort(Tables).
 
-%% Update the compilation state using the compiler pid as a key.
-%% Since it has an active Pid, it is assumed to have a DDL version already.
+%% Transition a compilation record from state `compiling'.
+%%
+%% The PID of the process responsible for compiling a DDL is an
+%% important hook into the DETS table. When the `riak_kv_ts_newtype'
+%% process receives an `EXIT' message indicating a compilation has
+%% succeeded or failed, the process that terminated is used to
+%% identify the relevant record to transition the state from
+%% `compiling' to `compiled' or `failed'.
+%%
+%% Another valid state transition, also using the PIDs as a key, is
+%% `compiling' to `retrying', called from `mark_compiling_for_retry/0'
+%% when a node launches after terminating during a DDL compilation.
 -spec update_state(CompilerPid :: pid(), State :: compiling_state()) ->
         ok | error | notfound.
 update_state(CompilerPid, State) when is_pid(CompilerPid),
-                                       ?is_compiling_state(State) ->
-    case dets:match(?TABLE, {'$1','$2','$3',CompilerPid,'_'}) of
+                                      ?is_compiling_state(State) ->
+    case dets:match(?TABLE, {'$1','$2','$3',CompilerPid,compiling}) of
         [[BucketType, DDLVersion, DDL]] ->
-            insert(BucketType, DDLVersion, DDL, CompilerPid, State);
+            %% Replace the PID with `undefined' because it's no longer
+            %% a live process. Prior to TS 1.5 the PID was left in the
+            %% table to potentially aid with log file investigation in
+            %% the case of a compilation failure, so users who've
+            %% ugpraded from earlier version of TS will still have old
+            %% PIDs in their DETS table.
+            insert(BucketType, DDLVersion, DDL, undefined, State);
         [] ->
             notfound
     end.
 
-%% Mark any lingering compilations as being retried
+%% Mark any compilations as being retried. Used during node launch for
+%% any compilation processes that were interrupted while the node
+%% stopped.
 -spec mark_compiling_for_retry() -> ok.
 mark_compiling_for_retry() ->
     CompilingPids = dets:match(?TABLE, {'_','_','_','$1',compiling}),

--- a/src/riak_kv_compile_tab.erl
+++ b/src/riak_kv_compile_tab.erl
@@ -78,7 +78,7 @@ delete_dets(FileDir) ->
 -spec insert(BucketType :: binary(),
              DDLVersion :: riak_ql_component:component_version(),
              DDL :: term(),
-             CompilerPid :: pid(),
+             CompilerPid :: pid()|'undefined',
              State :: compiling_state()) -> ok | error.
 insert(BucketType, DDLVersion, DDL, CompilerPid, State) ->
     lager:info("DDL DETS Update: ~p, ~p, ~p, ~p, ~p",

--- a/src/riak_kv_ts_newtype.erl
+++ b/src/riak_kv_ts_newtype.erl
@@ -181,13 +181,16 @@ flush_exit_message(CompilerPid) ->
         1000 -> ok
     end.
 
+%% Allows a `riak_test' intercept
+create_process(Fun) ->
+    proc_lib:spawn_link(Fun).
+
 %%
 -spec start_compilation(BucketType::binary(), DDL::?DDL{}) -> pid().
 start_compilation(BucketType, DDL) ->
-    Pid = proc_lib:spawn_link(
-        fun() ->
-            ok = compile_and_store(ddl_ebin_directory(), DDL)
-        end),
+    Pid = create_process(fun() ->
+                                 ok = compile_and_store(ddl_ebin_directory(), DDL)
+                         end),
     lager:info("Starting DDL compilation of ~s on Pid ~p", [BucketType, Pid]),
     ok = riak_kv_compile_tab:insert(BucketType, riak_ql_ddl_compiler:get_compiler_version(), DDL, Pid, compiling),
     Pid.


### PR DESCRIPTION
@hmmr discovered a scenario where frequently stopping and starting nodes while testing DDL compilation can result in an error due to lingering process IDs from the previous instantiation of the node.

Clean up PIDs after the compile is finished, and also explicitly match only `compiling` records so that users of prior versions with legacy data do not hit this bug.

Also extend commentary and add a `riak_test` intercept point to make system testing for this bug easier.
