### PR TITLE
Remove all warning suppressions for callback specs

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -13,9 +13,6 @@ riak_kv_vnode.erl:1441: Function do_backend_delete/4 has no local return
 ## The next two lines deal with that issue here.
 riak_kv_pb_object.erl:193: Record construction #rpbputreq{bucket::'undefined' | binary(),key::'undefined' | binary(),vclock::'undefined' | binary(),content::'undefined' | #rpbcontent{value::'undefined' | binary(),content_type::'undefined' | binary(),charset::'undefined' | binary(),content_encoding::'undefined' | binary(),vtag::'undefined' | binary(),links::[#rpblink{bucket::'undefined' | binary(),key::'undefined' | binary(),tag::'undefined' | binary()}],last_mod::'undefined' | non_neg_integer(),last_mod_usecs::'undefined' | non_neg_integer(),usermeta::[#rpbpair{key::'undefined' | binary(),value::'undefined' | binary()}],indexes::[#rpbpair{key::'undefined' | binary(),value::'undefined' | binary()}],deleted::'false' | 'true' | 'undefined' | 0 | 1,ttl::'undefined' | non_neg_integer()},w::'undefined' | non_neg_integer(),dw::'undefined' | non_neg_integer(),return_body::'false' | 'true' | 'undefined' | 0 | 1,pw::'undefined' | non_neg_integer(),if_none_match::'consistent',return_head::'false' | 'true' | 'undefined' | 0 | 1,timeout::'undefined' | non_neg_integer(),asis::'false' | 'true' | 'undefined' | 0 | 1,sloppy_quorum::'false' | 'true' | 'undefined' | 0 | 1,n_val::'undefined' | non_neg_integer(),type::'undefined' | binary()} violates the declared type of field if_none_match::'false' | 'true' | 'undefined' | 0 | 1
 riak_kv_pb_object.erl:252: The pattern 'consistent' can never match the type 'false' | 'true' | 'undefined' | 0 | 1
-# Callback info not available
-Callback info about the riak_core_vnode_worker behaviour is not available
-Callback info about the riak_core_coverage_fsm behaviour is not available
 Unknown functions:
   cluster_info:dump_all_connected/1
   cluster_info:dump_nodes/2


### PR DESCRIPTION
We now have callback specs defined in riak_core for these behaviors, so we no longer need to suppress any of these warnings related to them.