### PR TITLE
Fix put FSM race condition (#1526)

### DIFF
--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -1,0 +1,11 @@
+minimum_reviewers: 2
+merge: true
+build_steps:
+  - make clean
+  - make deps
+  - make compile
+  - make test
+  - make xref
+  - make dialyzer
+org_mode: true
+timeout: 1800

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,58 +1,60 @@
-riak_core_pb.erl
-riak_kv_bitcask_backend.erl:600: Guard test Dir1TS::nonempty_string() == [] can never succeed
-riak_kv_bitcask_backend.erl:602: Guard test Dir2TS::nonempty_string() == [] can never succeed
+riak_core_pb.erl:47: Guard test is_list(Records::tuple()) can never succeed
+riak_core_pb.erl:70: The pattern <_, 'optional', 'undefined', _, _> can never match the type <1 | 2 | 3,'required',_,'bytes',[]>
+riak_core_pb.erl:72: The pattern <_, 'repeated', 'undefined', _, _> can never match the type <1 | 2 | 3,'required',_,'bytes',[]>
+riak_core_pb.erl:74: The pattern <_, 'repeated_packed', 'undefined', _, _> can never match the type <1 | 2 | 3,'required',_,'bytes',[]>
+riak_core_pb.erl:75: The pattern <_, 'repeated_packed', [], _, _> can never match the type <1 | 2 | 3,'required',_,'bytes',[]>
+riak_core_pb.erl:80: The pattern <_, 'repeated', [], _, Acc> can never match the type <1 | 2 | 3,'required',_,'bytes',[]>
+riak_core_pb.erl:83: The pattern <FNum, 'repeated', [Head | Tail], Type, Acc> can never match the type <1 | 2 | 3,'required',_,'bytes',[]>
+riak_core_pb.erl:86: The pattern <FNum, 'repeated_packed', Data, Type, _> can never match the type <1 | 2 | 3,'required',_,'bytes',[]>
+riak_core_pb.erl:101: The call riak_core_pb:enum_to_int(Type::'bytes',Data::atom()) will never return since it differs in the 1st argument from the success typing arguments: ('pikachu','value')
+riak_core_pb.erl:148: The pattern 'true' can never match the type 'false'
+riak_core_pb.erl:154: The pattern 'true' can never match the type 'false'
+riak_core_pb.erl:163: The pattern 'true' can never match the type 'false'
+riak_core_pb.erl:175: The pattern {_, _, Dict} can never match the type 'false'
+riak_core_pb.erl:193: The pattern 'true' can never match the type 'false'
+riak_core_pb.erl:202: The pattern <Binary, 'string'> can never match the type <_,'bytes'>
+riak_core_pb.erl:222: The pattern <Types, [{Fnum, Bytes} | Tail], Acc> can never match the type <_,[],[{_,_}]>
+riak_kv_bitcask_backend.erl:24: Callback info about the riak_kv_backend behaviour is not available
+riak_kv_buckets_fsm.erl:27: Callback info about the riak_core_coverage_fsm behaviour is not available
+riak_kv_console.erl:154: The pattern {'error', 'legacy_mode'} can never match the type {'error','is_up' | 'not_member' | 'only_member'}
+riak_kv_eleveldb_backend.erl:24: Callback info about the riak_kv_backend behaviour is not available
 riak_kv_gcounter.erl:64: Invalid type specification for function riak_kv_gcounter:new/2. The success typing is (_,pos_integer()) -> {'ok',riak_kv_gcounter:gcounter()}
 riak_kv_gcounter.erl:75: Invalid type specification for function riak_kv_gcounter:update/3. The success typing is ('increment' | {'increment',pos_integer()},_,riak_kv_gcounter:gcounter()) -> {'ok',riak_kv_gcounter:gcounter()}
 riak_kv_gcounter.erl:85: Function merge/2 has no local return
 riak_kv_gcounter.erl:86: The call riak_kv_gcounter:merge(GCnt1::any(),GCnt2::any(),[]) does not have an opaque term of type riak_kv_gcounter:gcounter() as 3rd argument
 riak_kv_gcounter.erl:99: The call riak_kv_gcounter:merge(Rest::any(),RestOfClock2::[tuple()],[{_,_},...]) does not have opaque terms as 2nd and 3rd arguments
 riak_kv_gcounter.erl:101: The call riak_kv_gcounter:merge(Rest::any(),Clock2::[tuple()],[{_,_},...]) does not have opaque terms as 2nd and 3rd arguments
-riak_kv_pb_crdt.erl:138: The call riak_pb_dt_codec:encode_fetch_response(Type::any(),Value::any(),Ctx::'undefined' | binary(),[{'counter','riak_dt_pncounter'} | {'flag','riak_dt_od_flag'} | {'map','riak_dt_map'} | {'register','riak_dt_lwwreg'} | {'set','riak_dt_orswot'},...]) does not have an opaque term of type riak_pb_dt_codec:context() as 3rd argument
-riak_kv_pb_crdt.erl:142: The call riak_pb_dt_codec:encode_fetch_response(Type::any(),'undefined','undefined') breaks the contract (toplevel_type(),toplevel_value(),context()) -> #dtfetchresp{}
-riak_kv_pb_crdt.erl:189: The call riak_pb_dt_codec:encode_update_response(Type::any(),Value::any(),Key::'undefined' | binary(),'undefined' | binary(),[{'counter','riak_dt_pncounter'} | {'flag','riak_dt_od_flag'} | {'map','riak_dt_map'} | {'register','riak_dt_lwwreg'} | {'set','riak_dt_orswot'},...]) does not have an opaque term of type riak_pb_dt_codec:context() as 4th argument
-riak_kv_pb_crdt.erl:337: The call riak_pb_dt_codec:encode_fetch_response('counter' | 'flag' | 'map' | 'register' | 'set' | 'undefined',Val::any(),'undefined',[{'counter','riak_dt_pncounter'} | {'flag','riak_dt_od_flag'} | {'map','riak_dt_map'} | {'register','riak_dt_lwwreg'} | {'set','riak_dt_orswot'},...]) does not have an opaque term of type riak_pb_dt_codec:context() as 3rd argument
-riak_kv_pb_index.erl:93: Clause guard cannot succeed. The pattern {'ok', {'riak_kv_index_v3', _, _, Start, _, _, _, _, _, Re, _}} was matched against the type {'error',{'field_parsing_failed',{_,_}} | {'unknown_field_type',binary()} | {'downgrade_not_supported',_,{_,_,_} | {_,_,_,_} | {_,_,_,_,_,_,_,_,_} | {_,_,_,_,_,_,_,_,_,_,_}} | {'invalid_continuation',{_,_},{_,_,_,_,_,_,_,_,_,_,_}}} | {'ok',{'eq',binary(),'undefined' | binary()} | {'range',binary(),'undefined' | binary(),'undefined' | binary()} | #riak_kv_index_v2{start_key::binary(),filter_field::binary(),start_term::'undefined' | binary(),end_term::'undefined' | binary(),return_terms::boolean(),start_inclusive::boolean(),end_inclusive::boolean(),return_body::boolean()} | #riak_kv_index_v3{start_key::binary(),filter_field::binary(),start_term::'undefined' | binary(),end_term::'undefined' | binary(),return_terms::boolean(),start_inclusive::boolean(),end_inclusive::boolean(),return_body::boolean(),term_regex::'undefined' | binary(),max_results::'undefined' | integer()}}
-riak_kv_pb_index.erl:110: The pattern <{'error', Reason}, _Req, State> can never match the type <{'ok',{'eq',binary(),'undefined' | binary()} | {'range',binary(),'undefined' | binary(),'undefined' | binary()} | #riak_kv_index_v2{start_key::binary(),filter_field::binary(),start_term::'undefined' | binary(),end_term::'undefined' | binary(),return_terms::boolean(),start_inclusive::boolean(),end_inclusive::boolean(),return_body::boolean()} | #riak_kv_index_v3{start_key::binary(),filter_field::binary(),start_term::'undefined' | binary(),end_term::'undefined' | binary(),return_terms::boolean(),start_inclusive::boolean(),end_inclusive::boolean(),return_body::boolean(),term_regex::'undefined' | binary(),max_results::'undefined' | integer()}},#rpbindexreq{term_regex::'undefined' | binary() | maybe_improper_list(binary() | maybe_improper_list(any(),binary() | []) | byte(),binary() | [])},_>
-riak_kv_pipe_index.erl:155: Function queue_existing_pipe/4 has no local return
+riak_kv_index_fsm.erl:38: Callback info about the riak_core_coverage_fsm behaviour is not available
+riak_kv_keys_fsm.erl:38: Callback info about the riak_core_coverage_fsm behaviour is not available
+riak_kv_memory_backend.erl:40: Callback info about the riak_kv_backend behaviour is not available
+riak_kv_multi_backend.erl:24: Callback info about the riak_kv_backend behaviour is not available
+riak_kv_pipe_index.erl:164: Function queue_existing_pipe/4 has no local return
 riak_kv_pipe_listkeys.erl:159: Function queue_existing_pipe/3 has no local return
 riak_kv_pncounter.erl:100: Function merge/2 has no local return
 riak_kv_put_fsm.erl:233: Function init/1 has no local return
 riak_kv_put_fsm.erl:238: Record construction #state{robj::riak_object:riak_object(),options::[any()],bkey::{binary() | {binary(),binary()},binary()},vnode_options::[],precommit::[],postcommit::[],timing::[{atom(),{non_neg_integer(),non_neg_integer(),non_neg_integer()}},...],trace::'undefined' | {'ok',_},tracked_bucket::'false',bad_coordinators::[]} violates the declared type of field trace::boolean()
-riak_kv_put_fsm.erl:269: The created fun has no local return
-riak_kv_put_fsm.erl:822: The pattern <[COP = {'counter_op', _Amt} | T], Acc> can never match the type <[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()},...],[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()}]>
-riak_kv_put_fsm.erl:825: The pattern <[COP = {'crdt_op', _Op} | T], Acc> can never match the type <[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()},...],[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()}]>
-riak_kv_util.erl:294: The pattern 'error' can never match the type 'ok' | 'undefined'
-riak_kv_vnode.erl:23: Callback info about the riak_core_vnode behaviour is not available
+riak_kv_put_fsm.erl:270: The created fun has no local return
+riak_kv_put_fsm.erl:825: The pattern <[COP = {'counter_op', _Amt} | T], Acc> can never match the type <[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()},...],[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()}]>
+riak_kv_put_fsm.erl:828: The pattern <[COP = {'crdt_op', _Op} | T], Acc> can never match the type <[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()},...],[{'details' | 'dw' | 'n_val' | 'pw' | 'retry_put_coordinator_failure' | 'returnbody' | 'sloppy_quorum' | 'timeout' | 'update_last_modified' | 'w','false' | 'infinity' | 'true' | [any()] | non_neg_integer()}]>
+riak_kv_util.erl:283: The pattern 'error' can never match the type 'ok' | 'undefined'
 riak_kv_vnode.erl:839: The pattern Q = {'riak_kv_index_v3', _, _, _, _, _, _, _, _, RE, _} can never match the type 'undefined' | {_,_}
 riak_kv_vnode.erl:849: The pattern <{'riak_kv_index_v3', _, _, _, _, _, _, _, _, _, N}, DefaultSize> can never match the type <'undefined' | {_,_},'undefined' | pos_integer()>
