### PR TITLE
Mas i1691 pauseonbacklog

### DIFF
--- a/docs/NextGenREPL.md
+++ b/docs/NextGenREPL.md
@@ -98,7 +98,12 @@ Each node in `riak_kv` starts three processes that manage the inter-cluster repl
 
   * Queues may have data filtering rules to restrict what changes are distributed via that queue.  The filters can restrict replication to a specific bucket, or bucket type, a bucket name prefix or allow for any change to be published to that queue.
 
-  * __Real-time replication__ changes (i.e. PUTs that have just been co-ordinated on this node within the cluster), are sent to the `riak_kv_replrtq_src` as either references (e.g. Bucket, Key, Clock and co-ordinating vnode) or whole objects in the case of tombstones.  These are the highest priority items to be queued, and are placed on __every queue whose data filtering rules are matched__ by the object.
+  * __Real-time replication__ changes (i.e. PUTs that have just been co-ordinated on this node within the cluster), are sent to the `riak_kv_replrtq_src` in one of the following formats:
+    * {Bucket, Key, Clock, {tombstone, Object}};
+    * {Bucket, Key, Clock, {object, Object}};
+    * {Bucket, Key, Clock, to_fetch}.
+
+  * Real-time replicated objects are the highest priority items to be queued, and are placed on __every queue whose data filtering rules are matched__ by the object.  If the priority queue has grown beyond a limited number of items (the number being defined in `riak_kv.replrtq_srcobjectlimt`), then any {object, Object} references is stripped and replaced with `to_fetch`.  This is to help limit the memory consumed by the queue during failure conditions i.e. when a sink has stopped consuming from the source queue.
 
   * Changes identified by __AAE full-sync replication__ processes run by the `riak_kv_ttaaefs` manager on the local node are sent to the `riak_kv_replrtq_src` as references, and queued as the second highest priority.  These changes are queued only on __a single queue defined within the configuration__ of `riak_kv_ttaaefs_manager`.  The changes queued are only references to the object (Bucket, Key and Clock) not the actual object.
 
@@ -116,7 +121,7 @@ Each node in `riak_kv` starts three processes that manage the inter-cluster repl
 
   * There is a single actor on each node that manages the process of consuming from queues on the `riak_kv_replrtq_src` on remote clusters.
 
-  * The `riak_kv_replrtq_snk` can be configured to consume from up to two queues, across an open-ended number of peers.  For instance if each node on Cluster A maintains a queue named `cluster_c_full`, and each node on Cluster B maintains a queue named `cluster_c_partial` - then `riak_kv_replrtq_snk` can be configured to consume from the `cluster_c_full` from every node in Cluster A and from `cluster_c_partial` from every node in Cluster B.
+  * The `riak_kv_replrtq_snk` can be configured to consume from multiple queues, across an open-ended number of peers.  For instance if each node on Cluster A maintains a queue named `cluster_c_full`, and each node on Cluster B maintains a queue named `cluster_c_partial` - then `riak_kv_replrtq_snk` can be configured to consume from the `cluster_c_full` from every node in Cluster A and from `cluster_c_partial` from every node in Cluster B.
 
   * The `riak_kv_replrtq_snk` manages a finite number of workers for consuming from remote peers.  The `riak_kv_replrtq_snk` tracks the results of work in order to back-off slightly from peers regularly not returning results to consume requests (in favour of those peers indicating a backlog by regularly returning results).  The `riak_kv_replrtq_snk` also tracks the results of work in order to back-off severely from those peers returning errors (so as not to lock too many workers consuming from unreachable nodes).
 
@@ -129,17 +134,15 @@ Previous replication implementations initiate replication through a post-commit 
 
 In implementing the new replication solution, the point of firing off replication has been changed to the point that the co-ordinated PUT is completed.  So the replication of the PUT to the clusters may occur in parallel to the replication of the PUT to other nodes in the source cluster.  This is the first opportunity where sufficient information is known (e.g. the updated vector clock), and should help control the size of the time-window of inconsistency between the clusters.
 
-Replication is fired within the `riak_kv_vnode` `do_put/7`.  Once the put to the backend has been completed, and the reply sent back to the `riak_kv_put_fsm`, on condition of the vnode being a co-ordinator of the put, the following work is done:
+Replication is fired within the `riak_kv_vnode` `actual_put/8`.  Once the put to the backend has been completed, and the reply sent back to the `riak_kv_put_fsm`, on condition of the vnode being a co-ordinator of the put, and of `riak_kv.replrtq_enablesrc` being set to enabled (true), the following work is done:
 
 - The object reference to be replicated is determined, this is the type of reference to be placed on the replication queue.  
 
-  - If the object is now a tombstone, the whole object is used as the replication reference (due to the small size of the object, and the need to avoid race conditions with reaping activity if `delete_mode` is not `keep` - the cluster may not be able to fetch the tombstone to replicate in the future).
+  - If the object is now a tombstone, the whole object is used as the replication reference (due to the small size of the object, and the need to avoid race conditions with reaping activity if `delete_mode` is not `keep` - the cluster may not be able to fetch the tombstone to replicate in the future).  The whole object must be kept on the queue (i.e. the `riak_kv_replrtq_src` may not filter the object and replace with a `to_fetch` reference).
 
-  - If no `repl_cache` has been configured, the flag `to_fetch` replaces the object - to indicate that the object must be fetched via a standard `riak_kv_get_fsm` process. Configuration of the `repl_cache` is set using `riak_kv.enable_repl_cache`.
+  - If the object is below the `riak_kv.replrtq_srcobjectsize` (default 200KB) then whole object will be sent to the `riak_kv_replrtq_src`, and it will be queued as a whole object as long as the current size of the priority real-time queue does not exceed the `riak_kv.replrtq_srcobjectlimit` (default 1000).  If an object is over-size a `to_fetch` references will be sent instead of the object, and if the queue is too large the `riak_kv_replrtq_src` will substitute a `to_fetch` reference before queueing.
 
-  - If the `repl_cache` is enabled (through configuration), the object is placed in an ets table local to the vnode that acts as a cache of recently coordinated PUTs, and a reference to the vnode ID is used as a replication reference.  The ets table is fixed in size by the configuration item `riak_kv.repl_cache_size`.
-
-- The `{Bucket, Key, Clock, ObjectReference}` is then cast to the `riak_kv_replrtq_src`.  This cast will occur for all coordinated PUTs even if no replication is enabled - if replication is not enabled, then the `riak_kv_replrtq_src` will discard the event.
+- The `{Bucket, Key, Clock, ObjectReference}` is then cast to the `riak_kv_replrtq_src`.
 
 The reference now needs to be handled by the `riak_kv_replrtq_src`.  It has a simple task list:
 
@@ -157,11 +160,9 @@ On receipt of the `fetch` request the source node should:
 
   - If the fetch from the queue returns `queue_empty` this is relayed back to the sink-side worker, and ultimately the `riak_kv_replrtq_snk` which may then slow down the pace at which fetch requests are sent to this node/queue combination.
 
-  - If the fetch returns an actual tombstone object, this is relayed back to the sink worker.
+  - If the fetch returns an actual object, this is relayed back to the sink worker.
 
   - If the fetch returns a replication reference with the flag `to_fetch`, the `riak_kv_get_fsm` will continue down the standard path os states starting with `prepare`, and fetch the object which the will be returned to the sink worker.
