### PR TITLE
Mas i1714 readonlyfs

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -57,7 +57,7 @@
 -define(VERSION_FILE, "version.txt").
 -define(API_VERSION, 1).
 -define(CAPABILITIES, [async_fold,size]).
--define(TERMINAL_POSIX_ERRORS, [eacces, erofs, enodev]).
+-define(TERMINAL_POSIX_ERRORS, [eacces, erofs, enodev, enospc]).
 
 %% must not be 131, otherwise will match t2b in error
 %% yes, I know that this is horrible.

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -57,6 +57,7 @@
 -define(VERSION_FILE, "version.txt").
 -define(API_VERSION, 1).
 -define(CAPABILITIES, [async_fold,size]).
+-define(TERMINAL_POSIX_ERRORS, [eacces, erofs, enodev]).
 
 %% must not be 131, otherwise will match t2b in error
 %% yes, I know that this is horrible.
@@ -233,6 +234,11 @@ put(Bucket, PrimaryKey, _IndexSpecs, Val,
         ok ->
             {ok, State};
         {error, Reason} ->
+            lager:warning("Backend put error ~p", [Reason]),
+            % Should crash if the error is a permanent file system error
+            false =
+                is_tuple(Reason) and
+                    lists:member(element(2, Reason), ?TERMINAL_POSIX_ERRORS),
             {error, Reason, State}
     end.
 

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -201,6 +201,9 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, #state{ref=Ref,
         ok ->
             {ok, State};
         {error, Reason} ->
+            % Confirm this has not failed due to db_write error - as this is
+            % not recoverable and should result in a crash of the vnode
+            false = is_tuple(Reason) and (element(1, Reason) == db_write),
             {error, Reason, State}
     end.
 


### PR DESCRIPTION
This is related to issue - https://github.com/basho/riak_kv/issues/1714

This is tested by - https://github.com/basho/riak_test/blob/mas-i1714-readonlyfs/tests/verify_readonly.erl

If a file-system is unusable at startup, a node won't start.  However, if a node is up and running and then the file-system cannot be used (for example because permissions have been changed, or the a container has remounted the drive as read-only), then a bitcask or eleveldb backend will not crash.  It will instead return errors for every PUT.  Any PUT for which that vnode is chosen as the co-ordinator will then error back to the client (with a report of the file system error).

This error situation may continue for a long time without the cluster recovering.  Without a node going down, the cluster will not start fallback vnodes and change the ring.  To crash the node the vnodes must crash (to ripple the crash up the supervision tree).

This change detects certain low-level errors, and decides that they should cause the vnode to crash.  This is any `db_write` error in leveldb, or certain posix file system errors in bitcask (eacces, erofs, enodev, enospc).

With these changes the test now passes, if we remove write access permissions from a node, that node will fail and the cluster will recover with almost no PUT failures (worst case o(1)).