### PR TITLE
Optimize W1C DEL path to remove read-before-write

### DIFF
--- a/src/riak_kv_ts_svc.erl
+++ b/src/riak_kv_ts_svc.erl
@@ -346,7 +346,6 @@ sub_tsgetreq(Mod, _DDL, #tsgetreq{table = Table,
 
 sub_tsdelreq(Mod, _DDL, #tsdelreq{table = Table,
                                   key    = PbCompoundKey,
-                                  vclock  = VClock,
                                   timeout  = Timeout},
              State) ->
     Options =
@@ -356,7 +355,7 @@ sub_tsdelreq(Mod, _DDL, #tsdelreq{table = Table,
     CompoundKey = riak_pb_ts_codec:decode_cells(PbCompoundKey),
     Mod = riak_ql_ddl:make_module_name(Table),
     case riak_kv_ts_api:delete_data(
-           CompoundKey, Table, Mod, Options, VClock) of
+           CompoundKey, Table, Mod, Options) of
         ok ->
             {reply, tsdelresp, State};
         {error, no_type} ->

--- a/src/riak_kv_w1c_worker.erl
+++ b/src/riak_kv_w1c_worker.erl
@@ -215,7 +215,7 @@ ts_batch_put_encoded([{{Bucket, _LK}, _RObj0}|_Rest]=RObjs, DocIdx) ->
 
 
 w1c_vclock(RObj) ->
-    RObj2 = riak_object:set_vclock(RObj, vclock:fresh(<<0:8>>, 1)),
+    RObj2 = riak_object:set_vclock(RObj, riak_object:new_w1c_vclock()),
     RObj3 = riak_object:update_last_modified(RObj2),
     riak_object:apply_updates(RObj3).
 

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -87,7 +87,7 @@
 -export([actor_counter/2]).
 -export([key/1, get_metadata/1, get_metadatas/1, get_values/1, get_value/1]).
 -export([hash/1, hash/2, approximate_size/2]).
--export([vclock_encoding_method/0, vclock/1, vclock_header/1, encode_vclock/1, decode_vclock/1]).
+-export([vclock_encoding_method/0, vclock/1, vclock_header/1, encode_vclock/1, decode_vclock/1, new_w1c_vclock/0]).
 -export([encode_vclock/2, decode_vclock/2]).
 -export([update/5, update_value/2, update_metadata/2, bucket/1, bucket_only/1, type/1, value_count/1]).
 -export([get_update_metadata/1, get_update_value/1, get_contents/1]).
@@ -1252,6 +1252,19 @@ decode_vclock(Method, VClock) ->
         _           -> lager:error("Bad vclock encoding method ~p", [Method]),
                        throw(bad_vclock_encoding_method)
     end.
+
+%% An exported method to return a fresh vclock suitable for use on the
+%% write-once path, per the logic in riak_object:merge_write_once/2.
+%%
+%% That logic uses a lookup on Node <<0:8>> to retrieve the vclock
+%% timestamp (ignoring the associated counter).
+%%
+%% Here we initialize a new vclock with a timestamp stored in a
+%% <<0:8>>-tagged tuple.
+
+-spec new_w1c_vclock() -> vclock:vclock().
+new_w1c_vclock() ->
+    vclock:fresh(<<0:8>>, 1).
 
 -ifdef(TEST).
 


### PR DESCRIPTION
---
**Summary**

Key deletes on the normal path happen as follows:

- if no vclock is passed with the key to be deleted, a quorum read of the current value is forced
- a tombstone object is then written with this vclock to all nodes in the preflist
- a get_fsm is initiated to read back the values, ultimately deleting the keys if only tombstones are returned

For the write-once path, the vclock is _never_ used to resolve potential conflicts during a read, so the vclock is irrelevant.  This means that the initial read step above, to determine the vclock, is unnecessary.

This PR eliminates the unnecessary vclock read for both KV and TS versions of the write-once delete path, by substituting a valid empty vclock (i.e., `vclock:fresh()`) for `undefined` on initiation of the delete process.

---
**Files Modified**

There are three paths to write-once deletes.  I discuss each of these in turn, along with the corresponding file modifications:

1. **riak_client.erl** KV deletes are initiated via a call to `riak_client:delete`.  I have modified this to have the same structure as `riak_client:put`, i.e., instead of calling `normal_delete` it calls `maybe_normal_delete`, which checks if the bucket is a write-once bucket or a normal bucket.  If write-once, it calls `write_once_delete`, which initiates the `riak_kv_delete` process with an empty vclock (`vclock:fresh()`), bypassing the read-before-write (see `riak_kv_delete:delete/8`, which switches on the vclock).  If a normal bucket, the process is initiated with an `undefined` vclock, which does the usual read-before-write.

2. **riak_kv_ts_api.erl** TS deletes via the client `delete` API call are initiated via a call to `riak_kv_ts_api:delete_data`.   Previously, `delete_data/5` included a VClock0 arg which if undefined led to the read-before-write behavior discussed above, or allowed a vclock to be passed in if it pre-existed the call.    Because all TS buckets are write-once buckets, this vclock is _always_ irrelevant, and the argument and the logic to parse it and use it in the `riak_kv_delete` initialization are irrelevant.  I have removed the argument from `delete_data` and the logic to check the value.  The call to `riak_client:delete_vclock` has been replaced by a call to an explicitly exported function `riak_client:write_once_delete` to make clear what is going on.

   **riak_kv_ts_svc.erl** Because any vclock passed in with the `tsdelreq` request is ultimately unused, and because the vclock argument to `riak_kv_ts_api:delete_data/5` has been removed,  I have removed the code which extracts it from the `tsdelreq` structure here.

3. TS deletes via the query interface, e.g., `delete from Table where partitionKey='value' and time = 100` is the third path to the write-once delete.  This is initiated via a call to `riak_kv_ts_api:delete_data` from `riak_kv_qry.erl`, so the chain discussed above applies equally to query-deletes.

---
**Performance Tests**

To verify the changes, I've run latency-vs-object-size tests for deletes via all three paths discussed above.  For the KV path, I create a write-once bucket and measure the mean latency for deletes of 100 keys at each object size.  For both of the TS paths, I create a table schema with a single varchar column, and measure the mean latency for deletes of 100 keys at each column size.  Below, I compare delete latencies for the riak_ts-develop branch (dev) and this branch (opt).

Results indicate a similar improvement on all three delete paths.  For object sizes where the latency is dominated by _operational_ latency (ie, communication hops between client and server, and among server threads, < 100KB), the write-once latency drops by a factor of ~2 (1.7).  For object sizes where the latency is dominated by the object size (> 100KB), the latency drops dramatically, since removing the read largely eliminates any handling of the object contents in riak.

![screen shot 2017-02-23 at 2 33 38 pm](https://cloud.githubusercontent.com/assets/9666459/23282545/84d2d8ee-f9d6-11e6-8c0f-de6237acc182.png)
