### PR TITLE
Ensure a table exists before asking for its DDL

### DIFF
--- a/src/riak_kv_compile_tab.erl
+++ b/src/riak_kv_compile_tab.erl
@@ -211,15 +211,11 @@ get_table_ddl(_Table) ->
     DDL = {}, %% not used by caller
     {ok, Module, DDL}.
 
-is_table_supported(DDLRecCap, Table = <<"my_type2">>) ->
-    is_table_supported_not_active(DDLRecCap, Table);
-is_table_supported(DDLRecCap, Table) ->
-    is_table_supported_active(DDLRecCap, Table).
-
-is_table_supported_active(_DDLRecCap, _Table) ->
+is_table_supported(_DDLRecCap, <<"my_type2">>) ->
+    {error, "The table is not active"};
+is_table_supported(_DDLRecCap, _Table) ->
     true.
-is_table_supported_not_active(_DDLRecCap, _Table) ->
-    {error, "The table is not active"}.
+
 -endif.
 %% / Forwards/Mocks for getting table status, isolating the interaction for testability
 


### PR DESCRIPTION
Add `riak_kv_ts_util:is_table_active_and_supported/2` to make sure the DDL helper module exists before going on to check to see if features are supported.

Sadly `get_table_ddl` had issues when calling it against a non-existent table, so I went with `code:ensure_loaded/1`:

```
in function ets:lookup/2
  called as lookup(metadata_manager_prefixes_ets,{core,bucket_types})
in call from riak_core_metadata_manager:ets_tab/1 (src/riak_core_metadata_manager.erl, line 617)
in call from riak_core_metadata_manager:read/1 (src/riak_core_metadata_manager.erl, line 585)
in call from riak_core_metadata:get/3 (src/riak_core_metadata.erl, line 97)
in call from riak_core_claimant:get_bucket_type/3 (src/riak_core_claimant.erl, line 203)
in call from riak_core_bucket:get_bucket/1 (src/riak_core_bucket.erl, line 123)
in call from riak_kv_ts_util:get_table_ddl/1 (src/riak_kv_ts_util.erl, line 303)
in call from riak_kv_ts_util:is_table_active_and_supported/2 (src/riak_kv_ts_util.erl, line 689)
```