### PR TITLE
Update the riak_kv_backend behavior to use -callback specs

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -16,7 +16,6 @@ riak_kv_pb_object.erl:252: The pattern 'consistent' can never match the type 'fa
 # Callback info not available
 Callback info about the riak_core_vnode_worker behaviour is not available
 Callback info about the riak_core_coverage_fsm behaviour is not available
-Callback info about the riak_kv_backend behaviour is not available
 Unknown functions:
   cluster_info:dump_all_connected/1
   cluster_info:dump_nodes/2

--- a/src/riak_kv_backend.erl
+++ b/src/riak_kv_backend.erl
@@ -22,7 +22,6 @@
 
 -module(riak_kv_backend).
 
--export([behaviour_info/1]).
 -export([callback_after/3]).
 
 -type fold_buckets_fun() :: fun((binary(), any()) -> any() | no_return()).
@@ -31,33 +30,50 @@
 -type fold_objects_fun() :: fun((binary(), binary(), term(), any()) ->
                                        any() |
                                        no_return()).
+
 -export_type([fold_buckets_fun/0,
               fold_keys_fun/0,
               fold_objects_fun/0]).
 
--spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
-behaviour_info(callbacks) ->
-    [
-     {api_version,0},
-     {capabilities, 1},  % (State)
-     {capabilities, 2},  % (Bucket, State)
-     {start,2},          % (Partition, Config)
-     {stop,1},           % (State)
-     {get,3},            % (Bucket, Key, State)
-     {put,5},            % (Bucket, Key, IndexSpecs, Val, State)
-     {delete,4},         % (Bucket, Key, IndexSpecs, State)
-     {drop,1},           % (State)
-     {fold_buckets,4},   % (FoldBucketsFun, Acc, Opts, State),
-                         %   FoldBucketsFun(Bucket, Acc)
-     {fold_keys,4},      % (FoldKeysFun, Acc, Opts, State),
-                         %   FoldKeysFun(Bucket, Key, Acc)
-     {fold_objects,4},   % (FoldObjectsFun, Acc, Opts, State),
-                         %   FoldObjectsFun(Bucket, Key, Object, Acc)
-     {is_empty,1},       % (State)
-     {status,1},         % (State)
-     {callback,3}];      % (Ref, Msg, State) ->
-behaviour_info(_Other) ->
-    undefined.
+%% These are just here to make the callback specs more succinct and readable
+-type state() :: term().
+-type fold_acc() :: term().
+-type fold_opts() :: [term()]. %% TODO maybe more specific? [{atom(), term()}]?
+-type fold_result() :: {ok, fold_acc()} | {async, fun()} | {error, term()}.
+
+-callback api_version() -> {ok, number()}.
+
+-callback capabilities(state()) -> {ok, [atom()]}.
+-callback capabilities(riak_object:bucket(), state()) -> {ok, [atom()]}.
+
+-callback start(PartitionIndex :: non_neg_integer(), Config :: [{atom(), term()}]) ->
+    {ok, state()} | {error, term()}.
+-callback stop(state()) -> ok.
+
+-callback get(riak_object:bucket(), riak_object:key(), state()) ->
+    {ok, Value :: term(), state()} |
+    {ok, not_found, state()} |
+    {error, term(), state()}.
+%% TODO pull all the copy-pasted index_spec() type specs into this mod and use in the callback spec
+-callback put(riak_object:bucket(), riak_object:key(), IndexSpecs :: term(), Value :: binary(),
+              state()) ->
+    {ok, state()} |
+    {error, term(), state()}.
+-callback delete(riak_object:bucket(), riak_object:key(), IndexSpecs :: term(), state()) ->
+    {ok, state()} |
+    {error, term(), state()}.
+
+-callback drop(state()) -> {ok, state()} | {error, term(), state()}.
+
+-callback fold_buckets(fold_buckets_fun(), fold_acc(), fold_opts(), state()) -> fold_result().
+-callback fold_keys(fold_keys_fun(), fold_acc(), fold_opts(), state()) -> fold_result().
+-callback fold_objects(fold_objects_fun(), fold_acc(), fold_opts(), state()) -> fold_result().
+
+-callback is_empty(state()) -> boolean() | {error, term()}.
+
+-callback status(state()) -> [{atom(), term()}].
+
+-callback callback(reference(), Msg :: term(), state()) -> {ok, state()}.
 
 %% Queue a callback for the backend after Time ms.
 -spec callback_after(integer(), reference(), term()) -> reference().

--- a/src/riak_kv_backend.erl
+++ b/src/riak_kv_backend.erl
@@ -31,7 +31,7 @@
                                        any() |
                                        no_return()).
 
