### PR TITLE
Mas i1691 pushobject

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1012,8 +1012,8 @@
 %% @doc Enable this node to act as a real-time replication source
 {mapping, "replrtq_enablesrc", "riak_kv.replrtq_enablesrc", [
     {datatype, {flag, enabled, disabled}},
-    {default, enabled},
-    {commented, disabled}
+    {default, disabled},
+    {commented, enabled}
 ]}.
 
 %% @doc Limit the size of replication queues (for a queue and priority, i.e.

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1031,6 +1031,15 @@
   {default, 1000}
 ]}.
 
+%% @doc Limit the size of an object which may be pushed to the replication
+%% queue.  Objects larger than this will still be replicated, but by being
+%% re-fetched.  The product of replrtq_objectsize and replrtq_srcobjectlimit
+%% gives a theoretical maximum for the total memory consumed by the
+%% riak_kv_rpelrtq (in terms of objects).  Default of this product is 200MB.
+{mapping, "replrtq_srcobjectsize", "riak_kv.replrtq_srcobjectsize", [
+  {datatype, bytesize},
+  {default, "200KB"}
+]}.
 
 %% @doc Queue definitions
 %% Queues should be defined using a pipe '|' delimited string, of two

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1009,12 +1009,28 @@
     {commented, enabled}
 ]}.
 
+%% @doc Enable this node to act as a real-time replication source
+{mapping, "replrtq_enablesrc", "riak_kv.replrtq_enablesrc", [
+    {datatype, {flag, enabled, disabled}},
+    {default, enabled},
+    {commented, disabled}
+]}.
+
 %% @doc Limit the size of replication queues (for a queue and priority, i.e.
 %% each priority on each queue will have this as the limit)
 {mapping, "replrtq_srcqueuelimit", "riak_kv.replrtq_srcqueuelimit", [
   {datatype, integer},
   {default, 100000}
 ]}.
+
+%% @doc Limit the number of objects to be cached on the replication queue,
+%% with objects queued when the priority queue is beyond this limit stored as
+%% clocks only to be fetched on replication
+{mapping, "replrtq_srcobjectlimit", "riak_kv.replrtq_srcobjectlimit", [
+  {datatype, integer},
+  {default, 1000}
+]}.
+
 
 %% @doc Queue definitions
 %% Queues should be defined using a pipe '|' delimited string, of two
@@ -1042,7 +1058,8 @@
 %% @doc Enable this node to act as a sink and consume from a src cluster
 {mapping, "replrtq_enablesink", "riak_kv.replrtq_enablesink", [
     {datatype, {flag, enabled, disabled}},
-    {default, enabled}
+    {default, enabled},
+    {commented, disabled}
 ]}.
 
 

--- a/src/riak_kv_replrtq_src.erl
+++ b/src/riak_kv_replrtq_src.erl
@@ -251,7 +251,14 @@ waitforpop_rtq(QueueName, N) ->
     case popfrom_rtq(QueueName) of
         queue_empty ->
             timer:sleep(?CONSUME_DELAY),
-            waitforpop_rtq(QueueName, N - 1);
+            % Maybe a shutdown during sleep - so check process is alive when
+            % emerging from sleep to avoid noisy shutdown
+            case whereis(?MODULE) of
+                undefined ->
+                    queue_empty;
+                _ ->
+                    waitforpop_rtq(QueueName, N - 1)
+            end;
         R ->
             R
     end.

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -266,6 +266,18 @@ do_update({put_fsm_time, Bucket,  Microsecs, Stages, PerBucket, CRDTMod}) ->
 do_update({read_repairs, Indices, Preflist}) ->
     ok = exometer:update([?PFX, ?APP, node, gets, read_repairs], 1),
     do_repairs(Indices, Preflist);
