### PR TITLE
Develop 2.9

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -35,8 +35,8 @@
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {tag, "riak_kv-2.9.0"}}},
         {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {tag, "2.1.3-225"}}},
         {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag, "0.1.2"}}},
-        {leveled, ".*", {git, "https://github.com/martinsumner/leveled.git", {branch, "mas-i285-binarycopy"}}},
-	{kv_index_tictactree, ".*", {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "0.9.6"}}},
+        {leveled, ".*", {git, "https://github.com/martinsumner/leveled.git", {tag, "0.9.16"}}},
+	{kv_index_tictactree, ".*", {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "0.9.7"}}},
         {riak_core, ".*", {git, "https://github.com/basho/riak_core.git", {tag, "riak_kv-2.9.0"}}},
         {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {tag, "riak_kv-2.9.0"}}},
         {hyper, ".*", {git, "git://github.com/basho/hyper", {tag, "1.0.1"}}}

--- a/rebar.config
+++ b/rebar.config
@@ -35,7 +35,7 @@
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {tag, "riak_kv-2.9.0"}}},
         {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {tag, "2.1.3-225"}}},
         {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag, "0.1.2"}}},
-        {leveled, ".*", {git, "https://github.com/martinsumner/leveled.git", {tag, "0.9.15"}}},
+        {leveled, ".*", {git, "https://github.com/martinsumner/leveled.git", {branch, "mas-i285-binarycopy"}}},
 	{kv_index_tictactree, ".*", {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "0.9.6"}}},
         {riak_core, ".*", {git, "https://github.com/basho/riak_core.git", {tag, "riak_kv-2.9.0"}}},
         {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {tag, "riak_kv-2.9.0"}}},

--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -123,6 +123,10 @@ start(Partition, Config) ->
 
     case get_data_dir(DataRoot, integer_to_list(Partition)) of
         {ok, DataDir} ->
+            {ok, CHBin} = riak_core_ring_manager:get_chash_bin(),
+            PartitionCount = chashbin:num_partitions(CHBin),
+            RingIndexInc = chash:ring_increment(PartitionCount),
+            DBid = Partition div RingIndexInc,
             StartOpts = [{root_path, DataDir},
                             {max_journalsize, MJS},
                             {cache_size, BCS},
@@ -132,6 +136,7 @@ start(Partition, Config) ->
                             {compression_point, CMP},
                             {log_level, LOL},
                             {max_run_length, MRL},
+                            {database_id, DBid},
                             {maxrunlength_compactionpercentage, MCP},
                             {singlefile_compactionpercentage, SCP},
                             {snapshot_timeout_short, TOS},


### PR DESCRIPTION
Changes for riak kv 2.9.0 patch.

After discovery of another memory-related issue with leveled, this change:

- rolls forward the leveled version to include fix of memory management (using binary copy for sub-parts to prevent the retention of large binary objects)
- adds identification of leveled backends, and additional logging related to memory, to try and ease troubleshooting of memory issues going forward