--type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
+-type index_spec() :: {add | remove, binary(), riak_object:index_value()}.
 
 -export_type([fold_buckets_fun/0,
               fold_keys_fun/0,

--- a/src/riak_kv_backend.erl
+++ b/src/riak_kv_backend.erl
@@ -31,9 +31,12 @@
                                        any() |
                                        no_return()).
 
+-type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
+
 -export_type([fold_buckets_fun/0,
               fold_keys_fun/0,
-              fold_objects_fun/0]).
+              fold_objects_fun/0,
+              index_spec/0]).
 
 %% These are just here to make the callback specs more succinct and readable
 -type state() :: term().
@@ -54,12 +57,11 @@
     {ok, Value :: term(), state()} |
     {ok, not_found, state()} |
     {error, term(), state()}.
-%% TODO pull all the copy-pasted index_spec() type specs into this mod and use in the callback spec
--callback put(riak_object:bucket(), riak_object:key(), IndexSpecs :: term(), Value :: binary(),
+-callback put(riak_object:bucket(), riak_object:key(), [index_spec()], Value :: binary(),
               state()) ->
     {ok, state()} |
     {error, term(), state()}.
--callback delete(riak_object:bucket(), riak_object:key(), IndexSpecs :: term(), state()) ->
+-callback delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
     {ok, state()} |
     {error, term(), state()}.
 

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -222,10 +222,10 @@ get(Bucket, Key, #state{ref=Ref, key_vsn=KVers}=State) ->
 %% NOTE: The bitcask backend does not currently support
 %% secondary indexing and the_IndexSpecs parameter
 %% is ignored.
--type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
--spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
-                 {ok, state()} |
-                 {error, term(), state()}.
+-spec put(riak_object:bucket(), riak_object:key(), [riak_kv_backend:index_spec()],
+          binary(), state()) ->
+    {ok, state()} |
+    {error, term(), state()}.
 put(Bucket, PrimaryKey, _IndexSpecs, Val,
     #state{ref=Ref, key_vsn=KeyVsn}=State) ->
     BitcaskKey = make_bk(KeyVsn, Bucket, PrimaryKey),
@@ -240,8 +240,8 @@ put(Bucket, PrimaryKey, _IndexSpecs, Val,
 %% NOTE: The bitcask backend does not currently support
 %% secondary indexing and the_IndexSpecs parameter
 %% is ignored.
--spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
-                    {ok, state()}.
+-spec delete(riak_object:bucket(), riak_object:key(), [riak_kv_backend:index_spec()], state()) ->
+    {ok, state()}.
 delete(Bucket, Key, _IndexSpecs,
        #state{ref=Ref, key_vsn=KeyVsn}=State) ->
     BitcaskKey = make_bk(KeyVsn, Bucket, Key),

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -171,10 +171,10 @@ get(Bucket, Key, #state{read_opts=ReadOpts,
     end.
 
 %% @doc Insert an object into the eleveldb backend.
--type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
--spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
-                 {ok, state()} |
-                 {error, term(), state()}.
+-spec put(riak_object:bucket(), riak_object:key(), [riak_kv_backend:index_spec()],
+          binary(), state()) ->
+    {ok, state()} |
+    {error, term(), state()}.
 put(Bucket, PrimaryKey, IndexSpecs, Val, #state{ref=Ref,
                                                 write_opts=WriteOpts,
                                                 legacy_indexes=WriteLegacy,
@@ -307,9 +307,9 @@ fixed_index_status(#state{fixed_indexes=Fixed}) ->
     Fixed.
 
 %% @doc Delete an object from the eleveldb backend
--spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
-                    {ok, state()} |
-                    {error, term(), state()}.
+-spec delete(riak_object:bucket(), riak_object:key(), [riak_kv_backend:index_spec()], state()) ->
+    {ok, state()} |
+    {error, term(), state()}.
 delete(Bucket, PrimaryKey, IndexSpecs, #state{ref=Ref,
                                               write_opts=WriteOpts,
                                               fixed_indexes=FixedIndexes}=State) ->

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -203,9 +203,8 @@ get(Bucket, Key, State=#state{data_ref=DataRef,
     end.
 
 %% @doc Insert an object into the memory backend.
--type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
--spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
-                 {ok, state()}.
+-spec put(riak_object:bucket(), riak_object:key(), [riak_kv_backend:index_spec()],
+          binary(), state()) -> {ok, state()}.
 put(Bucket, PrimaryKey, IndexSpecs, Val, State=#state{data_ref=DataRef,
                                                       index_ref=IndexRef,
                                                       max_memory=MaxMemory,
@@ -253,7 +252,7 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, State=#state{data_ref=DataRef,
                      put_obj_size=Size}}.
 
 %% @doc Delete an object from the memory backend
--spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
+-spec delete(riak_object:bucket(), riak_object:key(), [riak_kv_backend:index_spec()], state()) ->
                     {ok, state()}.
 delete(Bucket, Key, IndexSpecs, State=#state{data_ref=DataRef,
                                              index_ref=IndexRef,

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -228,10 +228,10 @@ get(Bucket, Key, State) ->
 
 %% @doc Insert an object with secondary index
 %% information into the kv backend
--type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
--spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
-                 {ok, state()} |
-                 {error, term(), state()}.
+-spec put(riak_object:bucket(), riak_object:key(), [riak_kv_backend:index_spec()],
+          binary(), state()) ->
+    {ok, state()} |
+    {error, term(), state()}.
 put(Bucket, PrimaryKey, IndexSpecs, Value, State) ->
     {Name, Module, SubState} = get_backend(Bucket, State),
     case Module:put(Bucket, PrimaryKey, IndexSpecs, Value, SubState) of
@@ -244,7 +244,7 @@ put(Bucket, PrimaryKey, IndexSpecs, Value, State) ->
     end.
 
 %% @doc Delete an object from the backend
--spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
+-spec delete(riak_object:bucket(), riak_object:key(), [riak_kv_backend:index_spec()], state()) ->
                     {ok, state()} |
                     {error, term(), state()}.
 delete(Bucket, Key, IndexSpecs, State) ->

--- a/src/riak_kv_multi_prefix_backend.erl
+++ b/src/riak_kv_multi_prefix_backend.erl
@@ -273,10 +273,10 @@ get(Bucket, Key, State) ->
 
 %% @doc Insert an object with secondary index
 %% information into the kv backend
--type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
--spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
-                 {ok, state()} |
-                 {error, term(), state()}.
+-spec put(riak_object:bucket(), riak_object:key(), [riak_kv_backend:index_spec()],
+          binary(), state()) ->
+    {ok, state()} |
+    {error, term(), state()}.
 put(Bucket, PrimaryKey, IndexSpecs, Value, State) ->
     {Name, Module, SubState} = get_backend(Bucket, State),
     case Module:put(Bucket, PrimaryKey, IndexSpecs, Value, SubState) of
@@ -289,9 +289,9 @@ put(Bucket, PrimaryKey, IndexSpecs, Value, State) ->
     end.
 
 %% @doc Delete an object from the backend
--spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
-                    {ok, state()} |
-                    {error, term(), state()}.
+-spec delete(riak_object:bucket(), riak_object:key(), [riak_kv_backend:index_spec()], state()) ->
+    {ok, state()} |
+    {error, term(), state()}.
 delete(Bucket, Key, IndexSpecs, State) ->
     {Name, Module, SubState} = get_backend(Bucket, State),
     case Module:delete(Bucket, Key, IndexSpecs, SubState) of

--- a/src/riak_kv_yessir_backend.erl
+++ b/src/riak_kv_yessir_backend.erl
@@ -266,9 +266,8 @@ make_get_return_val(RObj, false = _WantsBinary, #state{op_get = Gets} = S) ->
     {ok, RObj, S#state{op_get = Gets + 1}}.
 
 %% @doc Store an object, yes, sir!
--type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
--spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
-                 {ok, state()}.
+-spec put(riak_object:bucket(), riak_object:key(), [riak_kv_backend:index_spec()],
+          binary(), state()) -> {ok, state()}.
 put(_Bucket, _PKey, _IndexSpecs, _Val, #state{op_put = Puts} = S) ->
     {ok, S#state{op_put = Puts + 1}}.
 
@@ -286,8 +285,8 @@ put_object(Bucket, PKey, _IndexSpecs, RObj, #state{op_put = Puts} = S) ->
     {{ok, S#state{op_put = Puts + 1}}, EncodedVal}.
 
 %% @doc Delete an object, yes, sir!
--spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
-                    {ok, state()}.
+-spec delete(riak_object:bucket(), riak_object:key(), [riak_kv_backend:index_spec()], state()) ->
+    {ok, state()}.
 delete(_Bucket, _Key, _IndexSpecs, #state{op_delete = Deletes} = S) ->
     {ok, S#state{op_delete = Deletes + 1}}.
 

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -29,7 +29,7 @@
 -include("riak_kv_wm_raw.hrl").
 -include("riak_object.hrl").
 
--export_type([riak_object/0, bucket/0, key/0, value/0, binary_version/0]).
+-export_type([riak_object/0, bucket/0, key/0, value/0, binary_version/0, index_value/0]).
 
 -type key() :: binary().
 -type bucket() :: binary() | {binary(), binary()}.


### PR DESCRIPTION
This updates the `riak_kv_backend` behavior to use `-callback` directives instead of the old-style `behaviour_info` system. I've also improved some related type specifications in a few places. These changes allow us to kill off another line in the dialyzer.ignore-warnings file.