### PR TITLE
Use the correct key to get the configured max quanta value [JIRA: RIAK-3143]

### DIFF
--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -681,7 +681,7 @@ hash_timestamp_to_quanta(QField, QSize, QUnit, QIndex, Where1) ->
             false -> Max1
         end,
     %% sanity check for the number of quanta we can handle
-    MaxQueryQuanta = app_helper:get_env(riak_kv, max_query_quanta, ?MAX_QUERY_QUANTA),
+    MaxQueryQuanta = app_helper:get_env(riak_kv, timeseries_query_max_quanta_span, ?MAX_QUERY_QUANTA),
     NQuanta = (Max2 - Min2) div riak_ql_quanta:unit_to_millis(QSize, QUnit),
     case NQuanta < MaxQueryQuanta of
         true ->


### PR DESCRIPTION
The call to get the max quanta value was using the wrong key, so always defaulting to 1000. This PR fixes the call to use the correct key and get the configured value, from the shell:

```sql
riak-shell(33)>SELECT * FROM WeatherStationData WHERE StationId = 'Station-1001' AND ReadingTimeStamp > 0 AND ReadingTimeStamp < 100000000000000000;;
Error (1025): Query spans too many quanta (1157407407, max 5000)
```