### PR TITLE
inverse distribution functions (PERCENTILE_{DISC,CONT}, MEDIAN, MODE)

### DIFF
--- a/include/riak_kv_ts.hrl
+++ b/include/riak_kv_ts.hrl
@@ -2,7 +2,7 @@
 %%
 %% riak_kv_ts: defines records used in the data description language
 %%
-%% Copyright (c) 2016 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2016-2017 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -225,10 +225,6 @@ start(_Type, _StartArgs) ->
                                           [true, false],
                                           false),
 
-            riak_core_capability:register({riak_kv, inverse_distrib_functions_supported},
-                                          [true, false],
-                                          false),
-
             riak_kv_compile_tab:populate_v3_table(),
             riak_kv_ts_newtype:recompile_ddl(),
             riak_kv_ts_newtype:verify_helper_modules(),

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -225,6 +225,10 @@ start(_Type, _StartArgs) ->
                                           [true, false],
                                           false),
 
+            riak_core_capability:register({riak_kv, inverse_distrib_functions_supported},
+                                          [true, false],
+                                          false),
+
             riak_kv_compile_tab:populate_v3_table(),
             riak_kv_ts_newtype:recompile_ddl(),
             riak_kv_ts_newtype:verify_helper_modules(),

--- a/src/riak_kv_qry.erl
+++ b/src/riak_kv_qry.erl
@@ -337,8 +337,10 @@ maybe_await_query_results(_) ->
 %% Format the multiple syntax errors into a multiline error
 %% message.
 format_query_syntax_errors(Errors) ->
-    iolist_to_binary(
-        [["\n", riak_ql_ddl:syntax_error_to_msg(E)] || E <- Errors]).
+    <<"\n", Msg/binary>> =
+        iolist_to_binary(
+          [["\n", riak_ql_ddl:syntax_error_to_msg(E)] || E <- Errors]),
+    Msg.
 
 
 -spec empty_result() -> query_tabular_result().

--- a/src/riak_kv_qry_buffers.erl
+++ b/src/riak_kv_qry_buffers.erl
@@ -588,10 +588,10 @@ do_fetch_limit(QBufRef,
     end.
 
 maybe_supply_offset([]) -> [0];
-maybe_supply_offset(Thing) -> Thing.
+maybe_supply_offset(Specs) -> Specs.
 
 maybe_supply_limits([]) -> [unlimited];
-maybe_supply_limits(Thing) -> Thing.
+maybe_supply_limits(Specs) -> Specs.
 
 static_fetcher({InmemBuffer, undefined}, [{Offset, unlimited}]) ->
     lists:nthtail(Offset, InmemBuffer);

--- a/src/riak_kv_qry_buffers_ldb.erl
+++ b/src/riak_kv_qry_buffers_ldb.erl
@@ -28,7 +28,7 @@
 -export([new_table/2,
          delete_table/3,
          add_rows/2,
-         fetch_rows/3]).
+         fetch_rows/2]).
 
 
 %% leveldb instance parameters
@@ -84,35 +84,35 @@ add_rows(LdbRef, Rows) ->
     end.
 
 
--spec fetch_rows(eleveldb:db_ref(), non_neg_integer(), unlimited|pos_integer()) ->
+-spec fetch_rows(eleveldb:db_ref(), [{Offset::non_neg_integer(),
+                                      Limit::unlimited|pos_integer()}]) ->
                         {ok, [riak_kv_qry_buffers:data_row()]} | {error, term()}.
-fetch_rows(LdbRef, Offset, LimitOrUnlim) ->
-    %% Because the database is read-only, the plan is to keep a cache
-    %% of iterators for faster seeking (to the nearest stored),
-    %% ideally also enable eleveldb to do the folding from stored
-    %% iterators rather than from 'first'.
+fetch_rows(LdbRef, SortedSpecs) ->
     FetchLimitFn =
