### PR TITLE
remove allow_qbuf_reuse

### DIFF
--- a/include/riak_kv_ts.hrl
+++ b/include/riak_kv_ts.hrl
@@ -103,7 +103,8 @@
           group_by = ?GROUP_BY_DEFAULT :: [{identifier, binary()}] | [{FieldPos::integer(), FieldName::binary()}],
           %% since v3
           'OFFSET'       = []   :: [riak_kv_qry_compiler:offset()],
-          %% to be supplied in #tsqueryreq{}
+          %% to be supplied in #tsqueryreq.qbuf_id, which is expected
+          %% to appear in a future release
           qbuf_id               :: undefined | binary()  %% control reuse of existing buffers
        }).
 

--- a/include/riak_kv_ts.hrl
+++ b/include/riak_kv_ts.hrl
@@ -103,7 +103,8 @@
           group_by = ?GROUP_BY_DEFAULT :: [{identifier, binary()}] | [{FieldPos::integer(), FieldName::binary()}],
           %% since v3
           'OFFSET'       = []   :: [riak_kv_qry_compiler:offset()],
-          allow_qbuf_reuse = false :: boolean()  %% control reuse of query buffers
+          %% to be supplied in #tsqueryreq{}
+          qbuf_id               :: undefined | binary()  %% control reuse of existing buffers
        }).
 
 -record(riak_sql_describe_v1,

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -264,6 +264,9 @@ prep_stop(_State) ->
         lager:info("unregistered webmachine routes"),
         wait_for_put_fsms(),
         lager:info("all active put FSMs completed"),
+
+        ok = riak_kv_qry_buffers:kill_all_qbufs(),
+        lager:info("cleaned up query buffers"),
         ok
     catch
         Type:Reason ->

--- a/src/riak_kv_pb_ts.erl
+++ b/src/riak_kv_pb_ts.erl
@@ -48,9 +48,11 @@ decode(Code, Bin) when Code >= 90, Code =< 103 ->
     Msg = riak_pb_codec:decode(Code, Bin),
     DecodedReq =
         case Msg of
-            #tsqueryreq{query = Q, cover_context = Cover, allow_qbuf_reuse = AllowQBufReuse} ->
+            #tsqueryreq{query = Query, cover_context = Cover} ->
+                %% this will be supplied in #tsqueryreq in 1.6
+                QBufId = undefined,
                 riak_kv_ts_svc:decode_query_common(
-                  Q, [{cover, Cover}, {allow_qbuf_reuse, AllowQBufReuse}]);
+                  Query, [{cover, Cover}, {qbuf_id, QBufId}]);
             #tsgetreq{table = Table}->
                 {ok, Msg, {riak_kv_ts_api:api_call_to_perm(get), Table}};
             #tsputreq{table = Table} ->

--- a/src/riak_kv_pb_ts.erl
+++ b/src/riak_kv_pb_ts.erl
@@ -49,10 +49,8 @@ decode(Code, Bin) when Code >= 90, Code =< 103 ->
     DecodedReq =
         case Msg of
             #tsqueryreq{query = Query, cover_context = Cover} ->
-                %% this will be supplied in #tsqueryreq in 1.6
-                QBufId = undefined,
                 riak_kv_ts_svc:decode_query_common(
-                  Query, [{cover, Cover}, {qbuf_id, QBufId}]);
+                  Query, [{cover, Cover}]);
             #tsgetreq{table = Table}->
                 {ok, Msg, {riak_kv_ts_api:api_call_to_perm(get), Table}};
             #tsputreq{table = Table} ->

--- a/src/riak_kv_qry_buffers.erl
+++ b/src/riak_kv_qry_buffers.erl
@@ -62,8 +62,7 @@
 
          %% utility functions
          limit_to_scalar/1,
-         offset_to_scalar/1,
-         make_qref/1
+         offset_to_scalar/1
         ]).
 
 -type qbuf_ref() :: binary().
@@ -144,28 +143,6 @@ set_max_query_data_size(Value) ->
 
 
 %% Utility functions that don't need or use the gen_server