+do_update(ngrfetch_nofetch) ->
+    ok = exometer:update([?PFX, ?APP, node, gets, ngrfetch_nofetch], 1);
+do_update(ngrfetch_prefetch) ->
+    ok = exometer:update([?PFX, ?APP, node, gets, ngrfetch_prefetch], 1);
+do_update(ngrfetch_tofetch) ->
+    ok = exometer:update([?PFX, ?APP, node, gets, ngrfetch_tofetch], 1);
+do_update(ngrrepl_empty) ->
+    ok = exometer:update([?PFX, ?APP, node, puts, ngrrepl_empty], 1);
+do_update(ngrrepl_object) ->
+    ok = exometer:update([?PFX, ?APP, node, puts, ngrrepl_object], 1);
+do_update(ngrrepl_error) ->
+    ok = exometer:update([?PFX, ?APP, node, puts, ngrrepl_error], 1);
 do_update(skipped_read_repairs) ->
     ok = exometer:update([?PFX, ?APP, node, gets, skipped_read_repairs], 1);
 do_update(coord_redir) ->
@@ -563,6 +575,12 @@ stats() ->
                                                {count, read_repairs_total}]},
      {[node, gets, skipped_read_repairs], spiral, [], [{one, skipped_read_repairs},
                                                        {count, skipped_read_repairs_total}]},
+     {[node, gets, ngrfetch_nofetch], spiral, [], [{one, ngrfetch_nofetch},
+                                                    {count, ngrfetch_nofetch_total}]},
+     {[node, gets, ngrfetch_prefetch], spiral, [], [{one, ngrfetch_prefetch},
+                                                    {count, ngrfetch_prefetch_total}]},
+     {[node, gets, ngrfetch_tofetch], spiral, [], [{one, ngrfetch_tofetch},
+                                                    {count, ngrfetch_tofetch_total}]},
      {[node, gets, siblings], histogram, [], [{mean  , node_get_fsm_siblings_mean},
                                               {median, node_get_fsm_siblings_median},
                                               {95    , node_get_fsm_siblings_95},
@@ -698,6 +716,12 @@ stats() ->
                                                {95    , node_put_fsm_map_time_95},
                                                {99    , node_put_fsm_map_time_99},
                                                {max   , node_put_fsm_map_time_100}]},
+     {[node, puts, ngrrepl_empty], spiral, [], [{one, ngrrepl_empty},
+                                                    {count, ngrrepl_empty_total}]},
+     {[node, puts, ngrrepl_object], spiral, [], [{one, ngrrepl_object},
+                                                    {count, ngrrepl_object_total}]},
+     {[node, puts, ngrrepl_error], spiral, [], [{one, ngrrepl_error},
+                                                    {count, ngrrepl_error_total}]},
 
      %% index & list{keys,buckets} & clusteraae stats
      {[index, fsm, create], spiral, [], [{one, index_fsm_create}]},

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -154,7 +154,8 @@
                 worker_pool_strategy = single :: none|single|dscp,
                 vnode_pool_pid :: undefined|pid(),
                 update_hook :: update_hook(),
-                enable_nextgenreplsrc = false :: boolean()
+                enable_nextgenreplsrc = false :: boolean(),
+                sizelimit_nextgenreplsrc = 0 :: non_neg_integer()
                }).
 
 -type index_op() :: add | remove.
@@ -736,6 +737,8 @@ init([Index]) ->
         app_helper:get_env(riak_kv, worker_pool_strategy),
     EnableNextGenReplSrc = 
         app_helper:get_env(riak_kv, replrtq_enablesrc, false),
+    SizeLimitNextGenReplSrc = 
+        app_helper:get_env(riak_kv, replrtq_srcobjectsize, 0),
 
     case catch Mod:start(Index, Configuration) of
         {ok, ModState} ->
@@ -763,7 +766,8 @@ init([Index]) ->
                            md_cache_size=MDCacheSize,
                            worker_pool_strategy=WorkerPoolStrategy,
                            update_hook=update_hook(),
-                           enable_nextgenreplsrc = EnableNextGenReplSrc},
+                           enable_nextgenreplsrc = EnableNextGenReplSrc,
+                           sizelimit_nextgenreplsrc = SizeLimitNextGenReplSrc},
             try_set_vnode_lock_limit(Index),
             case AsyncFolding of
                 true ->
@@ -2417,7 +2421,7 @@ do_put(Sender, Request, State) ->
 
 %% @private
 %% upon receipt of a client-initiated put