-riak_kv_vnode.erl:1092: The call riak_kv_vnode:raw_put(HOTarget::atom(),Key::{binary() | {binary(),binary()},binary()},Obj::riak_object:riak_object()) will never return since it differs in the 1st argument from the success typing arguments: ({_,_},any(),any())
-riak_kv_vnode.erl:1214: Function raw_put/3 has no local return
-riak_kv_vnode.erl:1214: The pattern <{Idx, Node}, Key, Obj> can never match the type <atom(),{binary() | {binary(),binary()},binary()},riak_object:riak_object()>
-riak_kv_vnode.erl:1254: Function do_backend_delete/3 has no local return
-riak_kv_vnode.erl:1922: Function delete_from_hashtree/3 has no local return
-riak_kv_vnode.erl:1926: The call riak_kv_index_hashtree:async_delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ({binary(),binary()} | [{binary(),binary()}],pid()) -> 'ok'
-riak_kv_vnode.erl:1929: The call riak_kv_index_hashtree:delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ([{binary(),binary()}],pid()) -> 'ok'
-riak_kv_vnode.erl:2065: Function update_index_delete_stats/1 will never be called
-riak_kv_wm_crdt.erl:387: Function produce_json/2 has no local return
-riak_kv_wm_crdt.erl:391: The call riak_kv_crdt_json:fetch_response_to_json(Type::'counter' | 'flag' | 'map' | 'register' | 'set' | 'undefined',Value::any(),'undefined' | binary(),[{'counter','riak_dt_pncounter'} | {'flag','riak_dt_od_flag'} | {'map','riak_dt_map'} | {'register','riak_dt_lwwreg'} | {'set','riak_dt_orswot'},...]) does not have an opaque term of type riak_kv_crdt_json:context() as 3rd argument
-riak_kv_wm_index.erl:214: Guard test is_integer(NormStart::'undefined' | binary()) can never succeed
-riak_kv_wm_utils.erl:288: The pattern {Scheme, _, Host, Port, _, _} can never match the type {'error','no_scheme' | {_,atom(),_}}
-cluster_info:dump_all_connected/1
-cluster_info:dump_nodes/2
-cluster_info:format/3
-cluster_info:register_app/1
-riak_kv_console.erl:154: The pattern {'error', 'legacy_mode'} can never match the type {'error','is_up' | 'not_member' | 'only_member'}
-# Callback info not available
-Callback info about the riak_pipe_vnode_worker behaviour is not available
-Callback info about the riak_core_vnode_worker behaviour is not available
-Callback info about the riak_core_vnode behaviour is not available
-Callback info about the riak_core_coverage_fsm behaviour is not available
-Callback info about the riak_kv_backend behaviour is not available
+riak_kv_vnode.erl:1270: Function do_backend_delete/3 has no local return
+riak_kv_vnode.erl:1977: Function delete_from_hashtree/3 has no local return
+riak_kv_vnode.erl:1981: The call riak_kv_index_hashtree:async_delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ({binary(),binary()} | [{binary(),binary()}],pid()) -> 'ok'
+riak_kv_vnode.erl:1984: The call riak_kv_index_hashtree:delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ([{binary(),binary()}],pid()) -> 'ok'
+riak_kv_vnode.erl:2127: Function update_index_delete_stats/1 will never be called
+riak_kv_worker.erl:25: Callback info about the riak_core_vnode_worker behaviour is not available
+riak_kv_yessir_backend.erl:109: Callback info about the riak_kv_backend behaviour is not available
 Unknown functions:
+  cluster_info:dump_all_connected/1
+  cluster_info:dump_nodes/2
+  cluster_info:format/3
+  cluster_info:register_app/1
   dtrace:init/0
   yz_kv:index/3
+  yz_kv:is_search_enabled_for_bucket/1
   yz_kv:should_handoff/1
-  yz_stat:search_stats/0
 Unknown types:
   base64:ascii_binary/0
   calendar:t_now/0

--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
 {deps, [
         {sidejob, ".*", {git, "git://github.com/basho/sidejob.git", {branch, "2.0"}}},
         {erlang_js, ".*", {git, "git://github.com/basho/erlang_js.git", {tag, "1.3.0"}}},
-        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {tag, "1.7.2p3"}}},
+        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {tag, "1.7.2p4"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", {tag, "0.78"}}},
         {sext, ".*", {git, "git://github.com/basho/sext.git", {tag, "1.1p3"}}},
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {branch, "2.0"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
 {deps, [
         {sidejob, ".*", {git, "git://github.com/basho/sidejob.git", {branch, "2.0"}}},
         {erlang_js, ".*", {git, "git://github.com/basho/erlang_js.git", {tag, "1.3.0"}}},
-        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {tag, "1.7.2p4"}}},
+        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {branch, "1.7"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", {tag, "0.78"}}},
         {sext, ".*", {git, "git://github.com/basho/sext.git", {tag, "1.1p3"}}},
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {branch, "2.0"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -24,11 +24,11 @@
 {deps, [
         {sidejob, ".*", {git, "git://github.com/basho/sidejob.git", {branch, "2.0"}}},
         {erlang_js, ".*", {git, "git://github.com/basho/erlang_js.git", {tag, "1.3.0"}}},
-        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {branch, "1.7"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", {tag, "0.78"}}},
         {sext, ".*", {git, "git://github.com/basho/sext.git", {tag, "1.1p3"}}},
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {branch, "2.0"}}},
         {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {branch, "2.0"}}},
         {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {branch, "2.0"}}},
+        {bitcask, ".*", {git, "git://github.com/basho/bitcask.git", {branch, "1.7"}}},
         {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag, "0.1.2"}}}
        ]}.

