### PR TITLE
Put Filters on Local Key Columns in the Query Keys is possible

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
             {d, 'TEST_FS2_BACKEND_IN_RIAK_KV'}]}.
 
 
-% {eunit_opts, [no_tty, {report, {unite_compact, []}}]}.
+{eunit_opts, [no_tty, {report, {unite_compact, []}}]}.
 
 {xref_checks, []}.
 %% XXX yz_kv is here becase Ryan has not yet made a generic hook interface for object modification


### PR DESCRIPTION
Optimise queries by putting filters that test equality of columns in the local key but not in the partition key, in the star and end key.

```sql
PRIMARY KEY((quantum(a,1,'m')),a,b)

SELECT * FROM table WHERE a > 2 and a < 6 AND b = 5
```

Instead of putting b just in the filter, put it in the start and end keys. This narrows the range from everything between `{2,_}` and `{6,_}` to everything between `{2,5}` and `{6,5}`.

For equality filters, it is not safe to remove the filter, because {3,7} is also in the range but should not be returned because only rows where b = 5 are correct for this query.

In this PR only the equality `=` operator is checked, to make this change a little smaller.

Depends on https://github.com/basho/riak_ql/pull/161