### PR TITLE
Mas i981 resethashtreetokens

### DIFF
--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -1032,7 +1032,9 @@ clear_tree(State=#state{index=Index}) ->
     lager:info("Clearing AAE tree: ~p", [Index]),
     IndexNs = responsible_preflists(State),
     State2 = destroy_trees(State),
+    lager:info("Completed destroy of AAE tree: ~p", [Index]),
     State3 = init_trees(IndexNs, true, State2#state{trees=orddict:new()}),
+    lager:info("Completed init of AAE tree: ~p", [Index]),
     State3#state{built=false, expired=false}.
 
 destroy_trees(State) ->
@@ -1093,6 +1095,8 @@ maybe_rebuild(State=#state{lock=undefined, built=true, expired=true, index=Index
     case Locked of
         true ->
             State2 = clear_tree(State),
+            lager:info("Sharing lock with ~w to trigger rebuild: ~p",
+                        [Pid, Index]),
             Pid ! {lock, Locked, State2},
             State2#state{built=Pid};
         _ ->

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -1095,8 +1095,7 @@ maybe_rebuild(State=#state{lock=undefined, built=true, expired=true, index=Index
     case Locked of
         true ->
             State2 = clear_tree(State),
-            lager:info("Sharing lock with ~w to trigger rebuild: ~p",
-                        [Pid, Index]),
+            lager:info("Informing process to trigger rebuild of tree: ~p", [Index]),
             Pid ! {lock, Locked, State2},
             State2#state{built=Pid};
         _ ->

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -49,6 +49,7 @@
          overload_reply/1,
          get_backend_config/3,
          is_modfun_allowed/2]).
+-export([report_hashtree_tokens/0, reset_hashtree_tokens/2]).
 
 -include_lib("riak_kv_vnode.hrl").
 
@@ -194,6 +195,46 @@ get_write_once(Bucket) ->
         {error, _}=Err ->
             Err
     end.
+
+
+
+%% ===================================================================
+%% Hashtree token management functions
+%% ===================================================================
+
+%% @doc
+%% Report the maximum and minimum count of hashtree tokens across all online
+%% primary vnodes
+-spec report_hashtree_tokens() -> {non_neg_integer(), non_neg_integer()}.
+report_hashtree_tokens() ->
+    OnlinePrimaries = riak_core_apl:active_owners(riak_kv),
+    ReportTokenFun = 
+        fun({{P, N}, _T}, {Min, Max}) ->
+            HT =
+                riak_core_vnode_master:sync_command({P, N},
+                                                    report_hashtree_tokens,
+                                                    riak_kv_vnode_master),
+            {min(Min, HT), max(Max, HT)}
+        end,
+    lists:foldl(ReportTokenFun, {infinity, 0}, OnlinePrimaries).
+
+%% @doc
+%% Rest the hashtree tokens on each online primary to a random integer between
+%% The minimum and maximum amount.
+-spec reset_hashtree_tokens(non_neg_integer(), non_neg_integer()) -> ok.
+reset_hashtree_tokens(MinToken, MaxToken) when MaxToken >= MinToken ->
+    OnlinePrimaries = riak_core_apl:active_owners(riak_kv),
+    ResetTokenFun = 
+        fun({{P, N}, _T}) ->
+            ok =
+                riak_core_vnode_master:sync_command({P, N},
+                                                    {reset_hashtree_tokens,
+                                                        MinToken, MaxToken},
+                                                    riak_kv_vnode_master)
+        end,
+    lists:foreach(ResetTokenFun, OnlinePrimaries),
+    ok.
+
 
 %% ===================================================================
 %% Preflist utility functions

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -219,8 +219,8 @@ report_hashtree_tokens() ->
     lists:foldl(ReportTokenFun, {infinity, 0}, OnlinePrimaries).
 
 %% @doc
-%% Rest the hashtree tokens on each online primary to a random integer between
-%% The minimum and maximum amount.
+%% Reset the hashtree tokens on each online primary to a random integer between
+%% the minimum and maximum amount.
 -spec reset_hashtree_tokens(non_neg_integer(), non_neg_integer()) -> ok.
 reset_hashtree_tokens(MinToken, MaxToken) when MaxToken >= MinToken ->
     OnlinePrimaries = riak_core_apl:active_owners(riak_kv),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1324,6 +1324,18 @@ handle_command({get_index_entries, Opts},
             {reply, ignore, State}
     end;
 
+handle_command(report_hashtree_tokens, _Sender, State) ->
+    {reply, get(hashtree_tokens), State};
+handle_command({reset_hashtree_tokens, MinToken, MaxToken}, _Sender, State) ->
+    case MaxToken > MinToken of
+        true ->
+            put(hashtree_tokens,
+                    MinToken + random:uniform(MaxToken - MinToken));
+        _ ->
+            put(hashtree_tokens, MaxToken)
+    end,
+    {reply, ok, State};
+
 handle_command(Req, Sender, State) ->
     handle_request(riak_kv_requests:request_type(Req), Req, Sender, State).
 


### PR DESCRIPTION
This is mitigation for the broader problems referred to in - https://github.com/basho/riak/issues/981.

This change is tested in:
https://github.com/nhs-riak/riak_test/blob/mas-i981-resethashtreetokens/tests/verify_aae_resettoken.erl

The idea is that in some circumstances we want to temporarily ensure that writes aren't blocked by AAE hashtree_token depletion.  This might be to prove that this isn't an issue behind slow writes, or because there is a need for coordinated AAE tree rebuilds to mitigate some other issue.

This can be managed through `riak attach`:

Get the current min and max token count across the cluster:

``{Min, Max} = riak_kv_util:return_hashtree_tokens().``

Set the max token count to be in a range between very large numbers on each vnode:

``riak_kv_util:reset_hashtree_tokens(200000, 250000).``

After completing any related work, reset back to the original range:

``riak_kv_util:reset_hashtree_tokens(Min, Max).``

This will work from any node in the cluster, across the cluster, in a healthy cluster.  There is no need to run the commands on each node.
