### PR TITLE
Change sink worker to allow for multiple queues in config

### DIFF
--- a/eqc/replrtq_snk_eqc.erl
+++ b/eqc/replrtq_snk_eqc.erl
@@ -130,9 +130,6 @@ start_next(#{config  := Sinks} = S, Pid, _Args) ->
 start_post(_S, _Args, Res) ->
     is_pid(Res) andalso is_process_alive(Res).
 
-start_process(_S, []) ->
-    worker.
-
 
 %% --- Operation: sleep ---
 
@@ -148,7 +145,7 @@ sleep_pre(#{time := Time}, [N]) -> Time + N =< ?TEST_DURATION.
 
 sleep(N) -> timer:sleep(N).
 
-sleep_next(S = #{time := T}, _, [N]) -> S#{time := T + N}.
+sleep_next(S = #{time := T}, _, [N]) -> S#{time => T + N}.
 
 %% --- Operation: suspend ---
 
@@ -197,7 +194,7 @@ add(#{queue := Q, peers := Peers, workers := N}) ->
 add_callouts(_S, [Sink]) -> ?APPLY(setup_sink, [Sink]).
 
 add_next(#{sinks := Sinks} = S, _V, [#{queue := Q} = Sink]) ->
-  S#{ sinks := Sinks#{ Q => Sink } }.
+  S#{ sinks => Sinks#{ Q => Sink } }.
 
 %% --- remove ---
 
@@ -212,7 +209,7 @@ remove(Q) ->
 
 remove_next(#{sinks := Sinks} = S, _, [Q]) ->
     Removed = maps:get(removed, S, []),
-    S#{sinks := maps:remove(Q, Sinks), removed => [Q | Removed]}.
+    S#{sinks => maps:remove(Q, Sinks), removed => [Q | Removed]}.
 
 %% -- Generators -------------------------------------------------------------
 
@@ -242,7 +239,7 @@ sink_gen(WorkersGen) ->
        workers => WorkersGen }.
 
 workers_gen() ->
-    frequency([{1, 0}, {10, choose(1, 5)}, {1, 24}]).
+    frequency([{1, 0}, {10, choose(1, 5)}]).
 
 peers_gen() ->
     ?LET(N, choose(1, 8), peers_gen(N)).

--- a/eqc/replrtq_snk_monitor.erl
+++ b/eqc/replrtq_snk_monitor.erl
@@ -53,7 +53,7 @@ init([]) ->
 
 handle_call({add_queue, Queue, Peers, Workers}, _From, State) ->
     Ref = make_ref(),
-    PeerMap = maps:from_list([{{Peer, Queue}, {Ref, Cfg}} || {Peer, Cfg} <- Peers]),
+    PeerMap = maps:from_list([{{{Host, Port}, Queue}, {Ref, Cfg}} || {{Host, Port, http}, Cfg} <- Peers]),
     Q = #queue{ref = Ref, name = Queue, peers = Peers, workers = Workers},
     {reply, ok, State#state{ queues = [Q | State#state.queues],
                              peers  = maps:merge(State#state.peers, PeerMap) }};

--- a/eqc/replrtq_snk_monitor.erl
+++ b/eqc/replrtq_snk_monitor.erl
@@ -9,7 +9,8 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/0, stop/0, fetch/2, push/4, suspend/1, resume/1, add_queue/3, remove_queue/1]).
+-export([start_link/0, stop/0, fetch/2, push/4, suspend/1, resume/1,
+         add_queue/3, remove_queue/1, update_workers/2]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -46,6 +47,10 @@ suspend(Queue) ->
 resume(Queue) ->
     gen_server:call(?SERVER, {resume, Queue}).
 
+update_workers(Queue, Workers) ->
+    gen_server:call(?SERVER, {update_workers, Queue, Workers}).
+
+
 %% -- Callbacks --------------------------------------------------------------
 
 init([]) ->
@@ -80,6 +85,10 @@ handle_call({suspend, Queue}, _From, State) ->
     {reply, ok, add_trace(State, Queue, suspend)};
 handle_call({resume, Queue}, _From, State) ->
     {reply, ok, add_trace(State, Queue, resume)};
+handle_call({update_workers, Q, Workers}, _From, State) ->
+    Queue = lists:keyfind(Q, #queue.name, State#state.queues),
+    NewQueue = Queue#queue{workers = Workers},
+    {reply, ok, State#state{ queues = [NewQueue | State#state.queues -- [Queue]]}};
 handle_call(_Request, _From, State) ->
     Reply = ok,
     {reply, Reply, State}.
@@ -123,4 +132,3 @@ final_trace(#state{ queues = Queues, traces = Traces }, Ref) ->
     Trace = maps:get(Ref, Traces),
     #queue{name = Name, peers = Peers, workers = Workers} = lists:keyfind(Ref, #queue.ref, Queues),
     {Name, Peers, Workers, lists:reverse(Trace)}.
-

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1036,43 +1036,38 @@
 %% cluster_a:any|cluster_b:block_rtq|cluster_c:bucketprefix.user
 {mapping, "replrtq_srcqueue", "riak_kv.replrtq_srcqueue", [
     {datatype, string},
-    {default, "qi_ttaaefs:block_rtq"}
+    {default, "q1_ttaaefs:block_rtq"}
 ]}.
 
 %% @doc Enable this node to act as a sink and consume from a src cluster
 {mapping, "replrtq_enablesink", "riak_kv.replrtq_enablesink", [
     {datatype, {flag, enabled, disabled}},
-    {default, enabled}
+    {default, disabled}
 ]}.
 
-
-%% @doc The node can act as a sink for one queue, from an unlimited number
-%% of peers (which may be in more than one cluster).  If the cluster needs
-%% to consume from multiple queues, then this can be achieved via directly
-%% changing replrtq_snk configuration via attach
-%% The queuename should be set to disabled if either of the two replication
-%% queues is not to be configured.  The queue name if it is to be configured
-%% must match a replq<n>_queuename on the source node.
-%% If more than two sink queues are required to be configured, then this
-%% can be achieved through an attach script.
+%% @doc Default queue name  to be used for peers (replrtq_sinkpeers) that are
+%% defined without a queue name.  Will be ignored where all peers are defined
+%% with a queue name
 {mapping, "replrtq_sinkqueue", "riak_kv.replrtq_sinkqueue", [
   {datatype, atom},
-  {default, disabled}
+  {default, q1_ttaaefs}
 ]}.
-
 
 %% @doc A list of peers is required to inform the sink node how to reach the
 %% src.  All src nodes will need to have entries consumed - so it is
 %% recommended that each src node is referred to in multiple sink node
 %% configurations.
-%% The list of peers is tokenised as host:port|host:port etc.
+%% The list of peers is tokenised as
+%% queue:host:port:protocol or host:port:protocol
+%% The queue will be converted to an atom and must be a queue_name at the peer
+%% The protocol may be http or pb.
 {mapping, "replrtq_sinkpeers", "riak_kv.replrtq_sinkpeers", [
     {datatype, string},
-    {commented, "127.0.0.1:8098"}
+    {commented, "q1_ttaaefs:127.0.0.1:8098:http"}
 ]}.
 
-%% @doc The number of workers to be used for that queue must be configured.
+%% @doc The number of workers to be used for each queue must be configured.
 {mapping, "replrtq_sinkworkers", "riak_kv.replrtq_sinkworkers", [
     {datatype, integer},
-    {default, 12}
+    {default, 24}
 ]}.

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -373,7 +373,7 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%%============================================================================
 
-% @doc calculate the mean avoiding divide by 0
+%% @doc calculate the mean avoiding divide by 0
 -spec calc_mean(non_neg_integer(), non_neg_integer()) -> string().
 calc_mean(_, 0) ->
     "no_result";
@@ -381,10 +381,13 @@ calc_mean(Time, Count) ->
     [Mean] = io_lib:format("~.3f",[Time / Count]),
     Mean.
 
-% @doc convert the tokenised string of peers from the configuration into actual
-% usable peer information.
-% tokenised string expected to be of form:
-% "192.168.10.1:8098|192.168.10.2:8098 etc"
+%% @doc convert the tokenised string of peers from the configuration into actual
+%% usable peer information.
+%% tokenised string expected to be of form:
+%% "192.168.10.1:8098:http|192.168.10.2:8098:http etc"
+%% Optionally the tokenised string may include a queue name, if more than the
+%% default queue name is to be used.  The queue name should be a prefix e.g.:
+%% "q1_ttaaefs:192.168.10.1:8097:pb|passive:192.168.10.2:8097:pb etc"
 -spec tokenise_peers(queue_name(), string()) -> list({queue_name(), peer_info()}).
 tokenise_peers(DefaultQueue, PeersString) ->
     PeerL0 = string:tokens(PeersString, "|"),

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -41,6 +41,7 @@
             suspend_snkqueue/1,
             resume_snkqueue/1,
             remove_snkqueue/1,
+            set_workercount/2,
             add_snkqueue/3]).
 
 -export([repl_fetcher/1]).
@@ -55,20 +56,33 @@
 -define(INACTIVITY_TIMEOUT_MS, 60000).
 
 -record(sink_work, {queue_name :: queue_name(),
+                        %% The name of the remote queue to be fetched from
                     work_queue = [] :: list(work_item()),
                     minimum_queue_length = 0 :: non_neg_integer(),
+                        %% The amount of work which must not be in progress
+                        %% in order to maintain the constraints around
+                        %% concurrent sink workers
                     deferred_queue_length = 0 :: non_neg_integer(),
+                        %% The volume of work awaiting requeue
                     peer_list = [] :: list(peer_info()),
                     max_worker_count = 1 :: pos_integer(),
+                        %% The target number of sink workers
                     queue_stats = ?ZERO_STATS :: queue_stats(),
                     suspended = false :: boolean()}).
 
 
 -record(state, {work = [] :: list(sink_work()),
+                iteration = 1 :: iteration(),
+                    %% The iteration number increments with each operator
+                    %% triggered change to the running configuration.  This
+                    %% is the iteration number when this configuration was
+                    %% setup.  Suspensions/resumes do not bump the
+                    %% iteration
                 enabled = false :: boolean()}).
 
 -type queue_name() :: atom().
 -type peer_id() :: pos_integer().
+-type iteration() :: pos_integer().
 -type remote_fun() ::
     fun((queue_name()) ->
         {ok, queue_empty}|{ok, {deleted, any(), binary()}}|{ok, binary()}).
@@ -76,13 +90,13 @@
 
 
 -type work_item() ::
-    {{queue_name(), peer_id()},
+    {{queue_name(), iteration(), peer_id()},
         riak_client:riak_client(),
         remote_fun(), renew_fun()}.
     % Identifier for the work item  - and the local and remote clients to use
 
 -type sink_work() ::
-    {queue_name(), #sink_work{}}.
+    {queue_name(), iteration(), #sink_work{}}.
     % Mapping between queue names and the work records
 
 -type peer_info() ::
@@ -166,11 +180,15 @@ remove_snkqueue(QueueName) ->
 %% Add temporarily to this process a configuration to reach a given queue via
 %% a passed-in list of peers, using a given count of workers.
 %% This added-in configuration will not be preserved between process restarts.
-%% This API may be used to support more than the two queue names for which
-%% configuration is permissable via riak.conf.
 -spec add_snkqueue(queue_name(), list(peer_info()), pos_integer()) -> ok.
 add_snkqueue(QueueName, Peers, WorkerCount) ->
     gen_server:call(?MODULE, {add, QueueName, Peers, WorkerCount}).
+
+%% @doc
+%% Change the number of concurrent workers supporting a given queue
+-spec set_workercount(queue_name(), pos_integer()) -> ok|not_found.
+set_workercount(QueueName, WorkerCount) ->
+    gen_server:call(?MODULE, {worker_count, QueueName, WorkerCount}).
 
 %%%============================================================================
 %%% gen_server callbacks
@@ -180,86 +198,107 @@ init([]) ->
     SinkEnabled = app_helper:get_env(riak_kv, replrtq_enablesink, false),
     case SinkEnabled of
         true ->
-            Sink = app_helper:get_env(riak_kv, replrtq_sinkqueue, disabled),
-            State1 =
-                case Sink of
-                    disabled ->
-                        #state{};
-                    SnkQueueName ->
-                        SinkPeers =
-                            app_helper:get_env(riak_kv, replrtq_sinkpeers),
-                        SnkPeerInfo =
-                            tokenise_peers(SinkPeers),
-                        SnkWorkerCount =
-                            app_helper:get_env(riak_kv, replrtq_sinkworkers),
-                        {SnkQueueLength, SnkWorkQueue} =
-                            determine_workitems(SnkQueueName,
-                                                SnkPeerInfo,
-                                                SnkWorkerCount),
-                        SnkW =
-                            #sink_work{queue_name = SnkQueueName,
-                                        work_queue = SnkWorkQueue,
-                                        minimum_queue_length = SnkQueueLength,
-                                        peer_list = SnkPeerInfo,
-                                        max_worker_count = SnkWorkerCount},
-                        #state{work = [{SnkQueueName, SnkW}]}
+            SinkPeers = app_helper:get_env(riak_kv, replrtq_sinkpeers, ""),
+            DefaultQueue = app_helper:get_env(riak_kv, replrtq_sinkqueue),
+            SnkQueuePeerInfo = tokenise_peers(DefaultQueue, SinkPeers),
+            SnkWorkerCount = app_helper:get_env(riak_kv, replrtq_sinkworkers, 1),
+            Iteration = 1,
+            MapPeerInfoFun =
+                fun({SnkQueueName, SnkPeerInfo}) ->
+                    {SnkQueueLength, SnkWorkQueue} =
+                        determine_workitems(SnkQueueName,
+                                            Iteration,
+                                            SnkPeerInfo,
+                                            SnkWorkerCount),
+                    SnkW =
+                        #sink_work{queue_name = SnkQueueName,
+                                    work_queue = SnkWorkQueue,
+                                    minimum_queue_length = SnkQueueLength,
+                                    peer_list = SnkPeerInfo,
+                                    max_worker_count = SnkWorkerCount},
+                    {SnkQueueName, Iteration, SnkW}
                 end,
-            {ok, State1#state{enabled = true}, ?INACTIVITY_TIMEOUT_MS};
+            Work = lists:map(MapPeerInfoFun, SnkQueuePeerInfo),
+            {ok, #state{enabled = true, work = Work}, ?INACTIVITY_TIMEOUT_MS};
         false ->
             {ok, #state{}}
     end.
-
 
 handle_call({suspend, QueueN}, _From, State) ->
     case lists:keyfind(QueueN, 1, State#state.work) of
         false ->
             {reply, not_found, State};
-        {QueueN, SinkWork} ->
+        {QueueN, I, SinkWork} ->
             SW0 = SinkWork#sink_work{suspended = true},
-            W0 = lists:keyreplace(QueueN, 1, State#state.work, {QueueN, SW0}),
+            W0 = lists:keyreplace(QueueN, 1, State#state.work, {QueueN, I, SW0}),
             {reply, ok, State#state{work = W0}}
     end;
 handle_call({resume, QueueN}, _From, State) ->
     case lists:keyfind(QueueN, 1, State#state.work) of
         false ->
             {reply, not_found, State};
-        {QueueN, SinkWork} ->
+        {QueueN, I, SinkWork} ->
             SW0 = SinkWork#sink_work{suspended = false},
-            W0 = lists:keyreplace(QueueN, 1, State#state.work, {QueueN, SW0}),
+            W0 = lists:keyreplace(QueueN, 1, State#state.work, {QueueN, I, SW0}),
             prompt_work(),
             {reply, ok, State#state{work = W0}}
     end;
 handle_call({remove, QueueN}, _From, State) ->
     W0 = lists:keydelete(QueueN, 1, State#state.work),
+    Iteration = State#state.iteration + 1,
     case W0 of
         [] ->
-            {reply, ok, State#state{work = W0, enabled = false}};
+            {reply,
+                ok,
+                State#state{work = W0, iteration = Iteration, enabled = false}};
         _ ->
-            {reply, ok, State#state{work = W0, enabled = true}}
+            {reply,
+                ok,
+                State#state{work = W0, iteration = Iteration, enabled = true}}
     end;
 handle_call({add, QueueN, Peers, WorkerCount}, _From, State) ->
-    {QueueLength, WorkQueue} = determine_workitems(QueueN, Peers, WorkerCount),
+    Iteration = State#state.iteration + 1,
+    {QueueLength, WorkQueue} =
+        determine_workitems(QueueN, Iteration, Peers, WorkerCount),
     SnkW =
         #sink_work{queue_name = QueueN,
                     work_queue = WorkQueue,
                     minimum_queue_length = QueueLength,
                     peer_list = Peers,
                     max_worker_count = WorkerCount},
-    W0 = lists:keystore(QueueN, 1, State#state.work, {QueueN, SnkW}),
+    W0 =
+        lists:keystore(QueueN, 1, State#state.work, {QueueN, Iteration, SnkW}),
     prompt_work(),
-    {reply, ok, State#state{work = W0, enabled = true}}.
+    {reply, ok, State#state{work = W0, iteration = Iteration, enabled = true}};
+handle_call({worker_count, QueueN, WorkerCount}, _From, State) ->
+    case lists:keyfind(QueueN, 1, State#state.work) of
+        false ->
+            {reply, not_found, State};
+        {QueueN, _I, SinkWork} ->
+            Iteration = State#state.iteration + 1,
+            {QueueLength, WorkQueue} =
+                determine_workitems(QueueN,
+                                    Iteration,
+                                    SinkWork#sink_work.peer_list,
+                                    WorkerCount),
+            SinkWork0 =
+                SinkWork#sink_work{work_queue = WorkQueue,
+                                    minimum_queue_length = QueueLength,
+                                    max_worker_count = WorkerCount},
+            W0 =
+                lists:keyreplace(QueueN, 1, State#state.work,
+                                    {QueueN, Iteration, SinkWork0}),
+            {reply, ok, State#state{work = W0, iteration = Iteration}}
+    end.
 
 
 handle_cast(prompt_work, State) ->
     Work0 = lists:map(fun do_work/1, State#state.work),
     {noreply, State#state{work = Work0}};
 handle_cast({done_work, WorkItem, Success, ReplyTuple}, State) ->
-    {{QueueName, PeerID}, _LC, _RC, _RNCF} = WorkItem,
+    {{QueueName, Iteration, PeerID}, _LC, _RC, _RNCF} = WorkItem,
     case lists:keyfind(QueueName, 1, State#state.work) of
-        false ->
-            % Work profile has changed since this work was prompted
-            {noreply, State};
-        {QueueName, SinkWork} ->
+        {QueueName, Iteration, SinkWork} ->
             QS = SinkWork#sink_work.queue_stats,
             QS0 = increment_queuestats(QS, ReplyTuple),
             PL = SinkWork#sink_work.peer_list,
@@ -269,7 +308,7 @@ handle_cast({done_work, WorkItem, Success, ReplyTuple}, State) ->
                                         queue_stats = QS0,
                                         deferred_queue_length = DQL0},
             UpdWork = lists:keyreplace(QueueName, 1, State#state.work,
-                                        {QueueName, UpdSW}),
+                                        {QueueName, Iteration, UpdSW}),
             case PW0 of
                 0 ->
                     requeue_work(WorkItem);
@@ -279,23 +318,26 @@ handle_cast({done_work, WorkItem, Success, ReplyTuple}, State) ->
                                         self(),
                                         {prompt_requeue, WorkItem})
             end,
-            {noreply, State#state{work = UpdWork}}
+            {noreply, State#state{work = UpdWork}};
+        _ ->
+            % Work profile has changed since this work was prompted
+            {noreply, State}
     end;
 handle_cast({requeue_work, WorkItem}, State) ->
-    {{QueueName, _PeerID}, _LC, _RC, _RNCF} = WorkItem,
+    {{QueueName, Iteration, _PeerID}, _LC, _RC, _RNCF} = WorkItem,
     case lists:keyfind(QueueName, 1, State#state.work) of
-        false ->
-            % Work profile has changed since this work was requeued
-            {noreply, State};
-        {QueueName, SinkWork} ->
+        {QueueName, Iteration, SinkWork} ->
             UpdWorkQueue = [WorkItem|SinkWork#sink_work.work_queue],
             DQL = SinkWork#sink_work.deferred_queue_length - 1,
             UpdSW = SinkWork#sink_work{work_queue = UpdWorkQueue,
                                         deferred_queue_length = DQL},
             UpdWork = lists:keyreplace(QueueName, 1, State#state.work,
-                                        {QueueName, UpdSW}),
+                                        {QueueName, Iteration, UpdSW}),
             prompt_work(),
-            {noreply, State#state{work = UpdWork}}
+            {noreply, State#state{work = UpdWork}};
+        _ ->
+            % Work profile has changed since this work was requeued
+            {noreply, State}
     end.
 
 handle_info(timeout, State) ->
@@ -339,25 +381,39 @@ calc_mean(Time, Count) ->
 % usable peer information.
 % tokenised string expected to be of form:
 % "192.168.10.1:8098|192.168.10.2:8098 etc"
--spec tokenise_peers(string()) -> list(peer_info()).
-tokenise_peers(PeersString) ->
+-spec tokenise_peers(queue_name(), string()) -> list({queue_name(), peer_info()}).
+tokenise_peers(DefaultQueue, PeersString) ->
     PeerL0 = string:tokens(PeersString, "|"),
     SplitHostPortFun =
-        fun(PeerString, Acc0) ->
-            {Host, Port, Protocol} =
+        fun(PeerString, Acc) ->
+            {QueueName, Host, Port, Protocol} =
                 case string:tokens(PeerString, ":") of
-                    [H, P] ->
-                        {H, P, http};
-                    [H, P, "http"] ->
-                        {H, P, http};
-                    [H, P, "pb"] ->
-                        {H, P, pb}
+                    [H, P, ProtStr] ->
+                        format_peer(DefaultQueue, H, P, ProtStr);
+                    [QN, H, P, ProtStr] ->
+                        format_peer(list_to_atom(QN), H, P, ProtStr)
                 end,
-            {{Acc0, ?STARTING_DELAYMS, Host, list_to_integer(Port), Protocol},
-                Acc0 + 1}
+            case lists:keytake(QueueName, 1, Acc) of
+                {value, {QueueName, PeerList}, Acc0} ->
+                    Peer =
+                        {length(PeerList) + 1,
+                            ?STARTING_DELAYMS,
+                            Host, Port, Protocol},
+                    lists:ukeysort(1, [{QueueName, PeerList ++ [Peer]}|Acc0]);
+                false ->
+                    Peer =
+                        {1,
+                            ?STARTING_DELAYMS,
+                            Host, Port, Protocol},
+                    lists:ukeysort(1, [{QueueName, [Peer]}|Acc])
+            end
         end,
-    {PeerList, _Acc} = lists:mapfoldl(SplitHostPortFun, 1, PeerL0),
-    PeerList.
+    lists:foldl(SplitHostPortFun, [], PeerL0).
+
+format_peer(QN, H, P, "http") ->
+    {QN, H, list_to_integer(P), http};
+format_peer(QN, H, P, "pb") ->
+    {QN, H, list_to_integer(P), pb}.
 
 
 %% @doc
@@ -366,12 +422,15 @@ tokenise_peers(PeersString) ->
 %% worker processes.
 %% The count of work items should allow for all workers to be busy with one
 %% peer yielding work, when all other peers have no work
--spec determine_workitems(queue_name(), list(peer_info()), pos_integer())
+-spec determine_workitems(queue_name(), iteration(), list(peer_info()),
+                            pos_integer())
                                     -> {non_neg_integer(), list(work_item())}.
-determine_workitems(QueueName, PeerInfo, WorkerCount) ->
+determine_workitems(QueueName, Iteration, PeerInfo, WorkerCount) ->
     WorkItems0 =
         lists:map(fun map_peer_to_wi_fun/1,
-                    lists:map(fun(PI) -> {QueueName, PI} end,
+                    lists:map(fun(PI) ->
+                                    {QueueName, Iteration, PI}
+                                end,
                                 PeerInfo)),
     WorkItems =
         lists:foldl(fun(_I, Acc) -> Acc ++ WorkItems0 end,
@@ -380,8 +439,8 @@ determine_workitems(QueueName, PeerInfo, WorkerCount) ->
     {length(WorkItems) - WorkerCount, WorkItems}.
 
 
--spec map_peer_to_wi_fun({queue_name(), peer_info()}) -> work_item().
-map_peer_to_wi_fun({QueueName, PeerInfo}) ->
+-spec map_peer_to_wi_fun({queue_name(), iteration(), peer_info()}) -> work_item().
+map_peer_to_wi_fun({QueueName, Iteration, PeerInfo}) ->
     {PeerID, _Delay, Host, Port, Protocol} = PeerInfo,
     LocalClient = riak_client:new(node(), undefined),
     GenClientFun = 
@@ -435,7 +494,8 @@ map_peer_to_wi_fun({QueueName, PeerInfo}) ->
                     end
                 end
         end,
-    {{QueueName, PeerID}, LocalClient, GenClientFun(), GenClientFun}.
+    {{QueueName, Iteration, PeerID},
+        LocalClient, GenClientFun(), GenClientFun}.
 
 check_pbc_client(no_pid) ->
     false;
@@ -448,22 +508,24 @@ check_pbc_client(PBC) ->
 %% snk worker (using the repl_fetcher fun) to manage that item of work.  The
 %% worker must ensure the wortk_item is delivered back on completion.
 -spec do_work(sink_work()) -> sink_work().
-do_work({QueueName, SinkWork}) ->
+do_work({QueueName, Iteration, SinkWork}) ->
     WorkQueue = SinkWork#sink_work.work_queue,
     MinQL = (SinkWork#sink_work.minimum_queue_length -
                 SinkWork#sink_work.deferred_queue_length),
     IsSuspended = SinkWork#sink_work.suspended,
     case IsSuspended of
         true ->
-            {QueueName, SinkWork};
+            {QueueName, Iteration, SinkWork};
         false ->
             case length(WorkQueue) - MinQL of
                 0 ->
-                    {QueueName, SinkWork};
+                    {QueueName, Iteration, SinkWork};
                 _ ->
                     {Rem, Work} = lists:split(lists:max([0, MinQL]), WorkQueue),
                     lists:foreach(fun work/1, Work),
-                    {QueueName, SinkWork#sink_work{work_queue = Rem}}
+                    {QueueName,
+                        Iteration,
+                        SinkWork#sink_work{work_queue = Rem}}
             end
     end.
 
@@ -478,7 +540,8 @@ work(WorkItem) ->
 -spec repl_fetcher(work_item()) -> ok.
 repl_fetcher(WorkItem) ->
     SW = os:timestamp(),
-    {{QueueName, _PeerID}, LocalClient, RemoteFun, RenewClientFun} = WorkItem,
+    {{QueueName, _Iter, _Peer}, LocalClient, RemoteFun, RenewClientFun}
+        = WorkItem,
     try
         case RemoteFun(QueueName) of
             {ok, queue_empty} ->
@@ -599,13 +662,13 @@ increment_delay(N) ->
 
 
 %% @doc
-%% Log details of the replictaion counts and times, and also the current delay
+%% Log details of the replication counts and times, and also the current delay
 %% to requeue work items for each peer (consistently low delay may indicate
 %% the need to configure more workers.
 %% At runtime changes to the number of workers can be managed via the
 %% remove_snkqueue/1 and add_snkqueue/3 api.
 -spec log_mapfun(sink_work()) -> sink_work().
-log_mapfun({QueueName, SinkWork}) ->
+log_mapfun({QueueName, Iteration, SinkWork}) ->
     {{success, SC}, {failure, EC},
         {repl_time, RT},
         {modified_time, MTS, MTM, MTH, MTD, MTL}}
@@ -622,7 +685,7 @@ log_mapfun({QueueName, SinkWork}) ->
     PeerDelays =
         lists:foldl(FoldPeerInfoFun, "", SinkWork#sink_work.peer_list),
     lager:info("Queue=~w has peer delays of~s", [QueueName, PeerDelays]),
-    {QueueName, SinkWork#sink_work{queue_stats = ?ZERO_STATS}}.
+    {QueueName, Iteration, SinkWork#sink_work{queue_stats = ?ZERO_STATS}}.
 
 
 %%%============================================================================
@@ -632,37 +695,44 @@ log_mapfun({QueueName, SinkWork}) ->
 -ifdef(TEST).
 
 tokenise_test() ->
-    String1 = "127.0.0.1:12008|127.0.0.1:12009|127.0.0.1:12009",
+    String1 =
+        "active:127.0.0.1:12008:http|active:127.0.0.1:12009:pb|"
+            ++ "active:127.0.0.1:12009:pb",
     Peer1A = {1, ?STARTING_DELAYMS, "127.0.0.1", 12008, http},
-    Peer2A = {2, ?STARTING_DELAYMS, "127.0.0.1", 12009, http},
-    Peer3A = {3, ?STARTING_DELAYMS, "127.0.0.1", 12009, http},
+    Peer2A = {2, ?STARTING_DELAYMS, "127.0.0.1", 12009, pb},
+    Peer3A = {3, ?STARTING_DELAYMS, "127.0.0.1", 12009, pb},
         % references not de-duped, allows certain peers to double-up on worker
         % time
-    ?assertMatch([Peer1A, Peer2A, Peer3A], tokenise_peers(String1)),
-    String2 = "127.0.0.1:12008:pb|127.0.0.1:12009:pb|127.0.0.1:12009:pb",
+    ?assertMatch([{active, [Peer1A, Peer2A, Peer3A]}],
+                    tokenise_peers(q1_ttaaefs, String1)),
+    String2 =
+        "127.0.0.1:12008:pb|qb:127.0.0.1:12009:pb|qb:127.0.0.1:12009:pb",
     Peer1B = {1, ?STARTING_DELAYMS, "127.0.0.1", 12008, pb},
-    Peer2B = {2, ?STARTING_DELAYMS, "127.0.0.1", 12009, pb},
-    Peer3B = {3, ?STARTING_DELAYMS, "127.0.0.1", 12009, pb},
+    Peer2B = {1, ?STARTING_DELAYMS, "127.0.0.1", 12009, pb},
+    Peer3B = {2, ?STARTING_DELAYMS, "127.0.0.1", 12009, pb},
         % references not de-duped, allows certain peers to double-up on worker
         % time
-    ?assertMatch([Peer1B, Peer2B, Peer3B], tokenise_peers(String2)).
+    ?assertMatch([{qa, [Peer1B]}, {qb, [Peer2B, Peer3B]}],
+                    tokenise_peers(qa, String2)).
 
 determine_workitems_test() ->
     Peer1 = {1, ?STARTING_DELAYMS, "127.0.0.1", 12008, http},
     Peer2 = {2, ?STARTING_DELAYMS, "127.0.0.1", 12009, http},
     Peer3 = {3, ?STARTING_DELAYMS, "127.0.0.1", 12009, http},
     WC1 = 5,
-    {MQL1, WIL1} = determine_workitems(queue1, [Peer1, Peer2, Peer3], WC1),
+    {MQL1, WIL1} = determine_workitems(queue1, 1, [Peer1, Peer2, Peer3], WC1),
     ?assertMatch(10, MQL1),
     ?assertMatch(15, length(WIL1)),
     WIL1A = lists:map(fun({K, _LC, _RC, _RNCF}) -> K end, WIL1),
-    ?assertMatch([{queue1, 1}, {queue1, 2}, {queue1, 3}], lists:sublist(WIL1A, 3)),
+    ?assertMatch([{queue1, 1, 1}, {queue1, 1, 2}, {queue1, 1, 3}],
+                    lists:sublist(WIL1A, 3)),
 
-    {MQL2, WIL2} = determine_workitems(queue1, [Peer1], WC1),
+    {MQL2, WIL2} = determine_workitems(queue1, 2, [Peer1], WC1),
     ?assertMatch(0, MQL2),
     ?assertMatch(5, length(WIL2)),
     WIL2A = lists:map(fun({K, _LC, _RC, _RNCF}) -> K end, WIL2),
-    ?assertMatch([{queue1, 1}, {queue1, 1}, {queue1, 1}], lists:sublist(WIL2A, 3)).
+    ?assertMatch([{queue1, 2, 1}, {queue1, 2, 1}, {queue1, 2, 1}],
+                    lists:sublist(WIL2A, 3)).
 
 adjust_wait_test() ->
     NullTS = {0, 0, 0},
@@ -685,7 +755,7 @@ adjust_wait_test() ->
 
 log_dont_blow_test() ->
     SW0 = #sink_work{queue_name = queue1},
-    {queue1, SW1} = log_mapfun({queue1, SW0}),
+    {queue1, 1, SW1} = log_mapfun({queue1, 1, SW0}),
     ?assertMatch(SW0, SW1),
     QS0 = SW1#sink_work.queue_stats,
     QS1 = increment_queuestats(QS0, {no_queue, 100}),
@@ -693,7 +763,8 @@ log_dont_blow_test() ->
     QS3 = increment_queuestats(QS2, {object, 150, 180}),
     QS4 = increment_queuestats(QS3, {error, tcp, closed}),
     QS5 = increment_queuestats(QS4, {no_queue, 100}),
-    {queue1, SW2} = log_mapfun({queue1, SW1#sink_work{queue_stats = QS5}}),
+    {queue1, 5, SW2} =
+        log_mapfun({queue1, 5, SW1#sink_work{queue_stats = QS5}}),
     ?assertMatch(?ZERO_STATS, SW2#sink_work.queue_stats),
     QSMT1 = add_modtime(?ZERO_STATS, 86400001),
     QSMT2 = add_modtime(QSMT1, 0),

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -185,7 +185,11 @@ add_snkqueue(QueueName, Peers, WorkerCount) ->
     gen_server:call(?MODULE, {add, QueueName, Peers, WorkerCount}).
 
 %% @doc
-%% Change the number of concurrent workers supporting a given queue
+%% Change the number of concurrent workers supporting a given queue.  Changing
+%% the count is equivalent to starting a new set of workers, and waiting for
+%% the old set of workers to expire once they have completed any outstanding
+%% work.  So for an initial period there may be more concurrent work ongoing
+%% until all in-flight work is finished.
 -spec set_workercount(queue_name(), pos_integer()) -> ok|not_found.
 set_workercount(QueueName, WorkerCount) ->
     gen_server:call(?MODULE, {worker_count, QueueName, WorkerCount}).


### PR DESCRIPTION
Peer configuration can now contain a queue-name, and hence we can have mutliple queues in the configuration.

Also allows for the worker count to be changed for a given queue.

There is now an iteration number kept - to make it easier when switching configurations to discard in-flight work items that relate to old configuration.

This change means that protocol no longer defaults to 'http' - it must be explicity set.