### PR TITLE
Changes following review

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -179,16 +179,7 @@ push(RObjMaybeBin, IsDeleted, _Opts, {?MODULE, [Node, _ClientId]}) ->
             true ->
                 RObjMaybeBin;
             false ->
-                case RObjMaybeBin of
-                    <<0:32/integer, BL:32/integer, B:BL/binary,
-                        KL:32/integer, K:KL/binary,
-                        ObjBin/binary>> ->
-                            riak_object:from_binary(B, K, ObjBin);
-                    <<TL:32/integer, T:TL/binary, BL:32/integer, B:BL/binary,
-                        KL:32/integer, K:KL/binary,
-                        ObjBin/binary>> ->
-                            riak_object:from_binary({T, B}, K, ObjBin)
-                end
+                riak_object:nextgenrepl_decode(RObjMaybeBin)
         end,
     Bucket = riak_object:bucket(RObj),
     Key = riak_object:key(RObj),

--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -139,7 +139,6 @@ start(Partition, Config) ->
                             {compression_method, CMM},
                             {compression_point, CMP},
                             {log_level, LOL},
-                            {database_id, DBid},
                             {max_run_length, MRL},
                             {database_id, DBid},
                             {maxrunlength_compactionpercentage, MCP},


### PR DESCRIPTION
Review feedback:

Move repl decode to riak_object with encode
Be consistent in case statements wrt erase_keys, reap_tombs in riak_kv_clusteraae_fsm
Remove merge issue with duplicate database_id in riak_kv_leveled_backend