### PR TITLE
deferred eleveldb ops for query buffers (in-mem ORDER BY/LIMIT)

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -929,6 +929,20 @@
      (_) -> false
   end}.
 
+%% @doc Max heap size before dumping query buffers to ldb
+{mapping, "riak_kv.query.timeseries.qbuf_inmem_max", "riak_kv.timeseries_query_buffers_inmem_max", [
+  {default, 1000000},
+  {datatype, integer},
+  {validators, ["validate_timeseries_query_buffers_inmem_max"]}
+]}.
+
+{validator,
+  "validate_timeseries_query_buffers_inmem_max",
+  "must be an integer >= 0",
+  fun(Value) when is_integer(Value), Value >= 0 -> true;
+     (_) -> false
+  end}.
+
 %% @doc Query buffer expiry time (in msec). Query buffers not accessed
 %% for longer than this value (rounded upward to the next whole
 %% second) will be deleted.

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -931,9 +931,8 @@
 
 %% @doc Max heap size before dumping query buffers to ldb
 {mapping, "riak_kv.query.timeseries.qbuf_inmem_max", "riak_kv.timeseries_query_buffers_inmem_max", [
-  {default, "10M"},
-  {datatype, bytesize},
-  {validators, ["validate_timeseries_query_buffers_inmem_max"]}
+  {default, "10MB"},
+  {datatype, bytesize}
 ]}.
 
 %% @doc Query buffer expiry time (in msec). Query buffers not accessed

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -931,17 +931,10 @@
 
 %% @doc Max heap size before dumping query buffers to ldb
 {mapping, "riak_kv.query.timeseries.qbuf_inmem_max", "riak_kv.timeseries_query_buffers_inmem_max", [
-  {default, 1000000},
-  {datatype, integer},
+  {default, "10M"},
+  {datatype, bytesize},
   {validators, ["validate_timeseries_query_buffers_inmem_max"]}
 ]}.
