### PR TITLE
Equality operator with quantum timestamp RTS-1286

### DIFF
--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -739,7 +739,26 @@ break_out_timeseries(Filters1, PartitionFields1, no_quanta) ->
 break_out_timeseries(Filters1, PartitionFields1, QuantumField) when is_binary(QuantumField) ->
     case find_timestamp_bounds(QuantumField, Filters1) of
         {_, {undefined, undefined}} ->
-            error({incomplete_where_clause, ?E_TSMSG_NO_BOUNDS_SPECIFIED});
+            %% if we don't have a time range then check for a time equality
+            %% filter e.g. mytime = 12345, which is rewritten as
+            %% mytime >= 12345 AND mytime <= 12345
+            {QEqFilters, OtherFilters} =
+                lists:splitwith(fun({Op, F, _}) ->
+                                    Op == '=' andalso F == QuantumField
+                                end, Filters1),
+            case QEqFilters of
+                [QEqFilter] ->
+                    {Body, Filters2} = split_key_from_filters(PartitionFields1, OtherFilters),
+                    Starts = setelement(1, QEqFilter, '>='),
+                    Ends = setelement(1, QEqFilter, '<='),
+                    {[Starts | Body], [Ends | Body], Filters2};
+                [] ->
+                    error({incomplete_where_clause, ?E_TSMSG_NO_BOUNDS_SPECIFIED});
+                [_|_] ->
+                    error(
+                        {cannot_have_two_equality_filters_on_quantum_without_range,
+                         ?E_CANNOT_HAVE_TWO_EQUALITY_FILTERS_ON_QUANTUM_WITHOUT_RANGE})
+            end;
         {_, {_, undefined}} ->
             error({incomplete_where_clause, ?E_TSMSG_NO_UPPER_BOUND});
         {_, {undefined, _}} ->
@@ -2279,6 +2298,35 @@ no_quantum_in_query_4_test() ->
           {filter,[]},
           {end_inclusive,true}],
         Select?SQL_SELECT.'WHERE'
+    ).
+
+eqality_filter_on_quantum_specifies_start_and_end_range_test() ->
+    DDL = get_ddl(
+        "CREATE TABLE tab1("
+        "a TIMESTAMP NOT NULL, "
+        "PRIMARY KEY  ((quantum(a, 15, 's')), a))"),
+    {ok, Q} = get_query(
+          "SELECT * FROM tab1 WHERE a = 1000"),
+    {ok, [Select]} = compile(DDL, Q, 100),
+    ?assertEqual(
+        [{startkey,[{<<"a">>,timestamp,1000}]},
+         {endkey,[{<<"a">>,timestamp,1000}]},
+         {filter,[]},
+         {end_inclusive,true}],
+        Select?SQL_SELECT.'WHERE'
+    ).
+
+cannot_have_two_equality_filters_on_quantum_without_range_test() ->
+    DDL = get_ddl(
+        "CREATE TABLE tab1("
+        "a TIMESTAMP NOT NULL, "
+        "PRIMARY KEY  ((quantum(a, 15, 's')), a))"),
+    {ok, Q} = get_query(
+          "SELECT * FROM tab1 WHERE a = 1000 AND a = 1"),
+    ?assertEqual(
+        {error, {cannot_have_two_equality_filters_on_quantum_without_range,
+                 ?E_CANNOT_HAVE_TWO_EQUALITY_FILTERS_ON_QUANTUM_WITHOUT_RANGE}},
+        compile(DDL, Q, 100)
     ).
 
 two_element_key_range_cannot_match_test() ->

--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -92,3 +92,10 @@
    iolist_to_binary(
      ["Too many subqueries (",integer_to_list(N),")"])
 ).
+
+-define(
+    E_CANNOT_HAVE_TWO_EQUALITY_FILTERS_ON_QUANTUM_WITHOUT_RANGE,
+    <<"There must only be one equality filter on the quantum field in the ",
+      "Where clause when a range is not specified, but more than one was ",
+      "specified.">>
+).


### PR DESCRIPTION
Rewrite queries with `WHERE mytimestamp = 1234' to 'WHERE mytimestamp >= 1234 AND mytimestamp <= 1234` when `mytimestamp` is the quantum is a partition key. This allows the the quantum time to be defined exactly, instead of having an inclusive range of the same time value.

With table `bios` defined as `CREATE TABLE bios ( ts timestamp PRIMARY KEY((id, QUANTUM(ts, 15, 'm')), ts));`.

``` sql
riak-shell(3)>DESCRIBE bios;         
+------+---------+-------+-----------+---------+--------+----+
|Column|  Type   |Is Null|Primary Key|Local Key|Interval|Unit|
+------+---------+-------+-----------+---------+--------+----+
|  ts  |timestamp| false |     1     |    1    |   15   | m  |
+------+---------+-------+-----------+---------+--------+----+

riak-shell(4)>SELECT * FROM bios WHERE ts > 1 AND ts < 200;
+------------------------+
|           ts           |
+------------------------+
|1970-01-01T00:00:00.01Z |
|1970-01-01T00:00:00.011Z|
+------------------------+

riak-shell(5)>SELECT * FROM bios WHERE ts = '1970-01-01T00:00:00.01Z';
+-----------------------+
|          ts           |
+-----------------------+
|1970-01-01T00:00:00.01Z|
+-----------------------
```
