### PR TITLE
provide hardcoded defaults for riak_kv_qry_sup parameters

### DIFF
--- a/src/riak_kv_qry_sup.erl
+++ b/src/riak_kv_qry_sup.erl
@@ -32,6 +32,15 @@
 %% Supervisor callbacks
 -export([init/1]).
 
+-define(TIMESERIES_MAX_CONCURRENT_QUERIES, 3).
+-define(TIMESERIES_QUERY_QUEUE_LENGTH, 15).
+-define(TIMESERIES_QUERY_MAX_RETURNED_DATA_SIZE, 10*1000*1000).
+-define(TIMESERIES_QUERY_BUFFERS_ROOT_PATH_SUFFIX, "query_buffers").  %% relative to platform_data_dir
+-define(TIMESERIES_QUERY_BUFFERS_SOFT_WATERMARK, 1*1024*1024*1024).
+-define(TIMESERIES_QUERY_BUFFERS_HARD_WATERMARK, 4*1024*1024*1024).
+-define(TIMESERIES_QUERY_BUFFERS_EXPIRE_MS, 5000).
+-define(TIMESERIES_QUERY_BUFFERS_INCOMPLETE_RELEASE_MS, 9000).
+
 -define(SERVER, ?MODULE).
 
 %%%===================================================================
@@ -58,7 +67,8 @@ init([]) ->
     Shutdown = 2000,
     Type = worker,
 
-    NumFSMs = app_helper:get_env(riak_kv, timeseries_max_concurrent_queries),
+    NumFSMs = app_helper:get_env(riak_kv, timeseries_max_concurrent_queries,
+                                 ?TIMESERIES_MAX_CONCURRENT_QUERIES),
 
     MakeNamesFn = fun(N) ->
                           Int   = integer_to_list(N),
@@ -71,20 +81,29 @@ init([]) ->
     Riak_kv_qry_q = {riak_kv_qry_queue,
                      {riak_kv_qry_queue, start_link,
                       [
-                       app_helper:get_env(riak_kv, timeseries_query_queue_length)
+                       app_helper:get_env(riak_kv, timeseries_query_queue_length,
+                                          ?TIMESERIES_QUERY_QUEUE_LENGTH)
                       ]},
                      Restart, Shutdown, Type, [riak_kv_qry_queue]},
 
     Riak_kv_qry_b = {riak_kv_qry_buffers,
                      {riak_kv_qry_buffers, start_link,
                       [
-                       [app_helper:get_env(riak_kv, timeseries_query_buffers_root_path),
-                       app_helper:get_env(riak_kv, timeseries_query_max_returned_data_size),
-                       app_helper:get_env(riak_kv, timeseries_query_buffers_soft_watermark),
-                       app_helper:get_env(riak_kv, timeseries_query_buffers_hard_watermark),
-                       app_helper:get_env(riak_kv, timeseries_query_buffers_expire_ms),
-                       app_helper:get_env(riak_kv, timeseries_query_buffers_incomplete_release_ms)
-                      ]]},
+                       [app_helper:get_env(riak_kv, timeseries_query_buffers_root_path,
+                                           filename:join(
+                                             app_helper:get_env(riak_core, platform_data_dir),
+                                             ?TIMESERIES_QUERY_BUFFERS_ROOT_PATH_SUFFIX)),
+                        app_helper:get_env(riak_kv, timeseries_query_max_returned_data_size,
+                                           ?TIMESERIES_QUERY_MAX_RETURNED_DATA_SIZE),
+                        app_helper:get_env(riak_kv, timeseries_query_buffers_soft_watermark,
+                                           ?TIMESERIES_QUERY_BUFFERS_SOFT_WATERMARK),
+                        app_helper:get_env(riak_kv, timeseries_query_buffers_hard_watermark,
+                                           ?TIMESERIES_QUERY_BUFFERS_HARD_WATERMARK),
+                        app_helper:get_env(riak_kv, timeseries_query_buffers_expire_ms,
+                                           ?TIMESERIES_QUERY_BUFFERS_EXPIRE_MS),
+                        app_helper:get_env(riak_kv, timeseries_query_buffers_incomplete_release_ms,
+                                           ?TIMESERIES_QUERY_BUFFERS_INCOMPLETE_RELEASE_MS)
+                       ]]},
                      Restart, Shutdown, Type, [riak_kv_qry_buffers]},
 
     {ok, {SupFlags, [


### PR DESCRIPTION
This helps to avoid `undefined`s entering circulation when riak.conf is empty and riak_kv.app is maliciously tampered with.

For @andytill to review.