### PR TITLE
Add test for concurrent sweeps

### DIFF
--- a/itest/riak_kv_sweeper_SUITE.erl
+++ b/itest/riak_kv_sweeper_SUITE.erl
@@ -80,7 +80,7 @@ meck_new_riak_core_modules(Partitions) ->
     VNodeIndices.
 
 meck_new_riak_core_ring(Partitions) ->
-    VNodeIndices = [N || N <- lists:seq(0, Partitions)],
+    VNodeIndices = [N || N <- lists:seq(1, Partitions)],
     meck:expect(riak_core_ring, my_indices, fun(ring) -> VNodeIndices end),
     VNodeIndices.
 

--- a/itest/riak_kv_sweeper_SUITE.erl
+++ b/itest/riak_kv_sweeper_SUITE.erl
@@ -982,22 +982,6 @@ is_running_sweep(#sweep{pid = Pid, state = running}) ->
 is_running_sweep(_) ->
     false.
 
-wait_for_concurrent_sweeps(ConcurrentSweeps) ->
-    wait_for_concurrent_sweeps(ConcurrentSweeps, []).
-
-wait_for_concurrent_sweeps(0, Result) ->
-    Result;
-
-wait_for_concurrent_sweeps(ConcurrentSweeps, Result) ->
-    {NewConcurrentSweeps, NewResult} =
-        receive {From, Index} when is_pid(From) ->
-                {ConcurrentSweeps - 1, [Result|Index]};
-                _ ->
-                {ConcurrentSweeps, Result}
-        end,
-
-    wait_for_concurrent_sweeps(NewConcurrentSweeps, NewResult).
-
 expected_obj_size_throttle_total_msecs(NumKeys, NumMutatedKeys, RiakObjSizeBytes, ThrottleAfterBytes, ThrottleWaitMsecs) ->
     ThrottleMsecs = expected_throttle_msecs(
                       NumKeys, ThrottleAfterBytes, ThrottleWaitMsecs, RiakObjSizeBytes),

--- a/itest/riak_kv_sweeper_SUITE.erl
+++ b/itest/riak_kv_sweeper_SUITE.erl
@@ -961,9 +961,7 @@ scheduler_sweep_concurrency_test(_Config) ->
     TestCasePid = self(),
     meck_new_backend(TestCasePid),
     true = RingSize > ConcurrentSweeps,
-    SP = meck_new_sweep_particpant(sweep_observer_1, TestCasePid),
-    SP1 = SP#sweep_participant{run_interval = 1},
-    riak_kv_sweeper:add_sweep_participant(SP1),
+    new_sweep_participant(sweep_observer_1, TestCasePid, 1),
     riak_kv_sweeper:enable_sweep_scheduling(),
     meck_new_visit_function(sweep_observer_1, {wait, TestCasePid, Indices}),
 

--- a/src/riak_kv_sweeper_state.erl
+++ b/src/riak_kv_sweeper_state.erl
@@ -43,7 +43,8 @@
 %% For testing/debug use only:
 -export([sweep_state/1,
          sweep_index/1,
-         sweep_queue_time/1
+         sweep_queue_time/1,
+         sweep_pid/1
         ]).
 
 -export_type([state/0, sweep/0]).
@@ -716,6 +717,7 @@ get_persistent_participants() ->
 sweep_state(#sweep{state = State}) -> State.
 sweep_index(#sweep{index = Index}) -> Index.
 sweep_queue_time(#sweep{queue_time = QueueTime}) -> QueueTime.
+sweep_pid(#sweep{pid = Pid}) -> Pid.
 
 -ifdef(TEST).
 


### PR DESCRIPTION
Reintroduce and fix the test removed in 054b62c. This testcase
validates sweep concurrency functionality asserting that an expected
number of sweeps are running in concurrently.