-
--spec make_qref(?SQL_SELECT{}) -> {ok, qbuf_ref()} | {error, query_non_pageable | bad_sql}.
-%% @doc Make a query ref (or hash), to identify this (and similar) queries as
-%%      having certain SELECT, FROM, WHERE and ORDER BY clauses.
-make_qref(?SQL_SELECT{'SELECT'   = #riak_sel_clause_v1{col_names = ColNames},
-                      'FROM'     = From,
-                      'WHERE'    = Where,
-                      'ORDER BY' = OrderBy})
-  when OrderBy /= undefined ->
-    Part0 = erlang:phash2(From),
-    Part1 = erlang:phash2(ColNames),
-    Part2 = erlang:phash2(Where),
-    Part3 = erlang:phash2(OrderBy),
-    {ok,
-     <<0,       %% marks an organic qref (1 = random qref for one-shot queries)
-       Part0:32/integer,
-       Part1:32/integer,
-       Part2:32/integer,
-       Part3:32/integer>>};
-make_qref(_) ->
-    {error, query_non_pageable}.
-
 
 limit_to_scalar([]) -> unlimited;
 limit_to_scalar([A]) when is_integer(A) -> A.
@@ -349,7 +326,7 @@ terminate(_Reason, #state{qbufs = QBufs,
     lists:foreach(
       fun({_QBufRef, #qbuf{ldb_ref = LdbRef,
                            ddl = ?DDL{table = Table}}}) ->
-              kill_qbuf(RootPath, Table, LdbRef)
+              kill_ldb(RootPath, Table, LdbRef)
       end,
       QBufs),
     ok.
@@ -371,12 +348,12 @@ do_get_or_create_qbuf(SQL = ?SQL_SELECT{'FROM' = OrigTable},
                              root_path        = RootPath,
                              total_size       = TotalSize,
                              qbuf_expire_msec = DefaultQBufExpireMsec} = State0) ->
-    case maybe_ensure_qref(SQL, QBufs0) of
-        {ok, {existing, QBufRef}} ->
+    case get_qref(SQL, QBufs0) of
+        {existing, QBufRef} ->
             lager:info("reusing existing query buffer ~p for ~p", [QBufRef, SQL]),
             State9 = touch_qbuf(QBufRef, State0),
             {reply, {ok, {existing, QBufRef}}, State9};
-        {ok, {new, QBufRef}} ->
+        {new, QBufRef} ->
             case TotalSize > SoftWMark of
                 true ->
                     {reply, {error, total_qbuf_size_limit_reached}, State0};
