### PR TITLE
expose riak_kv.query.timeseries.max_running_fsms

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -814,7 +814,7 @@
 %% @doc Throttle the number of simultaneously running FSMs.  This number times the size of data chunks
 %% determines the max volume of data the coordinator will have to deal with.
 {mapping, "riak_kv.query.timeseries.max_running_fsms", "riak_kv.timeseries_query_max_running_fsms", [
-  {default, 5},
+  {default, 20},
   {datatype, integer},
   {validators, ["validate_timeseries_query_max_running_fsms"]}
 ]}.

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -811,6 +811,22 @@
   end
 }.
 
+%% @doc Throttle the number of simultaneously running FSMs.  This number times the size of data chunks
+%% determines the max volume of data the coordinator will have to deal with.
+{mapping, "riak_kv.query.timeseries.max_running_fsms", "riak_kv.timeseries_query_max_running_fsms", [
+  {default, 5},
+  {datatype, integer},
+  {validators, ["validate_timeseries_query_max_running_fsms"]}
+]}.
+
+{validator,
+  "validate_timeseries_query_max_running_fsms",
+  "must be an integer > 0",
+  fun(Value) when is_integer(Value) andalso Value > 0 -> true;
+     (_) -> false
+  end}.
+
+
 %% @doc Largest estimated size of the data a query can return to the client.
 {mapping, "riak_kv.query.timeseries.max_returned_data_size", "riak_kv.timeseries_query_max_returned_data_size", [
   {default, 10*1000*1000},

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -45,7 +45,7 @@
 
 -include("riak_kv_ts.hrl").
 
--define(MAX_RUNNING_FSMS, 5).
+-define(MAX_RUNNING_FSMS, 20).
 -define(SUBQUERY_FSM_TIMEOUT, 10000).
 
 %% accumulators for different types of query results.

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -149,7 +149,9 @@ code_change(_OldVsn, State, _Extra) ->
 
 -spec new_state() -> #state{}.
 new_state() ->
-    #state{ }.
+    MaxRunningFSMs = app_helper:get_env(riak_kv, timeseries_query_max_running_fsms,
+                                        ?MAX_RUNNING_FSMS),
+    #state{max_running_fsms = MaxRunningFSMs}.
 
 prepare_fsm_options([], Acc) ->
     lists:reverse(Acc);


### PR DESCRIPTION
This is to make configurable the max number of index FSM spawned to serve TS queries.

For @erikleitch to review.