-        fun(_KV, {Off, Lim, Pos, Acc}) when Pos < Off ->
-                {Off, Lim, Pos + 1, Acc};
-           %% Fetching K (let alone V) while "seeking" to our Offset
-           %% is wasteful.  We need to properly implement sensible
-           %% iterator support in eleveldb (iterator_move et al
-           %% currently effectively dereferences the argument
-           %% iterator), before we can think up an iterator cache in
-           %% qbuf state.  For now, we have to trundle to Position
-           %% every time we serve a query.
-           ({_K, V}, {Off, Lim, Pos, Acc}) when Lim == unlimited orelse
-                                                Pos < Off + Lim ->
-                {Off, Lim, Pos + 1, [V | Acc]};
-           (_KV, {_, _, _, Acc}) ->
+        fun(_KV, {[{Off, _Lim}|_] = CurSegment, Pos, Acc}) when Pos < Off ->
+                {CurSegment, Pos + 1, Acc};
+
+           ({_K, V}, {[{Off, Lim}|RestSegment] = CurSegment, Pos, Acc})
+              when Lim == unlimited orelse Pos < Off + Lim ->
+                NextSegment =
+                    if Lim == unlimited ->
+                            CurSegment;
+                       Pos + 1 < Off + Lim ->
+                            CurSegment;
+                       el/=se ->
+                            RestSegment
+                    end,
+                {NextSegment, Pos + 1, [V | Acc]};
+
+           (_KV, {[], _Pos, Acc}) ->
                 throw({break, Acc})
         end,
     {ok, Fetched} =
         try eleveldb:fold(
               LdbRef, FetchLimitFn,
-              {Offset, LimitOrUnlim, 0, []},
+              {SortedSpecs, 0, []},
               [{fold_method, streaming}]) of
-            {_, _, _N, Acc} ->
+            {_, _, Acc} ->
                 {ok, Acc}
         catch
             {break, Acc} ->

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -4545,7 +4545,7 @@ validate_invdist_funcall_3_test() ->
 validate_invdist_funcall_4_test() ->
     ?assertEqual(
        {error,
-        {nonconst_expr_in_invdist_fun_arglist, <<"Non-const expression passed as parameter for inverse distribution function.">>}},
+        {nonconst_expr_in_invdist_fun_arglist, <<"Inverse distribution functions (PERCENTILE_*, MODE) must have a static const expression for its parameters.">>}},
        validate_invdist_funcall('PERCENTILE_DISC', [{identifier, [<<"x">>]}, {identifier, [<<"y">>]}])).
 
 compile_invdist_full_test() ->

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -2642,7 +2642,7 @@ compile_query_with_function_type_error_1_test() ->
           "WHERE time > 5000 AND time < 10000"
           "AND user = 'user_1' AND location = 'derby'"),
     ?assertEqual(
-        {error,{invalid_query,<<"\nFunction 'SUM' called with arguments of the wrong type [varchar].">>}},
+        {error,{invalid_query,<<"Function 'SUM' called with arguments of the wrong type [varchar].">>}},
         compile(get_standard_ddl(), Q)
     ).
 
@@ -2652,7 +2652,7 @@ compile_query_with_function_type_error_2_test() ->
           "WHERE time > 5000 AND time < 10000"
           "AND user = 'user_1' AND location = 'derby'"),
     ?assertEqual(
-        {error,{invalid_query,<<"\nFunction 'SUM' called with arguments of the wrong type [varchar].\n"
+        {error,{invalid_query,<<"Function 'SUM' called with arguments of the wrong type [varchar].\n"
                                 "Function 'AVG' called with arguments of the wrong type [varchar].">>}},
         compile(get_standard_ddl(), Q)
     ).
@@ -2663,7 +2663,7 @@ compile_query_with_function_type_error_3_test() ->
           "WHERE time > 5000 AND time < 10000"
           "AND user = 'user_1' AND location = 'derby'"),
     ?assertEqual(
-        {error,{invalid_query,<<"\nOperator '+' called with mismatched types [varchar vs sint64].">>}},
+        {error,{invalid_query,<<"Operator '+' called with mismatched types [varchar vs sint64].">>}},
         compile(get_standard_ddl(), Q)
     ).
 
@@ -2673,7 +2673,7 @@ compile_query_with_arithmetic_type_error_1_test() ->
           "WHERE time > 5000 AND time < 10000"
           "AND user = 'user_1' AND location = 'derby'"),
     ?assertEqual(
-        {error,{invalid_query,<<"\nOperator '+' called with mismatched types [varchar vs sint64].">>}},
+        {error,{invalid_query,<<"Operator '+' called with mismatched types [varchar vs sint64].">>}},
         compile(get_standard_ddl(), Q)
     ).
 