@@ -403,16 +380,8 @@ do_get_or_create_qbuf(SQL = ?SQL_SELECT{'FROM' = OrigTable},
                         {error, Reason} ->
                             {reply, {error, Reason}, State0}
                     end
-            end;
-        {error, Reason} ->
-            {reply, {error, Reason}, State0}
+            end
     end.
-
-maybe_ensure_qref(?SQL_SELECT{allow_qbuf_reuse = true} = SQL, QBufs) ->
-    ensure_qref(SQL, QBufs);
-maybe_ensure_qref(?SQL_SELECT{allow_qbuf_reuse = false}, _QBufs) ->
-    AlwaysUniqueRef = crypto:rand_bytes(8),
-    {ok, {new, <<1, AlwaysUniqueRef/binary>>}}.
 
 
 do_delete_qbuf(QBufRef, #state{qbufs = QBufs0,
@@ -530,7 +499,7 @@ do_fetch_limit(QBufRef,
         #qbuf{is_ready = false} ->
             {reply, {error, qbuf_not_ready}, State0};
         #qbuf{ldb_ref = LdbRef,
-              orig_qry = ?SQL_SELECT{allow_qbuf_reuse = AllowQBufReuse} = OrigQry,
+              orig_qry = OrigQry,
               ddl = ?DDL{fields = QBufFields,
                          table = Table}} ->
             case riak_kv_qry_buffers_ldb:fetch_rows(LdbRef, Offset, Limit) of
@@ -538,13 +507,7 @@ do_fetch_limit(QBufRef,
                     lager:debug("fetched ~p rows from ~p for ~p", [length(Rows), Table, OrigQry]),
                     ColNames = [Name || #riak_field_v1{name = Name} <- QBufFields],
                     ColTypes = [Type || #riak_field_v1{type = Type} <- QBufFields],
-                    State9 =
-                        case AllowQBufReuse of
-                            false ->  %% this is a one-shot query: delete it now
-                                kill_qbuf(QBufRef, State0);
-                            true ->
-                                touch_qbuf(QBufRef, State0)
-                        end,
+                    State9 = touch_qbuf(QBufRef, State0),
                     {reply, {ok, {ColNames, ColTypes, Rows}}, State9}
                 %% {error, Reason} ->
                 %%     {reply, {error, Reason}, State0}
@@ -593,7 +556,7 @@ do_reap_expired_qbufs(#state{qbufs = QBufs0,
                   ExpiresOn = advance_timestamp(LastAccessed, ExpireMsec),
                   case ExpiresOn < Now of
                       true ->
-                          ok = kill_qbuf(RootPath, Table, LdbRef),
+                          ok = kill_ldb(RootPath, Table, LdbRef),
                           lager:debug("Reaped expired qbuf ~p", [Table]),
                           false;
                       false ->
@@ -606,7 +569,7 @@ do_reap_expired_qbufs(#state{qbufs = QBufs0,
                   ExpiresOn = advance_timestamp(LastAccessed, IncompleteQbufReleaseMsec),
                   case ExpiresOn < Now of
                       true ->
-                          ok = kill_qbuf(RootPath, Table, LdbRef),
+                          ok = kill_ldb(RootPath, Table, LdbRef),
                           lager:debug("Reaped incompletely filled qbuf ~p", [Table]),
                           false;
                       false ->
@@ -700,17 +663,13 @@ compute_chunk_size(Data) ->
 
 %% buffer list maintenance
 
-ensure_qref(SQL, QBufs) ->
-    case make_qref(SQL) of
-        {ok, QBufRef} ->
-            case get_qbuf_record(QBufRef, QBufs) of
-                #qbuf{} ->
-                    {ok, {existing, QBufRef}};
-                false ->
-                    {ok, {new, QBufRef}}
-            end;
-        {error, _} = ErrorReason ->
-            ErrorReason
+get_qref(?SQL_SELECT{qbuf_id = RequestedQBufId}, QBufs) ->
+    case get_qbuf_record(RequestedQBufId, QBufs) of
+        #qbuf{} ->
+            {existing, RequestedQBufId};
+        false ->
+            AlwaysUniqueId = crypto:rand_bytes(8),
+            {new, AlwaysUniqueId}
     end.
 
 touch_qbuf(QBufRef, State0 = #state{qbufs = QBufs0}) ->
@@ -719,15 +678,7 @@ touch_qbuf(QBufRef, State0 = #state{qbufs = QBufs0}) ->
     State0#state{qbufs = lists:keyreplace(
                            QBufRef, 1, QBufs0, {QBufRef, QBuf9})}.
 
-kill_qbuf(QBufRef, #state{root_path = RootPath,
-                          qbufs = QBufs0} = State0) ->
-    #qbuf{ldb_ref = LdbRef,
-          ddl = ?DDL{table = Table}} = get_qbuf_record(QBufRef, QBufs0),
-    ok = kill_qbuf(RootPath, Table, LdbRef),
-    State0#state{qbufs = lists:keydelete(
-                           QBufRef, 1, QBufs0)}.
-
-kill_qbuf(RootPath, Table, LdbRef) ->
+kill_ldb(RootPath, Table, LdbRef) ->
     ok = riak_kv_qry_buffers_ldb:delete_table(Table, LdbRef, RootPath),
     ok.
 

--- a/src/riak_kv_qry_buffers.erl
+++ b/src/riak_kv_qry_buffers.erl
@@ -351,11 +351,11 @@ do_get_or_create_qbuf(SQL = ?SQL_SELECT{'FROM' = OrigTable},
                              total_size       = TotalSize,
                              qbuf_expire_msec = DefaultQBufExpireMsec} = State0) ->
     case get_qref(SQL, QBufs0) of
-        {existing, QBufRef} ->
+        {ok, {existing, QBufRef}} ->
             lager:info("reusing existing query buffer ~p for ~p", [QBufRef, SQL]),
             State9 = touch_qbuf(QBufRef, State0),
             {reply, {ok, {existing, QBufRef}}, State9};
-        {new, QBufRef} ->
+        {ok, {new, QBufRef}} ->
             case TotalSize > SoftWMark of
                 true ->
                     {reply, {error, total_qbuf_size_limit_reached}, State0};
@@ -382,7 +382,9 @@ do_get_or_create_qbuf(SQL = ?SQL_SELECT{'FROM' = OrigTable},
                         {error, Reason} ->
                             {reply, {error, Reason}, State0}
                     end
-            end
+            end;
+        {error, Reason} ->
+            {reply, {error, Reason}, State0}
     end.
 
 
@@ -670,13 +672,26 @@ compute_chunk_size(Data) ->
 
 %% buffer list maintenance
 
-get_qref(?SQL_SELECT{qbuf_id = RequestedQBufId}, QBufs) ->
+get_qref(?SQL_SELECT{qbuf_id = RequestedQBufId,
+                     'SELECT'   = Select,
+                     'FROM'     = From,
+                     'WHERE'    = Where,
+                     'ORDER BY' = OrderBy}, QBufs) ->
     case get_qbuf_record(RequestedQBufId, QBufs) of
+        %% queries must match in parts used to construct this buffer:
+        %% this check is needed to correctly error out when the user
+        %% messes up their qbuf_id's (i.e., issues a wrong follow-up
+        %% query)
+        #qbuf{orig_qry = ?SQL_SELECT{'SELECT'   = Select,
+                                     'FROM'     = From,
+                                     'WHERE'    = Where,
+                                     'ORDER BY' = OrderBy}} ->
+            {ok, {existing, RequestedQBufId}};
         #qbuf{} ->
