### PR TITLE
QuickCheck tests update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: compile rel cover test dialyzer
+.PHONY: compile rel cover test dialyzer eqc
 REBAR=./rebar3
 
 compile:
@@ -12,6 +12,10 @@ cover: test
 
 test: compile
 	$(REBAR) as test do eunit
+
+eqc:
+	$(REBAR) eqc
+
 
 dialyzer:
 	$(REBAR) dialyzer

--- a/eqc/fsm_eqc_util.erl
+++ b/eqc/fsm_eqc_util.erl
@@ -6,9 +6,6 @@
 -include_lib("eqc/include/eqc.hrl").
 -define(RING_KEY, riak_ring).
 
-not_empty(G) ->
-    ?SUCHTHAT(X, G, X /= [] andalso X /= <<>>).
-
 longer_list(K, G) ->
     ?SIZED(Size, resize(trunc(K*Size), list(resize(Size, G)))).
 
@@ -38,7 +35,7 @@ bkey() ->
      non_blank_string()}. %% key
 
 non_blank_string() ->
-    ?LET(X,not_empty(list(lower_char())), list_to_binary(X)).
+    ?LET(X, [lower_char() | list(lower_char())], list_to_binary(X)).
 
 %% Generate a lower 7-bit ACSII character that should not cause any problems
 %% with utf8 conversion.
@@ -122,7 +119,7 @@ partval() ->
                {1,Shrink(error)}]).
 
 partvals() ->
-    not_empty(fsm_eqc_util:longer_list(2, partval())).
+    non_empty(fsm_eqc_util:longer_list(2, partval())).
 
 %% Generate 5 riak objects with the same bkey
 %%

--- a/eqc/fsm_eqc_util.erl
+++ b/eqc/fsm_eqc_util.erl
@@ -184,13 +184,7 @@ cycle(Zs, N, []) ->
 start_mock_servers() ->
     Path = riak_kv_test_util:get_test_dir("fsm_util"),
     %% Start new core_vnode based EQC FSM test mock
-    case whereis(fsm_eqc_vnode) of
-        undefined -> ok;
-        Pid2      ->
-            unlink(Pid2),
-            exit(Pid2, shutdown),
-            riak_kv_test_util:wait_for_pid(Pid2)
-    end,
+    riak_kv_test_util:stop_process(fsm_eqc_vnode),
     {ok, _Pid3} = fsm_eqc_vnode:start_link(),
     application:load(riak_core),
     application:start(crypto),
@@ -272,6 +266,7 @@ last_spawn([_Hist|Rest]) ->
 
 
 start_fake_rng(ProcessName) ->
+    riak_kv_test_util:stop_process(ProcessName),
     Pid = spawn_link(?MODULE, fake_rng, [1]),
     register(ProcessName, Pid),
     {ok, Pid}.

--- a/eqc/get_fsm_eqc.erl
+++ b/eqc/get_fsm_eqc.erl
@@ -1,3 +1,18 @@
+%% Description
+%%
+%% The test is based on a fixed set of generated objects. These objects are
+%% then used as the randomised answers from vnodes to the get_fsm. The
+%% objects have a deterministic merge order (based on the assumption the
+%% timestamps generated are strictly monotonically increasing) - and so the
+%% test can compare the get_fsm result to the expected result.
+%%
+%% As well as varying the object responses, the GET options and parameters are
+%% mutated to create further scenarios.
+%%
+%% TODO:
+%% The test does not use dotted values at present, or HEAD responses
+%%
+
 -module(get_fsm_eqc).
 
 -ifdef(EQC).

--- a/eqc/get_fsm_eqc.erl
+++ b/eqc/get_fsm_eqc.erl
@@ -86,22 +86,10 @@ test() ->
     test(100).
 
 test(N) ->
-    fsm_eqc_util:start_mock_servers(),
-    fsm_eqc_util:start_fake_rng(?MODULE),
-    try quickcheck(numtests(N, prop_basic_get()))
-    after
-        fsm_eqc_util:cleanup_mock_servers(),
-        exit(whereis(?MODULE), kill)
-    end.
+    quickcheck(numtests(N, prop_basic_get())).
 
 check() ->
-    fsm_eqc_util:start_mock_servers(),
-    fsm_eqc_util:start_fake_rng(?MODULE),
-    try check(prop_basic_get(), current_counterexample())
-    after
-        fsm_eqc_util:cleanup_mock_servers(),
-        exit(whereis(?MODULE), kill)
-    end.
+    check(prop_basic_get(), current_counterexample()).
 
 %%====================================================================
 %% Generators

