### PR TITLE
Removed hard-coded dependency on yokozuna

### DIFF
--- a/src/riak_kv_noop_update_hook.erl
+++ b/src/riak_kv_noop_update_hook.erl
@@ -1,0 +1,53 @@
+%%
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%%
+
+-module(riak_kv_noop_update_hook).
+-behaviour(riak_kv_update_hook).
+
+-export([update/3,
+         update_binary/5,
+         requires_existing_object/1,
+         should_handoff/1]).
+
+
+-spec update(riak_kv_update_hook:object_pair(),
+             riak_kv_update_hook:update_reason(),
+             riak_kv_update_hook:partition()) -> ok.
+update(_ObjectPair, _UpdateReason, _Partition) ->
+    ok.
+
+-spec update_binary(
+        riak_core_bucket:bucket(),
+        riak_object:key(),
+        binary(),
+        riak_kv_update_hook:update_reason(),
+        riak_kv_update_hook:partition()) -> ok.
+update_binary(_Bucket, _Key, _Binary, _UpdateReason, _Partition) ->
+    ok.
+
+-spec requires_existing_object(Props :: riak_kv_bucket:props()) -> boolean().
+requires_existing_object(_Props) ->
+    false.
+
+-spec should_handoff(Destination :: riak_kv_update_hook:handoff_dest()) -> boolean().
+should_handoff(_Destionation) ->
+    true.

--- a/src/riak_kv_update_hook.erl
+++ b/src/riak_kv_update_hook.erl
@@ -1,0 +1,72 @@
+%%
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%%
+-module(riak_kv_update_hook).
+
+-include_lib("riak_core/include/riak_core_vnode.hrl").
+
+-export_type([object_pair/0, update_reason/0, repair/0, partition/0, handoff_dest/0]).
+
+-type object_pair() :: {riak_object:riak_object(), riak_object:riak_object() | no_old_object}.
+-type repair() :: full_repair | tree_repair | failed_repair.
+-type update_reason() ::
+    delete
+    | handoff
+    | put
+    | anti_entropy
+    | {delete, repair()}
+    | {anti_entropy, repair()}
+    | {anti_entropy_delete, repair()}
+    | anti_entropy_delete.
+
+
+%% @doc Update a Riak object, given a reason and partition under which
+%%      the object is being indexed.  The object pair contains the new
+%%      and old objects, in the case where a read-before-write resulted
+%%      in an old object.
+-callback update(
+    object_pair(),
+    update_reason(),
+    partition()
+) ->
+    ok.
+
+%% @doc Update a Riak object encoded as an erlang binary.  This function
+%%      is typically called from the write-once path, where there is no
+%%      old object to pass.
+-callback update_binary(
+    riak_core_bucket:bucket(),
+    riak_object:key(),
+    binary(),
+    update_reason(),
+    partition()
+) ->
+    ok.
+
+%% @doc Determine whether a bucket requires an existing object,
+%%      based on its properties.  If this function returns true,
+%%      this may result in a read-before-write in the vnode.
+-callback requires_existing_object(riak_kv_bucket:props()) ->
+    boolean().
+
+%% @doc Determine whether handoff should start.
+-callback should_handoff(handoff_dest()) ->
+    boolean().

--- a/src/riak_kv_update_hook.erl
+++ b/src/riak_kv_update_hook.erl
@@ -43,9 +43,9 @@
 %%      and old objects, in the case where a read-before-write resulted
 %%      in an old object.
 -callback update(
-    object_pair(),
-    update_reason(),
-    partition()
+    ObjectPair :: object_pair(),
+    UpdateReason :: update_reason(),
+    Partition :: partition()
 ) ->
     ok.
 
@@ -53,20 +53,20 @@
 %%      is typically called from the write-once path, where there is no
 %%      old object to pass.
 -callback update_binary(
-    riak_core_bucket:bucket(),
-    riak_object:key(),
-    binary(),
-    update_reason(),
-    partition()
+    Bucket :: riak_core_bucket:bucket(),
+    Key :: riak_object:key(),
+    ObjectBinary :: binary(),
+    UpdateReason :: update_reason(),
+    Partition :: partition()
 ) ->
     ok.
 
 %% @doc Determine whether a bucket requires an existing object,
 %%      based on its properties.  If this function returns true,
 %%      this may result in a read-before-write in the vnode.