-            {existing, RequestedQBufId};
+            {error, bad_followup_query};
         false ->
             AlwaysUniqueId = crypto:rand_bytes(8),
-            {new, AlwaysUniqueId}
+            {ok, {new, AlwaysUniqueId}}
     end.
 
 kill_all_qbufs(State0 = #state{qbufs = QBufs,

--- a/src/riak_kv_qry_buffers.erl
+++ b/src/riak_kv_qry_buffers.erl
@@ -352,7 +352,7 @@ do_get_or_create_qbuf(SQL = ?SQL_SELECT{'FROM' = OrigTable},
                              qbuf_expire_msec = DefaultQBufExpireMsec} = State0) ->
     case get_qref(SQL, QBufs0) of
         {ok, {existing, QBufRef}} ->
-            lager:info("reusing existing query buffer ~p for ~p", [QBufRef, SQL]),
+            lager:debug("reusing existing query buffer ~p for ~p", [QBufRef, SQL]),
             State9 = touch_qbuf(QBufRef, State0),
             {reply, {ok, {existing, QBufRef}}, State9};
         {ok, {new, QBufRef}} ->
@@ -362,7 +362,7 @@ do_get_or_create_qbuf(SQL = ?SQL_SELECT{'FROM' = OrigTable},
                 false ->
                     DDL = ?DDL{table = Table} =
                         sql_to_ddl(OrigTable, CompiledSelect, CompiledOrderBy),
-                    lager:info("creating new query buffer ~p (ref ~p) for ~p", [Table, QBufRef, SQL]),
+                    lager:debug("creating new query buffer ~p (ref ~p) for ~p", [Table, QBufRef, SQL]),
                     case riak_kv_qry_buffers_ldb:new_table(Table, RootPath) of
                         {ok, LdbRef} ->
                             QBuf = #qbuf{orig_qry      = SQL,
@@ -579,7 +579,7 @@ do_reap_expired_qbufs(#state{qbufs = QBufs0,
                   case ExpiresOn < Now of
                       true ->
                           ok = kill_ldb(RootPath, Table, LdbRef),
-                          lager:debug("Reaped incompletely filled qbuf ~p", [Table]),
+                          lager:info("Reaped incompletely filled qbuf ~p", [Table]),
                           false;
                       false ->
                           true
@@ -696,7 +696,7 @@ get_qref(?SQL_SELECT{qbuf_id = RequestedQBufId,
 
 kill_all_qbufs(State0 = #state{qbufs = QBufs,
                                root_path = RootPath}) ->
-    [lager:info("cleaning up ~b buffer(s)", [length(QBufs)]) || QBufs /= []],
+    [lager:debug("cleaning up ~b buffer(s)", [length(QBufs)]) || QBufs /= []],
     lists:foreach(
       fun({_QBufRef, #qbuf{ldb_ref = LdbRef,
                            ddl = ?DDL{table = Table}}}) ->

--- a/src/riak_kv_qry_buffers.erl
+++ b/src/riak_kv_qry_buffers.erl
@@ -667,7 +667,7 @@ compute_chunk_size(Data) ->
 %% buffer list maintenance
 
 get_qref(_SQL, _QBufs) ->
-    AlwaysUniqueId = crypto:rand_bytes(8),
+    AlwaysUniqueId = term_to_binary(make_ref()),
     {ok, {new, AlwaysUniqueId}}.
 
 kill_all_qbufs(State0 = #state{qbufs = QBufs,

--- a/src/riak_kv_qry_buffers_ldb.erl
+++ b/src/riak_kv_qry_buffers_ldb.erl
@@ -54,7 +54,7 @@ new_table(Table, Root) ->
               ],
     case eleveldb:open(Path, Options) of
         {ok, LdbRef} ->
-            lager:info("new LdbRef ~p in ~p", [LdbRef, Path]),
+            lager:debug("new LdbRef ~p in ~p", [LdbRef, Path]),
             {ok, LdbRef};
         {error, {Atom, _Message} = LdbError} ->
             lager:warning("qbuf eleveldb:open(~s) failed: ~p", [Path, LdbError]),

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -92,32 +92,32 @@ build_sql_record(Command, SQL, Options) ->
 build_sql_record_int(select, SQL, _Options = undefined) ->
     build_sql_record_int(select, SQL, []);
 build_sql_record_int(select, SQL, Options) ->
-    AllowQBufReuse = proplists:get_value(allow_qbuf_reuse, Options),
-    Cover          = proplists:get_value(cover, Options),
+    Cover  = proplists:get_value(cover, Options),
+    QBufId = proplists:get_value(qbuf_id, Options),
     if not (Cover == undefined orelse is_binary(Cover)) ->
             {error, bad_coverage_context};
        el/=se ->
-            T = proplists:get_value(tables, SQL),
-            F = proplists:get_value(fields, SQL),
-            W = proplists:get_value(where,  SQL),
-            L = proplists:get_value(limit,  SQL),
-            O = proplists:get_value(offset, SQL),
+            Tables  = proplists:get_value(tables, SQL),  %% plural is an historical reference, not a typo
+            Fields  = proplists:get_value(fields, SQL),
+            Where   = proplists:get_value(where,  SQL),
+            Limit   = proplists:get_value(limit,  SQL),
+            Offset  = proplists:get_value(offset, SQL),
             OrderBy = proplists:get_value(order_by, SQL),
             GroupBy = proplists:get_value(group_by, SQL),
-            case is_binary(T) of
+            case is_binary(Tables) of
                 true ->
-                    Mod = riak_ql_ddl:make_module_name(T),
+                    Mod = riak_ql_ddl:make_module_name(Tables),
                     {ok,
-                     ?SQL_SELECT{'SELECT'   = #riak_sel_clause_v1{clause = F},
-                                 'FROM'     = T,
-                                 'WHERE'    = convert_where_timestamps(Mod, W),
-                                 'LIMIT'    = L,
-                                 'OFFSET'   = O,
+                     ?SQL_SELECT{'SELECT'   = #riak_sel_clause_v1{clause = Fields},
+                                 'FROM'     = Tables,
+                                 'WHERE'    = convert_where_timestamps(Mod, Where),
+                                 'LIMIT'    = Limit,
+                                 'OFFSET'   = Offset,
                                  'ORDER BY' = OrderBy,
                                  helper_mod = Mod,
                                  cover_context = Cover,
-                                 allow_qbuf_reuse = AllowQBufReuse,
-                                 group_by = GroupBy }
+                                 qbuf_id       = QBufId,
+                                 group_by      = GroupBy }
                     };
                 false ->
                     {error, <<"Must provide exactly one table name">>}

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -93,7 +93,6 @@ build_sql_record_int(select, SQL, _Options = undefined) ->
     build_sql_record_int(select, SQL, []);
 build_sql_record_int(select, SQL, Options) ->
     Cover  = proplists:get_value(cover, Options),
-    QBufId = proplists:get_value(qbuf_id, Options),
     if not (Cover == undefined orelse is_binary(Cover)) ->
             {error, bad_coverage_context};
        el/=se ->
@@ -116,7 +115,6 @@ build_sql_record_int(select, SQL, Options) ->
                                  'ORDER BY' = OrderBy,
                                  helper_mod = Mod,
                                  cover_context = Cover,
-                                 qbuf_id       = QBufId,
                                  group_by      = GroupBy }
                     };
                 false ->

--- a/src/riak_kv_ttb_ts.erl
+++ b/src/riak_kv_ttb_ts.erl
@@ -49,10 +49,10 @@ decode(?TTB_MSG_CODE, Bin) ->
     Msg = riak_ttb_codec:decode(Bin),
     DecodedReq =
         case Msg of
-            #tsqueryreq{query = Q,
-                        cover_context = Cover,
-                        allow_qbuf_reuse = AllowQBufReuse} ->
-                riak_kv_ts_svc:decode_query_common(Q, [{cover, Cover}, {allow_qbuf_reuse, AllowQBufReuse}]);
+            #tsqueryreq{query = Query, cover_context = Cover} ->
+                %% this will be supplied in #tsqueryreq in 1.6
+                QBufId = undefined,
+                riak_kv_ts_svc:decode_query_common(Query, [{cover, Cover}, {qbuf_id, QBufId}]);
             #tsgetreq{table = Table}->
                 {ok, Msg, {riak_kv_ts_api:api_call_to_perm(get), Table}};
             #tsputreq{table = Table} ->

