### PR TITLE
enable gset support

### DIFF
--- a/include/riak_kv_types.hrl
+++ b/include/riak_kv_types.hrl
@@ -17,6 +17,8 @@
 -define(HLL_TYPE(Val), #crdt{mod=?HLL_TYPE,
                              ctype="application/riak_hll",
                              value=Val}).
+-define(GSET_TYPE, riak_dt_gset).
+-define(GSET_TYPE(Val), #crdt{mod=?GSET_TYPE, ctype="application/riak_gset", value=Val}).
 
 -define(MAP_TYPE, riak_dt_map).
 -define(MAP_TYPE(Val), #crdt{mod=?MAP_TYPE, ctype="application/riak_map", value=Val}).
@@ -29,15 +31,17 @@
 -define(V1_TOP_LEVEL_TYPES, [pncounter]).
 -define(V2_TOP_LEVEL_TYPES, [?COUNTER_TYPE, ?SET_TYPE, ?MAP_TYPE]).
 -define(V3_TOP_LEVEL_TYPES, [?HLL_TYPE]).
+-define(V4_TOP_LEVEL_TYPES, [?GSET_TYPE]).
 -define(TOP_LEVEL_TYPES, ?V1_TOP_LEVEL_TYPES ++ ?V2_TOP_LEVEL_TYPES ++
-            ?V3_TOP_LEVEL_TYPES).
+            ?V3_TOP_LEVEL_TYPES ++ ?V4_TOP_LEVEL_TYPES).
 -define(ALL_TYPES, ?TOP_LEVEL_TYPES ++ [?FLAG_TYPE, ?REG_TYPE]).
 -define(EMBEDDED_TYPES, [{map, ?MAP_TYPE}, {set, ?SET_TYPE},
                          {counter, ?EMCNTR_TYPE}, {flag, ?FLAG_TYPE},
                          {register, ?REG_TYPE}]).
 
+
 -define(MOD_MAP, [{map, ?MAP_TYPE}, {set, ?SET_TYPE},
-                  {counter, ?COUNTER_TYPE}, {hll, ?HLL_TYPE}]).
+                  {counter, ?COUNTER_TYPE}, {hll, ?HLL_TYPE}, {gset, ?GSET_TYPE}]).
 
 -define(DATATYPE_STATS_DEFAULTS, [actor_count]).
 -define(HLL_STATS, [bytes]).
@@ -51,6 +55,7 @@
                                {?SET_TYPE, 2},
                                {?COUNTER_TYPE, 2}]).
 -define(E3_DATATYPE_VERSIONS, ?E2_DATATYPE_VERSIONS ++ [{?HLL_TYPE, 1}]).