-do_put(Sender, {Bucket, Key}=BKey, RObj, ReqID, StartTime, Options, State) ->
+do_put(Sender, {Bucket, _Key}=BKey, RObj, ReqID, StartTime, Options, State) ->
     BProps =  case proplists:get_value(bucket_props, Options) of
                   undefined ->
                       riak_core_bucket:get_bucket(Bucket);
@@ -2447,38 +2451,6 @@ do_put(Sender, {Bucket, Key}=BKey, RObj, ReqID, StartTime, Options, State) ->
     {PrepPutRes, UpdPutArgs, State2} = prepare_put(State, PutArgs),
     {Reply, UpdState} = perform_put(PrepPutRes, State2, UpdPutArgs),
     riak_core_vnode:reply(Sender, Reply),
-
-    % Now the reply has been sent, check for replication requirements.  If no
-    % replication is enabled, then the replrtq_coordput/4 request will be
-    % discarded by the riak_kv_replrtq_src
-    case {Coord, Reply, State#state.enable_nextgenreplsrc} of
-        {_, _, false} ->
-            ok;
-        {true, {dw, _Idx, Obj, _ReqID}, _} ->
-            % This is the co-ordinator of the PUT - so cast this to the repl
-            % sink to check for replication need.
-            % If the replication cache is enabled, then add it to the cache.
-            % Note the Obj should always be present when the PUT is being
-            % coordinated as coordination will prompt the return_body to be
-            % set to true.
-            ObjectFormat =
-                case riak_kv_util:is_x_deleted(Obj) of
-                    true ->
-                        % This object may be reaped by the vnode before the 
-                        % sink attempts to fetch the tombstone from the vnode.
-                        % So the tombstone should but placed on the queue
-                        {tomb, Obj};
-                    false ->
-                        {object, Obj}
-                end,
-            riak_kv_replrtq_src:replrtq_coordput({Bucket,
-                                                    Key,
-                                                    riak_object:vclock(Obj),
-                                                    ObjectFormat});
-        _ ->
-            % Only cache co-ordinated PUTs
-            ok
-    end,
 
     update_index_write_stats(UpdPutArgs#putargs.is_index, UpdPutArgs#putargs.index_specs),
     {Reply, UpdState}.
@@ -2777,27 +2749,35 @@ perform_put({true, {_Obj, _OldObj}=Objects},
                      bkey=BKey,
                      reqid=ReqID,
                      index_specs=IndexSpecs,
-                     readrepair=ReadRepair}) ->
+                     readrepair=ReadRepair,
+                     coord=Coord}) ->
     case ReadRepair of
       true ->
         MaxCheckFlag = no_max_check;
       false ->
         MaxCheckFlag = do_max_check
     end,
-    actual_put(BKey, Objects, IndexSpecs, RB, ReqID, MaxCheckFlag, State).
+    actual_put(BKey, Objects, IndexSpecs,
+                RB, ReqID, MaxCheckFlag, Coord, State).
 
 actual_put(BKey, {Obj, OldObj}, IndexSpecs, RB, ReqID, State) ->
-    actual_put(BKey, {Obj, OldObj}, IndexSpecs, RB, ReqID, do_max_check, State).
+    actual_put(BKey, {Obj, OldObj}, IndexSpecs,
+                RB, ReqID, do_max_check, false, State).
 
-actual_put(BKey={Bucket, Key}, {Obj, OldObj}, IndexSpecs, RB, ReqID, MaxCheckFlag,
-           State=#state{idx=Idx,
-                        mod=Mod,
-                        modstate=ModState,
-                        update_hook=UpdateHook}) ->
+actual_put(BKey={Bucket, Key}, {Obj, OldObj}, IndexSpecs,
+            RB, ReqID, MaxCheckFlag, Coord,
+            State=#state{idx=Idx,
+                            mod=Mod,
+                            modstate=ModState,
+                            update_hook=UpdateHook}) ->
     case encode_and_put(Obj, Mod, Bucket, Key, IndexSpecs, ModState,
                        MaxCheckFlag) of
         {{ok, UpdModState}, EncodedVal} ->
             aae_update(Bucket, Key, Obj, OldObj, EncodedVal, State),
