### PR TITLE
i1707 merge fake object - log don't crash

### DIFF
--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -2408,7 +2408,7 @@ prepare_put_existing_object(#state{idx =Idx} = State,
         {oldobj, OldObj} ->
             {{false, {OldObj, unchanged_no_old_object}}, PutArgs, State2};
         {newobj, NewObj} ->
-            case enforce_allow_mult(NewObj, BProps) of
+            case enforce_allow_mult(NewObj, OldObj, BProps) of
                 {ok, AMObj} ->
                     IndexSpecs =
                         get_index_specs(IndexBackend, CacheData, RequiresGet,
@@ -2418,18 +2418,11 @@ prepare_put_existing_object(#state{idx =Idx} = State,
                     ObjectToStore =
                         maybe_do_crdt_update(Coord, CRDTOp, ActorId,
                                                 ObjToStore0),
-                    determine_put_result(ObjectToStore, OldObj, Idx, PutArgs,
-                                            State2, IndexSpecs, IndexBackend);
+                    determine_put_result(ObjectToStore, OldObj, Idx,
+                                            PutArgs, State2,
+                                            IndexSpecs, IndexBackend);
                 {error, Reason} ->
-                    lager:error("Put failure due to ~w with coord=~w " ++
-                                "old_clock=~w input_clock=~w " ++
-                                "for bucket=~w key=~w",
-                                [Reason, Coord,
-                                    riak_object:vclock(OldObj),
-                                    riak_object:vclock(RObj),
-                                    riak_object:bucket(RObj),
-                                    riak_object:key(RObj)]),
-                    lager:error("Put failure occurred with state=~w", [State2]),
+                    lager:error("Error on allow_mult ~w", [Reason]),
                     {{fail, Idx, Reason}, PutArgs, State2}
             end
     end.
@@ -2624,25 +2617,48 @@ do_reformat({Bucket, Key}=BKey, State=#state{mod=Mod, modstate=ModState}) ->
 %% @private
 %% enforce allow_mult bucket property so that no backend ever stores
 %% an object with multiple contents if allow_mult=false for that bucket
-enforce_allow_mult(Obj, BProps) ->
-    case proplists:get_value(allow_mult, BProps) of
-        true -> {ok, Obj};
-        _ ->
-            case riak_object:get_contents(Obj) of
-                [] ->
-                    {error, empty_contents};
-                [_] ->
-                    {ok, Obj};
-                Mult ->
-                    {MD, V} = select_newest_content(Mult),
-                    MergedObj = riak_object:set_contents(Obj, [{MD, V}]),
-                    case riak_object:is_head(MergedObj) of
-                        true ->
-                            {error, merge_result_ishead};
-                        false ->
-                            {ok, MergedObj}
-                    end
-            end
+%% Also provides a double check that the object is safe to store - its contents
+%% must not be empty, it should not be an object head.
+enforce_allow_mult(Obj, OldObj, BProps) ->
+    MergedContents = riak_object:get_contents(Obj),
+    case {proplists:get_value(allow_mult, BProps),
+            MergedContents,
+            riak_object:is_head(Obj)} of
+        {_, [], _} ->
+            % This is a known issue - 
+            % https://github.com/basho/riak_kv/issues/1707
+            % Extra logging added to try and resolve the issue
+            MergedClock = riak_object:vclock(Obj),
+            OldClock = riak_object:vclock(OldObj),
+            Bucket = riak_object:bucket(OldObj),
+            Key = riak_object:key(OldObj),
+            lager:error("Unexpected empty contents after merge"
+                            ++ " object bucket=~w key=~w"
+                            ++ " merged_clock=~w old_clock=~w",
+                            [Bucket, Key, MergedClock, OldClock]),
+            OldValSum =
+                lists:map(fun({D, V}) -> {D, erlang:phash2(V)} end,
+                            riak_object:get_dotted_values(OldObj)),
+            lager:error("Summary of old object values ~w", [OldValSum]),
+            {error, empty_contents};
+        {true, _, false} -> 
+            {ok, Obj};
+        {false, [_], false} ->
+            {ok, Obj};
+        {false, Mult, false} ->
+            {MD, V} = select_newest_content(Mult),
+            {ok, riak_object:set_contents(Obj, [{MD, V}])};
+        {_, _, true} ->
+            % This is not a known issue.  An object head check was added prior
+            % to the fake object check being being uplifted to dominates from
+            % descends.  If this never occurs in 2.9.0, then this check should
+            % be removed in 2.9.1 
+            Bucket = riak_object:bucket(OldObj),
+            Key = riak_object:key(OldObj),
+            lager:error("Unexpected head object after merge"
+                            ++ " object bucket=~w key=~w",
+                            [Bucket, Key]),
+            {error, head_object}
     end.
 
 %% @private
@@ -3133,7 +3149,7 @@ do_diffobj_put({Bucket, Key}=BKey, DiffObj,
                 {oldobj, _} ->
                     {ok, State2};
                 {newobj, NewObj} ->
-                    {ok, AMObj} = enforce_allow_mult(NewObj, riak_core_bucket:get_bucket(Bucket)),
+                    {ok, AMObj} = enforce_allow_mult(NewObj, OldObj, riak_core_bucket:get_bucket(Bucket)),
                     case IndexBackend of
                         true ->
                             IndexSpecs = riak_object:diff_index_specs(AMObj, OldObj);

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -252,6 +252,7 @@
                   crdt_op = undefined :: undefined | term(), %% if set this is a crdt operation
                   hash_ops = no_hash_ops
                  }).
+-type putargs() :: #putargs{}.
 
 -spec maybe_create_hashtrees(state()) -> state().
 maybe_create_hashtrees(State) ->
@@ -2306,6 +2307,17 @@ do_backend_delete(BKey, RObj, State = #state{idx = Idx,
 delete_hash(RObj) ->
     erlang:phash2(RObj, 4294967296).
 
+%% @doc
+%% Prepare PUT needs to prepare the correct transition from old object to new
+%% to be performed.  Returns {true, {new_object, old_object}} if an actual PUT
+%% to a new object should be made, or false if the transition does not require
+%% a change before being acknowledged.  {fail, Index, Reason} should be used
+%% where the PUT_FSM needs to be informed of a logical failure.
+-spec prepare_put(state(), putargs()) -> 
+                    {{fail, index(), atom()|tuple()}|
+                            {boolean(),
+                                {riak_object:riak_object(), old_object()}},
+                        putargs(), state()}.
 prepare_put(State=#state{vnodeid=VId,
                          mod=Mod,
                          modstate=ModState},
@@ -2396,11 +2408,30 @@ prepare_put_existing_object(#state{idx =Idx} = State,
         {oldobj, OldObj} ->
             {{false, {OldObj, unchanged_no_old_object}}, PutArgs, State2};
         {newobj, NewObj} ->
-            AMObj = enforce_allow_mult(NewObj, BProps),
-            IndexSpecs = get_index_specs(IndexBackend, CacheData, RequiresGet, AMObj, OldObj),
-            ObjToStore0 = maybe_prune_vclock(PruneTime, AMObj, BProps),
-            ObjectToStore = maybe_do_crdt_update(Coord, CRDTOp, ActorId, ObjToStore0),
-            determine_put_result(ObjectToStore, OldObj, Idx, PutArgs, State2, IndexSpecs, IndexBackend)
+            case enforce_allow_mult(NewObj, BProps) of
+                {ok, AMObj} ->
+                    IndexSpecs =
+                        get_index_specs(IndexBackend, CacheData, RequiresGet,
+                                        AMObj, OldObj),
+                    ObjToStore0 =
+                        maybe_prune_vclock(PruneTime, AMObj, BProps),
+                    ObjectToStore =
+                        maybe_do_crdt_update(Coord, CRDTOp, ActorId,
+                                                ObjToStore0),
+                    determine_put_result(ObjectToStore, OldObj, Idx, PutArgs,
+                                            State2, IndexSpecs, IndexBackend);
+                {error, Reason} ->
+                    lager:error("Put failure due to ~w with coord=~w " ++
+                                "old_clock=~w input_clock=~w " ++
+                                "for bucket=~w key=~w",
+                                [Reason, Coord,
+                                    riak_object:vclock(OldObj),
+                                    riak_object:vclock(RObj),
+                                    riak_object:bucket(RObj),
+                                    riak_object:key(RObj)]),
+                    lager:error("Put failure occurred with state=~w", [State2]),
+                    {{fail, Idx, Reason}, PutArgs, State2}
+            end
     end.
 
 determine_put_result({error, E}, _, Idx, PutArgs, State, _IndexSpecs, _IndexBackend) ->
@@ -2595,19 +2626,21 @@ do_reformat({Bucket, Key}=BKey, State=#state{mod=Mod, modstate=ModState}) ->
 %% an object with multiple contents if allow_mult=false for that bucket
 enforce_allow_mult(Obj, BProps) ->
     case proplists:get_value(allow_mult, BProps) of
-        true -> Obj;
+        true -> {ok, Obj};
         _ ->
             case riak_object:get_contents(Obj) of
-                [_] -> Obj;
+                [] ->
+                    {error, empty_contents};
+                [_] ->
+                    {ok, Obj};
                 Mult ->
                     {MD, V} = select_newest_content(Mult),
                     MergedObj = riak_object:set_contents(Obj, [{MD, V}]),
                     case riak_object:is_head(MergedObj) of
                         true ->
-                          lager:error("Merge resulted in head_only object"),
-                          MergedObj;
+                            {error, merge_result_ishead};
                         false ->
-                          MergedObj
+                            {ok, MergedObj}
                     end
             end
     end.
@@ -3100,7 +3133,7 @@ do_diffobj_put({Bucket, Key}=BKey, DiffObj,
                 {oldobj, _} ->
                     {ok, State2};
                 {newobj, NewObj} ->
-                    AMObj = enforce_allow_mult(NewObj, riak_core_bucket:get_bucket(Bucket)),
+                    {ok, AMObj} = enforce_allow_mult(NewObj, riak_core_bucket:get_bucket(Bucket)),
                     case IndexBackend of
                         true ->
                             IndexSpecs = riak_object:diff_index_specs(AMObj, OldObj);


### PR DESCRIPTION
Unable to pinpoint the cause of this issue.  This change logs some further details at the point the issue occurs, and protects from the vnode crash - causing only a PUT failure instead.