### PR TITLE
Optimize list_buckets in leveldb

### DIFF
--- a/test/backend_eqc.erl
+++ b/test/backend_eqc.erl
@@ -146,7 +146,7 @@ prop_backend(Backend, Volatile, Config, Cleanup) ->
 %%====================================================================
 
 bucket() ->
-    elements([<<"b1">>,<<"b2">>]).
+    elements([<<Seq>> || Seq <- lists:seq($a, $z)]).
 
 bucket(#qcst{backend=Backend}) ->
     try


### PR DESCRIPTION
This PR includes an optimization of the list_buckets path in the leveldb back end.

In the past, the leveldb back-end would delegate listing buckets to the eleveldb layer.

With this change, we leverage key sorting in leveldb to skip over all keys in a bucket until we get to the next BKey starting with the "next" bucket in lexical order.  This allows us to traverse the back-end data in O(k), where k is the number of buckets, instead of O(n), where n is the number of keys.

This feature requires leveldb, but there are no API changes that alter the behavior of other back ends.

Note: At some point, we should consider implementing the same
strategy in the memory back end.