-
-  - If the fetch returns a replication reference with a vnode reference (to indicate a potentially cached object), a `fetch_repl` request will be cast to the specific vnode (the original co-ordinator), and the `riak_kv_get_fsm` should transition to the `waiting_vnode_fetch`.  The vnode on receipt of a `fetch_repl` request should try and retrieve the object from the cache, and otherwise return the object from a backend GET.  The response will then be sent back to the `riak_kv_get_fsm` and relayed back to the sink worker.
 
 - If a successful fetch is relayed back to the sink worker it will replicate the PUT using a local `riak_client:push/4`.  The push will complete a PUT of the object on the sink cluster - using a `riak_kv_put_fsm` with appropriate options (e.g. `asis`, `disable-hooks`).
 
@@ -210,58 +211,58 @@ TODO
 
 ### Frequently Asked Questions
 
-TODO - potential questions below
-
 *Previously there were moves to run real-time replication via RabbitMQ, is this still the intention?*
 
-...
+Not presently, although it would not be a significant code change to modify the `riak_kc_replrtq_src` so that it would point to an external queue not an internal riak_core_priority_queue.
 
 
 *Can this be used to synchronise data between Riak and another data store (e.g. Elastic Search, Hadoop etc)?*
 
-...
+The intention is to open up this possibility by removing the need to understand the internal riak infrastructure to interface for replication.  The API calls used by replications (fetch, aae_fold) are now exposed and documented.  However, it will still require some implementation work in the destination database to replicate sink-side functionality - in particular the storing of keys and clocks so that they can be converted into a cluster-wide Merkle tree.
+
 
 *In this future will this mean there is 1 way of doing replication in Riak, or n + 1 ways?*
 
-...
+In the medium term it will certainly be an additional replication feature and not a replacement.  The `riak_repl` remains to assist in transition, but also Riak customers are committed to continued investment in improving `riak_repl`, and adding features such as improved replication filtering logic.
 
 
 *What is left to do to make this production ready?  When might it be production ready?*
 
-...
+Original release target was Autumn 2019, and the current target for release is e/o January 2020.  The release schedule has been extended as:
+
+- There was an increase in scope for the release to add in `riak_kv_reaper` and `riak_kv_eraser` functionality to improve support for mass deletion and tombstone management.
+
+- Initial volume tests indicated a need for improvements in observability and median replication latency.
 
 
 *Does this work with all Riak backends?  Does the efficiency of the solution change depending on backend choice?*
 
-...
+The full-scope of the solution is intended to work with all backends *if* Tictac AAE has been enabled as an anti-entropy mechanism.  For non-leveled backends there is a cost in enabling Tictac AAE (due to the need for the AAE keystore), and so the replication features have a higher cost in those backends.
+
+The replication sink workers, and the process of copying objects between processes can lead to increased CPU utilisation with nextgenrepl enabled.
 
 
 *How reliably does this mechanism handle deletions?  Might deleted data be resurrected?*
 
-...
+Whether or not deletions can be resurrected is a function of the delete_mode chosen, and the additional replication changes make no difference in this regard.  The release 2.9.1 does though enable the new `riak_kv_eraser` and `riak_kv_reaper` features, which allow for more efficient use of the delete_mode of keep.
 
 
 *Is this replication approach compatible with fixing a Time to Live for objects?*
 
-...
+If a backend TTL is used in Riak, objects will be removed from the backend without being erased from the AAE stores.  This will lead to a build-up of data in the AAE store, and when AAE store rebuilds occur large (and false) deltas being reported during intra-cluster and inter-cluster AAE checks.  If the intention is to used object TTLs, it would be better to use the `riak_kv_eraser` feature via `aae_fold` to expire objects rather than a backend TTL.
+
 
 *Will this replication approach work with Riak's strong consistency module `riak_ensemble`?*
 
-...
+No, and there are no plans to extend the solution to support strongly consistent PUTs.  It should be noted that the `riak_ensemble` feature remains an experimental solution not assured for production use (although customers have been known to sue it successfully in production).
+
+
+*What about hash collisions in the merkle tree - as only 4 byte hashes are used rather than full cryptographic hashes*
+
+The aae_fold feature allows for a modification in the hash_method so that instead of the pre-calculated hash, each hash will be recalculated using a combination of the vector clock (the current hash input) and an initialisation vector (passed in through the hash_method).  So it is possible to validate synchronisation against hash collisions, although the `riak_kv_ttaaefs_manager` doe snot support the orchestartion of such validation.
 
 
 ### Outstanding TODO
-
-*Can we prove that crashing the riak_kv_replrtq_src will not crash all the riak_kv_vnode processes on the node.  If so, should the repl work be moved back to the riak_kv_put_fsm?*
-
-Some advantages of using a vnode - src cannot be overloaded by unbalanced sending of load into the cluster, load between src will be distributed in line with hash/ring.
-
-Small distributed caches seems intuitively to be efficient, a good use of riak capability, and avoids the cache becoming a bottleneck.
-
-*riak_kv_replrtq_src needs to pick-up config at startup*
-
-Add with new test - https://github.com/nhs-riak/riak_test/blob/mas-i1691-ttaaefullsync/tests/nextgenrepl_ttaaefs_autoall.erl
-
 
 *Extend the replication support to the write once path by implementing it within the riak_kv_w1c_worker.  Initial thoughts are that the push on the repl side should not use the write once path*
 
@@ -271,61 +272,6 @@ Add with new test - https://github.com/nhs-riak/riak_test/blob/mas-i1691-ttaaefu
 
 ...
 
-*Volume and performance tests*
-
-...
-
-*Further riak_test tests*
-
-typed buckets, replication filters, replicating CRDTs
-
-https://github.com/nhs-riak/riak_test/blob/mas-i1691-ttaaefullsync/tests/nextgenrepl_rtq_autotypes.erl
-https://github.com/nhs-riak/riak_test/blob/mas-i1691-ttaaefullsync/tests/nextgenrepl_rtq_autocrdt.erl
-
-*Location of the cache - is having a cache at each vnode the right thing*
-
-The location of the cache for fetching could be:
-
-- The vnode (as currently implemented);
-
-- The `riak_kv_replrtq_src`;
-
-- Another named process on the node (e.g. a `riak_kv_replrtq_cache`);
-
-- A public ets table.
-
-The reasons for choosing the vnode:
-
-- Less worry about contention over access to the cache being a bottleneck;
-
-- No overhead in serializing the object to cast it to the cache at PUT time - minimise extension of vnode delay for PUT.
-
-*Add stats gathered at src/snk into riak stats*
-
-...
-
-*AAE Fold implementation*
-
-Added on 30/4.  New test https://github.com/nhs-riak/riak_test/blob/mas-i1691-ttaaefullsync/tests/nextgenrepl_aaefold.erl
-
-*Provide support for non-utf8 keys*
-
-Need to write pb api for services.  HTTP API will blow up on a non-utf8 bucket or key (true for all services, not just repl)
-
-*Upgrade ibrowse to handle connection pooling*
-
-...
-
-*Allow for ssl support in replication*
-
-...
-
-*External data format to be supported in fetch i.e. a fetch that would return a GET response, not a specific internal riak repl format*
-
-...
-
-*Add prefix support for filters on source queue.  Maybe add bucketname_exc and bucketname_inc to allow "all but bucket name" as well as "none but bucket name"*
-
-Added.  New test https://github.com/nhs-riak/riak_test/blob/mas-i1691-ttaaefullsync/tests/nextgenrepl_rtq_autotypes.erl
-
 *Add validation functions for tokenised inputs (peer list on rpel sink, queue definitions on repl source). Startup should fail due to invalid config*
