### PR TITLE
use Mod:revert_ordering_on_local_key in {get,delete}_data for DESC keys

### DIFF
--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -187,10 +187,8 @@ make_key_conversion_fun(Table) ->
     Mod = riak_ql_ddl:make_module_name(Table),
     DDL = Mod:get_ddl(),
     fun(Key) when is_binary(Key) ->
-            {ok, DescAdjustedKey} =
-                riak_ql_ddl:negate_if_desc(
-                  tuple_to_list(sext:decode(Key)), Mod, DDL),
-            {ok, PK} = riak_ql_ddl:lk_to_pk(DescAdjustedKey, Mod, DDL),
+            {ok, PK} = riak_ql_ddl:lk_to_pk(
+                         Mod:revert_ordering_on_local_key(sext:decode(Key)), Mod, DDL),
             list_to_tuple(PK);
        (Key) ->
             lager:error("Key conversion function "

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -187,6 +187,8 @@ make_key_conversion_fun(Table) ->
     Mod = riak_ql_ddl:make_module_name(Table),
     DDL = Mod:get_ddl(),
     fun(Key) when is_binary(Key) ->
+            %% The key is organic here (it is read as previously
+            %% written), so no need to check for errors in lk_to_pk.
             {ok, PK} = riak_ql_ddl:lk_to_pk(
                          Mod:revert_ordering_on_local_key(sext:decode(Key)), Mod, DDL),
             list_to_tuple(PK);

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -187,8 +187,11 @@ make_key_conversion_fun(Table) ->
     Mod = riak_ql_ddl:make_module_name(Table),
     DDL = Mod:get_ddl(),
     fun(Key) when is_binary(Key) ->
-            {ok, PK} = riak_ql_ddl:lk_to_pk(sext:decode(Key), DDL, Mod),
-            PK;
+            {ok, DescAdjustedKey} =
+                riak_ql_ddl:negate_if_desc(
+                  tuple_to_list(sext:decode(Key)), Mod, DDL),
+            {ok, PK} = riak_ql_ddl:lk_to_pk(DescAdjustedKey, Mod, DDL),
+            list_to_tuple(PK);
        (Key) ->
             lager:error("Key conversion function "
                         "encountered a non-binary object key: ~p", [Key]),

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -42,11 +42,11 @@
          terminate/2,
          code_change/3,
 
-	 %% decode_results/1 is now exported because it may be used in
-	 %% riak_kv_vnode to pre-decode query results at the vnode
-	 %% rather than here
+         %% decode_results/1 is now exported because it may be used in
+         %% riak_kv_vnode to pre-decode query results at the vnode
+         %% rather than here
 
-	 decode_results/1 
+         decode_results/1
         ]).
 
 -include("riak_kv_ts.hrl").

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -290,11 +290,11 @@ get_data(Key, Table, Mod0, Options) ->
         end,
     DDL = Mod:get_ddl(),
     Result1 =
-        case riak_ql_ddl:desc_adjusted_key(Key, Mod, DDL) of
+        case riak_ql_ddl:negate_if_desc(Key, Mod, DDL) of
             {ok, LKVals} ->
-                %% if riak_ql_ddl:desc_adjusted_key has succeeded,
+                %% if riak_ql_ddl:negate_if_desc has succeeded,
                 %% :lk_to_pk also must
