### PR TITLE
Mas i1714 readonlyfs

### DIFF
--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -57,7 +57,7 @@
 -define(VERSION_FILE, "version.txt").
 -define(API_VERSION, 1).
 -define(CAPABILITIES, [async_fold,size]).
--define(TERMINAL_POSIX_ERRORS, [eacces, erofs, enodev]).
+-define(TERMINAL_POSIX_ERRORS, [eacces, erofs, enodev, enospc]).
 
 %% must not be 131, otherwise will match t2b in error
 %% yes, I know that this is horrible.

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -57,6 +57,7 @@
 -define(VERSION_FILE, "version.txt").
 -define(API_VERSION, 1).
 -define(CAPABILITIES, [async_fold,size]).
+-define(TERMINAL_POSIX_ERRORS, [eacces, erofs, enodev]).
 
 %% must not be 131, otherwise will match t2b in error
 %% yes, I know that this is horrible.
@@ -233,6 +234,11 @@ put(Bucket, PrimaryKey, _IndexSpecs, Val,
         ok ->
             {ok, State};
         {error, Reason} ->
+            lager:warning("Backend put error ~p", [Reason]),
+            % Should crash if the error is a permanent file system error
+            false =
+                is_tuple(Reason) and
+                    lists:member(element(2, Reason), ?TERMINAL_POSIX_ERRORS),
             {error, Reason, State}
     end.
 

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -201,6 +201,9 @@ put(Bucket, PrimaryKey, IndexSpecs, Val, #state{ref=Ref,
         ok ->
             {ok, State};
         {error, Reason} ->
+            % Confirm this has not failed due to db_write error - as this is
+            % not recoverable and should result in a crash of the vnode
+            false = is_tuple(Reason) and (element(1, Reason) == db_write),
             {error, Reason, State}
     end.
 


### PR DESCRIPTION
This is a missing change in develop-3.0 - but is in develop-2.9.

The develop-2.9 commit history is a mess at the moment after the mistaken merge in of 2.9.1 work (and then the reverting of that).  Trying to merge in develop-2.9 into develop-3.0 directly will bring this mess across, and attempts at rebasing having cleared things up.

In order to update develop-3.0 with recent changes to develop-2.9 I therefore intend to merge back the individual feature branches. 

Hopefully the long-term mess can be resolved when 3.0 is updated from 2.9.1.

So this is a repeat of https://github.com/basho/riak_kv/pull/1717.