--- a/eqc/get_fsm_eqc.erl
+++ b/eqc/get_fsm_eqc.erl
@@ -140,7 +140,7 @@ is_sibling(Lin1, Lin2) ->
 
 
 vnodegetresps() ->
-    fsm_eqc_util:not_empty(fsm_eqc_util:longer_list(2, vnodegetresp())).
+    non_empty(fsm_eqc_util:longer_list(2, vnodegetresp())).
 
 vnodegetresp() ->
     {fsm_eqc_util:partval(), nodestatus()}.

--- a/eqc/get_fsm_eqc.erl
+++ b/eqc/get_fsm_eqc.erl
@@ -83,7 +83,7 @@ prepare() ->
     fsm_eqc_util:start_mock_servers().
 
 test() ->
-    test(100).
+    test(10000).
 
 test(N) ->
     quickcheck(numtests(N, prop_basic_get())).

--- a/eqc/put_fsm_eqc.erl
+++ b/eqc/put_fsm_eqc.erl
@@ -137,7 +137,7 @@ cleanup(started) ->
 %% {notfound|{ok, lineage()}, FirstResp, FirstSeq, SecondResp, SecondSeq}
 
 vnodeputresps() ->
-    fsm_eqc_util:not_empty(fsm_eqc_util:longer_list(2, vnodeputresp())).
+    non_empty(fsm_eqc_util:longer_list(2, vnodeputresp())).
 
 vnodeputresp() ->
     {vputpartval(),
@@ -860,4 +860,3 @@ check_puts_sent(ExpectedPuts, VPutResp) ->
               equals(ExpectedPuts, NumPutReqs)).
 
 -endif. % EQC
-

--- a/eqc/put_fsm_eqc.erl
+++ b/eqc/put_fsm_eqc.erl
@@ -87,7 +87,7 @@ setup() ->
     error_logger:logfile({open, Path ++ "/put_fsm_eqc.log"}),
 
     %% Exometer starts lager.  Therefore, we need start it before lager to ensure
-    %% that cconfiguration customizations in this test case are not inadvertantly
+    %% that configuration customizations in this test case are not inadvertantly
     %% overwritten ...
     ok = exometer:start(),
     application:stop(lager),

--- a/rebar.config
+++ b/rebar.config
@@ -38,7 +38,8 @@
                  ]}.
 
 {profiles, [
-    {test, [{deps, [meck]}]},
+    {test, [{deps, [meck,
+                    {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag, "v0.5.0"}}}]}]},
     {eqc, [{deps, [meck]}]}
 ]}.
 
@@ -52,7 +53,6 @@
         {sext, ".*", {git, "git://github.com/uwiger/sext.git", {tag, "1.4.1"}}},
         {riak_pipe, ".*", {git, "git://github.com/basho/riak_pipe.git", {branch, "develop-3.0"}}},
         {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {branch, "develop-3.0"}}},
-        {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag, "v0.5.0"}}},
         {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {branch, "develop-3.0"}}},
         {hyper, ".*", {git, "git://github.com/basho/hyper", {branch, "develop-3.0"}}},
         {leveled, ".*", {git, "https://github.com/martinsumner/leveled.git", {branch, "master"}}},

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -835,7 +835,7 @@ ttl_ets_timeref_leak_get_after_expiry_test() ->
     {ok, State1} = put(Bucket, Key, [], Value, State),
     {ok, #state{time_ref=TimeRef} = State2} = put(Bucket, Key, [], Value, State1),
     ?assertEqual(1, get_time_ref_count(TimeRef)),
-    timer:sleep(timer:seconds(1)),
+    timer:sleep(timer:seconds(1) + 1),
     {error, not_found, _State3} = get(Bucket, Key, State2),
     ?assertEqual(0, get_time_ref_count(TimeRef)).
 


### PR DESCRIPTION
Using `os:timestamp()` in the QuickCheck property made us move from monotonic to non-monotonic time. In get_fsm_eqc we test with `allow_mult == false` and assumed monotonic time. Therefore, failures popped up that are well known to appear if time is none monotonic and therefore there is a `allow_mult == true` option.

We changed the property to always use monotonically increasing time.

Other changes are mostly cosmetic. Note that we move eunit-formatter from a production dependency to a test dependency. 