+
+...

--- a/docs/NextGenREPL.md
+++ b/docs/NextGenREPL.md
@@ -220,7 +220,7 @@ Not presently, although it would not be a significant code change to modify the 
 
 *Can this be used to synchronise data between Riak and another data store (e.g. Elastic Search, Hadoop etc)?*
 
-The intention is to open up this possibility by removing the need to understand the internal riak infrastructure to interface for replication.  The API calls used by replications (fetch, aae_fold) are now exposed and documented.  However, it will still require some implementation work in the destination database to replicate sink-side functionality - in particular the storing of keys and clocks so that they can be converted into a cluster-wide Merkle tree.
+The intention is to open up this possibility by removing the need to understand the internal riak infrastructure, when trying to interface to Riak for replication.  The API calls used by replications (fetch, aae_fold) are now exposed and documented.  However, it will still require some implementation work in the destination database to replicate sink-side functionality - in particular the storing of keys and clocks so that they can be converted into a cluster-wide Merkle tree for comparison.
 
 
 *In this future will this mean there is 1 way of doing replication in Riak, or n + 1 ways?*

--- a/eqc/eraser_eqc.erl
+++ b/eqc/eraser_eqc.erl
@@ -1,0 +1,90 @@
+-module(eraser_eqc).
+
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eqc/include/eqc_component.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+%% -- State ------------------------------------------------------------------
+initial_state() ->
+  #{ deletes => [] }.
+
+%% -- Operations -------------------------------------------------------------
+
+%% --- Operation: start ---
+start_pre(S) -> not maps:is_key(pid, S).
+
+start_args(_S) ->
+  [gen_delete_mode()].
+
+start(DelMode) ->
+  {ok, Pid} = gen_server:start_link(riak_kv_eraser, [eqc_job, fun erase/2, DelMode], []),
+  Pid.
+
+start_next(S, Pid, [DelMode]) ->
+  S#{ delete_mode => DelMode, pid => Pid }.
+
+%% --- Operation: delete ---
+delete_pre(S) -> maps:is_key(pid, S).
+
+delete_args(#{ pid := Pid }) ->
+  [Pid, gen_delete_ref()].
+
+delete(Pid, {Ref, Retries}) ->
+  ets:insert(?MODULE, {Ref, Retries}),
+  riak_kv_eraser:request_delete(Pid, Ref).
+
+delete_next(S = #{ deletes := Ds }, _Value, [_Pid, {Ref, Retries}]) ->
+  S#{ deletes := [{Ref, Retries} | Ds] }.
+
+delete_features(_, [_, {_, N}], _) ->
+  [{retries, N}].
+
+%% -- Generators -------------------------------------------------------------
+gen_delete_mode() ->
+  elements([keep, immediate]).
+
+gen_delete_ref() ->
+  ?LET(Ref, gen_reference(),
+    weighted_default({4, {Ref, 1}}, {1, {Ref, choose(2, 5)}})).
+
+gen_reference() ->
+  os:timestamp().
+
+%% -- Properties -------------------------------------------------------------
+
+prop_eraser() ->
+  application:set_env(riak_kv, eraser_redo_timeout, 20),
+  ?FORALL(Cmds, commands(?MODULE),
+  begin
+    ets:new(?MODULE, [named_table, public]),
+    {H, S, Res} = run_commands(Cmds),
+    StopRes = stop_job(maps:get(pid, S, undefined)),
+    ETSRes = ets:tab2list(?MODULE),
+    ets:delete(?MODULE),
+    aggregate(call_features(H),
+      pretty_commands(?MODULE, Cmds, {H, S, Res},
+        conjunction([
+          {result, equals(Res, ok)},
+          {stop,   equals(StopRes, ok)},
+          {ets,    equals(ETSRes, [])}])))
+  end).
+
+stop_job(undefined) -> ok;
+stop_job(Pid) ->
+  MonRef = monitor(process, Pid),
+  riak_kv_eraser:stop_job(Pid),
+  receive
+    {'DOWN', MonRef, _, _, _} -> ok
+  after 1000 ->
+    timeout_stop_job
+  end.
+
+
+erase(Ref, _) ->
+  case ets:lookup(?MODULE, Ref) of
+    [{_, 1}] ->
+      ets:delete(?MODULE, Ref), true;
+    [{_, N}] ->
+      ets:insert(?MODULE, {Ref, N - 1}), false
+  end.

--- a/eqc/reaper_eqc.erl
+++ b/eqc/reaper_eqc.erl
@@ -1,0 +1,87 @@
+-module(reaper_eqc).
+
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eqc/include/eqc_component.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+%% -- State ------------------------------------------------------------------
+initial_state() ->
+  #{ reaps => [] }.
+
+%% -- Operations -------------------------------------------------------------
+
+%% --- Operation: start ---
+start_pre(S) -> not maps:is_key(pid, S).
+
+start_args(_S) ->
+  [].
+
+start() ->
+  {ok, Pid} = gen_server:start_link(riak_kv_reaper, [eqc_job, fun reaper/1], []),
+  Pid.
+
+start_next(S, Pid, []) ->
+  S#{ pid => Pid }.
+
+%% --- Operation: reap ---
+reap_pre(S) -> maps:is_key(pid, S).
+
+reap_args(#{ pid := Pid }) ->
+  [Pid, gen_reap_ref()].
+
+reap(Pid, {Ref, Retries}) ->
+  ets:insert(?MODULE, {Ref, Retries}),
+  riak_kv_reaper:request_reap(Pid, Ref).
+
+reap_next(S = #{ reaps := Ds }, _Value, [_Pid, {Ref, Retries}]) ->
+  S#{ reaps := [{Ref, Retries} | Ds] }.
+
+reap_features(_, [_, {_, N}], _) ->
+  [{retries, N}].
+
+%% -- Generators -------------------------------------------------------------
+gen_reap_ref() ->
+  ?LET(Ref, gen_reference(),
+    weighted_default({4, {Ref, 1}}, {1, {Ref, choose(2, 5)}})).
+
+gen_reference() ->
+  os:timestamp().
+
+%% -- Properties -------------------------------------------------------------
+
+prop_reaper() ->
+  application:set_env(riak_kv, reaper_redo_timeout, 20),
+  ?FORALL(Cmds, commands(?MODULE),
+  begin
+    ets:new(?MODULE, [named_table, public]),
+    {H, S, Res} = run_commands(Cmds),
+    StopRes = stop_job(maps:get(pid, S, undefined)),
+    ETSRes = ets:tab2list(?MODULE),
+    ets:delete(?MODULE),
+    aggregate(call_features(H),
+      pretty_commands(?MODULE, Cmds, {H, S, Res},
+        conjunction([
+          {result, equals(Res, ok)},
+          {stop,   equals(StopRes, ok)},
+          {ets,    equals(ETSRes, [])}])))
+  end).
+
+stop_job(undefined) -> ok;
+stop_job(Pid) ->
+  MonRef = monitor(process, Pid),
+  riak_kv_reaper:stop_job(Pid),
+  receive
+    {'DOWN', MonRef, _, _, _} -> ok
+  after 1000 ->
+    timeout_stop_job
+  end.
+
+
+reaper(Ref) ->
+  case ets:lookup(?MODULE, Ref) of
+    [{_, 1}] ->
+      ets:delete(?MODULE, Ref), true;
+    [{_, N}] ->
+      ets:insert(?MODULE, {Ref, N - 1}), false
+  end.

--- a/eqc/replrtq_snk_eqc.erl
+++ b/eqc/replrtq_snk_eqc.erl
@@ -64,31 +64,30 @@ config_pre(S) ->
 
 %% We configure the same amount of workes for all sinks
 config_args(_S) ->
-    ?LET(N, workers_gen(),
-         [weighted_default({1, disabled}, {19, enabled}),
-          list(sink_gen(N)), N]).
+    [weighted_default({1, disabled}, {19, enabled}), sink_gen()].
 
-config_pre(_, [_Enabled, Sinks, _]) ->
-    Queues = [ Q || #{queue := Q} <- Sinks ],
-    lists:usort(Queues) == lists:sort(Queues).
+config_pre(_, [_Enabled, #{queue := _Q, peerlimit:= PL, workers := N}]) ->
+    PL =< N.
 
-config(Enabled, Sinks, Workers) ->
+config(Enabled, #{queue := Q, peers := Peers, peerlimit:= PL, workers := N} = Sink) ->
     application:set_env(riak_kv, replrtq_enablesink, Enabled == enabled),
     %% default Queue will be called "default" in tests
     application:set_env(riak_kv, replrtq_sinkqueue, default),
     %% We presupose that all queues have the same number of workers....
-    application:set_env(riak_kv, replrtq_sinkworkers, Workers),
-    PeerConfig = [ pp_peers(Q, Peers) || #{queue := Q, peers := Peers} <- Sinks ],
-    application:set_env(riak_kv, replrtq_sinkpeers, string:join(PeerConfig, "|")),
-    [ setup_sink(Sink) || Sink <- Sinks, Enabled == enabled ],
+    application:set_env(riak_kv, replrtq_sinkworkers, N),
+    application:set_env(riak_kv, replrtq_sinkpeerlimit, PL),
+    application:set_env(riak_kv, replrtq_sinkpeers, pp_peers(Q, Peers)),
+    [ setup_sink(Sink) || Enabled == enabled ],
     ok.
 
-setup_sink(#{queue := Q, peers := Peers, workers := N}) ->
-    replrtq_snk_monitor:add_queue(Q, Peers, N).
 
-config_next(S, _Value, [Enabled, Sinks, _]) ->
+setup_sink(#{queue := Q, peers := Peers, workers := N, peerlimit := PL}) ->
+    %% possibly take peerlimit into account here?
+    replrtq_snk_monitor:add_queue(Q, Peers, N, PL).
+
+config_next(S, _Value, [Enabled, Sink]) ->
     S#{ enabled => Enabled == enabled,
-        config  => Sinks }.
+        config  => [Sink]}.
 
 
 %% --- Operation: start ---
@@ -102,6 +101,7 @@ start_args(_S) ->
 start() ->
     {ok, Pid} = riak_kv_replrtq_snk:start_link(),
     unlink(Pid),
+    %% we don't yet test auto starting
     riak_kv_replrtq_snk:prompt_work(),
     Pid.
 
@@ -109,18 +109,22 @@ start_callouts(#{enabled := false}, _Args) -> ?EMPTY;
 start_callouts(#{config := Sinks}, _Args) ->
     ?PAR([ ?APPLY(setup_sink, [Sink]) || Sink <- Sinks ]).
 
-setup_sink_callouts(_S, [#{queue := disabled}]) -> ?EMPTY;
-setup_sink_callouts(_S, [#{peers := Peers}]) ->
-    ?SEQ([ ?CALLOUT(rhc, create, [Host, Port, ?WILDCARD, ?WILDCARD], {Host, Port})
-           || {{Host, Port, http}, _} <- Peers ]).
+%% setup_sink_callouts(_S, [#{queue := disabled}]) -> ?EMPTY;
+setup_sink_callouts(_S, [#{peers := Peers, peerlimit := Peerlimit}]) ->
+    ?PAR([ ?CALLOUT(rhc, create, [Host, Port, ?WILDCARD, ?WILDCARD], {Host, Port})
+           || {{Host, Port, http}, _} <- Peers, _ <- lists:seq(1, Peerlimit) ]).
 
 start_next(#{enabled := false} = S, Pid, []) -> S#{ pid => Pid, sinks => #{} };
 start_next(#{config  := Sinks} = S, Pid, _Args) ->
     S#{pid   => Pid,
-       sinks => maps:from_list([ {Q, Sink} || #{queue := Q} = Sink <- Sinks, Q /= disabled ])}.
+       sinks => maps:from_list([ {Q, Sink} || #{queue := Q} = Sink <- Sinks ])}.
 
 start_post(_S, _Args, Res) ->
     is_pid(Res) andalso is_process_alive(Res).
+
+%% start_process(_S, []) ->
+%%     worker.
+
 
 
 %% --- Operation: sleep ---
@@ -148,6 +152,7 @@ suspend_args(S) -> [maybe_active_queue_gen(S)].
 suspend(QueueName) ->
     R = riak_kv_replrtq_snk:suspend_snkqueue(QueueName),
     replrtq_snk_monitor:suspend(QueueName),
+    timer:sleep(1),
     R.
 
 suspend_next(S, _, [QueueName]) ->
@@ -172,13 +177,19 @@ add_pre(S) -> maps:is_key(sinks, S).
 
 add_args(_S) -> [sink_gen()].
 
-add_pre(#{sinks := Sinks}, [#{queue := Q}]) ->
-    not maps:is_key(Q, Sinks).
+add_pre(#{sinks := Sinks}, [#{queue := Q, workers := N}]) ->
+    not maps:is_key(Q, Sinks) andalso N > 0.
 
-add(#{queue := Q, peers := Peers, workers := N}) ->
-    PeerInfo = fun({{Host, Port, Protocol}, _}) -> {Host, 8, Host, Port, Protocol} end,
-    replrtq_snk_monitor:add_queue(Q, Peers, N),
-    riak_kv_replrtq_snk:add_snkqueue(Q, lists:map(PeerInfo, Peers), N).
+add(#{queue := Q, peers := Peers, workers := N, peerlimit := PL}) ->
+    PeerInfo = fun(I, {{Host, Port, Protocol}, _}) -> {I, 8, Host, Port, Protocol} end,
+    replrtq_snk_monitor:add_queue(Q, Peers, N, PL),
+    PeerInfos = [PeerInfo(I, Peer) ||
+                    {I, Peer} <- lists:zip(lists:seq(1, length(Peers)), Peers) ],
+    if PL == N ->
+            riak_kv_replrtq_snk:add_snkqueue(Q, PeerInfos, N);
+       PL =/= N ->
+            riak_kv_replrtq_snk:add_snkqueue(Q, PeerInfos, N, PL)
+    end.
 
 add_callouts(_S, [Sink]) -> ?APPLY(setup_sink, [Sink]).
 
@@ -217,12 +228,12 @@ nrworkers(Q, Workers) ->
 
 nrworkers_next(#{sinks := Sinks} = S, _Value, [Q, Workers]) ->
     Sink = maps:get(Q, Sinks),
-    S#{sinks => Sinks#{Q => Sink#{workers => Workers}},
+    S#{sinks => Sinks#{Q => Sink#{workers => Workers, peerlimit => Workers}},
        with_dynamic_workers => [Q | maps:get(with_dynamic_workers, S, [])]}.
 
-nrworkers_callouts(#{sinks := Sinks}, [Q, _Workers]) ->
+nrworkers_callouts(#{sinks := Sinks}, [Q, Workers]) ->
     Sink = maps:get(Q, Sinks),
-    ?APPLY(setup_sink, [Sink]).
+    ?APPLY(setup_sink, [Sink#{ workers => Workers, peerlimit => Workers }]).
 
 
 
@@ -240,18 +251,21 @@ pp_peer(Q, {Name, Port, Protocol}) ->
 
 
 queue_names() ->
-   [ queue1, queue2, a, aa, b, c, banana, sledge_hammer ].
+   [ queue1, queue2, a, b, c, banana, sledge_hammer ].
 
 sink_queue_gen() ->
     weighted_default({1, default}, {9, elements(queue_names())}).
 
+%% Workers  =< Peerlimit * nr(Peers)
 sink_gen() ->
-    sink_gen(workers_gen()).
+    ?LET(Peers, peers_gen(),
+    ?LET(Workers, choose(1, 30),
+    ?LET(Peerlimit, choose((Workers + length(Peers) - 1) div length(Peers), Workers),
+         #{ queue   => sink_queue_gen(),
+            peers   => Peers,
+            peerlimit => Peerlimit,
+            workers => Workers}))).
 
-sink_gen(WorkersGen) ->
-    #{ queue   => sink_queue_gen(),
-       peers   => peers_gen(),
-       workers => WorkersGen }.
 
 workers_gen() ->
     frequency([{1, 0}, {10, choose(1, 5)}]).
@@ -279,7 +293,7 @@ url() ->
 
 peer_config_gen() ->
     {elements([inactive, active]),
-     choose(1, 10)}.    %% Response time
+     choose(5, 20)}.    %% Response time
 
 
 %% -- Property ---------------------------------------------------------------
@@ -329,8 +343,8 @@ prop_repl() ->
     end))).
 
 check_traces(Traces, WithDynamicWorkers) ->
-    conjunction([ {QueueName, check_trace(QueueName, Peers, get_workers(Workers, Trace))}
-                  || {QueueName, Peers, Workers, Trace} <- Traces,
+    conjunction([ {QueueName, check_trace(QueueName, Peerlimit, Peers, get_workers(Workers, Trace))}
+                  || {QueueName, Peerlimit, Peers, Workers, Trace} <- Traces,
                       not lists:member(QueueName, WithDynamicWorkers)]).
 
 %% We only need this if we have non dynamic worker count changes
@@ -340,13 +354,16 @@ get_workers(Workers, Trace) ->
         _ -> {Workers, Trace}
     end.
 
-check_trace(QueueName, Peers, {Workers, Trace}) ->
+check_trace(QueueName, Peerlimit, Peers, {Workers, Trace}) ->
     Concurrent = concurrent_fetches(Trace),
     {Suspended, Active} = split_suspended(Concurrent),
     Max        = lists:max([0 | [N || {_, N} <- Active ++ Suspended]]),
     Avg        = weighted_average(Active),
     ActiveTime = lists:sum([ T || {T, _} <- Active ]),
-    AnyActive  = lists:any(fun({_, {A, _}}) -> A == active end, Peers),
+    ActivePeers = length([ x || {_, {active, _}} <- Peers ]),
+    AnyActive  = ActivePeers > 0,
+    ActiveWorkers = min(ActivePeers * Peerlimit, Workers),
+    MinActiveWorkers = min(ActiveWorkers - 1, 0.8 * ActiveWorkers),
     ?WHENFAIL(eqc:format("Trace for ~p:\n  ~p\nworkers ~p\n", [QueueName, Trace, Workers]),
     conjunction([{max_workers, case Trace of
                                    [{_, stop}] -> true;
@@ -355,8 +372,8 @@ check_trace(QueueName, Peers, {Workers, Trace}) ->
                  {avg_workers,
                     %% Check that the average number of active workers is >= WorkerCount - 1
                     ?WHENFAIL(eqc:format("Concurrent =\n~s\n~.1f < ~p\n",
-                                         [format_concurrent(Active), Avg, Workers - 1]),
-                        Avg >= Workers - 1
+                                         [format_concurrent(Active), Avg, MinActiveWorkers]),
+                        Avg >= MinActiveWorkers
                             orelse not AnyActive        %% Don't check saturation if no work
                             orelse ActiveTime < 40000   %% or if mostly suspended
                         )},
@@ -368,7 +385,7 @@ format_concurrent(Xs) ->
     [ io_lib:format("  ~p for ~5.1fms\n", [C, T / 1000])
       || {T, C} <- Xs, T >= 100 ].
 
--define(SLACK, 100). %% allow fetches 100µs after suspension
+-define(SLACK, 900). %% allow fetches 900µs after suspension
 
 drop_slack(Chunk) -> drop_slack(0, Chunk).
 drop_slack(_, []) -> [];
@@ -440,7 +457,8 @@ get_env(riak_kv, Key) -> get_env(riak_kv, Key, undefined).
 lager_spec() ->
     #api_module{ name = lager, fallback = ?MODULE }.
 
-warning(_, _) ->
+warning(F, As) ->
+    %% io:format(F++"\n", As),
     ok.
 
 rhc_spec() ->

--- a/eqc/replrtq_snk_monitor.erl
+++ b/eqc/replrtq_snk_monitor.erl
@@ -50,6 +50,8 @@ resume(Queue) ->
 update_workers(Queue, Workers) ->
     gen_server:call(?SERVER, {update_workers, Queue, Workers}).
 
+create(Host, Port, _, _) ->
+    {Host, Port}.
 
 %% -- Callbacks --------------------------------------------------------------
 
@@ -102,7 +104,8 @@ handle_info({return, From, QueueName, Active}, State) ->
     Reply =
         case Active of
             active   -> {ok, <<"riak_obj">>};
-            inactive -> {ok, queue_empty}
+            inactive -> {ok, queue_empty};
+            error    -> {error, no_client}
         end,
     gen_server:reply(From, Reply),
     {noreply, add_trace(State, QueueName, {return, Active})};

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1097,3 +1097,11 @@
     {datatype, integer},
     {default, 24}
 ]}.
+
+%% @doc The maximume number of workers to be for any given peer may be
+%% configured - if not configured will default to the number of sinkworkers
+{mapping, "replrtq_sinkpeerlimit", "riak_kv.replrtq_sinkpeerlimit", [
+    {datatype, integer},
+    {commented, 24}
+]}.
+

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1020,7 +1020,7 @@
 %% each priority on each queue will have this as the limit)
 {mapping, "replrtq_srcqueuelimit", "riak_kv.replrtq_srcqueuelimit", [
   {datatype, integer},
-  {default, 100000}
+  {default, 300000}
 ]}.
 
 %% @doc Limit the number of objects to be cached on the replication queue,

--- a/src/riak_kv_clusteraae_fsm.erl
+++ b/src/riak_kv_clusteraae_fsm.erl
@@ -724,9 +724,9 @@ handle_in_batches(Type, RefList, BatchCount, Worker)
 handle_in_batches(Type, [Ref|RestRefs], BatchCount, Worker) ->
     case Type of
         reap_tombs ->
-            ok = riak_kv_reaper:request_reap(Worker, Ref, 2);
+            ok = riak_kv_reaper:request_reap(Worker, Ref);
         erase_keys ->
-            ok = riak_kv_eraser:request_delete(Worker, Ref, 2)
+            ok = riak_kv_eraser:request_delete(Worker, Ref)
     end,
     handle_in_batches(Type, RestRefs, BatchCount + 1, Worker).
 

--- a/src/riak_kv_eraser.erl
+++ b/src/riak_kv_eraser.erl
@@ -162,7 +162,7 @@ handle_info(Msg, State) ->
             {noreply, S0, 0}
     end.
 
-terminate(normal, _State) ->
+terminate(_Reason, _State) ->
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/riak_kv_eraser.erl
+++ b/src/riak_kv_eraser.erl
@@ -38,8 +38,8 @@
 
 -export([start_link/0,
             start_job/1,
+            request_delete/1,
             request_delete/2,
-            request_delete/3,
             delete_stats/1,
             override_redo/1,
             clear_queue/1,
@@ -95,11 +95,17 @@ start_job(JobID) ->
     DeleteMode = app_helper:get_env(riak_kv, delete_mode, 3000),
     gen_server:start_link(?MODULE, [JobID, fun erase/2, DeleteMode], []).
 
--spec request_delete(delete_reference(), priority()) -> ok.
-request_delete(DelReference, Priority) when Priority == 1; Priority == 2 ->
-    gen_server:cast(?MODULE, {request_delete, DelReference, Priority}).
+-spec request_delete(delete_reference()) -> ok.
+request_delete(DeleteReference) ->
+    request_delete(?MODULE, DeleteReference, 2).
 
--spec request_delete(pid(), delete_reference(), priority()) -> ok.
+-spec request_delete(pid(), delete_reference()) -> ok.
+request_delete(Pid, DeleteReference) ->
+    request_delete(Pid, DeleteReference, 2).
+
+%% @doc
+%% Priority of Deletes is by default 2. 1 is reserved for redo of deletes
+-spec request_delete(pid()|atom(), delete_reference(), priority()) -> ok.
 request_delete(Pid, DelReference, Priority)
                                         when Priority == 1; Priority == 2 ->
     gen_server:cast(Pid, {request_delete, DelReference, Priority}).

--- a/src/riak_kv_eraser.erl
+++ b/src/riak_kv_eraser.erl
@@ -151,7 +151,7 @@ init([JobID, DelFun, DeleteMode]) ->
         end,
     RedoTimeout = app_helper:get_env(riak_kv, eraser_redo_timeout, ?REDO_TIMEOUT),
     {ok, #state{job_id = JobID, erase_fun = DelFun, redo_deletes = Redo,
-                redo_timeout = RedoTemout}, 0}.
+                redo_timeout = RedoTimeout}, 0}.
 
 handle_call(Msg, _From, State) ->
     {reply, R, S0} = handle_sync_message(Msg, State),

--- a/src/riak_kv_reaper.erl
+++ b/src/riak_kv_reaper.erl
@@ -147,7 +147,7 @@ handle_info(Msg, State) ->
             {noreply, S0, 0}
     end.
 
-terminate(normal, _State) ->
+terminate(_Reason, _State) ->
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/riak_kv_reaper.erl
+++ b/src/riak_kv_reaper.erl
@@ -43,8 +43,8 @@
 
 -export([start_link/0,
             start_job/1,
+            request_reap/1,
             request_reap/2,
-            request_reap/3,
             direct_reap/1,
             reap_stats/1,
             clear_queue/1,
@@ -94,11 +94,17 @@ start_link() ->
 start_job(JobID) ->
     gen_server:start_link(?MODULE, [JobID, fun reap/1], []).
 
--spec request_reap(reap_reference(), priority()) -> ok.
-request_reap(ReapReference, Priority) when Priority == 1; Priority == 2 ->
-    gen_server:cast(?MODULE, {request_reap, ReapReference, Priority}).
+-spec request_reap(reap_reference()) -> ok.
+request_reap(ReapReference) ->
+    request_reap(?MODULE, ReapReference, 2).
 
--spec request_reap(pid(), reap_reference(), priority()) -> ok.
+-spec request_reap(pid(), reap_reference()) -> ok.
+request_reap(Pid, ReapReference) ->
+    request_reap(Pid, ReapReference, 2).
+
+%% @doc
+%% Priority of Reaps is by default 2. 1 is reserved for redo of reaps
+-spec request_reap(pid()|atom(), reap_reference(), priority()) -> ok.
 request_reap(Pid, ReapReference, Priority) when Priority == 1; Priority == 2 ->
     gen_server:cast(Pid, {request_reap, ReapReference, Priority}).
 

--- a/src/riak_kv_reaper.erl
+++ b/src/riak_kv_reaper.erl
@@ -64,7 +64,7 @@
             pending_close = false :: boolean(),
             last_tick_time = os:timestamp() :: erlang:timestamp(),
             reap_fun :: reap_fun(),
-            redo_timeout :: non_negative_integer()
+            redo_timeout :: non_neg_integer()
 }).
 
 -type priority() :: 1..2.

--- a/src/riak_kv_reaper.erl
+++ b/src/riak_kv_reaper.erl
@@ -63,7 +63,8 @@
             job_id :: non_neg_integer(), % can be 0 for named reaper
             pending_close = false :: boolean(),
             last_tick_time = os:timestamp() :: erlang:timestamp(),
-            reap_fun :: reap_fun()
+            reap_fun :: reap_fun(),
+            redo_timeout :: non_negative_integer()
 }).
 
 -type priority() :: 1..2.
@@ -132,7 +133,8 @@ stop_job(Pid) ->
 
 init([JobID, ReapFun]) ->
     erlang:send_after(?LOG_TICK, self(), log_queue),
-    {ok, #state{job_id = JobID, reap_fun = ReapFun}, 0}.
+    RedoTimeout = app_helper:get_env(riak_kv, reaper_redo_timeout, ?REDO_TIMEOUT),
+    {ok, #state{job_id = JobID, reap_fun = ReapFun, redo_timeout = RedoTimeout}, 0}.
 
 
 handle_call(Msg, _From, State) ->
@@ -222,18 +224,18 @@ handle_async_message(timeout, State) ->
                             AT0 = State#state.reap_attempts + 1,
                             QL0 = {RedoQL - 1, 0},
                             {noreply,
-                                State#state{reap_queue = Q0, 
+                                State#state{reap_queue = Q0,
                                             reap_attempts = AT0,
                                             pqueue_length = QL0}};
                         false ->
                             AB0 = State#state.reap_aborts + 1,
                             Q1 = riak_core_priority_queue:in(ReapRef, 1, Q0),
                             {override_timeout,
-                                ?REDO_TIMEOUT,
-                                {noreply, 
-                                    State#state{reap_queue = Q1, 
+                                State#state.redo_timeout,
+                                {noreply,
+                                    State#state{reap_queue = Q1,
                                                 reap_aborts = AB0}}}
-                    end;
+                   end;
                 {empty, Q0} ->
                     %% This shoudn't happen - must have miscalulated
                     %% queue lengths
@@ -344,7 +346,7 @@ standard_reaper_tester() ->
     spawn(fun() ->
                 lists:foreach(fun(R) -> request_reap(P, R, 2) end, RefList)
             end),
-    WaitFun = 
+    WaitFun =
         fun(Sleep, Done) ->
             case Done of
                 false ->
@@ -383,7 +385,7 @@ somefail_reaper_tester(N) ->
     spawn(fun() ->
                 lists:foreach(fun(R) -> request_reap(P, R, 2) end, RefList)
             end),
-    WaitFun = 
+    WaitFun =
         fun(Sleep, Done) ->
             case Done of
                 false ->

--- a/src/riak_kv_reaper.erl
+++ b/src/riak_kv_reaper.erl
@@ -77,6 +77,7 @@
 -type reap_stats() :: {non_neg_integer(), non_neg_integer(), queue_length()}.
 
 -type reap_fun() :: fun((reap_reference()) -> boolean()).
+-type reaper_state() :: #state{}.
 
 -export_type([reap_reference/0, job_id/0]).
 
@@ -127,25 +128,64 @@ init([JobID, ReapFun]) ->
     erlang:send_after(?LOG_TICK, self(), log_queue),
     {ok, #state{job_id = JobID, reap_fun = ReapFun}, 0}.
 
-handle_call(reap_stats, _From, State) ->
+
+handle_call(Msg, _From, State) ->
+    {reply, R, S0} = handle_sync_message(Msg, State),
+    {reply, R, S0, 0}.
+
+handle_cast(Msg, State) ->
+    {noreply, S0} = handle_async_message(Msg, State),
+    {noreply, S0, 0}.
+
+handle_info(Msg, State) ->
+    case handle_async_message(Msg, State) of
+        {override_timeout, none, R} ->
+            R;
+        {override_timeout, T0, {noreply, S0}} ->
+            {noreply, S0, T0};
+        {noreply, S0} ->
+            {noreply, S0, 0}
+    end.
+
+terminate(normal, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+
+%%%============================================================================
+%%% Actual Callbacks
+%%%============================================================================
+
+%% Handle a call message - with a reply.  The handle_call function will enforce
+%% the addition of an immediate timeout
+-spec handle_sync_message(any(), reaper_state()) ->
+        {reply, any(), reaper_state()}.
+handle_sync_message(reap_stats, State) ->
     Stats =
         {State#state.reap_attempts,
             State#state.reap_aborts,
             State#state.pqueue_length},
-    {reply, Stats, State, 0};
-handle_call({direct_reap, ReapReference}, _From, State) ->
-    {reply, reap(ReapReference), State, 0};
-handle_call(clear_queue, _From, State) ->
+    {reply, Stats, State};
+handle_sync_message({direct_reap, ReapReference}, State) ->
+    {reply, reap(ReapReference), State};
+handle_sync_message(clear_queue, State) ->
     {reply,
         ok,
         State#state{reap_queue = riak_core_priority_queue:new(),
-                    pqueue_length = {0, 0}},
-        0};
-handle_call(stop_job, _From, State) ->
-    {reply, ok, State#state{pending_close = true}, 0}.
+                    pqueue_length = {0, 0}}};
+handle_sync_message(stop_job, State) ->
+    {reply, ok, State#state{pending_close = true}}.
 
-handle_cast({request_reap, ReapReference, Priority}, State) ->
-
+%% Handle a cast or info message - with a reply.  The handle_cast function
+%% will expet a {noreply, State} response and will override the return with
+%% an immediate timeout.  the handle_info may also receive a reply with an
+%% overrride to the timeout.
+-spec handle_async_message(any(), reaper_state()) ->
+        {noreply, reaper_state()}|
+        {override_timeout, none|pos_integer(), tuple()}.
+handle_async_message({request_reap, ReapReference, Priority}, State) ->
     UpdQL =
         setelement(Priority,
                     State#state.pqueue_length,
@@ -154,18 +194,17 @@ handle_cast({request_reap, ReapReference, Priority}, State) ->
         riak_core_priority_queue:in(ReapReference,
                                     Priority,
                                     State#state.reap_queue),
-    {noreply, State#state{pqueue_length = UpdQL, reap_queue = UpdQ}, 0}.
-
-handle_info(timeout, State) ->
+    {noreply, State#state{pqueue_length = UpdQL, reap_queue = UpdQ}};
+handle_async_message(timeout, State) ->
     ReapFun = State#state.reap_fun,
     case State#state.pqueue_length of
         {0, 0} ->
             case State#state.pending_close of
                 true ->
-                    {stop, normal, State};
+                    {override_timeout, none, {stop, normal, State}};
                 false ->
                     %% No timeout here, as no work to do
-                    {noreply, State}
+                    {override_timeout, none, {noreply, State}}
             end;
         {RedoQL, 0} ->
             %% Work a single item on the redo queue, and no immediate timeout
@@ -179,23 +218,22 @@ handle_info(timeout, State) ->
                             {noreply,
                                 State#state{reap_queue = Q0, 
                                             reap_attempts = AT0,
-                                            pqueue_length = QL0},
-                                0};
+                                            pqueue_length = QL0}};
                         false ->
                             AB0 = State#state.reap_aborts + 1,
                             Q1 = riak_core_priority_queue:in(ReapRef, 1, Q0),
-                            {noreply,
-                                State#state{reap_queue = Q1, 
-                                            reap_aborts = AB0},
-                                ?REDO_TIMEOUT}
+                            {override_timeout,
+                                ?REDO_TIMEOUT,
+                                {noreply, 
+                                    State#state{reap_queue = Q1, 
+                                                reap_aborts = AB0}}}
                     end;
                 {empty, Q0} ->
                     %% This shoudn't happen - must have miscalulated
                     %% queue lengths
                     {noreply,
                         State#state{reap_queue = Q0,
-                                    pqueue_length = {0, 0}},
-                        0}
+                                    pqueue_length = {0, 0}}}
             end;
         {RedoQL, ReapQL} ->
             %% Work a batch of items from the reap queue before yielding
@@ -226,10 +264,9 @@ handle_info(timeout, State) ->
                 State#state{reap_queue = UpdQ,
                             reap_attempts = AT0,
                             reap_aborts = AB0,
-                            pqueue_length = {RedoQL, ReapQL - BatchSize}},
-                0}
+                            pqueue_length = {RedoQL, ReapQL - BatchSize}}}
     end;
-handle_info(log_queue, State) ->
+handle_async_message(log_queue, State) ->
     lager:info("Reaper Job ~w has queue lengths ~w " ++
                     " reap_attempts=~w reap_aborts=~w ",
                 [State#state.job_id,
@@ -237,14 +274,7 @@ handle_info(log_queue, State) ->
                     State#state.reap_attempts,
                     State#state.reap_aborts]),
     erlang:send_after(?LOG_TICK, self(), log_queue),
-    {noreply, State#state{reap_attempts = 0, reap_aborts = 0}, 0}.
-
-
-terminate(normal, _State) ->
-    ok.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
+    {noreply, State#state{reap_attempts = 0, reap_aborts = 0}}.
 
 
 %%%============================================================================

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -409,7 +409,7 @@ handle_info({prompt_requeue, WorkItem}, State) ->
     requeue_work(WorkItem),
     {noreply, State}.
 
-terminate(normal, _State) ->
+terminate(_Reason, _State) ->
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -198,7 +198,8 @@ add_snkqueue(QueueName, Peers, WorkerCount) ->
 %% number of workers overall
 -spec add_snkqueue(queue_name(), list(peer_info()),
                     pos_integer(), pos_integer()) -> ok.
-add_snkqueue(QueueName, Peers, WorkerCount, PerPeerLimit) ->
+add_snkqueue(QueueName, Peers, WorkerCount, PerPeerLimit) 
+                                            when PerPeerLimit =< WorkerCount ->
     gen_server:call(?MODULE,
                     {add, QueueName, Peers, WorkerCount, PerPeerLimit}).
 
@@ -219,7 +220,8 @@ set_workercount(QueueName, WorkerCount) ->
 %% workers per peer
 -spec set_workercount(queue_name(), pos_integer(), pos_integer())
                                                             -> ok|not_found.
-set_workercount(QueueName, WorkerCount, PerPeerLimit) ->
+set_workercount(QueueName, WorkerCount, PerPeerLimit)
+                                            when PerPeerLimit =< WorkerCount ->
     gen_server:call(?MODULE,
                     {worker_count, QueueName, WorkerCount, PerPeerLimit}).
 

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -298,6 +298,7 @@ handle_call({worker_count, QueueN, WorkerCount}, _From, State) ->
             W0 =
                 lists:keyreplace(QueueN, 1, State#state.work,
                                     {QueueN, Iteration, SinkWork0}),
+            prompt_work(),
             {reply, ok, State#state{work = W0, iteration = Iteration}}
     end.
 

--- a/src/riak_kv_replrtq_src.erl
+++ b/src/riak_kv_replrtq_src.erl
@@ -415,7 +415,7 @@ handle_info(log_queue, State) ->
     erlang:send_after(State#state.log_frequency_in_ms, self(), log_queue),
     {noreply, State}.
 
-terminate(normal, _State) ->
+terminate(_Reason, _State) ->
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -278,6 +278,8 @@ do_update(precommit_fail) ->
     exometer:update([?PFX, ?APP, precommit_fail], 1);
 do_update(postcommit_fail) ->
     exometer:update([?PFX, ?APP, postcommit_fail], 1);
+do_update({controller_queue, QueueTime}) ->
+    ok = create_or_update([?PFX, ?APP, tictacaae_controller_queue], QueueTime, histogram);
 do_update(write_once_merge) ->
     exometer:update([?PFX, ?APP, write_once_merge], 1);
 do_update({fsm_spawned, Type}) when Type =:= gets; Type =:= puts ->
@@ -720,6 +722,8 @@ stats() ->
      {[vnode, backend, leveldb, read_block_error],
       {function, ?MODULE, leveldb_read_block_errors, [], match, value}, [],
       [{value, leveldb_read_block_error}]},
+     {tictacaae_controller_queue, histogram, [], [{mean, tictacaae_queue_microsec_mean},
+                                                    {max, tictacaae_queue_microsec__max}]},
 
      %% datatype stats
      {[counter, actor_count], histogram, [], [{mean  , counter_actor_counts_mean},

--- a/src/riak_kv_ttaaefs_manager.erl
+++ b/src/riak_kv_ttaaefs_manager.erl
@@ -454,7 +454,7 @@ sync_clusters(From, ReqID, LNVal, RNVal, Filter, NextBucketList, Ref, State) ->
             
             lager:info("Starting full-sync ReqID=~w id=~s pid=~w",
                             [ReqID0, ExID, ExPid]),
-            
+            stop_client(RemoteClient, RemoteMod),
             {State#state{bucket_list = NextBucketList},
                 ?CRASH_TIMEOUT}
     end.
@@ -525,6 +525,13 @@ init_client(pb, IP, Port, Credentials) ->
     Options = [{auto_reconnect, true}|SecurityOpts],
     init_pbclient(IP, Port, Options).
 
+%% @doc
+%% Stop the client (if PBC), nothing started for RHC.
+-spec stop_client(rhc:rhc()|pid(), rhc|riak_c_pb_socket) -> ok.
+stop_client(_RemoteClient, rhc) ->
+    ok;
+stop_client(RemoteClient, Mod) ->
+    Mod:stop(RemoteClient).
 
 init_pbclient(IP, Port, Options) ->
     {ok, Pid} = riakc_pb_socket:start_link(IP, Port, Options),

--- a/src/riak_kv_ttaaefs_manager.erl
+++ b/src/riak_kv_ttaaefs_manager.erl
@@ -402,7 +402,7 @@ handle_info({work_item, WorkItem}, State) ->
     process_workitem(WorkItem, no_reply, os:timestamp()),
     {noreply, State}.
 
-terminate(normal, _State) ->
+terminate(_Reason, _State) ->
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1789,7 +1789,7 @@ handle_aaefold({reap_tombs,
                     DH = riak_object:delete_hash(VV),
                     case ReapMethod of
                         local ->
-                            riak_kv_reaper:request_reap({{BF, KF}, DH}, 2),
+                            riak_kv_reaper:request_reap({{BF, KF}, DH}),
                             NewCount = element(2, TombHashAcc) + 1,
                             setelement(2, TombHashAcc, NewCount);
                         count ->
@@ -1839,7 +1839,7 @@ handle_aaefold({erase_keys,
                     {clock, VV} = lists:keyfind(clock, 1, EFs),
                     case DeleteMethod of
                         local ->
-                            riak_kv_eraser:request_delete({{BF, KF}, VV}, 2),
+                            riak_kv_eraser:request_delete({{BF, KF}, VV}),
                             NewCount = element(2, EraseKeyAcc) + 1,
                             setelement(2, EraseKeyAcc, NewCount);
                         count ->


### PR DESCRIPTION
The legacy AAE implementation had defence against the vnode backend being able to handle PUT load at a much faster pace than the AAE backend.  This would work by having a counter of PUTs, and every N PUTs rather than sending the PUT async, it would do so sync - and the vnode would be delayed to allow the AAE system to catch-up.

This is the token-based mechanism used on the old AAE implementation - https://github.com/basho/riak_kv/blob/develop-2.9/src/riak_kv_vnode.erl#L3317-L3325.
 
There were two problems with this in production - the delay could be very long (especially when rebuilds had been initiated), and there was no monitoring logs/stats to inform the operator that the delay was occurring.

Originally, the potential for an AAE backlog was ignored when implementing Tictac AAE - there was no mechanism to pause the vnode.  This PR provides this extra defence, but is designed so that:

- vnode is only delayed when the backlog reaches 1s
- the vnode is not delayed indefinitely
- the operator is informed at each stage.

The PR also rolls in two fixes that have been discovered during load testing.

- updating the count of sink workers doesn't have the required prompt_work() built in;
- there is a process leak in the riak_kv_ttaaefs_manager whereby it keeps initiating new PBC clients, but doesn't stop them.