### PR TITLE
Add support for SHOW TABLES to is_table_active_and_supported/2

### DIFF
--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -689,6 +689,10 @@ check_table_feature_supported(DDLRecCap, DecodedReq) ->
 -spec is_table_active_and_supported(DDLRecCap::atom(),
                                     Table::binary()) ->
                                         boolean() | {error, string()}.
+is_table_active_and_supported(_, << >>) ->
+    %% an empty binary for the table name means that the request is not for a
+    %% specific table e.g. SHOW TABLES
+    true;
 is_table_active_and_supported(DDLRecCap, Table) ->
     case get_table_ddl(Table) of
         {ok, _Mod, _DDL} ->


### PR DESCRIPTION
The addition of `is_table_active_and_supported/2` bypassed one of the clauses in `is_table_supported/2` required for **SHOW TABLES**