### PR TITLE
Mas i1719 multihead

### DIFF
--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -562,7 +562,12 @@ callback(Ref, compact_journal, State) ->
                                         State#state.compactions_perday,
                                         State#state.valid_hours),
              {ok, State}
-    end.
+    end;
+callback(Ref, UnexpectedCallback, State) ->
+    lager:info("Ignoring unexpected callback ~w with ref ~w " ++
+                "may be expected if multi-backend",
+                [UnexpectedCallback, Ref]),
+    {ok, State}.
 
 %% ===================================================================
 %% Internal functions

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -135,11 +135,6 @@ capabilities(Bucket, State) ->
             capabilities(State)
     end.
 
--spec fetch_bucket_capability(riak_object:bucket(), state()) -> {ok, [atom()]}.
-fetch_bucket_capability(Bucket, State) ->
-    {_Name, Mod, ModState} = get_backend(Bucket, State),
-    Mod:capabilities(ModState).
-
 %% @doc Start the backends
 -spec start(integer(), config()) -> {ok, state()} | {error, term()}.
 start(Partition, Config) ->
@@ -470,6 +465,14 @@ fixed_index_status(Mod, ModState, Status) ->
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
+
+%% @private
+%% Fetch the capabilities of a backend assocaited with a bucket
+-spec fetch_bucket_capability(riak_object:bucket(), state()) -> {ok, [atom()]}.
+fetch_bucket_capability(Bucket, State) ->
+    {_Name, Mod, ModState} = get_backend(Bucket, State),
+    Mod:capabilities(ModState).
+
 
 %% @private
 %% Given a Bucket name and the State, return the

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -135,7 +135,7 @@ capabilities(Bucket, State) ->
             capabilities(State)
     end.
 
--spec fetch_bucket_capability(rika_object:bucket(), state()) -> {ok, [atom()]}.
+-spec fetch_bucket_capability(riak_object:bucket(), state()) -> {ok, [atom()]}.
 fetch_bucket_capability(Bucket, State) ->
     {_Name, Mod, ModState} = get_backend(Bucket, State),
     Mod:capabilities(ModState).

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -77,6 +77,8 @@
          mark_indexes_fixed/2,
          fixed_index_status/1]).
 
+-export([head/3]).
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
@@ -123,11 +125,20 @@ capabilities(State) ->
 
 %% @doc Return the capabilities of the backend.
 -spec capabilities(riak_object:bucket(), state()) -> {ok, [atom()]}.
-capabilities(Bucket, State) when is_binary(Bucket) ->
+capabilities(Bucket, State) ->
+    case Bucket of
+        B when is_binary(B) ->
+            fetch_bucket_capability(Bucket, State);
+        {T, B} when is_binary(T), is_binary(B) ->
+            fetch_bucket_capability(Bucket, State);
+        _ ->
+            capabilities(State)
+    end.
+
+-spec fetch_bucket_capability(rika_object:bucket(), state()) -> {ok, [atom()]}.
+fetch_bucket_capability(Bucket, State) ->
     {_Name, Mod, ModState} = get_backend(Bucket, State),
-    Mod:capabilities(ModState);
-capabilities(_Bucket, State) ->
-    capabilities(State).
+    Mod:capabilities(ModState).
 
 %% @doc Start the backends
 -spec start(integer(), config()) -> {ok, state()} | {error, term()}.
