### PR TITLE
Move `extract_user_meta/1` into `riak_kv_wm_utils` 

### DIFF
--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -730,7 +730,7 @@ accept_doc_body(RD, Ctx=#ctx{bucket_type=T, bucket=B, key=K, client=C, links=L, 
            end,
     VclockDoc = riak_object:set_vclock(Doc0, decode_vclock_header(RD)),
     {CType, Charset} = extract_content_type(RD),
-    UserMeta = extract_user_meta(RD),
+    UserMeta = riak_kv_wm_utils:extract_user_meta(RD),
     CTypeMD = dict:store(?MD_CTYPE, CType, dict:new()),
     CharsetMD = if Charset /= undefined ->
                         dict:store(?MD_CHARSET, Charset, CTypeMD);
@@ -811,17 +811,6 @@ extract_content_type(RD) ->
             Params = [ list_to_tuple(string:tokens(P, "=")) || P <- RawParams],
             {CType, proplists:get_value("charset", Params)}
     end.
-
--spec extract_user_meta(#wm_reqdata{}) -> proplists:proplist().
-%% @doc Extract headers prefixed by X-Riak-Meta- in the client's PUT request
-%%      to be returned by subsequent GET requests.
-extract_user_meta(RD) ->
-    lists:filter(fun({K,_V}) ->
-                    lists:prefix(
-                        ?HEAD_USERMETA_PREFIX,
-                        string:to_lower(riak_kv_wm_utils:any_to_list(K)))
-                end,
-                mochiweb_headers:to_list(wrq:req_headers(RD))).
 
 -spec multiple_choices(#wm_reqdata{}, context()) ->
           {boolean(), #wm_reqdata{}, context()}.

--- a/src/riak_kv_wm_utils.erl
+++ b/src/riak_kv_wm_utils.erl
@@ -42,7 +42,8 @@
          ensure_bucket_type/3,
          bucket_type_exists/1,
          maybe_bucket_type/2,
-         method_to_perm/1
+         method_to_perm/1,
+         extract_user_meta/1
         ]).
 
 -include_lib("webmachine/include/webmachine.hrl").
@@ -495,3 +496,15 @@ method_to_perm('GET') ->
     "riak_kv.get";
 method_to_perm('DELETE') ->
     "riak_kv.delete".
+
+-spec extract_user_meta(#wm_reqdata{}) -> proplists:proplist().
+%% @doc Extract headers prefixed by X-Riak-Meta- in the client's PUT request
+%%      to be returned by subsequent GET requests.
+extract_user_meta(RD) ->
+    lists:filter(
+        fun({K, _V}) ->
+            lists:prefix(
+                ?HEAD_USERMETA_PREFIX,
+                string:to_lower(riak_kv_wm_utils:any_to_list(K)))
+        end,
+        mochiweb_headers:to_list(wrq:req_headers(RD))).


### PR DESCRIPTION
Other web-based endpoints have a use for `extract_user_meta/1` - move it to the wm_utils module and export it.