### PR TITLE
Disable tombstone reaping by default

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -702,8 +702,8 @@
 %% @doc Time between sweeps for reap tombstone.
 %% tombstone.grace_period needs to be defined for these to run
 {mapping, "tombstone.sweep_interval", "riak_kv.reap_sweep_interval", [
-   {default, "1d"},
-   {datatype, {duration, s}},
+   {default, disabled},
+   {datatype, [{duration, s}, {atom, disabled}]},
    {validators, ["minimum_sweep_interval"]},
    hidden
 ]}.

--- a/test/riak_kv_schema_tests.erl
+++ b/test/riak_kv_schema_tests.erl
@@ -100,7 +100,7 @@ basic_schema_test() ->
     %% Default Sweeper Properties
     cuttlefish_unit:assert_config(Config, "riak_kv.sweep_concurrency", 1),
     cuttlefish_unit:assert_config(Config, "riak_kv.tombstone_grace_period", disabled),
-    cuttlefish_unit:assert_config(Config, "riak_kv.reap_sweep_interval", 86400), %% 1d
+    cuttlefish_unit:assert_config(Config, "riak_kv.reap_sweep_interval", disabled),
     cuttlefish_unit:assert_config(Config, "riak_kv.obj_ttl_sweep_interval", disabled),
 
     ok.


### PR DESCRIPTION
We discussed this in a meeting this afternoon and decided we're not going to have this plugin enabled by default in the next release.