### PR TITLE
QuickCheck model for snkworker changes

### DIFF
--- a/eqc/replrtq_snk_eqc.erl
+++ b/eqc/replrtq_snk_eqc.erl
@@ -130,9 +130,6 @@ start_next(#{config  := Sinks} = S, Pid, _Args) ->
 start_post(_S, _Args, Res) ->
     is_pid(Res) andalso is_process_alive(Res).
 
-start_process(_S, []) ->
-    worker.
-
 
 %% --- Operation: sleep ---
 
@@ -148,7 +145,7 @@ sleep_pre(#{time := Time}, [N]) -> Time + N =< ?TEST_DURATION.
 
 sleep(N) -> timer:sleep(N).
 
-sleep_next(S = #{time := T}, _, [N]) -> S#{time := T + N}.
+sleep_next(S = #{time := T}, _, [N]) -> S#{time => T + N}.
 
 %% --- Operation: suspend ---
 
@@ -197,7 +194,7 @@ add(#{queue := Q, peers := Peers, workers := N}) ->
 add_callouts(_S, [Sink]) -> ?APPLY(setup_sink, [Sink]).
 
 add_next(#{sinks := Sinks} = S, _V, [#{queue := Q} = Sink]) ->
-  S#{ sinks := Sinks#{ Q => Sink } }.
+  S#{ sinks => Sinks#{ Q => Sink } }.
 
 %% --- remove ---
 
@@ -212,7 +209,7 @@ remove(Q) ->
 
 remove_next(#{sinks := Sinks} = S, _, [Q]) ->
     Removed = maps:get(removed, S, []),
-    S#{sinks := maps:remove(Q, Sinks), removed => [Q | Removed]}.
+    S#{sinks => maps:remove(Q, Sinks), removed => [Q | Removed]}.
 
 %% -- Generators -------------------------------------------------------------
 
@@ -242,7 +239,7 @@ sink_gen(WorkersGen) ->
        workers => WorkersGen }.
 
 workers_gen() ->
-    frequency([{1, 0}, {10, choose(1, 5)}, {1, 24}]).
+    frequency([{1, 0}, {10, choose(1, 5)}]).
 
 peers_gen() ->
     ?LET(N, choose(1, 8), peers_gen(N)).

--- a/eqc/replrtq_snk_monitor.erl
+++ b/eqc/replrtq_snk_monitor.erl
@@ -53,7 +53,7 @@ init([]) ->
 
 handle_call({add_queue, Queue, Peers, Workers}, _From, State) ->
     Ref = make_ref(),
-    PeerMap = maps:from_list([{{Peer, Queue}, {Ref, Cfg}} || {Peer, Cfg} <- Peers]),
+    PeerMap = maps:from_list([{{{Host, Port}, Queue}, {Ref, Cfg}} || {{Host, Port, http}, Cfg} <- Peers]),
     Q = #queue{ref = Ref, name = Queue, peers = Peers, workers = Workers},
     {reply, ok, State#state{ queues = [Q | State#state.queues],
                              peers  = maps:merge(State#state.peers, PeerMap) }};

--- a/eqc/replrtq_snk_monitor.erl
+++ b/eqc/replrtq_snk_monitor.erl
@@ -9,7 +9,8 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/0, stop/0, fetch/2, push/4, suspend/1, resume/1, add_queue/3, remove_queue/1]).
+-export([start_link/0, stop/0, fetch/2, push/4, suspend/1, resume/1,
+         add_queue/3, remove_queue/1, update_workers/2]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -46,6 +47,10 @@ suspend(Queue) ->
 resume(Queue) ->
     gen_server:call(?SERVER, {resume, Queue}).
 
+update_workers(Queue, Workers) ->
+    gen_server:call(?SERVER, {update_workers, Queue, Workers}).
+
+
 %% -- Callbacks --------------------------------------------------------------
 
 init([]) ->
@@ -80,6 +85,10 @@ handle_call({suspend, Queue}, _From, State) ->
     {reply, ok, add_trace(State, Queue, suspend)};
 handle_call({resume, Queue}, _From, State) ->
     {reply, ok, add_trace(State, Queue, resume)};
+handle_call({update_workers, Q, Workers}, _From, State) ->
+    Queue = lists:keyfind(Q, #queue.name, State#state.queues),
+    NewQueue = Queue#queue{workers = Workers},
+    {reply, ok, State#state{ queues = [NewQueue | State#state.queues -- [Queue]]}};
 handle_call(_Request, _From, State) ->
     Reply = ok,
     {reply, Reply, State}.
@@ -123,4 +132,3 @@ final_trace(#state{ queues = Queues, traces = Traces }, Ref) ->
     Trace = maps:get(Ref, Traces),
     #queue{name = Name, peers = Peers, workers = Workers} = lists:keyfind(Ref, #queue.ref, Queues),
     {Name, Peers, Workers, lists:reverse(Trace)}.
-


### PR DESCRIPTION
The QuickCheck model has been adapted to use the protocol (http) 
and different configuration of arbitrary queues for sinks

I experimented with adding the API function `riak_kv_replrtq_snk:set_workercount(Q, Workers).`
but this screws up the trace analysis for max_workers and avgs_workers. Only way around would be to add these events to the trace and use them in the calculations. Therefore, left the comment out of the model for now. Works fine, but tests fail for obvious reason.