### PR TITLE
Fix race between capabilities registration and AAE startup. [JIRA: RIAK-2985]

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -163,10 +163,6 @@ start(_Type, _StartArgs) ->
                                            mapred_2i_pipe,
                                            [{true, true}, {false, false}]}),
 
-            riak_core_capability:register({riak_kv, anti_entropy},
-                                          [enabled_v1, disabled],
-                                          disabled),
-
             riak_core_capability:register({riak_kv, handoff_data_encoding},
                                           [encode_raw, encode_zlib],
                                           encode_zlib),
@@ -200,10 +196,6 @@ start(_Type, _StartArgs) ->
             riak_core_capability:register({riak_kv, put_fsm_ack_execute},
                                           [enabled, disabled],
                                           disabled),
-
-            riak_core_capability:register({riak_kv, object_hash_version},
-                                          [0, legacy],
-                                          legacy),
 
             HealthCheckOn = app_helper:get_env(riak_kv, enable_health_checks, false),
             %% Go ahead and mark the riak_kv service as up in the node watcher.

--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -277,6 +277,7 @@ cancel_exchanges() ->
 
 -spec init([]) -> {'ok',state()}.
 init([]) ->
+    register_capabilities(),
     riak_core_throttle:init(riak_kv,
                             ?AAE_THROTTLE_KEY,
                             {aae_throttle_limits, ?DEFAULT_AAE_THROTTLE_LIMITS},
@@ -302,6 +303,14 @@ init([]) ->
     State2 = reset_build_tokens(State),
     schedule_reset_build_tokens(),
     {ok, State2}.
+
+register_capabilities() ->
+    riak_core_capability:register({riak_kv, object_hash_version},
+                                  [0, legacy],
+                                  legacy),
+    riak_core_capability:register({riak_kv, anti_entropy},
+                                  [enabled_v1, disabled],
+                                  disabled).
 
 handle_call({set_mode, Mode}, _From, State=#state{mode=CurrentMode}) ->
     State2 = case {CurrentMode, Mode} of

--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -98,6 +98,7 @@ init([]) ->
 
     % Build the process list...
     Processes = lists:flatten([
+        EntropyManager,
         ?IF(HasStorageBackend, VMaster, []),
         FastPutSup,
         DeleteSup,
@@ -105,7 +106,6 @@ init([]) ->
         BucketsFsmSup,
         KeysFsmSup,
         IndexFsmSup,
-        EntropyManager,
         [EnsemblesKV || riak_core_sup:ensembles_enabled()],
         JSSup,
         MapJSPool,


### PR DESCRIPTION
During testing, it was found to be possible for a hashtree to start
_before_ the `{riak_kv, object_hash}` capability was registered, causing
the wrong version to be chosen when the tree started up. This can cause
old trees to be loaded, ignoring new trees that have more recent data,
and the wrong hash version to be used, which can cause unnecessary
repairs.

Moving the registration of the anti-entropy-related capabilities
to `riak_kv_entropy_manager` and changing the order of startup in
`riak_kv_sup` to make sure the entropy manager is started before
the vnodes start ensures that the capability is registered and
negotiated before hashtrees try to start.

This can be tested by running the `yz_aae_test` in a loop on certain hardware - found during testing of 2.2.0, and tends to reproduce more readily on a SmartOS-hosted Centos 7 machine. Unfortunately, it's a race condition, which makes it difficult to test in isolation.