### PR TITLE
Silently take blob data over HTTP as base64

### DIFF
--- a/src/riak_kv_wm_timeseries.erl
+++ b/src/riak_kv_wm_timeseries.erl
@@ -61,7 +61,7 @@
         ]).
 
 %% webmachine body-producing functions
--export([to_json/2]).
+-export([to_json/2, value_to_json_compat/1]).
 
 -include_lib("webmachine/include/webmachine.hrl").
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
@@ -262,14 +262,28 @@ delete_resource(RD, #ctx{table = Table,
      end.
 
 -spec to_json(#wm_reqdata{}, #ctx{}) ->  cb_rv_spec(iolist()|halt()).
-to_json(RD, #ctx{api_call = get, object = Object} = Ctx) ->
+to_json(RD, #ctx{api_call = get, object = Object, mod = Mod} = Ctx) ->
     try
-        Json = mochijson2:encode(Object),
+        Object2 = row_to_json_compat(Object, Mod),
+        Json = mochijson2:encode(Object2),
         {Json, RD, Ctx}
     catch
         _:Reason ->
             riak_kv_wm_ts_util:handle_error({riak_error, Reason}, RD, Ctx)
     end.
+
+-spec row_to_json_compat(list(tuple(binary(), term())), atom()) ->
+                                list(tuple(binary(), term())).
+row_to_json_compat(Row, Mod) ->
+    lists:map(fun(R) -> field_to_json_compat(R, Mod) end, Row).
+
+field_to_json_compat({Header, Value}, Mod) ->
+    {Header, value_to_json_compat({Mod:get_field_type([Header]), Value})}.
+
+value_to_json_compat({blob, Value}) ->
+    base64:encode(Value);
+value_to_json_compat({_, Value}) ->
+    Value.
 
 -spec extract_params([{string(), string()}], #ctx{}) -> #ctx{} .
 %% @doc right now we only allow a timeout parameter or nothing.
@@ -410,7 +424,7 @@ extract_field_value({Name, Type, Optional}, FVList) ->
 %% We could validate the entire record in one go with
 %% Mod:validate_obj/1, but then we lose the details in the error being
 %% reported should it fail.
-check_field_value(_Name, blob, V) when is_binary(V)            -> V;
+check_field_value(_Name, blob, V) when is_binary(V)            -> base64:decode(V);
 check_field_value(_Name, varchar, V) when is_binary(V)         -> V;
 check_field_value(_Name, sint64, V) when is_integer(V)         -> V;
 check_field_value(_Name, double, V) when is_number(V)          -> V;

--- a/src/riak_kv_wm_timeseries.erl
+++ b/src/riak_kv_wm_timeseries.erl
@@ -355,6 +355,8 @@ convert_fv(Table, Mod, FieldRaw, V) ->
             throw({bad_field, Table, Field})
     end.
 
+convert_field(_T, F, blob, V) ->
+    {F, base64:decode(V)};
 convert_field(_T, F, varchar, V) ->
     {F, list_to_binary(V)};
 convert_field(_T, F, sint64, V) ->

--- a/src/riak_kv_wm_timeseries_listkeys.erl
+++ b/src/riak_kv_wm_timeseries_listkeys.erl
@@ -182,6 +182,8 @@ key_to_string(KFTypes) ->
        || {Key, {Field, Type}} <- KFTypes],
       "/").
 
+value_to_url_string(V, blob) ->
+    base64:encode_to_string(V);
 value_to_url_string(V, varchar) ->
     binary_to_list(V);
 value_to_url_string(V, sint64) ->

--- a/src/riak_kv_wm_timeseries_query.erl
+++ b/src/riak_kv_wm_timeseries_query.erl
@@ -209,8 +209,8 @@ process_post_(RD, #ctx{sql_type = QueryType,
                        table = Table} = Ctx, DDL) ->
     case riak_kv_ts_api:query(SQL, DDL) of
         {ok, Data} ->
-            {ColumnNames, _ColumnTypes, Rows} = Data,
-            Json = to_json({ColumnNames, Rows}),
+            {ColumnNames, ColumnTypes, Rows} = Data,
+            Json = to_json({ColumnNames, ColumnTypes, Rows}),
             {true, wrq:append_to_response_body(Json, RD), Ctx};
         %% the following timeouts are known and distinguished:
         {error, qry_worker_timeout} ->
@@ -302,12 +302,20 @@ produce_doc_body(RD, Ctx = #ctx{result = {Columns, Rows}}) ->
                  {<<"rows">>, Rows}]}),
      RD, Ctx}.
 
-to_json({Columns, Rows}) when is_list(Columns), is_list(Rows) ->
+to_json({Columns, Types, Rows}) ->
     mochijson2:encode(
       {struct, [{<<"columns">>, Columns},
-                {<<"rows">>, Rows}]});
+                {<<"rows">>, rows_to_json_compat(Types, Rows)}]});
 to_json(Other) ->
     mochijson2:encode(Other).
+
+rows_to_json_compat(Types, Rows) ->
+    lists:map(fun(R) -> row_to_json_compat(Types, R) end,
+              Rows).
+
+row_to_json_compat(Types, Row) ->
+    lists:map(fun riak_kv_wm_timeseries:value_to_json_compat/1,
+              lists:zip(Types, Row)).
 
 %% log(Format, Args) ->
 %%     lager:log(info, self(), Format, Args).


### PR DESCRIPTION
@christophermancini identified a key issue: JSON does *not* like binary data. Since JSON is our sole interface for inserting and retrieving records via HTTP, that's a bit of a problem.

This set of changes allows HTTP clients such as our PHP library to use the industry-standard base64 encoding to upload and retrieve blob data for insert, query, get, and list_keys.

Must consider branching the logic to allow `0x`-prefaced strings to be sent instead of base64 to maintain consistency with the SQL command line. (This will be the only way to do SQL queries with blob as key values). Outstanding question: which format should we use for output?

And need tests, badly.