### PR TITLE
Use query buffers path for queries with any of OFFSET/LIMIT/ORDER BY RTS-1527

### DIFF
--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -277,7 +277,9 @@ do_select(SQL, ?DDL{table = BucketType} = DDL) ->
                                        {ok, {new|existing, riak_kv_qry_buffers:qbuf_ref()} |
                                              undefined} |
                                        {error, any()}.
-maybe_create_query_buffer(?SQL_SELECT{'ORDER BY' = []},  %% LIMIT implies ORDER BY
+maybe_create_query_buffer(?SQL_SELECT{'ORDER BY' = [],
+                                      'LIMIT'    = [],
+                                      'OFFSET'   = []},
                           _NSubQueries, _CompiledSelect, _CompiledOrderBy, _Options) ->
     {ok, undefined};
 maybe_create_query_buffer(SQL, NSubqueries, CompiledSelect, CompiledOrderBy, Options) ->


### PR DESCRIPTION
Now that the parser emits `?SQL_SELECT` records with `'GROUP BY' = []` (and not `undefined`) when the query has no ORDER BY clause but may have LIMIT and/or OFFSET clause, we need to check for all these other clauses as well in order to decide whether to send the query execution down query buffer
path.

This fixes the problem when a query with *no* ORDER BY clause but *with* a LIMIT clause, fails to effectively apply the LIMIT restriction.