-                {ok, PKVals} = riak_ql_ddl:lk_to_pk(Key, DDL, Mod),
+                {ok, PKVals} = riak_ql_ddl:lk_to_pk(Key, Mod, DDL),
                 riak_client:get(
                   riak_kv_ts_util:table_to_bucket(Table),
                   {list_to_tuple(PKVals),
@@ -363,9 +363,9 @@ delete_data(Key, Table, Mod0, Options0, VClock0) ->
                 %% to avoid a separate get
                 riak_object:decode_vclock(VClock0)
         end,
-    case riak_ql_ddl:desc_adjusted_key(Key, Mod, DDL) of
+    case riak_ql_ddl:negate_if_desc(Key, Mod, DDL) of
         {ok, LKVals} ->
-            {ok, PKVals} = riak_ql_ddl:lk_to_pk(Key, DDL, Mod),
+            {ok, PKVals} = riak_ql_ddl:lk_to_pk(Key, Mod, DDL),
             riak_client:delete_vclock(
               riak_kv_ts_util:table_to_bucket(Table),
               {list_to_tuple(PKVals),

--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -294,10 +294,11 @@ get_data(Key, Table, Mod0, Options) ->
             {ok, LKVals} ->
                 %% if riak_ql_ddl:desc_adjusted_key has succeeded,
                 %% :lk_to_pk also must
-                {ok, PKVals} = riak_ql_ddl:lk_to_pk(list_to_tuple(LKVals), DDL, Mod),
+                {ok, PKVals} = riak_ql_ddl:lk_to_pk(Key, DDL, Mod),
                 riak_client:get(
                   riak_kv_ts_util:table_to_bucket(Table),
-                  {PKVals, list_to_tuple(LKVals)}, Options,
+                  {list_to_tuple(PKVals),
+                   list_to_tuple(LKVals)}, Options,
                   {riak_client, [node(), undefined]});
             ErrorReason1 ->
                 ErrorReason1
@@ -364,9 +365,11 @@ delete_data(Key, Table, Mod0, Options0, VClock0) ->
         end,
     case riak_ql_ddl:desc_adjusted_key(Key, Mod, DDL) of
         {ok, LKVals} ->
-            {ok, PKVals} = riak_ql_ddl:lk_to_pk(list_to_tuple(LKVals), DDL, Mod),
+            {ok, PKVals} = riak_ql_ddl:lk_to_pk(Key, DDL, Mod),
             riak_client:delete_vclock(
-              riak_kv_ts_util:table_to_bucket(Table), {PKVals, list_to_tuple(LKVals)}, VClock, Options,
+              riak_kv_ts_util:table_to_bucket(Table),
+              {list_to_tuple(PKVals),
+               list_to_tuple(LKVals)}, VClock, Options,
               {riak_client, [node(), undefined]});
         ErrorReason ->
             ErrorReason

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -418,10 +418,10 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
                 %% columns, the quantum range is defined as `(...]`
                 %% rather than as `[..)`).
                 {ok, DescAdjustedKey} =
-                    riak_ql_ddl:desc_adjusted_key(
+                    riak_ql_ddl:negate_if_desc(
                       tuple_to_list(sext:decode(Key)), Mod, DDL),
                 {ok, PK} = riak_ql_ddl:lk_to_pk(
-                             DescAdjustedKey, DDL, Mod),
+                             DescAdjustedKey, Mod, DDL),
                 list_to_tuple(PK);
            (Key) ->
                 %% Key read from leveldb should always be binary.

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -422,6 +422,9 @@ sub_tslistkeysreq(Mod, DDL, #tslistkeysreq{table = Table,
                 %% quantum boundaries (this is because for DESC
                 %% columns, the quantum range is defined as `(...]`
                 %% rather than as `[..)`).
+                %% The key is organic here (it is read as previously
+                %% written), so no need to check for errors in lk_to_pk
+                %% result.
                 DescAdjustedKey =
                     Mod:revert_ordering_on_local_key(sext:decode(Key)),
                 {ok, PK} = riak_ql_ddl:lk_to_pk(

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -34,6 +34,7 @@
          get_column_types/2,
          get_table_ddl/1,
          lk/1,
+         local_to_partition_key/2,
          maybe_parse_table_def/2,
          pk/1,
          queried_table/1,
@@ -795,6 +796,46 @@ rm_direntries(Dir, [F|Rest]) ->
         ER ->
             ER
     end.
+
+
+-spec local_to_partition_key({binary(), binary()}, binary()) -> tuple().
+%% @doc Convert from TS local key to TS partition key.
+%%
+%% This is needed because coverage filter functions must check the
+%% hash of the partition key, not the local key, when folding over
+%% keys in the backend.
+%%
+%% It needs to be an {M, F} tuple and not a simple fun, in order to
+%% allow it to operate in mixed clusters where vnode invoking doing
+%% the conversion and the coordinator starting index FSMs are of
+%% different versions (having different beams).  Passing a function
+%% object is going to result in a badfun error at call site.
+local_to_partition_key({Table, Table}, Key)
+  when is_binary(Key) ->
+    Mod = riak_ql_ddl:make_module_name(Table),
+    DDL = Mod:get_ddl(),
+    %% 1. We need to adjust (negate) values in DESC columns in order
+    %%    for lk_to_pk to correctly pick the keys at quantum
+    %%    boundaries (this is because for DESC columns, the quantum
+    %%    range is defined as `(...]` rather than as `[..)`).
+    %% 2. The key is organic here (it is read as previously written),
+    %%    so no need to check for errors in lk_to_pk result.  The key
+    %%    is organic here (it is read as previously written), so no
+    %%    need to check for errors in lk_to_pk.
+    {ok, PK} = riak_ql_ddl:lk_to_pk(
+                 Mod:revert_ordering_on_local_key(
+                   sext:decode(Key)), Mod, DDL),
+    list_to_tuple(PK);
+local_to_partition_key(Table, Key) ->
+    %% 3. Key read from leveldb should always be binary.  This clause
+    %%    is just to keep dialyzer quiet (otherwise dialyzer will
+    %%    complain about no local return, since we have no way to spec
+    %%    the type of Key for an anonymous function).
+    %%
+    %%    Nonetheless, we log an error in case this branch is ever
+    %%    exercised
+    lager:error("Non-binary object key in table ~p: ~p", [Table, Key]),
+    Key.
 
 
 flat_format(Format, Args) ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1078,7 +1078,13 @@ handle_coverage_fold(FoldType, Bucket, ItemFilter, ResultFun,
                                   modstate      = ModState}) ->
     %% Construct the filter function
     FilterVNode = proplists:get_value(Index, FilterVNodes),
-    KeyConvFn   = proplists:get_value(key_conv_fn, FilterVNodes),
+    KeyConvFn =
+        case proplists:get_value(key_conv_fn, FilterVNodes) of
+            {M, F} ->
+                fun(X) -> M:F(Bucket, X) end;
+            FunOrSomething ->
+                FunOrSomething
+        end,
     Filter = riak_kv_coverage_filter:build_filter(Bucket, ItemFilter, FilterVNode, KeyConvFn),
     BufferMod = riak_kv_fold_buffer,
     BufferSize = proplists:get_value(buffer_size, Opts0, DefaultBufSz),


### PR DESCRIPTION
Depends on https://github.com/basho/riak_ql/pull/162.

Single-key primitive operations in `riak_kv_ts_api` need to provide to `riak_client:get` and `:delete` keys adjusted for fields declared DESC in the DDL, as is done for list_keys in https://github.com/basho/riak_kv/blob/riak_ts-develop/src/riak_kv_qry_worker.erl#L190.

This fixes regressions currently seen in `ts_simple_single_key_ops` (and possibly others).