### PR TITLE
qry_buffers_ldb: use async eleveldb:put

### DIFF
--- a/src/riak_kv_qry_buffers_ldb.erl
+++ b/src/riak_kv_qry_buffers_ldb.erl
@@ -93,7 +93,7 @@ add_rows(LdbRef, Rows, ChunkId,
                   %% d. Encode the record (don't bother constructing a
                   %%    riak_object with metadata, vclocks):
                   RowEnc = sext:encode(Row),
-                  ok = eleveldb:put(LdbRef, KeyEnc, RowEnc, [{sync, true}])
+                  ok = eleveldb:put(LdbRef, KeyEnc, RowEnc, [{sync, false}])
           end,
           RowsIndexed)
     catch


### PR DESCRIPTION
This is likely to improve the latencies of queries involving query buffers.