### PR TITLE
Update rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -35,9 +35,9 @@
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {tag, "2.1.5-225"}}},
         {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {tag, "2.1.3-225"}}},
         {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag, "0.1.2"}}},
-        {leveled, ".*", {git, "https://github.com/martinsumner/leveled.git", {tag, "0.9.12"}}},
-	{kv_index_tictactree, ".*", {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "0.9.5"}}},
+        {leveled, ".*", {git, "https://github.com/martinsumner/leveled.git", {branch, "develop-2.9"}}},
+	{kv_index_tictactree, ".*", {git, "https://github.com/martinsumner/kv_index_tictactree.git", {branch, "develop-2.9"}}},
         {riak_core, ".*", {git, "https://github.com/basho/riak_core.git", {branch, "develop-2.9"}}},
-        {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {tag, "2.1.6-225"}}},
+        {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {branch, "develop-2.9"}}},
         {hyper, ".*", {git, "git://github.com/basho/hyper", {tag, "1.0.1"}}}
        ]}.


### PR DESCRIPTION
Use develop-2.9 branches for modified repos.

This adds in the api updates to be able to set the recbuf in advanced.config.  Note though, in order to do this we bring mochiweb significantly more up to date from the mainstream mochi repo.  This provides a number of security and bug fixes, and some refactoring of the code.