@@ -2683,7 +2683,7 @@ compile_query_with_arithmetic_type_error_2_test() ->
           "WHERE time > 5000 AND time < 10000"
           "AND user = 'user_1' AND location = 'derby'"),
     ?assertEqual(
-        {error,{invalid_query,<<"\nOperator '+' called with mismatched types [varchar vs sint64].">>}},
+        {error,{invalid_query,<<"Operator '+' called with mismatched types [varchar vs sint64].">>}},
         compile(get_standard_ddl(), Q)
     ).
 

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -4502,7 +4502,7 @@ validate_invdist_funcall_1_test() ->
 validate_invdist_funcall_2_test() ->
     ?assertEqual(
        {error,
-        {invalid_static_invdist_fn_param, <<"Invalid argument 2 in call to function PERCENTILE.">>}},
+        {invalid_static_invdist_fn_param, <<"Invalid argument 2 in call to function PERCENTILE_DISC.">>}},
        validate_invdist_funcall('PERCENTILE_DISC', [{identifier, [<<"x">>]}, {float, 1.3}])).
 
 validate_invdist_funcall_3_test() ->

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -215,7 +215,7 @@ check_invdist_funs_consistent_with_select(CompiledOrderBys,
                %% we allow multiple PERCENTILE calls in a single SELECT,
                %% but they all must have the same column argument
                case lists:usort(CompiledOrderBys) of
-                   [_SameColumndOrderBy] ->
+                   [_SameColumnOrderBy] ->
                        ok;
                    _Multiple ->
                        {error, {multiple_invdist_funs_with_different_column_args,
@@ -248,16 +248,10 @@ occurs(F, FF) ->
 %% convert successfully validated invdist funcalls (a list of them,
 %% to allow for percentile(x, 0.42), percentile(y, 0.24)) into a list
 %% of ORDER BYs, LIMITs and OFFSETs; or report validation errors if any.
-compile_inverdist_funcalls_to_orderby(InvDistFuns) ->
-    lists:foldl(
-      fun({ok, FC}, {AccSpecs, AccErrors}) ->
-              CompiledSpec = compile_invdist_funcall(FC),
-              {AccSpecs ++ [CompiledSpec], AccErrors};
-         ({error, Reason}, {AccSpecs, AccErrors}) ->
-              {AccSpecs, AccErrors ++ [Reason]}
-      end,
-      {[], []},
-      InvDistFuns).
+compile_inverdist_funcalls_to_orderby(PrecompiledSpecs) ->
+    Specs = [compile_invdist_funcall(FC) || {ok, FC} <- PrecompiledSpecs],
+    Errors = [Reason || {error, Reason} <- PrecompiledSpecs],
+    {Specs, Errors}.
 
 compile_invdist_funcall({FnName, ThisColumn, Args}) ->
     {_OrderBy = {ThisColumn, asc, nulls_last},

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -4358,4 +4358,28 @@ query_with_desc_last_local_key_column_no_quantum_test() ->
         [W || ?SQL_SELECT{'WHERE' = W} <- SubQueries]
     ).
 
+validate_invdist_funcall_1_test() ->
+    ?assertEqual(
+       {ok, [0.3]},
+       validate_invdist_funcall('PERCENTILE', [{identifier, [<<"x">>]}, {float, 0.3}])).
+
+validate_invdist_funcall_2_test() ->
+    ?assertEqual(
+       {error,
+        {invalid_static_invdist_fn_param, <<"Invalid argument 2 in call to function PERCENTILE.">>}},
+       validate_invdist_funcall('PERCENTILE', [{identifier, [<<"x">>]}, {float, 1.3}])).
+
+validate_invdist_funcall_3_test() ->
+    ?assertEqual(
+       {error,
+        {invalid_expr_in_invdist_fun_arglist, <<"Invalid expression passed as parameter for inverse distribution function.">>}},
+       validate_invdist_funcall('PERCENTILE', [{identifier, [<<"x">>]}, {'+', {float, 1.3}, {boolean, true}}])).
+
+validate_invdist_funcall_4_test() ->
+    ?assertEqual(
+       {error,
+        {nonconst_expr_in_invdist_fun_arglist, <<"Non-const expression passed as parameter for inverse distribution function.">>}},
+       validate_invdist_funcall('PERCENTILE', [{identifier, [<<"x">>]}, {identifier, [<<"y">>]}])).
+
+
 -endif.

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -572,17 +572,11 @@ compile_select_col(DDL, Select) ->
 %% possible other such columns and converted to the actual function in
 %% `compile_order_by`.
 prepare_invdist_funcall(FnName, [{identifier, [ColumnArg]}|_] = Args) ->
-    case riak_core_capability:get({riak_kv, inverse_distrib_functions_supported}) of
-        true ->
-            case validate_invdist_funcall(FnName, Args) of
-                {ok, OtherArgsBare} ->
-                    {ok, {FnName, ColumnArg, OtherArgsBare}};
-                ER ->
-                    ER
-            end;
-        _ ->
-            {error, {not_supported_by_cluster,
-                     ?E_INVERSE_DIST_NOT_SUPPORTED}}
+    case validate_invdist_funcall(FnName, Args) of
+        {ok, OtherArgsBare} ->
+            {ok, {FnName, ColumnArg, OtherArgsBare}};
+        ER ->
+            ER
     end;
 prepare_invdist_funcall(FnName, _Args) ->
     {error, {missing_invdist_fn_column_arg,

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -566,11 +566,17 @@ compile_select_col(DDL, Select) ->
 %% possible other such columns and converted to the actual function in
 %% `compile_order_by`.
 prepare_invdist_funcall(FnName, [{identifier, [ColumnArg]}|_] = Args) ->
-    case validate_invdist_funcall(FnName, Args) of
-        {ok, OtherArgsBare} ->
-            {ok, {FnName, ColumnArg, OtherArgsBare}};
-        ER ->
-            ER
+    case riak_core_capability:get({riak_kv, inverse_distrib_functions_supported}) of
+        true ->
+            case validate_invdist_funcall(FnName, Args) of
+                {ok, OtherArgsBare} ->
+                    {ok, {FnName, ColumnArg, OtherArgsBare}};
+                ER ->
+                    ER
+            end;
+        _ ->
+            {error, {not_supported_by_cluster,
+                     ?E_INVERSE_DIST_NOT_SUPPORTED}}
     end;
 prepare_invdist_funcall(FnName, _Args) ->
     {error, {missing_invdist_fn_column_arg,

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -4383,7 +4383,7 @@ validate_invdist_funcall_4_test() ->
         {nonconst_expr_in_invdist_fun_arglist, <<"Non-const expression passed as parameter for inverse distribution function.">>}},
        validate_invdist_funcall('PERCENTILE_DISC', [{identifier, [<<"x">>]}, {identifier, [<<"y">>]}])).
 
-compile_invdist_good_test() ->
+compile_invdist_full_test() ->
     DDL = get_ddl(
         "create table t ("
         "b timestamp not null,"
@@ -4410,5 +4410,15 @@ compile_invdist_good_test() ->
        [_Offset],
        Offset
       ).
+
+compile_invdist_partial_test() ->
+    {ok, Rec} = get_query(
+        "select percentile_disc(mysint, 0.1) from mytab"),
+    {ok, _Select, [{ok, Spec}]} = compile_select_clause(get_sel_ddl(), Rec),
+    ?assertMatch(
+        {'PERCENTILE_DISC', <<"mysint">>, [0.1]},
+        Spec
+      ).
+
 
 -endif.

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -26,6 +26,10 @@
 -export([finalise_aggregate/2]).
 -export([run_select/2, run_select/3]).
 
+%% Exporting this local function to work around an obscure dialyzer
+%% issue.  See details in a comment near this function head.
+-export([compile_order_by/2]).
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
@@ -146,6 +150,12 @@ compile_order_by(?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{calc_type = CalcType
     {error, {inverdist_function_with_groupby_or_aggregate_function,
              ?E_CANNOT_HAVE_GROUPING_OR_AGGREGATION_WITH_INVERSE_DIST_FUNCTION}};
 
+%% This is a local function. It is exported because otherwise dialyzer
+%% believes all calls to this function are made with its second arg,
+%% InvDistFuns = []. As tests pass (specifically, those involving
+%% queries with multiple calls to percentile functions, this is not
+%% true.  The supplier of InvDistFuns is compile_select_clause, where
+%% it generates InvDistFuns in a foldl.
 compile_order_by(?SQL_SELECT{'SELECT' = Select,
                              'WHERE'  = [Where]} = Q,
                  InvDistFuns = [_|_]) ->

--- a/src/riak_kv_qry_compiler.erl
+++ b/src/riak_kv_qry_compiler.erl
@@ -272,7 +272,7 @@ compile_group_by(Mod, [{identifier,FieldName}|Tail], Acc, Q)
   when is_binary(FieldName) ->
     case Mod:get_field_position([FieldName]) of
         undefined ->
-            {error, {unknown_column, FieldName}};
+            group_by_column_does_not_exist_error(Mod, FieldName);
         Pos ->
             compile_group_by(Mod, Tail, [{Pos,FieldName}|Acc], Q)
     end;
@@ -3513,7 +3513,7 @@ group_by_on_non_existing_column_returns_error_test() ->
         "WHERE a > 1 AND a < 6 "
         "GROUP BY x;"),
     ?assertMatch(
-       {error,{invalid_query,<<_/binary>>}},
+       {error, {invalid_query, <<_/binary>>}},
        compile(DDL,Query)
     ).
 

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -510,9 +510,7 @@ prepare_final_results(#state{qbuf_ref = QBufRef,
                              qry = ?SQL_SELECT{'SELECT' = #riak_sel_clause_v1{calc_type = rows} = Select,
                                                'LIMIT'  = Limit,
                                                'OFFSET' = Offset}} = State) ->
-    try riak_kv_qry_buffers:fetch_limit(QBufRef,
-                                        riak_kv_qry_buffers:limit_to_scalar(Limit),
-                                        riak_kv_qry_buffers:offset_to_scalar(Offset)) of
+    try riak_kv_qry_buffers:fetch_limit(QBufRef, Limit, Offset) of
         {ok, {_ColNames, _ColTypes, FetchedRows}} ->
             prepare_final_results2(Select, FetchedRows);
         {error, qbuf_not_ready} ->

--- a/src/riak_kv_qry_worker.erl
+++ b/src/riak_kv_qry_worker.erl
@@ -302,7 +302,13 @@ estimate_query_size(#state{total_query_data  = TotalQueryData,
   when QBufRef /= undefined ->
 
     %% query buffer-backed, has a LIMIT: consider the latter
-    EstLimitData = round(Limit * (TotalQueryData / TotalQueryRows)),
+    EstLimitData =
+        case TotalQueryRows of
+            0 ->
+                0;
+            _ ->
+                round(Limit * (TotalQueryData / TotalQueryRows))
+        end,
     IsLimitTooBig = EstLimitData > MaxQueryData,
 
     %% but also check the grand total, for the case when LIMIT is big

--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -108,3 +108,45 @@
      "Where clause when a range is not specified, but more than one was ",
      "specified.">>
 ).
+
+-define(
+   E_CANNOT_HAVE_ORDERBY_WITH_INVERSE_DIST_FUNCTION,
+   <<"Inverse distribution functions cannot be used with any of ORDER BY, LIMIT or OFFSET clauses.">>
+).
+-define(
+   E_CANNOT_HAVE_GROUPING_OR_AGGREGATION_WITH_INVERSE_DIST_FUNCTION,
+   <<"Inverse distribution functions cannot be used with GROUP BY clause or aggregating window functions.">>
+).
+-define(
+   E_INVERSE_DIST_FUN_MISSING_COLUMN_ARG(FName),
+   iolist_to_binary(
+     ["Inverse distribution function ", atom_to_list(FName), " missing column argument."])
+).
+-define(
+   E_INVERSE_DIST_FUN_INVAL_COLUMN_ARG(FName, Column),
+   iolist_to_binary(
+     ["Invalid column argument (", Column, ") in call to inverse distribution function ", atom_to_list(FName), "."])
+).
+-define(
+   E_INVERSE_DIST_FUN_MULTIPLE_COLUMN_ARG,
+   <<"Multiple inverse distribution functions must all have the same column argument.">>
+).
+-define(
+   E_INVERSE_DIST_FUN_WITH_OTHER_COLUMN,
+   <<"Inverse distribution functions cannot be used with other columns in SELECT clause.">>
+).
+-define(
+   E_INVERSE_DIST_FUN_BAD_PARAMETER(FnName, Pos),
+   iolist_to_binary(
+     ["Invalid argument ", integer_to_list(Pos), " in call to function ", atom_to_list(FnName), "."])
+).
+-define(
+   E_INVERSE_DIST_FUN_NONCONST_ARG,
+   iolist_to_binary(
+     ["Non-const expression passed as parameter for inverse distribution function."])
+).
+-define(
+   E_INVERSE_DIST_FUN_INVAL_EXPR,
+   iolist_to_binary(
+     ["Invalid expression passed as parameter for inverse distribution function."])
+).

--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -150,3 +150,8 @@
    iolist_to_binary(
      ["Invalid expression passed as parameter for inverse distribution function."])
 ).
+-define(
+   E_INVERSE_DIST_NOT_SUPPORTED,
+   iolist_to_binary(
+     ["Inverse distribution functions not supported by all nodes in this cluster."])
+).

--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -150,8 +150,3 @@
    iolist_to_binary(
      ["Invalid expression passed as parameter for inverse distribution function."])
 ).
--define(
-   E_INVERSE_DIST_NOT_SUPPORTED,
-   iolist_to_binary(
-     ["Inverse distribution functions not supported by all nodes in this cluster."])
-).

--- a/src/riak_kv_ts_error_msgs.hrl
+++ b/src/riak_kv_ts_error_msgs.hrl
@@ -111,11 +111,11 @@
 
 -define(
    E_CANNOT_HAVE_ORDERBY_WITH_INVERSE_DIST_FUNCTION,
-   <<"Inverse distribution functions cannot be used with any of ORDER BY, LIMIT or OFFSET clauses.">>
+   <<"Inverse distribution functions (PERCENTILE_*, MODE) cannot be used with any of ORDER BY, LIMIT or OFFSET clauses.">>
 ).
 -define(
    E_CANNOT_HAVE_GROUPING_OR_AGGREGATION_WITH_INVERSE_DIST_FUNCTION,
-   <<"Inverse distribution functions cannot be used with GROUP BY clause or aggregating window functions.">>
+   <<"Inverse distribution functions (PERCENTILE_*, MODE) cannot be used with GROUP BY clause or other aggregating window functions.">>
 ).
 -define(
    E_INVERSE_DIST_FUN_MISSING_COLUMN_ARG(FName),
@@ -129,11 +129,11 @@
 ).
 -define(
    E_INVERSE_DIST_FUN_MULTIPLE_COLUMN_ARG,
-   <<"Multiple inverse distribution functions must all have the same column argument.">>
+   <<"Multiple inverse distribution functions (PERCENTILE_*, MODE) must all have the same column argument.">>
 ).
 -define(
    E_INVERSE_DIST_FUN_WITH_OTHER_COLUMN,
-   <<"Inverse distribution functions cannot be used with other columns in SELECT clause.">>
+   <<"Inverse distribution functions (PERCENTILE_*, MODE) cannot be used with other columns in SELECT clause.">>
 ).
 -define(
    E_INVERSE_DIST_FUN_BAD_PARAMETER(FnName, Pos),
@@ -143,7 +143,7 @@
 -define(
    E_INVERSE_DIST_FUN_NONCONST_ARG,
    iolist_to_binary(
-     ["Non-const expression passed as parameter for inverse distribution function."])
+     ["Inverse distribution functions (PERCENTILE_*, MODE) must have a static const expression for its parameters."])
 ).
 -define(
    E_INVERSE_DIST_FUN_INVAL_EXPR,


### PR DESCRIPTION
RTS-545, RTS-1165 (MEDIAN); RTS-1173, RTS-1553 (PERCENTILE); RTS-547, RTS-1222 (MODE)

RFC in https://github.com/basho/rfc/pull/55. Depends on https://github.com/basho/riak_ql/pull/167. Tests in https://github.com/basho/riak_test/pull/1270.

Support for inverse distribution functions, currently including PERCENTILE_DISC, PERCENTILE_CONT, MEDIAN and MODE.

Additionally, a fix for a div-by-zero hiccup that happens when the first chunk received by the coordinator has zero rows.