### PR TITLE
Mas i1706 tictacprimary

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -79,10 +79,14 @@
 
 %% @doc Frequency to prompt exchange per vnode
 %% The number of milliseconds which the vnode must wait between self-pokes to
-%% maybe prompt the next exchange. Default is 2 minutes.  
+%% maybe prompt the next exchange. Default is 2 minutes 30 seconds.
+%% Note if this is to be reduced below this value the riak_core
+%% vnode_inactivity_timeout should also be reduced or handoffs may be
+%% blocked.  To be safe the vnode_inactivity_timeout must be < 0.5 * the
+%% tictacaae_exchangetick. 
 {mapping, "tictacaae_exchangetick", "riak_kv.tictacaae_exchangetick", [
   {datatype, integer},
-  {default, 120000},
+  {default, 150000},
   hidden
 ]}.
 
@@ -94,6 +98,16 @@
   {default, 1800000},
   hidden
 ]}.
+
+%% @doc Exchange only between primary vnodes
+%% Setting this to false allows Tictac AAE exchanges between both primary and
+%% fallback vnodes.
+{mapping, "tictacaae_primaryonly", "riak_kv.tictacaae_primaryonly", [
+  {datatype, flag},
+  {default, on},
+  hidden
+]}.
+
 
 %% @doc Pool Strategy - should a single node_worker_pool or multiple pools be
 %% used for queueing potentially longer-running "background" queries

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -291,8 +291,10 @@ maybe_create_hashtrees(true, State=#state{idx=Index, upgrade_hashtree=Upgrade,
 
 -spec maybe_start_aaecontroller(active|passive, state()) -> state().
 %% @doc
-%% Start an AAE controller if riak_kv has been consfigured to use cached
-%% tictac tree based AAE
+%% Start an AAE controller if riak_kv has been configured to use cached
+%% tictac tree based AAE.  Note that a controller will always start, and
+%% receive updates, even if the vnode is not a primary (and will not be
+%% involved in exchanges).
 maybe_start_aaecontroller(passive, State) ->
     State#state{tictac_aae=false, aae_controller=undefined};
 maybe_start_aaecontroller(active, State=#state{mod=Mod, 
@@ -1118,10 +1120,10 @@ handle_command(tictacaae_exchangepoke, _Sender, State) ->
             PrimaryOnly =
                 app_helper:get_env(riak_kv, tictacaae_primaryonly, true),
                 % By default TictacAAE exchanges are run only between primary
-                % vnodes, and not between fallback and vnodes.  Changing this
+                % vnodes, and not between fallback vnodes.  Changing this
                 % to false will allow fallback vnodes to be populated via AAE,
                 % increasing the workload during failure scenarios, but also
-                % reducing the potential for entropy in long-term failures
+                % reducing the potential for entropy in long-term failures.
             PlLup = <<(DocIdx-1):160/integer>>,
             PL =
                 case PrimaryOnly of

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1149,7 +1149,8 @@ handle_command(tictacaae_exchangepoke, _Sender, State) ->
                 _ ->
                     lager:warning("Proposed exchange between ~w and ~w " ++ 
                                     "not currently supported within " ++
-                                    "preflist for IndexN=~w",
+                                    "preflist for IndexN=~w possibly due to " ++
+                                    "node failure",
                                     [Local, Remote, {DocIdx, N}])
             end,
             {noreply, State#state{tictac_exchangequeue = Rest}}


### PR DESCRIPTION
Make tictac AAE effective between primary nodes only, but with configuration to have AAE to backfill fallbacks

Tested by https://github.com/basho/riak_test/pull/1320