### PR TITLE
Include option for security on nextgen_repl

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -943,6 +943,31 @@
   {default, http}
 ]}.
 
+%% @doc The filepath for the ca certificate to validate the ssl connection
+%% to the remote peer.
+{mapping, "repl_cacert_filename", "riak_kv.repl_cacert_filename", [
+    {datatype, string}
+]}.
+
+%% @doc The filepath for the certificate to be used by this node when acting
+%% as a client for replication.  Must be trusted by the cluster with security
+%% enabled
+{mapping, "repl_cert_filename", "riak_kv.repl_cert_filename", [
+    {datatype, string}
+]}.
+
+%% @doc The filepath for the key to related to the certificate in
+%% repl_cert_filename
+{mapping, "repl_key_filename", "riak_kv.repl_key_filename", [
+    {datatype, string}
+]}.
+
+%% @doc When security is enabled on the remote cluster for replication as
+%% username is required to identify the replication client.  This username
+%% must be configured on the remote cluster with appropriate access rights
+{mapping, "repl_username", "riak_kv.repl_username", [
+    {datatype, string}
+]}.
 
 %% @doc How many times per 24hour period should all the data be checked to
 %% confirm it is fully sync'd

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -394,9 +394,27 @@ map_peer_to_wi_fun({QueueName, PeerInfo}) ->
                     fun(QN) -> rhc:fetch(HTC, QN) end
                 end;
             pb ->
+                CaCertificateFilename =
+                    app_helper:get_env(riak_kv, repl_cacert_filename),
+                CertfiicateFilename =
+                    app_helper:get_env(riak_kv, repl_cert_filename),
+                KeyFilename =
+                    app_helper:get_env(riak_kv, repl_key_filename),
+                SecuritySitename = 
+                    app_helper:get_env(riak_kv, repl_username),
+                Opts = 
+                    case CaCertificateFilename of
+                        undefined ->
+                            [{silence_terminate_crash, true}];
+                        CaCert ->
+                            [{silence_terminate_crash, true},
+                                {credentials, SecuritySitename, ""},
+                                {cacertfile, CaCert},
+                                {certfile, CertfiicateFilename},
+                                {keyfile, KeyFilename}]
+                    end,
                 InitClientFun =
                     fun() ->
-                        Opts = [{silence_terminate_crash, true}],
                         case riakc_pb_socket:start(Host, Port, Opts) of
                             {ok, PBpid} ->
                                 PBpid;

--- a/src/riak_kv_ttaaefs_manager.erl
+++ b/src/riak_kv_ttaaefs_manager.erl
@@ -500,7 +500,7 @@ generate_sendfun(SendClient, NVal) ->
 %% @doc
 %% Make a remote client for connecting to the remote cluster
 -spec init_client(client_protocol(), client_ip(), client_port(),
-                    string()|undefined)
+                    ssl_credentials()|undefined)
                     -> {rhc:rhc()|no_client, rhc}|
                         {pid()|no_client, riakc_pb_socket}.
 init_client(http, IP, Port, _Cert) ->


### PR DESCRIPTION
Can add security on protocol buffers interface only.  It is required to be certificate-authenticated SSL - no other security options are supported - so client as well as server certificates are required.

Tested within the test [nextgenrepl_rtq_pbsecurity](https://github.com/basho/riak_test/blob/mas-i1691-ttaaefullsync/tests/nextgenrepl_rtq_pbsecurity.erl)

Note that enabling replication security for nextgen_repl requires security to be enabled for all applications of the cluster.  This is a change form riak_repl where security was an independent option to security on the general API.

Not all failure scenarios are tested here - the pc_security riak_test provides a more general test of the API security features.