### PR TITLE
catch sudden qbuf gen_server EXITs in riak kv_qry_worker

### DIFF
--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -246,8 +246,10 @@ do_select(SQL, ?DDL{table = BucketType} = DDL) ->
                     %% these fields are used to create a DDL for the query buffer table;
                     %% we extract them here to avoid doing another compilation of OrigQry
                     %% in riak_kv_qry_buffers:get_or_create_qbuf
-                    ?SQL_SELECT{'SELECT' = CompiledSelect,
-                                'ORDER BY' = CompiledOrderBy} = hd(SubQueries),
+                    ?SQL_SELECT{'SELECT'   = CompiledSelect,
+                                'ORDER BY' = CompiledOrderBy,
+                                'LIMIT'    = Limit,
+                                'OFFSET'   = Offset} = hd(SubQueries),
                     FullCycle =
                         fun(QBufRef) ->
                             maybe_await_query_results(
@@ -271,8 +273,8 @@ do_select(SQL, ?DDL{table = BucketType} = DDL) ->
                             %% query: yay results!
                             try riak_kv_qry_buffers:fetch_limit(
                                   QBufRef,
-                                  riak_kv_qry_buffers:limit_to_scalar(SQL?SQL_SELECT.'LIMIT'),
-                                  riak_kv_qry_buffers:offset_to_scalar(SQL?SQL_SELECT.'OFFSET')) of
+                                  riak_kv_qry_buffers:limit_to_scalar(Limit),
+                                  riak_kv_qry_buffers:offset_to_scalar(Offset)) of
                                 Result ->
                                     Result
                             catch


### PR DESCRIPTION
This is an attempt to address a crash such as observed in `riak_kv_qry_N` gen_server with these symptoms:

```
2016-12-06 17:08:58.573 [info] <0.450.0>@riak_kv_qry_worker:estimate_query_size:284 Cancelling LIMIT 99999 query because projected result size exceeds limit (26999730 > 100, subqueries 2 of 50 done, query {riak_select_v3,{riak_sel_clause_v1,rows,[],[varchar,varchar,timestamp,varchar,sint64],[<<"a">>,<<"b">>,<<"c">>,<<"d">>,<<"e">>],[#Fun<riak_kv_qry_compiler.5.29991689>],[#Fun<riak_kv_qry_compiler.8.29991689>]},<<"t1">>,[{startkey,[{<<"a">>,varchar,<<"A00001">>},{<<"b">>,varchar,<<"B">>},{<<"c">>,timestamp,5000000}]},{endkey,[{<<"a">>,varchar,<<"A00001">>},{<<"b">>,varchar,<<"B">>},{<<"c">>,timestamp,5010000}]},{filter,[]}],[{<<"d">>,asc,nulls_last}],[99999],riak_ql_table_t1_320523031941664944417524937300681317050,{key_v1,[{param_v2,[<<"a">>],undefined},{param_v2,[<<"b">>],undefined},{hash_fn_v1,riak_ql_quanta,quantum,[{param_v2,[<<"c">>],undefined},10,s],timestamp}]},true,timeseries,undefined,{key_v1,[{param_v2,[<<"a">>],undefined},{param_v2,[<<"b">>],undefined},{param_v2,[<<"c">>],undefined}]},[],[],undefined})
2016-12-06 17:08:58.619 [warning] <0.446.0>@riak_kv_qry_buffers_ldb:new_table:60 qbuf eleveldb:open(./data/query_buffers/t1_a+b+c+d+e_d.al__00000441380000618066) failed: {db_open,"IO error: ./data/query_buffers/t1_a+b+c+d+e_d.al__00000441380000618066/LOCK: Not a directory"}
2016-12-06 17:08:58.619 [warning] <0.2354.0>@riak_kv_qry:maybe_create_query_buffer:300 Failed to set up query buffer for {riak_select_v3,{riak_sel_clause_v1,rows,[],[],[],[{identifier,[<<"*">>]}],[]},<<"t1">>,[{and_,{'<=',<<"c">>,{integer,5510000}},{and_,{'>=',<<"c">>,{integer,5000000}},{and_,{'=',<<"a">>,{binary,<<"A00001">>}},{'=',<<"b">>,{binary,<<"B">>}}}}}],[{<<"d">>,asc,nulls_last}],[],riak_ql_table_t1_320523031941664944417524937300681317050,none,false,sql,undefined,undefined,[],[],undefined}: db_open
2016-12-06 17:09:08.097 [info] <0.446.0>@riak_kv_qry_buffers:do_reap_expired_qbufs:576 Reaped incompletely filled qbuf <<"t1_a+b+c+d+e_d.al__00000441380000420040">>
2016-12-06 17:09:08.104 [info] <0.446.0>@riak_kv_qry_buffers:do_reap_expired_qbufs:576 Reaped incompletely filled qbuf <<"t1_a+b+c+d+e_d.al__00000441380000512049">>
2016-12-06 17:09:14.794 [warning] <0.6.0> lager_error_logger_h dropped 16 messages in the last second that exceeded the limit of 100 messages/sec
2016-12-06 17:09:14.794 [error] <0.450.0> gen_server riak_kv_qry_2 terminated with reason: {timeout,{gen_server,call,[riak_kv_qry_buffers,{batch_put,<<131,114,0,3,100,0,14,100,101,118,49,64,49,50,55,46,48,46,48,46,49,1,0,0,78,13,0,0,0,0,0,0,0,0>>,[[<<"A00001">>,<<"B">>,5370000,<<"k00031">>,369],[<<"A00001">>,<<"B">>,5372000,<<"k00-31">>,371],[<<"A00001">>,<<"B">>,5374000,<<"k00-81">>,373],[<<"A00001">>,<<"B">>,5376000,<<"k0-100">>,[]],[<<"A00001">>,<<"B">>,5378000,<<"k00-81">>,377]]}]}}
2016-12-06 17:09:14.794 [error] <0.450.0> CRASH REPORT Process riak_kv_qry_2 with 0 neighbours exited with reason: {timeout,{gen_server,call,[riak_kv_qry_buffers,{batch_put,<<131,114,0,3,100,0,14,100,101,118,49,64,49,50,55,46,48,46,48,46,49,1,0,0,78,13,0,0,0,0,0,0,0,0>>,[[<<"A00001">>,<<"B">>,5370000,<<"k00031">>,369],[<<"A00001">>,<<"B">>,5372000,<<"k00-31">>,371],[<<"A00001">>,<<"B">>,5374000,<<"k00-81">>,373],[<<"A00001">>,<<"B">>,5376000,<<"k0-100">>,[]],[<<"A00001">>,<<"B">>,5378000,<<"k00-81">>,377]]}]}} in gen_server:terminate/6 line 744
2016-12-06 17:09:14.795 [error] <0.444.0> Supervisor riak_kv_qry_sup had child riak_kv_qry_2 started with riak_kv_qry_worker:start_link(riak_kv_qry_2) at <0.450.0> exit with reason {timeout,{gen_server,call,[riak_kv_qry_buffers,{batch_put,<<131,114,0,3,100,0,14,100,101,118,49,64,49,50,55,46,48,46,48,46,49,1,0,0,78,13,0,0,0,0,0,0,0,0>>,[[<<"A00001">>,<<"B">>,5370000,<<"k00031">>,369],[<<"A00001">>,<<"B">>,5372000,<<"k00-31">>,371],[<<"A00001">>,<<"B">>,5374000,<<"k00-81">>,373],[<<"A00001">>,<<"B">>,5376000,<<"k0-100">>,[]],[<<"A00001">>,<<"B">>,5378000,<<"k00-81">>,377]]}]}} in context child_terminated
```

In a session of speculative debugging (apparently this requires superfast or superslow machines as it could not be reproduced locally) of a failing run of `ts_simple_query_buffers`), I see the situation leading up to the crash unfolding as follows:

* In test case `query_orderby_max_data_size_error`, a query with a lot of subqueries (the one with `LIMIT 99999`) spawns 20 query workers (the current value of `riak_kv.timeseries_query_max_running_fsms`;
* On arrival of the first two, `riak_kv_qry_worker:estimate_query_size` figures the total expected size of the query will be too large, and invokes `cancel_error_query`, with the remaining 18 still spinning;
* Over at `ts_simple_query_buffers`, CT machinery receives and acks the error, and proceed to run the next test case, `query_orderby_ldb_io_error`;
* That test case does evil to the query_buffer directory, effectively causing all calls involving the underlying leveldb instance to fail with `db_open` -- again, this is the expected outcome in this test case, and it is duly acked;
* Those late query workers start sending chunks of data, eventually calling `riak_kv_qry_buffers:put_data`, which for reasons unclear to me, times out. Exactly why it times out -- and why that should throw an exception -- is unclear.
* The exception propagates and brings down the `riak_kv_qry_N` worker.

Again, I did not see the exception itself, but there's an advice I figured I should follow: http://erlang.org/pipermail/erlang-questions/2013-June/074131.html. That is, protect calls of `riak_kv_qry_buffer` functions with a catch.