@@ -218,6 +229,22 @@ stop(#state{backends=Backends}) ->
 get(Bucket, Key, State) ->
     {Name, Module, SubState} = get_backend(Bucket, State),
     case Module:get(Bucket, Key, SubState) of
+        {ok, Value, NewSubState} ->
+            NewState = update_backend_state(Name, Module, NewSubState, State),
+            {ok, Value, NewState};
+        {error, Reason, NewSubState} ->
+            NewState = update_backend_state(Name, Module, NewSubState, State),
+            {error, Reason, NewState}
+    end.
+
+%% @doc Retrieve an object from the leveled backend as a binary
+-spec head(riak_object:bucket(), riak_object:key(), state()) ->
+                 {ok, any(), state()} |
+                 {ok, not_found, state()} |
+                 {error, term(), state()}.
+head(Bucket, Key, State) ->
+    {Name, Module, SubState} = get_backend(Bucket, State),
+    case Module:head(Bucket, Key, SubState) of
         {ok, Value, NewSubState} ->
             NewState = update_backend_state(Name, Module, NewSubState, State),
             {ok, Value, NewState};

--- a/src/riak_kv_multi_prefix_backend.erl
+++ b/src/riak_kv_multi_prefix_backend.erl
@@ -95,6 +95,8 @@
          mark_indexes_fixed/2,
          fixed_index_status/1]).
 
+-export([head/3]).
+
 -ifdef(TEST).
 -ifdef(TEST_IN_RIAK_KV).
 -include_lib("eunit/include/eunit.hrl").
@@ -270,6 +272,23 @@ get(Bucket, Key, State) ->
             NewState = update_backend_state(Name, Module, NewSubState, State),
             {error, Reason, NewState}
     end.
+
+%% @doc Retrieve an object from the leveled backend as a binary
+-spec head(riak_object:bucket(), riak_object:key(), state()) ->
+                 {ok, any(), state()} |
+                 {ok, not_found, state()} |
+                 {error, term(), state()}.
+head(Bucket, Key, State) ->
+    {Name, Module, SubState} = get_backend(Bucket, State),
+    case Module:head(Bucket, Key, SubState) of
+        {ok, Value, NewSubState} ->
+            NewState = update_backend_state(Name, Module, NewSubState, State),
+            {ok, Value, NewState};
+        {error, Reason, NewSubState} ->
+            NewState = update_backend_state(Name, Module, NewSubState, State),
+            {error, Reason, NewState}
+    end.
+
 
 %% @doc Insert an object with secondary index
 %% information into the kv backend

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1356,9 +1356,9 @@ handle_request(kv_get_request, Req, Sender, State) ->
 handle_request(kv_head_request, Req, Sender, State) ->
     Mod = State#state.mod,
     ModState = State#state.modstate,
-    BKey = riak_kv_requests:get_bucket_key(Req),
+    {BT, _K} = BKey = riak_kv_requests:get_bucket_key(Req),
     ReqId = riak_kv_requests:get_request_id(Req),
-    {ok, Capabilities} = Mod:capabilities(ModState),
+    {ok, Capabilities} = Mod:capabilities(BT, ModState),
     case maybe_support_head_requests(Capabilities) of
         true ->
             do_head(Sender, BKey, ReqId, State);
@@ -3645,11 +3645,12 @@ maybe_check_md_cache(Table, BKey) ->
 %% Should return {undefined, undefined} if there is no cache to be used or
 %% {not_found, undefined} if the lack of object has been confirmed, or
 %% {VClock, IndexData} if the result is found
-maybefetch_clock_and_indexdata(Table, BKey, Mod, ModState, Coord, IsSearchable) ->
+maybefetch_clock_and_indexdata(Table, {BT, _K} = BKey,
+                                Mod, ModState, Coord, IsSearchable) ->
     CacheResult = maybe_check_md_cache(Table, BKey),
     case CacheResult of
         {undefined, undefined} ->
-            {ok, Capabilities} = Mod:capabilities(ModState),
+            {ok, Capabilities} = Mod:capabilities(BT, ModState),
             CanGetHead = maybe_support_head_requests(Capabilities)
                             andalso (not IsSearchable)
                             andalso (not Coord),


### PR DESCRIPTION
Adds support for head/3 request to the multi_backend if the underlying backend mapped to that bucket supports it.

This is tested in https://github.com/basho/riak_test/pull/1326

The test covers backend assignment direct to bucket properties and via types.