### PR TITLE
Unify how CREATE TABLE is serviced and ensure table is query-ready [JIRA: RIAK-3173]

### DIFF
--- a/src/riak_kv_ts_api.erl
+++ b/src/riak_kv_ts_api.erl
@@ -29,6 +29,7 @@
          api_call_from_sql_type/1,
          api_call_to_perm/1,
          api_calls/0,
+         create_table/3,
          put_data/2, put_data/3,
          get_data/2, get_data/3, get_data/4,
          delete_data/2, delete_data/3, delete_data/4, delete_data/5,
@@ -44,6 +45,12 @@
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 -include("riak_kv_wm_raw.hrl").
 -include("riak_kv_ts.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+ -define(TABLE_ACTIVATE_WAIT, 30). %%<< make TABLE_ACTIVATE_WAIT configurable in tsqueryreq
 
 %% external API calls enumerated
 -type query_api_call() :: create_table | query_select | describe_table | query_insert | query_explain | show_tables | query_delete.
@@ -96,6 +103,57 @@ api_calls() ->
     [create_table, query_select, describe_table, query_insert,
      show_tables, show_create_table, get, put, delete, list_keys, coverage].
 
+
+-spec create_table(module(), ?DDL{}, proplists:proplist()) -> ok|{error,term()}.
+create_table(SvcMod, ?DDL{table = Table}=DDL1, WithProps) ->
+    DDLRecCap = riak_core_capability:get({riak_kv, riak_ql_ddl_rec_version}),
+    DDL2 = convert_ddl_to_cluster_supported_version(DDLRecCap, DDL1),
+    CompilerVersion = riak_ql_ddl_compiler:get_compiler_version(),
+    {ok, Props1} = riak_kv_ts_util:apply_timeseries_bucket_props(DDL2,
+                                                                 CompilerVersion,
+                                                                 WithProps),
+    case catch [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props1] of
+        {bad_linkfun_modfun, {M, F}} ->
+            {error, SvcMod:make_table_create_fail_resp(Table,
+                                                       flat_format(
+                                                         "Invalid link mod or fun in bucket type properties: ~p:~p\n", [M, F]))};
+        {bad_linkfun_bkey, {B, K}} ->
+            {error, SvcMod:make_table_create_fail_resp(Table,
+                                                       flat_format(
+                                                         "Malformed bucket/key for anon link fun in bucket type properties: ~p/~p\n", [B, K]))};
+        {bad_chash_keyfun, {M, F}} ->
+            {error, SvcMod:make_table_create_fail_resp(Table,
+                                                       flat_format(
+                                                         "Invalid chash mod or fun in bucket type properties: ~p:~p\n", [M, F]))};
+        Props2 ->
+            create_table1(SvcMod, Table, Props2, DDLRecCap, ?TABLE_ACTIVATE_WAIT)
+    end.
+
+create_table1(SvcMod, Table, Props, DDLRecCap, Seconds) ->
+    case riak_core_bucket_type:create(Table, Props) of
+        ok -> wait_until_active(SvcMod, Table, DDLRecCap, Seconds);
+        {error, Reason} -> {error, SvcMod:make_table_create_fail_resp(Table, Reason)}
+    end.
+
+wait_until_active(SvcMod, Table, _DDLRecCap, _Seconds=0) ->
+    {error, SvcMod:make_table_activate_error_timeout_resp(Table)};
+wait_until_active(SvcMod, Table, DDLRecCap, Seconds) ->
+    case riak_core_bucket_type:activate(Table) of
+        ok -> ok;
+        {error, not_ready} ->
+            timer:sleep(1000),
+            lager:info("Waiting for table ~ts to be ready for activation", [Table]),
+            wait_until_active(SvcMod, Table, DDLRecCap, Seconds - 1);
+        {error, undefined} ->
+            {error, SvcMod:make_table_created_missing_resp(Table)}
+    end.
+convert_ddl_to_cluster_supported_version(DDLRecCap, DDL) when is_atom(DDLRecCap) ->
+    DDLConversions = riak_ql_ddl:convert(DDLRecCap, DDL),
+    [LowestDDL|_] = lists:sort(fun ddl_comparator/2, DDLConversions),
+    LowestDDL.
+
+ddl_comparator(A, B) ->
+    riak_ql_ddl:is_version_greater(element(1,A), element(1,B)) == true.
 
 -spec query(string() | riak_kv_qry:sql_query_type_record(), ?DDL{}) ->
                    {ok, riak_kv_qry:query_tabular_result()} |
@@ -401,3 +459,28 @@ compile_to_per_quantum_queries(Mod, SQL) ->
                     {error, invalid_query}
             end
     end.
+
+flat_format(Format, Args) ->
+    lists:flatten(io_lib:format(Format, Args)).
+
+-ifdef(TEST).
+convert_ddl_to_cluster_supported_version_v1_test() ->
+    ?assertMatch(
+       #ddl_v1{},
+       convert_ddl_to_cluster_supported_version(
+         v1, #ddl_v2{local_key = ?DDL_KEY{ast = []},
+                     partition_key = ?DDL_KEY{ast = []},
+                     fields=[#riak_field_v1{type=varchar}]})
+      ).
+
+convert_ddl_to_cluster_supported_version_v2_test() ->
+    DDLV2 = #ddl_v2{
+               local_key = ?DDL_KEY{ast = []},
+               partition_key = ?DDL_KEY{ast = []},
+               fields = [#riak_field_v1{type = varchar}]
+              },
+    ?assertMatch(
+       DDLV2,
+       convert_ddl_to_cluster_supported_version(v2, DDLV2)
+      ).
+-endif. %%<< TEST

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -248,7 +248,7 @@ decode_keys_for_streaming(Mod, [K1|Tail]) ->
 -spec create_table({?DDL{}, proplists:proplist()}, #state{}) ->
                           {reply, tsqueryresp | #rpberrorresp{}, #state{}}.
 create_table({?DDL{} = DDL1, WithProps}, State) ->
-    case riak_kv_ts_util:create_table(?MODULE, DDL1, WithProps) of
+    case riak_kv_ts_api:create_table(?MODULE, DDL1, WithProps) of
         ok -> {reply, tsqueryresp, State};
         {error, Reason} -> {reply, Reason, State}
     end.

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -66,6 +66,11 @@
          process/2,
          process_stream/3]).
 
+%% exports for create_table
+-export([make_table_create_fail_resp/2,
+         make_table_activate_error_timeout_resp/1,
+         make_table_created_missing_resp/1]).
+
 -type ts_requests() :: #tsputreq{} | #tsdelreq{} | #tsgetreq{} |
                        #tslistkeysreq{} | #tsqueryreq{}.
 -type ts_responses() :: #tsputresp{} | #tsdelresp{} | #tsgetresp{} |
@@ -242,65 +247,11 @@ decode_keys_for_streaming(Mod, [K1|Tail]) ->
 
 -spec create_table({?DDL{}, proplists:proplist()}, #state{}) ->
                           {reply, tsqueryresp | #rpberrorresp{}, #state{}}.
-create_table({?DDL{table = Table} = DDL1, WithProps}, State) ->
-    DDLRecCap = riak_core_capability:get({riak_kv, riak_ql_ddl_rec_version}),
-    DDL2 = convert_ddl_to_cluster_supported_version(DDLRecCap, DDL1),
-    {ok, Props1} = riak_kv_ts_util:apply_timeseries_bucket_props(
-                     DDL2, riak_ql_ddl_compiler:get_compiler_version(), WithProps),
-    case catch [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props1] of
-        {bad_linkfun_modfun, {M, F}} ->
-            {reply, make_table_create_fail_resp(
-                      Table, flat_format(
-                               "Invalid link mod or fun in bucket type properties: ~p:~p\n", [M, F])),
-             State};
-        {bad_linkfun_bkey, {B, K}} ->
-            {reply, make_table_create_fail_resp(
-                      Table, flat_format(
-                               "Malformed bucket/key for anon link fun in bucket type properties: ~p/~p\n", [B, K])),
-             State};
-        {bad_chash_keyfun, {M, F}} ->
-            {reply, make_table_create_fail_resp(
-                      Table, flat_format(
-                               "Invalid chash mod or fun in bucket type properties: ~p:~p\n", [M, F])),
-             State};
-        Props2 ->
-            case riak_core_bucket_type:create(Table, Props2) of
-                ok ->
-                    wait_until_active(Table, State, ?TABLE_ACTIVATE_WAIT);
-                {error, Reason} ->
-                    {reply, make_table_create_fail_resp(Table, Reason), State}
-            end
+create_table({?DDL{} = DDL1, WithProps}, State) ->
+    case riak_kv_ts_util:create_table(?MODULE, DDL1, WithProps) of
+        ok -> {reply, tsqueryresp, State};
+        {error, Reason} -> {reply, Reason, State}
     end.
-
-%%
-convert_ddl_to_cluster_supported_version(DDLRecCap, DDL) when is_atom(DDLRecCap) ->
-    DDLConversions = riak_ql_ddl:convert(DDLRecCap, DDL),
-    [LowestDDL|_] = lists:sort(fun ddl_comparator/2, DDLConversions),
-    LowestDDL.
-
-%%
-ddl_comparator(A, B) ->
-    riak_ql_ddl:is_version_greater(element(1,A), element(1,B)) == true.
-
-wait_until_active(Table, State, 0) ->
-    {reply, make_table_activate_error_timeout_resp(Table), State};
-wait_until_active(Table, State, Seconds) ->
-    case riak_core_bucket_type:activate(Table) of
-        ok ->
-            {reply, tsqueryresp, State};
-        {error, not_ready} ->
-            timer:sleep(1000),
-            lager:info("Waiting for table ~ts to be ready for activation", [Table]),
-            wait_until_active(Table, State, Seconds - 1);
-        {error, undefined} ->
-            %% this is inconceivable because create(Table) has
-            %% just succeeded, so it's here mostly to pacify
-            %% the dialyzer (and of course, for the odd chance
-            %% of Erlang imps crashing nodes between create
-            %% and activate calls)
-            {reply, make_table_created_missing_resp(Table), State}
-    end.
-
 
 %% ---------------------------------------------------
 %% functions called from check_table_and_call, one per ts* request
@@ -762,23 +713,6 @@ missing_helper_module_test() ->
     ?assertMatch(
         #rpberrorresp{errcode = ?E_MISSING_TS_MODULE },
         make_missing_helper_module_resp(<<"mytype">>, [{ddl, ?DDL{}}])
-    ).
-
-convert_ddl_to_cluster_supported_version_v1_test() ->
-    ?assertMatch(
-        #ddl_v1{},
-        convert_ddl_to_cluster_supported_version(
-          v1, #ddl_v2{local_key = ?DDL_KEY{ast = []}, partition_key = ?DDL_KEY{ast = []}, fields=[#riak_field_v1{type=varchar}]})
-    ).
-
-convert_ddl_to_cluster_supported_version_v2_test() ->
-    DDLV2 = #ddl_v2{
-        local_key = ?DDL_KEY{ast = []},
-        partition_key = ?DDL_KEY{ast = []},
-        fields=[#riak_field_v1{type=varchar}]},
-    ?assertMatch(
-        DDLV2,
-        convert_ddl_to_cluster_supported_version(v2, DDLV2)
     ).
 
 get_create_table_sql(TableName) when is_binary(TableName) ->

--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -534,20 +534,20 @@ make_missing_helper_module_resp(Table, BucketProps)
 make_missing_type_resp(Table) ->
     make_rpberrresp(
       ?E_MISSING_TYPE,
-      flat_format("Time Series table ~s does not exist", [Table])).
+      flat_format("Time Series table ~ts does not exist", [Table])).
 
 %%
 -spec make_nonts_type_resp(Table::binary()) -> #rpberrorresp{}.
 make_nonts_type_resp(Table) ->
     make_rpberrresp(
       ?E_NOT_TS_TYPE,
-      flat_format("Attempt Time Series operation on non Time Series table ~s", [Table])).
+      flat_format("Attempt Time Series operation on non Time Series table ~ts", [Table])).
 
 -spec make_missing_table_module_resp(Table::binary()) -> #rpberrorresp{}.
 make_missing_table_module_resp(Table) ->
     make_rpberrresp(
       ?E_MISSING_TS_MODULE,
-      flat_format("The compiled module for Time Series table ~s cannot be loaded", [Table])).
+      flat_format("The compiled module for Time Series table ~ts cannot be loaded", [Table])).
 
 -spec make_key_element_count_mismatch_resp(Got::integer(), Need::integer()) -> #rpberrorresp{}.
 make_key_element_count_mismatch_resp(Got, Need) ->
@@ -626,7 +626,7 @@ make_failed_listkeys_resp(Reason) ->
 
 make_table_create_fail_resp(Table, Reason) ->
     make_rpberrresp(
-      ?E_CREATE, flat_format("Failed to create table ~s: ~p", [Table, Reason])).
+      ?E_CREATE, flat_format("Failed to create table ~ts: ~p", [Table, Reason])).
 
 make_table_activate_error_timeout_resp(Table) ->
     make_rpberrresp(
@@ -641,7 +641,7 @@ make_table_not_activated_resp(Table) ->
 make_table_created_missing_resp(Table) ->
     make_rpberrresp(
       ?E_CREATED_GHOST,
-      flat_format("Table ~s has been created but found missing", [Table])).
+      flat_format("Table ~ts has been created but found missing", [Table])).
 
 to_string(X) when is_atom(X) ->
     atom_to_list(X);

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -28,6 +28,7 @@
          apply_timeseries_bucket_props/3,
          build_sql_record/3,
          check_table_feature_supported/2,
+         create_table/3,
          is_table_supported/2,
          encode_typeval_key/1,
          explain_query/1, explain_query/2,
@@ -53,6 +54,8 @@
 -include_lib("eunit/include/eunit.hrl").
 -compile(export_all).
 -endif.
+
+-define(TABLE_ACTIVATE_WAIT, 30). %%<< make TABLE_ACTIVATE_WAIT configurable in tsqueryreq
 
 %% NOTE on table_to_bucket/1: Clients will work with table
 %% names. Those names map to a bucket type/bucket name tuple in Riak,
@@ -705,6 +708,67 @@ check_table_feature_supported(DDLRecCap, DecodedReq) ->
     end.
 
 %%
+convert_ddl_to_cluster_supported_version(DDLRecCap, DDL) when is_atom(DDLRecCap) ->
+    DDLConversions = riak_ql_ddl:convert(DDLRecCap, DDL),
+    [LowestDDL|_] = lists:sort(fun ddl_comparator/2, DDLConversions),
+    LowestDDL.
+
+ddl_comparator(A, B) ->
+    riak_ql_ddl:is_version_greater(element(1,A), element(1,B)) == true.
+
+-spec create_table(module(), ?DDL{}, proplists:proplist()) -> ok|{error,term()}.
+create_table(SvcMod, ?DDL{table = Table}=DDL1, WithProps) ->
+    DDLRecCap = riak_core_capability:get({riak_kv, riak_ql_ddl_rec_version}),
+    DDL2 = convert_ddl_to_cluster_supported_version(DDLRecCap, DDL1),
+    CompilerVersion = riak_ql_ddl_compiler:get_compiler_version(),
+    {ok, Props1} = riak_kv_ts_util:apply_timeseries_bucket_props(DDL2,
+                                                                 CompilerVersion,
+                                                                 WithProps),
+    case catch [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props1] of
+        {bad_linkfun_modfun, {M, F}} ->
+            {error, SvcMod:make_table_create_fail_resp(Table,
+                                         flat_format(
+                                           "Invalid link mod or fun in bucket type properties: ~p:~p\n", [M, F]))};
+        {bad_linkfun_bkey, {B, K}} ->
+            {error, SvcMod:make_table_create_fail_resp(Table,
+                                         flat_format(
+                                           "Malformed bucket/key for anon link fun in bucket type properties: ~p/~p\n", [B, K]))};
+        {bad_chash_keyfun, {M, F}} ->
+            {error, SvcMod:make_table_create_fail_resp(Table,
+                                         flat_format(
+                                           "Invalid chash mod or fun in bucket type properties: ~p:~p\n", [M, F]))};
+        Props2 ->
+            create_table1(SvcMod, Table, Props2, DDLRecCap, ?TABLE_ACTIVATE_WAIT)
+    end.
+
+create_table1(SvcMod, Table, Props, DDLRecCap, Seconds) ->
+    case riak_core_bucket_type:create(Table, Props) of
+        ok -> wait_until_active_and_supported(SvcMod, Table, DDLRecCap, Seconds);
+        {error, Reason} -> {error, SvcMod:make_table_create_fail_resp(Table, Reason)}
+    end.
+
+wait_until_supported(SvcMod, Table, _DDLRecCap, _Seconds=0) ->
+    {error, SvcMod:make_table_activate_error_timeout_resp(Table)};
+wait_until_supported(SvcMod, Table, DDLRecCap, Seconds) ->
+    case is_table_supported(DDLRecCap, Table) of
+        true -> ok;
+        _ -> wait_until_supported(SvcMod, Table, DDLRecCap, Seconds - 1)
+    end.
+
+wait_until_active_and_supported(SvcMod, Table, _DDLRecCap, _Seconds=0) ->
+    {error, SvcMod:make_table_activate_error_timeout_resp(Table)};
+wait_until_active_and_supported(SvcMod, Table, DDLRecCap, Seconds) ->
+    case riak_core_bucket_type:activate(Table) of
+        ok -> wait_until_supported(SvcMod, Table, DDLRecCap, Seconds);
+        {error, not_ready} ->
+            timer:sleep(1000),
+            lager:info("Waiting for table ~ts to be ready for activation", [Table]),
+            wait_until_active_and_supported(SvcMod, Table, DDLRecCap, Seconds - 1);
+        {error, undefined} ->
+            {error, SvcMod:make_table_created_missing_resp(Table)}
+    end.
+
+%%
 -spec is_table_active_and_supported(DDLRecCap::atom(),
                                     Table::binary()) ->
                                         boolean() | {error, string()}.
@@ -1051,4 +1115,20 @@ check_table_feature_supported_when_table_is_disabled_test() ->
         check_table_feature_supported(v2, DecodedReq)
     ).
 
+convert_ddl_to_cluster_supported_version_v1_test() ->
+    ?assertMatch(
+       #ddl_v1{},
+       convert_ddl_to_cluster_supported_version(
+         v1, #ddl_v2{local_key = ?DDL_KEY{ast = []}, partition_key = ?DDL_KEY{ast = []}, fields=[#riak_field_v1{type=varchar}]})
+    ).
+
+convert_ddl_to_cluster_supported_version_v2_test() ->
+    DDLV2 = #ddl_v2{
+               local_key = ?DDL_KEY{ast = []},
+               partition_key = ?DDL_KEY{ast = []},
+               fields=[#riak_field_v1{type=varchar}]},
+    ?assertMatch(
+       DDLV2,
+       convert_ddl_to_cluster_supported_version(v2, DDLV2)
+    ).
 -endif.

--- a/src/riak_kv_wm_timeseries_query.erl
+++ b/src/riak_kv_wm_timeseries_query.erl
@@ -280,13 +280,13 @@ flat_format(Format, Args) ->
     lists:flatten(io_lib:format(Format, Args)).
 
 make_table_create_fail_resp(Table, Reason) ->
-    flat_format("Failed to create table ~s: ~p", [Table, Reason]).
+    flat_format("Failed to create table ~ts: ~p", [Table, Reason]).
 
 make_table_activate_error_timeout_resp(Table) ->
     flat_format("Timed out while attempting to activate table ~ts", [Table]).
 
 make_table_created_missing_resp(Table) ->
-    flat_format("Table ~s has been created but found missing", [Table]).
+    flat_format("Table ~ts has been created but found missing", [Table]).
 
 -spec produce_doc_body(#wm_reqdata{}, #ctx{}) -> cb_rv_spec(iolist()).
 produce_doc_body(RD, Ctx = #ctx{result = {Columns, Rows}}) ->

--- a/src/riak_kv_wm_timeseries_query.erl
+++ b/src/riak_kv_wm_timeseries_query.erl
@@ -48,6 +48,11 @@
          produce_doc_body/2
         ]).
 
+%% exports for create table
+-export([make_table_create_fail_resp/2,
+         make_table_activate_error_timeout_resp/1,
+         make_table_created_missing_resp/1]).
+
 -include_lib("webmachine/include/webmachine.hrl").
 -include_lib("riak_ql/include/riak_ql_ddl.hrl").
 -include("riak_kv_wm_raw.hrl").
@@ -265,35 +270,23 @@ compile_query(QueryStr) ->
     end.
 
 
-create_table(DDL = ?DDL{table = Table}, Props) ->
-    %% would be better to use a function to get the table out.
-    {ok, Props1} = riak_kv_ts_util:apply_timeseries_bucket_props(
-                     DDL, riak_ql_ddl_compiler:get_compiler_version(), Props),
-    Props2 = [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props1],
-    case riak_core_bucket_type:create(Table, Props2) of
-        ok ->
-            wait_until_active(Table, ?TABLE_ACTIVATE_WAIT);
-        {error, Reason} ->
-            {error, {table_create_fail, Table, Reason}}
+create_table(DDL = ?DDL{table = Table}, WithProps) ->
+    case riak_kv_ts_util:create_table(?MODULE, DDL, WithProps) of
+        ok -> ok;
+        {error, Reason} -> {error, {table_create_fail, Table, Reason}}
     end.
 
-wait_until_active(Table, 0) ->
-    {error, {table_activate_fail, Table}};
-wait_until_active(Table, Seconds) ->
-    case riak_core_bucket_type:activate(Table) of
-        ok ->
-            ok;
-        {error, not_ready} ->
-            timer:sleep(1000),
-            wait_until_active(Table, Seconds - 1);
-        {error, undefined} ->
-            %% this is inconceivable because create(Table) has
-            %% just succeeded, so it's here mostly to pacify
-            %% the dialyzer (and of course, for the odd chance
-            %% of Erlang imps crashing nodes between create
-            %% and activate calls)
-            {error, {table_created_missing, Table}}
-    end.
+flat_format(Format, Args) ->
+    lists:flatten(io_lib:format(Format, Args)).
+
+make_table_create_fail_resp(Table, Reason) ->
+    flat_format("Failed to create table ~s: ~p", [Table, Reason]).
+
+make_table_activate_error_timeout_resp(Table) ->
+    flat_format("Timed out while attempting to activate table ~ts", [Table]).
+
+make_table_created_missing_resp(Table) ->
+    flat_format("Table ~s has been created but found missing", [Table]).
 
 -spec produce_doc_body(#wm_reqdata{}, #ctx{}) -> cb_rv_spec(iolist()).
 produce_doc_body(RD, Ctx = #ctx{result = {Columns, Rows}}) ->

--- a/src/riak_kv_wm_timeseries_query.erl
+++ b/src/riak_kv_wm_timeseries_query.erl
@@ -271,7 +271,7 @@ compile_query(QueryStr) ->
 
 
 create_table(DDL = ?DDL{table = Table}, WithProps) ->
-    case riak_kv_ts_util:create_table(?MODULE, DDL, WithProps) of
+    case riak_kv_ts_api:create_table(?MODULE, DDL, WithProps) of
         ok -> ok;
         {error, Reason} -> {error, {table_create_fail, Table, Reason}}
     end.


### PR DESCRIPTION
* fix for CREATE TABLE removing the delta between how the request is serviced between HTTP and PB and RPC.
* fix for CREATE TABLE, removing the delta between the post-condition of CREATE TABLE (was active bucket-type only) and "query-ready" (is bucket-type active, DDL module compiled and min capability met).

Depends on: https://github.com/basho/riak_core/pull/890
Tested by: https://github.com/basho/riak_test/pull/1254
Relates to: riak_test ts_cluster_riak_shell_regression_log which otherwise exposes a race condition between the CREATE TABLE and subsequent INSERT queries.