### PR TITLE
Queries on descending keys tables sometimes do not return results RTS-1678

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
             {d, 'TEST_FS2_BACKEND_IN_RIAK_KV'}]}.
 
 
-% {eunit_opts, [no_tty, {report, {unite_compact, []}}]}.
+{eunit_opts, [no_tty, {report, {unite_compact, []}}]}.
 
 {xref_checks, []}.
 %% XXX yz_kv is here becase Ryan has not yet made a generic hook interface for object modification

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -153,7 +153,7 @@ expand_query(?DDL{local_key = LK, partition_key = PK},
         {error, E} ->
             {error, E};
         {ok, Where2} ->
-            IsDescending = is_partition_key_cols_descending(Mod:field_orders(), PK),
+            IsDescending = is_last_partition_column_descending(Mod:field_orders(), PK),
             SubQueries1 =
                 [Q1?SQL_SELECT{
                        is_executable = true,
@@ -171,8 +171,6 @@ expand_query(?DDL{local_key = LK, partition_key = PK},
             {ok, SubQueries2}
     end.
 
-%% Check if any columns in the partition key have the DESC keyword applied.
-%%
 %% Only check the last column in the partition key, otherwise the start/end key
 %% does not need to be flipped. The data is not stored in a different order to
 %% the start/end key.
@@ -180,7 +178,7 @@ expand_query(?DDL{local_key = LK, partition_key = PK},
 %% Checking the last column in the partition key is safe while the other columns
 %% must be exactly specified e.g. anything but the QUANTUM column must be
 %% covered with an equals operator in the where clause.
-is_partition_key_cols_descending(FieldOrders, #key_v1{ast = AST}) ->
+is_last_partition_column_descending(FieldOrders, #key_v1{ast = AST}) ->
     PKOrders = lists:sublist(FieldOrders, length(AST)),
     lists:last(PKOrders) == descending.
 

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -503,8 +503,6 @@ fix_start_order(W) ->
     %% timestamp field.
     W1 = lists:keystore(startkey, 1, W, {startkey, EndKey0}),
     W2 = lists:keystore(endkey, 1, W1, {endkey, StartKey0}),
-    W1 = lists:keystore(startkey, 1, W, {startkey, EndKey0}),
-    W2 = lists:keystore(endkey, 1, W1, {endkey, StartKey0}),
     %% start inclusive defaults true, end inclusive defaults false
     W3 = lists:keystore(start_inclusive, 1, W2,
                         {start_inclusive, proplists:get_value(end_inclusive, W, false)}),


### PR DESCRIPTION
There was a check on the keys to work out if the start/end keys should be swapped, sometimes this was returning false (do not swap) when it should have returned true. Date for descending keys is stored like.

```
(1,2,-3)
(1,2,-2)
(1,2,-1)
```

Where the last column is descending and the inserted values were un-negated e.g. `(1,2,3)` etc. And the query start/end keys need to be `c >= -3 AND C <= -1`. If the query start/end keys are **not** swapped then the range will not be possible e.g. `c >= -1 AND c <= -3`.

Symptoms are:
1. Depending on the column names, results may not be returned. Column names were mistakenly used in the data used for comparison.
2. When the `DESC` keyword is used a local key column that is not also in the partition key e.g. `PRIMARY KEY((a,b,QUANTUM(c,1,'s'),a,b,c,d))` , then no results can be returned.

This PR fixes both issues above.