### PR TITLE
No warning on lz4

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -57,6 +57,6 @@
         {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {branch, "develop-3.0"}}},
         {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {branch, "develop-3.0"}}},
         {hyper, ".*", {git, "git://github.com/basho/hyper", {branch, "develop-3.0"}}},
-        {leveled, ".*", {git, "https://github.com/martinsumner/leveled.git", {branch, "master"}}},
+        {leveled, ".*", {git, "https://github.com/martinsumner/leveled.git", {branch, "develop-3.0"}}},
 	{kv_index_tictactree, ".*", {git, "https://github.com/martinsumner/kv_index_tictactree.git", {branch, "master"}}}
        ]}.


### PR DESCRIPTION
Switch to develop-3.0 leveled which refers to now warning free lz4 library.