--- a/src/riak_kv_ttb_ts.erl
+++ b/src/riak_kv_ttb_ts.erl
@@ -50,9 +50,7 @@ decode(?TTB_MSG_CODE, Bin) ->
     DecodedReq =
         case Msg of
             #tsqueryreq{query = Query, cover_context = Cover} ->
-                %% this will be supplied in #tsqueryreq in 1.6
-                QBufId = undefined,
-                riak_kv_ts_svc:decode_query_common(Query, [{cover, Cover}, {qbuf_id, QBufId}]);
+                riak_kv_ts_svc:decode_query_common(Query, [{cover, Cover}]);
             #tsgetreq{table = Table}->
                 {ok, Msg, {riak_kv_ts_api:api_call_to_perm(get), Table}};
             #tsputreq{table = Table} ->


### PR DESCRIPTION
Depends on https://github.com/basho/riak_pb/pull/212. Accompanying changes in riak_test are in https://github.com/basho/riak_test/pull/1213.

After consultations, the newly introduced flag `#tsqueryreq.allow_qbuf_reuse` (#1479) to set up query buffers for reuse by follow-up queries, appears to not sufficiently cover the circumstances such a reuse could be unequivocally understood by the user. Specifically, it does not prevent a client to accidentally reuse query buffers it did not create (such as when some client B happened to issue a similar query before, and it has not expired by the time client A issues its own, expecting it to fetch fresh data).

An adequate solution would involve generating unique query buffer id (not a hash of query parts, as before), which will be passed in `#tsqueryresp` and accepted in `#tsqueryreq`. The present PR also lays some groundwork for this change.

Compared to the use of query buffers with `allow_qbuf_reuse = false`, there is no change in query execution semantics. Compared to the (unsupported) practice of flipping the flag to true, some queries will take longer to execute as every query, follow-up or not, still gets a new query buffer set up and populated for it.

This should also ease the upgrade/downgrade chores as 1.4 clients will be able to communicate with 1.5.

Additionally, this PR has a separate commit (https://github.com/basho/riak_kv/commit/d60714c282cc548d6e4342b581281b4f9a3c33fa) to ensure all query buffer ldb instances are cleaned up on riak_kv application shutdown.