+            nextgenrepl(Bucket, Key, Obj, size(EncodedVal),
+                        Coord,
+                        State#state.enable_nextgenreplsrc,
+                        State#state.sizelimit_nextgenreplsrc),
             maybe_cache_object(BKey, Obj, State),
             maybe_update(UpdateHook, {Obj, maybe_old_object(OldObj)}, put, Idx),
             Reply = case RB of
@@ -3403,6 +3383,41 @@ do_diffobj_put({Bucket, Key}=BKey, DiffObj,
             end
     end.
 
+
+-spec nextgenrepl(riak_object:bucket(), riak_object:key(),
+                    riak_object:riak_object(),
+                    pos_integer(), boolean(), boolean(), non_neg_integer()) ->
+                        ok.
+nextgenrepl(_B, _K, _Obj, _Size, false, _Enabled, _Limit) ->
+    ok;
+nextgenrepl(_B, _K, _Obj, _Size, _, false, _Limit) ->
+    ok;
+nextgenrepl(Bucket, Key, Obj, Size, true, true, Limit) ->
+    % This is the co-ordinator of the PUT, and nextgenrepl is enabled - so
+    % cast this to the repl src.
+    ObjectFormat =
+        case riak_kv_util:is_x_deleted(Obj) of
+            true ->
+                % This object may be reaped by the vnode before the 
+                % sink attempts to fetch the tombstone from the vnode.
+                % So the tombstone should be placed on the queue
+                {tomb, Obj};
+            false ->
+                % Check the size of the object before pushing the
+                % object to the replication queue.  Larger objects
+                % will have only a reference pushed, and will need
+                % to be fetched.
+                case Size > Limit of
+                    true ->
+                        to_fetch;
+                    _ ->
+                        {object, Obj}
+                end
+        end,
+    riak_kv_replrtq_src:replrtq_coordput({Bucket,
+                                            Key,
+                                            riak_object:vclock(Obj),
+                                            ObjectFormat}).
 
 -spec aae_update(binary(), binary(),
                     riak_object:riak_object()|none|undefined|use_binary,

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -3388,10 +3388,6 @@ do_diffobj_put({Bucket, Key}=BKey, DiffObj,
                     riak_object:riak_object(),
                     pos_integer(), boolean(), boolean(), non_neg_integer()) ->
                         ok.
-nextgenrepl(_B, _K, _Obj, _Size, false, _Enabled, _Limit) ->
-    ok;
-nextgenrepl(_B, _K, _Obj, _Size, _, false, _Limit) ->
-    ok;
 nextgenrepl(Bucket, Key, Obj, Size, true, true, Limit) ->
     % This is the co-ordinator of the PUT, and nextgenrepl is enabled - so
     % cast this to the repl src.
@@ -3417,7 +3413,10 @@ nextgenrepl(Bucket, Key, Obj, Size, true, true, Limit) ->
     riak_kv_replrtq_src:replrtq_coordput({Bucket,
                                             Key,
                                             riak_object:vclock(Obj),
-                                            ObjectFormat}).
+                                            ObjectFormat});
+nextgenrepl(_B, _K, _Obj, _Size, _Coord, _Enabled, _Limit) ->
+    ok.
+
 
 -spec aae_update(binary(), binary(),
                     riak_object:riak_object()|none|undefined|use_binary,


### PR DESCRIPTION
When load testing mas-i1691-ttaaefullsync, two problems were discovered:

- The time taken for an object to real-time replicate from one cluster to another was higher than expected (and higher than when testing with `riak_repl`).
- The logging and stats produced were insufficient to quickly determine why this is.

This PR contains two changes to address this:

- A capability to push the whole object to the queue.  This has two sub-features, firstly a configurable limit on the number of objects that can be queued (before they are stripped back to be references only), and a maximum size an object can be before it is queued this way.  The second sub-feature is a change to config to enforce the sending of real-time references to the nextgenrepl queue to be explicitly turned on - meaning that non nextgenrepl users won't see any performance hit.
- some improvements to the detail of the logging, and some counters added to riak_kv_stat.

There are a bunch of riak_test changes in a `mas-i1691-pushobject` riak_test branch.

Volume testing these changes has shown an improvement in median, mean and high percentile latency (when compared to riak_repl).