--- a/src/riak_kv_crdt.erl
+++ b/src/riak_kv_crdt.erl
@@ -358,7 +358,7 @@ meta(undefined, ?CRDT{ctype=CType}) ->
     M3 = dict:store(?MD_VTAG, riak_kv_util:make_vtag(Now), M2),
     dict:store(?MD_CTYPE, CType, M3);
 meta(Meta, _CRDT) ->
-    Meta.
+    drop_the_dot(Meta).
 
 %% Just a simple take the largest for meta values based on last mod
 merge_meta(CType, Meta1, Meta2) ->

--- a/src/riak_kv_entropy_info.erl
+++ b/src/riak_kv_entropy_info.erl
@@ -235,8 +235,12 @@ compute_exchange_info({M,F}, Ring, Index, #index_info{exchanges=Exchanges,
     AllTime = merge_to_first(KnownTime, Defaults),
     %% Rely upon fact that undefined < tuple
     AllTime2 = lists:keysort(2, AllTime),
-    {_, LastAll} = hd(AllTime2),
-    {_, Recent} = hd(lists:reverse(AllTime2)),
+    {LastAll, Recent} = case AllTime2 of
+                            [] ->
+                                {undefined, undefined};
+                            _ ->
+                                {element(2, hd(AllTime2)), element(2, lists:last(AllTime2))}
+                        end,
     {Index, Recent, LastAll, stat_tuple(Repaired)}.
 
 %% Merge two lists together based on the key at position 1. When both lists

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -257,11 +257,12 @@ init([From, RObj, Options0, Monitor]) ->
             ?DTRACE(?C_PUT_FSM_INIT, [TombNum], ["init", TombStr]);
         _ ->
             ok
-    end,        
-    {ok, prepare, StateData, 0};
+    end,
+    gen_fsm:send_event(self(), timeout),
+    {ok, prepare, StateData};
 init({test, Args, StateProps}) ->
     %% Call normal init
-    {ok, prepare, StateData, 0} = init(Args),
+    {ok, prepare, StateData} = init(Args),
 
     %% Then tweak the state record with entries provided by StateProps
     Fields = record_info(fields, state),
@@ -274,7 +275,7 @@ init({test, Args, StateProps}) ->
 
     %% Enter into the validate state, skipping any code that relies on the
     %% state of the rest of the system
-    {ok, validate, TestStateData, 0}.
+    {ok, validate, TestStateData}.
 
 %% @private
 prepare(timeout, StateData0 = #state{from = From, robj = RObj,
@@ -753,9 +754,11 @@ new_state(StateName, StateData) ->
 %% Move to the new state, marking the time it started and trigger an immediate
 %% timeout.
 new_state_timeout(StateName, StateData=#state{trace = true}) ->
-    {next_state, StateName, add_timing(StateName, StateData), 0};
+    gen_fsm:send_event(self(), timeout),
+    {next_state, StateName, add_timing(StateName, StateData)};
 new_state_timeout(StateName, StateData) ->
-    {next_state, StateName, StateData, 0}.
+    gen_fsm:send_event(self(), timeout),
+    {next_state, StateName, StateData}.
 
 %% What to do once enough responses from vnodes have been received to reply
 process_reply(Reply, StateData = #state{postcommit = PostCommit,

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1129,7 +1129,7 @@ handle_info({ensemble_put, Key, Obj, From}, State=#state{handoff_target=HOTarget
                         {fail, _Idx, _ReqID} ->
                             failed
                     end,
-            ((Reply =/= failed) and (HOTarget =/= undefined)) andalso raw_put(HOTarget, Key, Obj),
+            ((Reply =/= failed) and (HOTarget =/= undefined)) andalso raw_put({Idx, HOTarget}, Key, Obj),
             riak_kv_ensemble_backend:reply(From, Reply),
             {ok, State2};
         Fwd when is_atom(Fwd) ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1280,7 +1280,7 @@ do_backend_delete(BKey, RObj, State = #state{idx = Idx,
     {Bucket, Key} = BKey,
     case Mod:delete(Bucket, Key, IndexSpecs, ModState) of
         {ok, UpdModState} ->
-            ?INDEX(RObj, delete, Idx),
+            ?INDEX({RObj, no_old_object}, delete, Idx),
             delete_from_hashtree(Bucket, Key, State),
             maybe_cache_evict(BKey, State),
             update_index_delete_stats(IndexSpecs),

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -75,7 +75,7 @@
 -define(EMPTY_VTAG_BIN, <<"e">>).
 
 -export([new/3, new/4, ensure_robject/1, ancestors/1, reconcile/2, equal/2]).
--export([increment_vclock/2, increment_vclock/3]).
+-export([increment_vclock/2, increment_vclock/3, prune_vclock/3, vclock_descends/2]).
 -export([key/1, get_metadata/1, get_metadatas/1, get_values/1, get_value/1]).
 -export([hash/1, approximate_size/2]).
 -export([vclock_encoding_method/0, vclock/1, vclock_header/1, encode_vclock/1, decode_vclock/1]).
@@ -623,6 +623,18 @@ get_update_value(#r_object{updatevalue=UV}) -> UV.
 %% @doc  INTERNAL USE ONLY.  Set the vclock of riak_object O to V.
 -spec set_vclock(riak_object(), vclock:vclock()) -> riak_object().
 set_vclock(Object=#r_object{}, VClock) -> Object#r_object{vclock=VClock}.
+
+%% @doc Prune vclock
+-spec prune_vclock(riak_object(), vclock:timestamp(), [proplists:property()]) ->
+    riak_object().
+prune_vclock(Obj=#r_object{vclock=VC}, PruneTime, BucketProps) ->
+    VC2 = vclock:prune(VC, PruneTime, BucketProps),
+    Obj#r_object{vclock=VC2}.
+
+%% @doc Does the `riak_object' descend the provided `vclock'?
+-spec vclock_descends(riak_object(), vclock:vclock()) -> boolean().
+vclock_descends(#r_object{vclock=ObjVC}, VC) ->
+    vclock:descends(ObjVC, VC).
 
 %% @doc  Increment the entry for ClientId in O's vclock.
 -spec increment_vclock(riak_object(), vclock:vclock_node()) -> riak_object().


### PR DESCRIPTION
Cannot rely on a gen_fsm timeout event being sent even when the timeout
is set to zero. In particular, another message or event can preempt and
unset the timeout if the handler of that event does not reset it. Rather
than trying to save and restore the timeout state, manually send a
timeout event using gen_fsm:send_event.