### PR TITLE
Unify how CREATE TABLE is serviced and ensure table is query-ready [JIRA: RIAK-3220]

### DIFF
--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -66,6 +66,11 @@
          process/2,
          process_stream/3]).
 
+%% exports for create_table
+-export([make_table_create_fail_resp/2,
+         make_table_activate_error_timeout_resp/1,
+         make_table_created_missing_resp/1]).
+
 -type ts_requests() :: #tsputreq{} | #tsdelreq{} | #tsgetreq{} |
                        #tslistkeysreq{} | #tsqueryreq{}.
 -type ts_responses() :: #tsputresp{} | #tsdelresp{} | #tsgetresp{} |
@@ -242,65 +247,11 @@ decode_keys_for_streaming(Mod, [K1|Tail]) ->
 
 -spec create_table({?DDL{}, proplists:proplist()}, #state{}) ->
                           {reply, tsqueryresp | #rpberrorresp{}, #state{}}.
-create_table({?DDL{table = Table} = DDL1, WithProps}, State) ->
-    DDLRecCap = riak_core_capability:get({riak_kv, riak_ql_ddl_rec_version}),
-    DDL2 = convert_ddl_to_cluster_supported_version(DDLRecCap, DDL1),
-    {ok, Props1} = riak_kv_ts_util:apply_timeseries_bucket_props(
-                     DDL2, riak_ql_ddl_compiler:get_compiler_version(), WithProps),
-    case catch [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props1] of
-        {bad_linkfun_modfun, {M, F}} ->
-            {reply, make_table_create_fail_resp(
-                      Table, flat_format(
-                               "Invalid link mod or fun in bucket type properties: ~p:~p\n", [M, F])),
-             State};
-        {bad_linkfun_bkey, {B, K}} ->
-            {reply, make_table_create_fail_resp(
-                      Table, flat_format(
-                               "Malformed bucket/key for anon link fun in bucket type properties: ~p/~p\n", [B, K])),
-             State};
-        {bad_chash_keyfun, {M, F}} ->
-            {reply, make_table_create_fail_resp(
-                      Table, flat_format(
-                               "Invalid chash mod or fun in bucket type properties: ~p:~p\n", [M, F])),
-             State};
-        Props2 ->
-            case riak_core_bucket_type:create(Table, Props2) of
-                ok ->
-                    wait_until_active(Table, State, ?TABLE_ACTIVATE_WAIT);
-                {error, Reason} ->
-                    {reply, make_table_create_fail_resp(Table, Reason), State}
-            end
+create_table({?DDL{} = DDL1, WithProps}, State) ->
+    case riak_kv_ts_api:create_table(?MODULE, DDL1, WithProps) of
+        ok -> {reply, tsqueryresp, State};
+        {error, Reason} -> {reply, Reason, State}
     end.
-
-%%
-convert_ddl_to_cluster_supported_version(DDLRecCap, DDL) when is_atom(DDLRecCap) ->
-    DDLConversions = riak_ql_ddl:convert(DDLRecCap, DDL),
-    [LowestDDL|_] = lists:sort(fun ddl_comparator/2, DDLConversions),
-    LowestDDL.
-
-%%
-ddl_comparator(A, B) ->
-    riak_ql_ddl:is_version_greater(element(1,A), element(1,B)) == true.
-
-wait_until_active(Table, State, 0) ->
-    {reply, make_table_activate_error_timeout_resp(Table), State};
-wait_until_active(Table, State, Seconds) ->
-    case riak_core_bucket_type:activate(Table) of
-        ok ->
-            {reply, tsqueryresp, State};
-        {error, not_ready} ->
-            timer:sleep(1000),
-            lager:info("Waiting for table ~ts to be ready for activation", [Table]),
-            wait_until_active(Table, State, Seconds - 1);
-        {error, undefined} ->
-            %% this is inconceivable because create(Table) has
-            %% just succeeded, so it's here mostly to pacify
-            %% the dialyzer (and of course, for the odd chance
-            %% of Erlang imps crashing nodes between create
-            %% and activate calls)
-            {reply, make_table_created_missing_resp(Table), State}
-    end.
-
 
 %% ---------------------------------------------------
 %% functions called from check_table_and_call, one per ts* request
@@ -583,20 +534,20 @@ make_missing_helper_module_resp(Table, BucketProps)
 make_missing_type_resp(Table) ->
     make_rpberrresp(
       ?E_MISSING_TYPE,
-      flat_format("Time Series table ~s does not exist", [Table])).
+      flat_format("Time Series table ~ts does not exist", [Table])).
 
 %%
 -spec make_nonts_type_resp(Table::binary()) -> #rpberrorresp{}.
 make_nonts_type_resp(Table) ->
     make_rpberrresp(
       ?E_NOT_TS_TYPE,
-      flat_format("Attempt Time Series operation on non Time Series table ~s", [Table])).
+      flat_format("Attempt Time Series operation on non Time Series table ~ts", [Table])).
 
 -spec make_missing_table_module_resp(Table::binary()) -> #rpberrorresp{}.
 make_missing_table_module_resp(Table) ->
     make_rpberrresp(
       ?E_MISSING_TS_MODULE,
-      flat_format("The compiled module for Time Series table ~s cannot be loaded", [Table])).
+      flat_format("The compiled module for Time Series table ~ts cannot be loaded", [Table])).
 
 -spec make_key_element_count_mismatch_resp(Got::integer(), Need::integer()) -> #rpberrorresp{}.
 make_key_element_count_mismatch_resp(Got, Need) ->
