### PR TITLE
reduce qbuf expiry and total size defaults; use async eleveldb:put [JIRA: RIAK-3145]

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -901,7 +901,7 @@
 %% queries can be accepted. Does not affect existing queries for which
 %% data collection is in progress.
 {mapping, "riak_kv.query.timeseries.qbuf_soft_watermark", "riak_kv.timeseries_query_buffers_soft_watermark", [
-  {default, 1*1024*1024*1024},
+  {default, 800*1024*1024},
   {datatype, integer},
   {validators, ["validate_timeseries_query_buffers_soft_watermark"]}
 ]}.
@@ -917,7 +917,7 @@
 %% queries can continue to collect data into query buffers. Queries
 %% tripping this threshold will be cancelled.
 {mapping, "riak_kv.query.timeseries.qbuf_hard_watermark", "riak_kv.timeseries_query_buffers_hard_watermark", [
-  {default, 4*1024*1024*1024},
+  {default, 1*1024*1024*1024},
   {datatype, integer},
   {validators, ["validate_timeseries_query_buffers_hard_watermark"]}
 ]}.
@@ -933,7 +933,7 @@
 %% for longer than this value (rounded upward to the next whole
 %% second) will be deleted.
 {mapping, "riak_kv.query.timeseries.qbuf_expire_ms", "riak_kv.timeseries_query_buffers_expire_ms", [
-  {default, 5000},
+  {default, 500},
   {datatype, integer},
   {validators, ["validate_timeseries_query_buffers_expire_ms"]}
 ]}.

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -889,10 +889,11 @@
   end
 }.
 
-%% @doc Root path for leveldb instances backing node-local query buffers.
+%% @doc Root path for leveldb instances backing node-local query
+%% buffers. Placing it on a fast media is recommended.
 {mapping, "riak_kv.query.timeseries.qbuf_root_path", "riak_kv.timeseries_query_buffers_root_path", [
   {datatype, directory},
-  {default, "/tmp/riak-qb"},
+  {default, "$(platform_data_dir)/query_buffers"},
   {validators, ["validate_timeseries_query_buffers_root_path"]},
   hidden
 ]}.

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -892,7 +892,7 @@
 %% @doc Root path for leveldb instances backing node-local query buffers.
 {mapping, "riak_kv.query.timeseries.qbuf_root_path", "riak_kv.timeseries_query_buffers_root_path", [
   {datatype, directory},
-  {default, "$(platform_data_dir)/query_buffers"},
+  {default, "/tmp/riak-qb"},
   {validators, ["validate_timeseries_query_buffers_root_path"]},
   hidden
 ]}.

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -274,7 +274,7 @@ prep_stop(_State) ->
         wait_for_put_fsms(),
         lager:info("all active put FSMs completed"),
 
-        ok = riak_kv_qry_buffers:kill_all_qbufs(),
+        ok = riak_kv_qry_buffers:shutdown(),
         lager:info("cleaned up query buffers"),
         ok
     catch

--- a/src/riak_kv_qry_buffers_ldb.erl
+++ b/src/riak_kv_qry_buffers_ldb.erl
@@ -93,7 +93,7 @@ add_rows(LdbRef, Rows, ChunkId,
                   %% d. Encode the record (don't bother constructing a
                   %%    riak_object with metadata, vclocks):
                   RowEnc = sext:encode(Row),
-                  ok = eleveldb:put(LdbRef, KeyEnc, RowEnc, [{sync, true}])
+                  ok = eleveldb:put(LdbRef, KeyEnc, RowEnc, [{sync, false}])
           end,
           RowsIndexed)
     catch


### PR DESCRIPTION
This PR:

* Suggests placing the query buffers root dir on /tmp (because this directory is commonly mounted on memory-backed tmpfs);
* Lowers the watermark values limiting the max volume of data stored at any time in temp tables (from 4 to 1G);
* Uses async `eleveldb:put`, to speed things up.

A corresponding PR in riak_test is https://github.com/basho/riak_test/pull/1252.