### PR TITLE
Handle empty exchange history

### DIFF
--- a/src/riak_kv_entropy_info.erl
+++ b/src/riak_kv_entropy_info.erl
@@ -235,8 +235,12 @@ compute_exchange_info({M,F}, Ring, Index, #index_info{exchanges=Exchanges,
     AllTime = merge_to_first(KnownTime, Defaults),
     %% Rely upon fact that undefined < tuple
     AllTime2 = lists:keysort(2, AllTime),
-    {_, LastAll} = hd(AllTime2),
-    {_, Recent} = hd(lists:reverse(AllTime2)),
+    {LastAll, Recent} = case AllTime2 of
+                            [] ->
+                                {undefined, undefined};
+                            _ ->
+                                {element(2, hd(AllTime2)), element(2, lists:last(AllTime2))}
+                        end,
     {Index, Recent, LastAll, stat_tuple(Repaired)}.
 
 %% Merge two lists together based on the key at position 1. When both lists


### PR DESCRIPTION
When compute_exchange_info is called on an index with no previous
exchanges return undefined for the Recent and LastAll timestamps.