### PR TITLE
Don't let Thumbs auto-squash

### DIFF
--- a/.thumbs.yml
+++ b/.thumbs.yml
@@ -1,5 +1,6 @@
 minimum_reviewers: 2
-merge: true
+merge: false
+merge_method: merge
 build_steps:
   - make clean
   - make deps


### PR DESCRIPTION
Discussed with the team. We would rather not have Thumbs auto-merge, and we're not a fan of squashing by default either. Editing the config to match our preferences.