### PR TITLE
place qbufs in a unique dir under timeseries_query_buffers_root_path

### DIFF
--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -274,7 +274,7 @@ prep_stop(_State) ->
         wait_for_put_fsms(),
         lager:info("all active put FSMs completed"),
 
-        ok = riak_kv_qry_buffers:kill_all_qbufs(),
+        ok = riak_kv_qry_buffers:shutdown(),
         lager:info("cleaned up query buffers"),
         ok
     catch


### PR DESCRIPTION
With associated changes to ensure that it is deleted on shutdown.

This may be relevant for setups where `timeseries_query_buffers_root_path` is set to some directory outside of `"$(platform_data_dir)`, which can potentially be shared between other nodes.