### PR TITLE
Check table existence before it is used RTS-1094

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
             {d, 'TEST_FS2_BACKEND_IN_RIAK_KV'}]}.
 
 
-% {eunit_opts, [no_tty, {report, {unite_compact, []}}]}.
+{eunit_opts, [no_tty, {report, {unite_compact, []}}]}.
 
 {xref_checks, []}.
 %% XXX yz_kv is here becase Ryan has not yet made a generic hook interface for object modification

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -269,24 +269,12 @@ queried_table(
     #riak_sql_explain_query_v1{'EXPLAIN'=?SQL_SELECT{'FROM' = Table}}) ->
         Table.
 
--spec get_table_ddl(binary()) ->
-                           {ok, module(), ?DDL{}} |
-                           {error, term()}.
+-spec get_table_ddl(binary()) -> {ok, module(), ?DDL{}}.
 %% Check that Table is in good standing and ready for TS operations
 %% (its bucket type has been activated and it has a DDL in its props)
 get_table_ddl(Table) when is_binary(Table) ->
-    case riak_core_bucket:get_bucket(table_to_bucket(Table)) of
-        {error, _} = Error ->
-            Error;
-        [_|_] ->
-            Mod = riak_ql_ddl:make_module_name(Table),
-            case catch Mod:get_ddl() of
-                {_, {undef, _}} ->
-                    {error, missing_helper_module};
-                DDL ->
-                    {ok, Mod, DDL}
-            end
-    end.
+    Mod = riak_ql_ddl:make_module_name(Table),
+    {ok, Mod, Mod:get_ddl()}.
 
 
 %%


### PR DESCRIPTION
Two recent changes circumvented previous checks for table existence.

1. Checks for tables being disabled because of capabilities/table features.
2. The insert API requires the helper module to exist to create the record for it, which happens before the check for table existence.

How to reproduce, open the riak-shell and run without creating table gerp.

```sql
riak-shell(1)>INSERT INTO gerp VALUES(9);
Error (1019): gerp is not an active table
```

This changes the point at which checks for table existence are made. It is not in the decode phase of the riak_api behaviour and before records are created.