+-define(E4_DATATYPE_VERSIONS, ?E2_DATATYPE_VERSIONS ++ [{?HLL_TYPE, 1}, {?GSET_TYPE, 2}]).
 
 -type crdt() :: ?CRDT{}.
 -type crdt_op() :: ?CRDT_OP{}.

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -186,13 +186,17 @@ start(_Type, _StartArgs) ->
             riak_core_capability:register({riak_kv, crdt},
                                           [?TOP_LEVEL_TYPES,
                                            ?V1_TOP_LEVEL_TYPES ++
+                                               ?V2_TOP_LEVEL_TYPES ++
+                                               ?V3_TOP_LEVEL_TYPES,
+                                           ?V1_TOP_LEVEL_TYPES ++
                                            ?V2_TOP_LEVEL_TYPES,
                                            ?V1_TOP_LEVEL_TYPES,
                                            []],
                                           []),
 
             riak_core_capability:register({riak_kv, crdt_epoch_versions},
-                                          [?E3_DATATYPE_VERSIONS,
+                                          [?E4_DATATYPE_VERSIONS,
+                                           ?E3_DATATYPE_VERSIONS,
                                            ?E2_DATATYPE_VERSIONS,
                                            ?E1_DATATYPE_VERSIONS],
                                           ?E1_DATATYPE_VERSIONS),

--- a/src/riak_kv_crdt.erl
+++ b/src/riak_kv_crdt.erl
@@ -26,7 +26,7 @@
 -export([to_binary/2, to_binary/1, from_binary/1]).
 -export([log_merge_errors/4, meta/2, merge_value/2, maybe_apply_props/2]).
 %% MR helper funs
--export([value/1, counter_value/1, set_value/1, map_value/1, hll_value/1]).
+-export([value/1, counter_value/1, set_value/1, map_value/1, hll_value/1, gset_value/1]).
 %% Other helper funs
 -export([is_crdt/1,
          is_crdt/2,
@@ -146,6 +146,13 @@ set_value(RObj) ->
 -spec hll_value(riak_object:riak_object()) -> riak_kv_hll:card().
 hll_value(RObj) ->
     simple_value(RObj, ?HLL_TYPE).
+
+%% @doc convenience for (e.g.) MapReduce functions. Pass an object,
+%% get a 2.0+ GSet type value, or `[]' if no Set is present.
+-spec gset_value(riak_object:riak_object()) -> list().
+gset_value(RObj) ->
+    {{_Ctx, GSet}, _Stats}  = value(RObj, ?GSET_TYPE),
+    GSet.
 
 %% @doc convenience for (e.g.) MapReduce functions. Pass an object,
 %% get a 2.0+ Map type value, or `[]' if no Map is present.
@@ -509,7 +516,9 @@ to_record(?MAP_TYPE, Val) ->
 to_record(?SET_TYPE, Val) ->
     ?SET_TYPE(Val);
 to_record(?HLL_TYPE, Val) ->
-    ?HLL_TYPE(Val).
+    ?HLL_TYPE(Val);
+to_record(?GSET_TYPE, Val) ->
+    ?GSET_TYPE(Val).
 
 %% @doc Check cluster capability for crdt support
 supported(Mod) ->
@@ -541,6 +550,8 @@ to_mod("sets") ->
     ?SET_TYPE;
 to_mod("hlls") ->
     ?HLL_TYPE;
+to_mod("gsets") ->
+    ?GSET_TYPE;
 to_mod("counters") ->
     ?COUNTER_TYPE;
 to_mod("maps") ->

--- a/src/riak_kv_crdt_json.erl
+++ b/src/riak_kv_crdt_json.erl
@@ -23,7 +23,8 @@
 -export([update_request_from_json/3, fetch_response_to_json/4]).
 -compile([{inline, [bad_op/2, bad_field/1]}]).
 
--define(FIELD_PATTERN, "^(.*)_(counter|set|register|flag|map|hll)$").
+
+-define(FIELD_PATTERN, "^(.*)_(counter|gset|set|register|flag|map|hll)$").
 
 -ifdef(TEST).
 -compile(export_all).
@@ -38,7 +39,7 @@
 -type context() :: binary().
 -type map_field() :: {binary(), embedded_type()}.
 -type embedded_type() :: counter | set | register | flag | map.
--type toplevel_type() :: counter | set | map | hll.
+-type toplevel_type() :: counter | gset | set | map | hll.
 -type type_mappings() :: [{embedded_type(), module()}].
 -type all_type() :: toplevel_type() | register | flag.
 
@@ -48,6 +49,8 @@
                          {add_all, [binary()]} | {remove_all, [binary()]}.
 -type set_op() :: simple_set_op() | {update, [simple_set_op()]}.
 -type hll_op() :: {add, binary()} | {add_all, [binary()]}.
+-type simple_gset_op() :: {add, binary()} | {add_all, [binary()]} .
+-type gset_op() :: simple_gset_op() | {update, [simple_gset_op()]}.
 -type flag_op() :: enable | disable.
 -type register_op() :: {assign, binary()}.
 -type simple_map_op() :: {remove, map_field()} | {update, map_field(),
@@ -55,7 +58,7 @@
 -type map_op() :: simple_map_op() | {update, [simple_map_op()]}.
 -type embedded_type_op() :: counter_op() | set_op() | register_op() | flag_op()
                           | map_op().
--type toplevel_op() :: counter_op() | set_op() | map_op() | hll_op().
+-type toplevel_op() :: counter_op() | gset_op() | set_op() | map_op() | hll_op().
 -type update() :: {toplevel_type(), toplevel_op(), context()}.
 -type all_type_op() :: toplevel_op() | register_op() | flag_op().
 
@@ -76,6 +79,7 @@ update_request_from_json(Type, JSON0, Mods) ->
 %% NB we assume that the internal format is well-formed and don't guard it.
 -spec value_to_json(all_type(), term(), type_mappings()) -> term().
 value_to_json(counter, Int, _) -> Int;
+value_to_json(gset, List, _) -> List;
 value_to_json(set, List, _) -> List;
 value_to_json(flag, Bool, _) -> Bool;
 value_to_json(register, Bin, _) -> Bin;
@@ -149,6 +153,7 @@ op_from_json(register, Op, _Mods) -> register_op_from_json(Op);
 op_from_json(counter, Op, _Mods) -> counter_op_from_json(Op);
 op_from_json(set, Op, _Mods) -> set_op_from_json(Op);
 op_from_json(hll, Op, _Mods) -> hll_op_from_json(Op);
+op_from_json(gset, Op, _Mods) -> gset_op_from_json(Op);
 op_from_json(map, Op, Mods) -> map_op_from_json(Op, Mods).
 
 %% Map: {"update":{Field:Op, ...}}
@@ -196,6 +201,29 @@ counter_op_from_json({struct, [{<<"increment">>,Int}]}) when is_integer(Int) -> 
 counter_op_from_json({struct, [{<<"decrement">>,Int}]}) when is_integer(Int) -> {decrement, Int};
 counter_op_from_json(Op) -> bad_op(counter, Op).
 
+-spec gset_op_from_json(mochijson2:json_term() |
+                       {mochijson2:json_string(), mochijson2:json_term()}) ->
+                              gset_op().
+gset_op_from_json({struct, Ops}) when is_list(Ops) ->
+    try
+        {update, [ gset_op_from_json(Op) || Op <- Ops]}
+    catch
+        throw:{invalid_operation, {gset, _}} ->
+            bad_op(gset, {struct, Ops})
+    end;
+gset_op_from_json({<<"add">>, Bin}) when is_binary(Bin) -> {add, Bin};
+gset_op_from_json({Verb, BinList}=Op) when is_list(BinList), (Verb == <<"add_all">>)->
+    case check_set_members(BinList) of
+        true ->
+            {binary_to_atom(Verb, utf8), BinList};
+        false ->
+            bad_op(gset, Op)
+    end;
+gset_op_from_json({<<"update">>, {struct, Ops}}) when is_list(Ops) ->
+    {update, [ gset_op_from_json(Op) || Op <- Ops]};
+gset_op_from_json({<<"update">>, Ops}) when is_list(Ops) ->
+    {update, [ gset_op_from_json(Op) || Op <- Ops]};
+gset_op_from_json(Op) -> bad_op(gset, Op).
 
 -spec set_op_from_json(mochijson2:json_term() |
                        {mochijson2:json_string(), mochijson2:json_term()}) ->


### PR DESCRIPTION
Adding GSet support to 2.2. It was merged into basho/riak_kv develop, but not a 2.2 branch afaict.

Tests at https://github.com/basho/riak_test/pull/1302
Needs

https://github.com/basho/riak-erlang-client/pull/373
https://github.com/basho/riak-erlang-http-client/pull/70
https://github.com/basho/riak_pb/pull/229
https://github.com/basho/riak_test/pull/1302
