### PR TITLE
Fix some issues with run interval funs for existing sweeper plugins

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -710,15 +710,15 @@
 
 %% @doc Time between sweeps for object ttl
 {mapping, "obj_ttl.sweep_interval", "riak_kv.obj_ttl_sweep_interval", [
-   {default, off},
-   {datatype, [{duration, s}, flag]},
+   {default, disabled},
+   {datatype, [{duration, s}, {atom, disabled}]},
    {validators, ["minimum_sweep_interval"]},
    hidden
 ]}.
 
 {validator, "minimum_sweep_interval", "sweep interval can't be shorter then 6h",
  fun(Value) ->
-    Value == false orelse (is_integer(Value) andalso Value >= 6 * 3600)
+    Value == disabled orelse (is_integer(Value) andalso Value >= 6 * 3600)
  end}.
 
 %% @doc Whether to allow list buckets.

--- a/src/riak_kv_delete_sup.erl
+++ b/src/riak_kv_delete_sup.erl
@@ -29,6 +29,7 @@
 -export([start_delete/2]).
 -export([start_link/0]).
 -export([init/1]).
+%% Exported for testing/debugging only:
 -export([maybe_add_sweep_participant/0]).
 
 start_delete(Node, Args) ->
@@ -55,10 +56,10 @@ maybe_add_sweep_participant() ->
 
 maybe_add_obj_ttl_sweep_participant() ->
     RunIntervalFun =
-        fun() -> app_helper:get_env(riak_kv, obj_ttl_sweep_interval, false) end,
+        fun() -> app_helper:get_env(riak_kv, obj_ttl_sweep_interval, disabled) end,
     case RunIntervalFun() of
-        false ->
-            false;
+        disabled ->
+            do_nothing;
         _ ->
             add_obj_ttl_sweep_participant(RunIntervalFun)
     end.
@@ -72,7 +73,7 @@ add_obj_ttl_sweep_participant(RunInterval) ->
 
 maybe_add_reap_sweep_participant() ->
     RunIntervalFun =
-        fun() -> app_helper:get_env(riak_kv, reap_sweep_interval, undefined) end,
+        fun() -> app_helper:get_env(riak_kv, reap_sweep_interval, disabled) end,
     case app_helper:get_env(riak_kv, tombstone_grace_period, disabled) of
         disabled ->
             do_nothing;

--- a/src/riak_kv_sweeper.erl
+++ b/src/riak_kv_sweeper.erl
@@ -79,7 +79,7 @@
                   | 'modify_fun'
                   | 'observe_fun'.
 
--type run_interval_fun() :: fun(() -> non_neg_integer()).
+-type run_interval_fun() :: fun(() -> disabled | non_neg_integer()).
 
 -type run_interval() :: non_neg_integer() | run_interval_fun().
 

--- a/src/riak_kv_sweeper_fold.erl
+++ b/src/riak_kv_sweeper_fold.erl
@@ -59,7 +59,7 @@
          module :: atom(),          %% module where the sweep call back lives.
          fun_type :: riak_kv_sweeper:fun_type(), %% delete_fun | modify_fun | observe_fun
          sweep_fun :: fun(),        %%
-         run_interval :: integer() | fun(), %% Defines how often participant wants to run.
+         run_interval :: riak_kv_sweeper:run_interval(), %% How often participant wants to run
          acc :: any(),
          options = [] :: list(),    %% optional values that will be added during sweep
          errors = 0 :: integer(),

--- a/test/riak_kv_schema_tests.erl
+++ b/test/riak_kv_schema_tests.erl
@@ -101,7 +101,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_kv.sweep_concurrency", 1),
     cuttlefish_unit:assert_config(Config, "riak_kv.tombstone_grace_period", disabled),
     cuttlefish_unit:assert_config(Config, "riak_kv.reap_sweep_interval", 86400), %% 1d
-    cuttlefish_unit:assert_config(Config, "riak_kv.obj_ttl_sweep_interval", false),
+    cuttlefish_unit:assert_config(Config, "riak_kv.obj_ttl_sweep_interval", disabled),
 
     ok.
 


### PR DESCRIPTION
We had a couple of sweeper funs that weren't defaulting to the correct value of `'disabled'` when there was no defined run interval. This could've caused issues if the value was unset on a running node.

Type specs have also been updated to correctly define what sorts of return values are allowed from run interval funs. Unfortunately, Dialyzer failed to flag any problems with the existing run interval funs, even after the type specs were updated. But at least things are documented correctly now.