### PR TITLE
Local keys must be specified, fix test data to include the local key

### DIFF
--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -387,8 +387,7 @@ describe_table_columns_test() ->
             " t timestamp not null,"
             " w sint64    not null,"
             " p double,"
-            " PRIMARY KEY ((f, s, quantum(t, 15, m)), "
-            " f, s, t))")),
+            " PRIMARY KEY ((f, s, quantum(t, 15, m)), f, s, t))")),
     Res = do_describe(DDL),
     ?assertMatch(
        {ok, {_, _,
@@ -409,7 +408,7 @@ describe_table_columns_no_quantum_test() ->
                 " t timestamp not null,"
                 " w sint64    not null,"
                 " p double,"
-                " PRIMARY KEY (f, s, t))")),
+                " PRIMARY KEY ((f, s, t), f, s, t))")),
     Res = do_describe(DDL),
     ?assertMatch(
         {ok, {_, _,


### PR DESCRIPTION
Fix a failing test. Local keys must be specified, fix test data to include the local key.