-
-{validator,
-  "validate_timeseries_query_buffers_inmem_max",
-  "must be an integer >= 0",
-  fun(Value) when is_integer(Value), Value >= 0 -> true;
-     (_) -> false
-  end}.
 
 %% @doc Query buffer expiry time (in msec). Query buffers not accessed
 %% for longer than this value (rounded upward to the next whole

--- a/src/riak_kv_qry_buffers.erl
+++ b/src/riak_kv_qry_buffers.erl
@@ -396,8 +396,6 @@ do_delete_qbuf(QBufRef, #state{qbufs = QBufs0,
     case get_qbuf_record(QBufRef, QBufs0) of
         false ->
             {reply, {error, bad_qbuf_ref}, State0};
-        #qbuf{all_chunks_received = false} ->
-            {reply, {error, qbuf_not_ready}, State0};
         #qbuf{ldb_ref = LdbRef,
               ddl = ?DDL{table = Table}} ->
             ok = riak_kv_qry_buffers_ldb:delete_table(Table, LdbRef, RootPath),

--- a/src/riak_kv_qry_buffers.erl
+++ b/src/riak_kv_qry_buffers.erl
@@ -396,6 +396,8 @@ do_delete_qbuf(QBufRef, #state{qbufs = QBufs0,
     case get_qbuf_record(QBufRef, QBufs0) of
         false ->
             {reply, {error, bad_qbuf_ref}, State0};
+        #qbuf{ldb_ref = undefined} ->
+            {reply, ok, State0#state{qbufs = lists:keydelete(QBufRef, 1, QBufs0)}};
         #qbuf{ldb_ref = LdbRef,
               ddl = ?DDL{table = Table}} ->
             ok = riak_kv_qry_buffers_ldb:delete_table(Table, LdbRef, RootPath),

--- a/src/riak_kv_qry_buffers.erl
+++ b/src/riak_kv_qry_buffers.erl
@@ -470,7 +470,7 @@ add_chunk(#qbuf{ldb_ref       = LdbRef,
                                last_accessed = os:timestamp(),
                                all_chunks_received = AllChunksReceived},
 
-            HaveLdbOpened = (LdbRef /= undefined),
+            IsBackendOpened = (LdbRef /= undefined),
             InmemAcc = lists:append(InmemBuffer0, KeyedData),
             EleveldbPutF =
                 fun(Ref) ->
@@ -485,14 +485,14 @@ add_chunk(#qbuf{ldb_ref       = LdbRef,
                         end
                 end,
 
-            case (HaveLdbOpened orelse not can_afford_inmem(InmemMax)) of
+            case (IsBackendOpened orelse not can_afford_inmem(InmemMax)) of
                 false ->
                     InmemBuffer =
                         lists:sort(InmemAcc),
                     lager:debug("adding chunk ~b of ~b to inmem buffer", [ChunksGot, ChunksNeed]),
                     QBuf = QBuf1#qbuf{inmem_buffer = maybe_only_rows(InmemBuffer, AllChunksReceived)},
                     {ok, QBuf};
-                true when HaveLdbOpened ->
+                true when IsBackendOpened ->
                     EleveldbPutF(LdbRef);
                 true ->
                     case DelayedCreateFun() of

--- a/src/riak_kv_qry_buffers.erl
+++ b/src/riak_kv_qry_buffers.erl
@@ -739,6 +739,14 @@ tstamp() ->
 
 %% data ops
 
+-spec enkey([data_row()],
+            KeyFieldPositions::[non_neg_integer()],
+            OrdByFieldQualifiers::[{asc|desc, nulls_first|nulls_last}],
+            ChunkId::non_neg_integer()) ->
+                   [{{KeyOrd::riak_pb_ts_codec:ldbvalue(),
+                      ChunkId::non_neg_integer(),
+                      Idx::non_neg_integer()},
+                     data_row()}].
 enkey(Rows, KeyFieldPositions, OrdByFieldQualifiers, ChunkId)
   when is_list(KeyFieldPositions) ->
     %% 0. The new key is composed from fields appearing in the ORDER

--- a/src/riak_kv_qry_buffers_ldb.erl
+++ b/src/riak_kv_qry_buffers_ldb.erl
@@ -75,7 +75,7 @@ add_rows(LdbRef, Rows) ->
     try
         lists:foreach(
           fun({K, V}) ->
-                  ok = eleveldb:put(LdbRef, K, V, [{sync, true}])
+                  ok = eleveldb:put(LdbRef, sext:encode(K), sext:encode(V), [{sync, false}])
           end,
           Rows)
     catch

--- a/src/riak_kv_qry_sup.erl
+++ b/src/riak_kv_qry_sup.erl
@@ -38,6 +38,7 @@
 -define(TIMESERIES_QUERY_BUFFERS_ROOT_PATH_SUFFIX, "query_buffers").  %% relative to platform_data_dir
 -define(TIMESERIES_QUERY_BUFFERS_SOFT_WATERMARK, 1*1024*1024*1024).
 -define(TIMESERIES_QUERY_BUFFERS_HARD_WATERMARK, 4*1024*1024*1024).
+-define(TIMESERIES_QUERY_BUFFERS_INMEM_MAX, 10*1024*1024).
 -define(TIMESERIES_QUERY_BUFFERS_EXPIRE_MS, 5000).
 -define(TIMESERIES_QUERY_BUFFERS_INCOMPLETE_RELEASE_MS, 9000).
 
@@ -99,6 +100,8 @@ init([]) ->
                                            ?TIMESERIES_QUERY_BUFFERS_SOFT_WATERMARK),
                         app_helper:get_env(riak_kv, timeseries_query_buffers_hard_watermark,
                                            ?TIMESERIES_QUERY_BUFFERS_HARD_WATERMARK),
+                        app_helper:get_env(riak_kv, timeseries_query_buffers_inmem_max,
+                                           ?TIMESERIES_QUERY_BUFFERS_INMEM_MAX),
                         app_helper:get_env(riak_kv, timeseries_query_buffers_expire_ms,
                                            ?TIMESERIES_QUERY_BUFFERS_EXPIRE_MS),
                         app_helper:get_env(riak_kv, timeseries_query_buffers_incomplete_release_ms,


### PR DESCRIPTION
RTS-1641

Associated tests in https://github.com/basho/riak_test/pull/1257.

The underlying idea is to keep the accumulated data in memory until memory shortage occurs in the qry_buffers gen_server process. The two costliest operations, `eleveldb:open` and `:put` (as well as sext en-/decoding) are thus deferred, and for short queries and under light load, may never actually take place.

The heuristic to determine when to start dumping accumulated query results to leveldb is, in this initial implementation, simply a check of

      (heap_size - stack_size) < HeapSizeLimit

with the limit set in riak.conf by parameter `riak_kv.timeseries_query_buffers_inmem_max` (10M by default).

For previous comments and discussion, see https://github.com/basho/riak_kv/pull/1587.