### PR TITLE
Fix schema paths for make test

### DIFF
--- a/src/riak_kv_test_util.erl
+++ b/src/riak_kv_test_util.erl
@@ -288,7 +288,7 @@ dep_apps(Test, Extra) ->
 %% see dep_apps/2
 -spec do_dep_apps(load | start | stop, [ atom() | fun() ]) -> [ any() ].
 do_dep_apps(start, Apps) ->
-    lists:foldl(fun do_dep_apps_fun/2,%% fun(A, Acc) when is_atom(A) ->
+    lists:foldl(fun do_dep_apps_fun/2,
                 [], Apps);
 do_dep_apps(LoadStop, Apps) ->
     lists:map(fun(A) when is_atom(A) ->
@@ -363,7 +363,7 @@ guess_deps_dir() ->
             case filelib:is_dir("deps") of
                 true ->
                     %% probably a root checkout
-                    "deps";
+                    "deps/";
                 false ->
                     %% probably part of an applications deps
                     "../"
@@ -372,7 +372,7 @@ guess_deps_dir() ->
             %% probably running in .eunit
             case filelib:is_dir("../deps") of
                 true ->
-                    "../deps";
+                    "../deps/";
                 false ->
                     %% maybe we're in a deps/* situation, worse case tests
                     %% fail, which is what they did before this hack


### PR DESCRIPTION
When tests run from a riak_kv repo checkout (not from a top-level riak
checkout) there were failures due to paths in setup for riak_core clique
schema loading.

Also remove commented out code.