--callback requires_existing_object(riak_kv_bucket:props()) ->
+-callback requires_existing_object(BucketProps :: riak_kv_bucket:props()) ->
     boolean().
 
 %% @doc Determine whether handoff should start.
--callback should_handoff(handoff_dest()) ->
+-callback should_handoff(Destination :: handoff_dest()) ->
     boolean().

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -2698,23 +2698,17 @@ highest_actor(ActorBase, Obj) ->
     {Actor, Epoch, riak_object:actor_counter(Actor, Obj)}.
 
 %%
-%% Technical note:  The index_module configuration parameter should contain
-%% a module name which must implement the following functions:
-%%
-%%     - index(object_pair(), write_reason(), p()) -> ok.
-%%     - index_binary(bucket(), key(), binary(), write_reason(), p()) -> ok.
-%%     - is_searchable(riak_kv_bucket:props()) -> boolean().
-%%
-%% The indexing module will be called on puts, deletes, handoff, and
-%% anti-entropy activity.  In the case of puts, if an object is being over-written,
-%% the old object will be passed as the second parameter in the object pair.
-%% The indexing module may use this old object to optimize the update (e.g.,
-%% to handle the special case of sibling writes, which may not map directly to
-%% Riak puts).
-%%
-%% NB. Currently, yokozuna is the only repository that currently
-%% implements this behavior.  C.f., Yokozuna cuttlefish schema, to see
-%% where this configuration is implicitly set.
+%% Maintenance note:  The riak_kv.update_hook configuration parameter should
+%% contain a module name which must implement riak_kv_update_hook behavior.
+%% Currently, this behavior is completely internal and is not intended for
+%% use outside of Riak; Yokozuna is the only repository that currently
+%% implements this behavior.  (C.f., Yokozuna cuttlefish schema, to see
+%% where this configuration is set.)  In the future, we may want
+%% make the riak_kv.update_hook configuration parameter a list of hooks, and
+%% call a sequence of hooks on updates, but since we currently only have one
+%% use-case, and since this is a purely internal API (and local to the riak node),
+%% we can safely make that change in the future without an impact on
+%% backwards compatibility.
 %%
 
 -spec update_hook()-> update_hook().

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -149,6 +149,7 @@
 -type state() :: #state{}.
 -type vnodeid() :: binary().
 -type counter_lease_error() :: {error, counter_lease_max_errors | counter_lease_timeout}.
+-type hashtree_action() :: delete | tombstone | update.
 
 
 -define(MD_CACHE_BASE, "riak_kv_vnode_md_cache").
@@ -1424,7 +1425,7 @@ do_put(Sender, {Bucket,_Key}=BKey, RObj, ReqID, StartTime, Options, State) ->
 
 -spec do_backend_delete(
     {riak_core_bucket:bucket(), riak_object:key()},
-    riak_object:riak_object(), #state{}
+    riak_object:riak_object(), hashtree_action(), #state{}
 ) -> #state{}.
 do_backend_delete(BKey, RObj, HashtreeAction,  
     State = #state{


### PR DESCRIPTION
This PR removed a hard-coded dependency on yokozuna by indirecting calls into yokozuna through a module that is loaded via configuration, using the new `index_module` (internally defined) configuration variable.

By default (for the purposes of riak_kv, by itself), the `index_module` configuration variable is undefined, which will result in a no-op during puts, deletes, and handoff operations from the vnode.

Downstream repos (notably, yokozuna), configure `index_module` to be a module the `riak_kv_vnode` will call as part of the above set of operations.

The `index_module` configuration variable is not intended to be shared with users, as its only function is to indirect calls into an indexing subsystem.

Dependent PRs: -none-
Downstream PRs: https://github.com/basho/yokozuna/pull/716

## Checklist

- [x] Observability
This PR has no impact on a running system, at least as we deploy riak today.  Any new configuration we add is hidden and should get picked up automatically as part of an upgrade.
- [x] Performance
In general this change should have no impact on performance.  In the case where yokozuna is not deployed with riak_kv (no known deployments), this change should eliminate calls into yokozuna, theoretically resulting in fewer reductions
- [x] Fault-tolerance
There are no remote processes or IPC added as part of this PR
- [x] Testing
This PR does not affect code paths in any existing tests.  No specific tests have been added for this PR, as there is no new functionality being added.
- [x] Code Clarity/Quality
- [x] Code Documentation
The rationale for the index_module configuration documentation is explained in the source code documentation.
- [x] External Documentation
n/a
- [x] Release Notes
n/a