@@ -675,7 +626,7 @@ make_failed_listkeys_resp(Reason) ->
 
 make_table_create_fail_resp(Table, Reason) ->
     make_rpberrresp(
-      ?E_CREATE, flat_format("Failed to create table ~s: ~p", [Table, Reason])).
+      ?E_CREATE, flat_format("Failed to create table ~ts: ~p", [Table, Reason])).
 
 make_table_activate_error_timeout_resp(Table) ->
     make_rpberrresp(
@@ -690,7 +641,7 @@ make_table_not_activated_resp(Table) ->
 make_table_created_missing_resp(Table) ->
     make_rpberrresp(
       ?E_CREATED_GHOST,
-      flat_format("Table ~s has been created but found missing", [Table])).
+      flat_format("Table ~ts has been created but found missing", [Table])).
 
 to_string(X) when is_atom(X) ->
     atom_to_list(X);
@@ -762,23 +713,6 @@ missing_helper_module_test() ->
     ?assertMatch(
         #rpberrorresp{errcode = ?E_MISSING_TS_MODULE },
         make_missing_helper_module_resp(<<"mytype">>, [{ddl, ?DDL{}}])
-    ).
-
-convert_ddl_to_cluster_supported_version_v1_test() ->
-    ?assertMatch(
-        #ddl_v1{},
-        convert_ddl_to_cluster_supported_version(
-          v1, #ddl_v2{local_key = ?DDL_KEY{ast = []}, partition_key = ?DDL_KEY{ast = []}, fields=[#riak_field_v1{type=varchar}]})
-    ).
-
-convert_ddl_to_cluster_supported_version_v2_test() ->
-    DDLV2 = #ddl_v2{
-        local_key = ?DDL_KEY{ast = []},
-        partition_key = ?DDL_KEY{ast = []},
-        fields=[#riak_field_v1{type=varchar}]},
-    ?assertMatch(
-        DDLV2,
-        convert_ddl_to_cluster_supported_version(v2, DDLV2)
     ).
 
 get_create_table_sql(TableName) when is_binary(TableName) ->

--- a/src/riak_kv_ts_util.erl
+++ b/src/riak_kv_ts_util.erl
@@ -54,6 +54,8 @@
 -compile(export_all).
 -endif.
 
+-define(TABLE_ACTIVATE_WAIT, 30). %%<< make TABLE_ACTIVATE_WAIT configurable in tsqueryreq
+
 %% NOTE on table_to_bucket/1: Clients will work with table
 %% names. Those names map to a bucket type/bucket name tuple in Riak,
 %% with both the type name and the bucket name matching the table.
@@ -1050,5 +1052,4 @@ check_table_feature_supported_when_table_is_disabled_test() ->
         {error, _},
         check_table_feature_supported(v2, DecodedReq)
     ).
-
 -endif.


### PR DESCRIPTION
…IRA: RIAK-3173 (#1577)] (#1577)

* fix for CREATE TABLE, removing the delta between how the request is serviced between HTTP and PB and RPC. fix for CREATE TABLE, removing the delta between the post-condition of CREATE TABLE (was active bucket-type only) and "query-ready" (is bucket-type active, DDL module compiled and min capability met throughout the ring).
* removed wait_until_supported/4 from CREATE TABLE post-condition ensurance b/c the DDL is surely the version supported.
* moved create_table unified logic to riak_kv_ts_api instead of riak_kv_ts_util.
* (STILL FAILING) added recommended check around the ring of active nodes to ensure the DDL module is compiled as a postcondition of CREATE TABLE.
* change to include the node in getting table ready state, including a change to rpc:multicall over sequential rpc:call.
* changed INSERT postcondition check to match the precondition of INSERT, riak_kv_ts_util:is_table_supported/2.
* changed retry delay on CREATE TABLE postcondition assurance to 200ms. corrected error formats involving table to be unicode friendly.