### PR TITLE
correct sorting order wrt nulls first/last spec [JIRA: RIAK-3209]

### DIFF
--- a/src/riak_kv_qry_buffers_ldb.erl
+++ b/src/riak_kv_qry_buffers_ldb.erl
@@ -102,12 +102,12 @@ add_rows(LdbRef, Rows, ChunkId,
     end.
 
 make_sorted_keys([], desc, nulls_first) ->
-    0;     %% sort before entupled value
-make_sorted_keys([], asc, nulls_last) ->
-    <<>>;  %% sort after entupled value
+    <<>>;  %% sorts before entupled value
+make_sorted_keys([], asc,  nulls_last) ->
+    <<>>;  %% sorts after entupled value
+make_sorted_keys([], asc,  nulls_first) ->
+    0;
 make_sorted_keys([], desc, nulls_last) ->
-    <<>>;
-make_sorted_keys([], asc, nulls_first) ->
     0;
 make_sorted_keys(F, asc, _) ->
     {F};


### PR DESCRIPTION
This fixes the ordering logic of ORDER BY for columns with nulls, to conform to the SQL Standard (https://drive.google.com/file/d/0B-2H_9GJ40JpMDAwY0VyWjkwSWc, page 617). Specifically, a column with nulls will be sorted as follows:

ASC NULLS LAST yields
```1, 2, 3, null, null```
ASC NULLS FIRST yields
```null, null, 1, 2, 3```
DESC NULLS LAST yields
```null, null, 3, 2, 1```
DESC NULLS FIRST yields
```3, 2, 1, null, null```

Note that the test was also updated to reflect this change: https://github.com/basho/riak_test/pull/1257/commits/c595fe7e0f5a8d8d53c18f34383bc499f5bae73b.