### PR TITLE
better handle and report errors from unresponsive qry_buffer gen_server

### DIFF
--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -281,7 +281,7 @@ do_select(SQL, ?DDL{table = BucketType} = DDL) ->
                                 Error:Reason ->
                                     lager:warning("Failed to fetch results from qbuf for ~p: ~p:~p",
                                                   [SQL, Error, Reason]),
-                                    {error, Reason}
+                                    {error, {qbuf_internal_error, "qbuf manager died/restarted unexpectedly"}}
                             end
                     end
             end;

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -136,6 +136,10 @@ handle_info({{SubQId, QId}, {error, Reason} = Error},
 handle_info({{_SubQId, QId1}, _}, State = #state{qid = QId2}) when QId1 =/= QId2 ->
     %% catches late results or errors such getting results for invalid QIds.
     lager:debug("Bad query id ~p (expected ~p)", [QId1, QId2]),
+    {noreply, State};
+
+handle_info(_Unexpected, State) ->
+    lager:info("Not handling unexpected message \"~p\" in state ~p", [_Unexpected, State]),
     {noreply, State}.
 
 -spec terminate(term(), #state{}) -> term().
@@ -322,8 +326,8 @@ add_subquery_result(SubQId, Chunk, #state{sub_qrys = SubQs,
             catch
                 error:divide_by_zero ->
                     cancel_error_query(divide_by_zero, State);
-                throw:{qbuf_error, Reason} ->
-                    cancel_error_query(Reason, State)
+                throw:{qbuf_internal_error, Reason} ->
+                    cancel_error_query({qbuf_internal_error, Reason}, State)
             end;
         false ->
             lager:warning("unexpected chunk received for non-existing query ~p when state is ~p", [SubQId, State]),
@@ -407,12 +411,12 @@ run_select_on_rows_chunk(_SubQId, SelClause, DecodedChunk, _QueryResult1, QBufRe
         ok ->
             ok;
         {error, Reason} ->
-            throw({qbuf_error, Reason})
+            throw({qbuf_internal_error, Reason})
     catch
         Error:Reason ->
             lager:warning("Failed to send data to qbuf ~p serving subquery ~p of ~p: ~p:~p",
                           [QBufRef, _SubQId, SelClause, Error, Reason]),
-            throw({qbuf_error, Reason})
+            throw({qbuf_internal_error, "qbuf manager died/restarted mid-query"})
     end.
 
 %%
@@ -427,7 +431,7 @@ run_select_on_aggregate_chunk(SelClause, DecodedChunk, QueryResult1) ->
         State2::#state{}.
 cancel_error_query(Error, #state{qbuf_ref = QBufRef,
                                  receiver_pid = ReceiverPid}) ->
-    _ = riak_kv_qry_buffers:delete_qbuf(QBufRef),  %% is a noop on undefined
+    catch riak_kv_qry_buffers:delete_qbuf(QBufRef),  %% is a noop on undefined
     ReceiverPid ! {error, Error},
     pop_next_query(),
     new_state().
@@ -464,9 +468,9 @@ prepare_final_results(#state{qbuf_ref = QBufRef,
                              qry = ?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{calc_type = rows} = Select,
                                                'LIMIT'  = Limit,
                                                'OFFSET' = Offset}} = State) ->
-    case riak_kv_qry_buffers:fetch_limit(QBufRef,
-                                         riak_kv_qry_buffers:limit_to_scalar(Limit),
-                                         riak_kv_qry_buffers:offset_to_scalar(Offset)) of
+    try riak_kv_qry_buffers:fetch_limit(QBufRef,
+                                        riak_kv_qry_buffers:limit_to_scalar(Limit),
+                                        riak_kv_qry_buffers:offset_to_scalar(Offset)) of
         {ok, {_ColNames, _ColTypes, FetchedRows}} ->
             prepare_final_results2(Select, FetchedRows);
         {error, qbuf_not_ready} ->
@@ -476,11 +480,17 @@ prepare_final_results(#state{qbuf_ref = QBufRef,
                 {qbuf_ready, QBufRef} ->
                     prepare_final_results(State)
             after 60000 ->
-                    cancel_error_query(qbuf_timeout, State)
+                    lager:error("qbuf ~p took too long to signal ready to ship results", [QBufRef]),
+                    cancel_error_query({qbuf_internal_error, "qbuf took too long to signal ready to ship results"}, State)
             end;
         {error, bad_qbuf_ref} ->
             %% the query buffer is gone: we can still retry (should we, really?)
             cancel_error_query(bad_qbuf_ref, State)
+    catch
+        Error:Reason ->
+            lager:warning("Failed to fetch data from qbuf ~p: ~p:~p",
+                          [QBufRef, Error, Reason]),
+            cancel_error_query({qbuf_internal_error, "qbuf manager died/restarted mid-query"}, State)
     end;
 
 prepare_final_results(#state{

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -55,6 +55,7 @@
 -define(E_QBUF_CREATE_ERROR,     1023).
 -define(E_QBUF_LDB_ERROR,        1024).
 -define(E_QUANTA_LIMIT,          1025).
+-define(E_QBUF_INTERNAL_ERROR,   1026).
 
 -define(FETCH_RETRIES, 10).  %% TODO make it configurable in tsqueryreq
 -define(TABLE_ACTIVATE_WAIT, 30). %% ditto
@@ -527,6 +528,8 @@ sub_tsqueryreq(_Mod, DDL = ?DDL{table = Table}, SQL, State) ->
             {reply, make_qbuf_create_error(Reason), State};
         {error, {qbuf_ldb_error, Reason}} ->
             {reply, make_qbuf_ldb_error(Reason), State};
+        {error, {qbuf_internal_error, Reason}} ->
+            {reply, make_qbuf_internal_error(Reason), State};
         {error, {identifier_unexpected, Identifier}} ->
             {reply, make_identifier_unexpected_resp(Identifier), State};
 
@@ -654,6 +657,11 @@ make_qbuf_ldb_error(Reason) ->
     make_rpberrresp(
       ?E_QBUF_LDB_ERROR,
       flat_format("Query buffer I/O error: ~p", [Reason])).
+
+make_qbuf_internal_error(Reason) ->
+    make_rpberrresp(
+      ?E_QBUF_INTERNAL_ERROR,
+      flat_format("Query buffer internal error: ~p", [Reason])).
 
 make_max_query_quanta_resp(NQuanta, MaxQueryQuanta) ->
     make_rpberrresp(

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -55,7 +55,7 @@
 -define(E_QBUF_CREATE_ERROR,     1023).
 -define(E_QBUF_LDB_ERROR,        1024).
 -define(E_QUANTA_LIMIT,          1025).
--define(E_QBUF_INTERNAL_ERROR,   1026).
+-define(E_QBUF_INTERNAL_ERROR,   1027).
 
 -define(FETCH_RETRIES, 10).  %% TODO make it configurable in tsqueryreq
 -define(TABLE_ACTIVATE_WAIT, 30). %% ditto


### PR DESCRIPTION
Another attempt to fix `ts_simple_query_buffers_SUITE`.

Also, consume and drop messages riak_kv_qry_N workers are not supposed to handle.