### PR TITLE
Schema Review

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1071,9 +1071,14 @@
     {commented, enabled}
 ]}.
 
-%% @doc Default queue name  to be used for peers (replrtq_sinkpeers) that are
-%% defined without a queue name.  Will be ignored where all peers are defined
-%% with a queue name
+%% @doc Queue name  to be used for peers (replrtq_sinkpeers) that are
+%% defined without a queue name.  Each node is expected to have a single
+%% queue from which it will consume (by name).  This queue may be consumed
+%% from multiple peers - and those peers may sit on multiple clusters.
+%% If more than one queue name is to be consumed from, real-time changes can
+%% be made through `riak_kv_replrtq_snk:add_snkqueue/3`.  The peer list can
+%% also be extended to add different queue names into definitions - however
+%% it is strongly recommended to use a single sinkqueue name per node.
 {mapping, "replrtq_sinkqueue", "riak_kv.replrtq_sinkqueue", [
   {datatype, atom},
   {default, q1_ttaaefs}
@@ -1083,13 +1088,13 @@
 %% src.  All src nodes will need to have entries consumed - so it is
 %% recommended that each src node is referred to in multiple sink node
 %% configurations.
-%% The list of peers is tokenised as
-%% queue:host:port:protocol or host:port:protocol
-%% The queue will be converted to an atom and must be a queue_name at the peer
-%% The protocol may be http or pb.
+%% The list of peers is tokenised as host:port:protocol
+%% In exceptional circumstances this definition can be extended to
+%% queuename:host:port:protocol - but restricting the definitions of queuename
+%% to the single queue specified in replrtq_sinkqueue is strongly recommended.
 {mapping, "replrtq_sinkpeers", "riak_kv.replrtq_sinkpeers", [
     {datatype, string},
-    {commented, "q1_ttaaefs:127.0.0.1:8098:http"}
+    {commented, "127.0.0.1:8098:http"}
 ]}.
 
 %% @doc The number of workers to be used for each queue must be configured.

--- a/src/riak_kv_replrtq_src.erl
+++ b/src/riak_kv_replrtq_src.erl
@@ -40,7 +40,7 @@
 
 -export([start_link/0,
             replrtq_aaefold/2,
-            replrtq_ttaefs/2,
+            replrtq_ttaaefs/2,
             replrtq_coordput/1,
             register_rtq/2,
             delist_rtq/1,
@@ -53,7 +53,7 @@
 
 -ifdef(TEST).
 -export([ replrtq_aaefold/3,
-          replrtq_ttaefs/3 ]).
+          replrtq_ttaaefs/3 ]).
 -endif.
 
 -define(BACKOFF_PAUSE, 1000).
@@ -170,16 +170,18 @@ replrtq_aaefold(QueueName, ReplEntries, BackoffPause) ->
 %% higher priority).
 %% This should be use to replicate the outcome of Tictac AAE full-sync
 %% aae_exchange.
--spec replrtq_ttaefs(queue_name(), list(repl_entry())) -> ok | pause.
-replrtq_ttaefs(QueueName, ReplEntries) ->
-    replrtq_ttaefs(QueueName, ReplEntries,  ?BACKOFF_PAUSE).
+-spec replrtq_ttaaefs(queue_name(), list(repl_entry())) -> ok | pause.
+replrtq_ttaaefs(QueueName, ReplEntries) ->
+    replrtq_ttaaefs(QueueName, ReplEntries,  ?BACKOFF_PAUSE).
 
 
--spec replrtq_ttaefs(queue_name(), list(repl_entry()), pos_integer()) -> ok | pause.
+-spec replrtq_ttaaefs(queue_name(), list(repl_entry()), pos_integer())
+                                                                -> ok | pause.
 %% @hidden
 %% Used for testing if we want to have control over the length of pausing.
-replrtq_ttaefs(QueueName, ReplEntries, BackoffPause) ->
-    % This is a call as we don't want this process to be able to overload the src
+replrtq_ttaaefs(QueueName, ReplEntries, BackoffPause) ->
+    % This is a call as we don't want this process to be able to overload
+    % the src
     case gen_server:call(?MODULE,
                             {rtq_ttaaefs, QueueName, ReplEntries},
                             infinity) of
@@ -634,12 +636,12 @@ basic_singlequeue_test() ->
     Grp5 = lists:map(generate_replentryfun(?TB2), lists:seq(41, 50)),
     ?assertMatch(true, register_rtq(?QN1, any)),
     lists:foreach(fun(RE) -> replrtq_coordput(RE) end, Grp1),
-    ok = replrtq_ttaefs(?QN1, lists:reverse(Grp2)),
+    ok = replrtq_ttaaefs(?QN1, lists:reverse(Grp2)),
     {?TB1, <<1:32/integer>>, _VC1, to_fetch} = popfrom_rtq(?QN1),
     ?assertMatch({?QN1, {0, 10, 9}}, length_rtq(?QN1)),
     {?TB1, <<2:32/integer>>, _VC2, to_fetch} = popfrom_rtq(?QN1),
     ?assertMatch({?QN1, {0, 10, 8}}, length_rtq(?QN1)),
-    ok = replrtq_ttaefs(?QN1, lists:reverse(Grp3)),
+    ok = replrtq_ttaaefs(?QN1, lists:reverse(Grp3)),
     {?TB1, <<3:32/integer>>, _VC3, to_fetch} = popfrom_rtq(?QN1),
     ?assertMatch({?QN1, {0, 20, 7}}, length_rtq(?QN1)),
     lists:foreach(fun(_I) -> popfrom_rtq(?QN1) end, lists:seq(1, 7)),
@@ -656,7 +658,7 @@ basic_singlequeue_test() ->
     {?TB3, <<30:32/integer>>, _VC30, to_fetch} = popfrom_rtq(?QN1),
     ?assertMatch({?QN1, {0, 0, 0}}, length_rtq(?QN1)),
     ?assertMatch(queue_empty, popfrom_rtq(?QN1)),
-    ok = replrtq_ttaefs(?QN1, lists:reverse(Grp5)),
+    ok = replrtq_ttaaefs(?QN1, lists:reverse(Grp5)),
     ?assertMatch({?QN1, {0, 10, 0}}, length_rtq(?QN1)),
     {?TB2, <<41:32/integer>>, _VC41, to_fetch} = popfrom_rtq(?QN1),
     ?assertMatch({?QN1, {0, 9, 0}}, length_rtq(?QN1)),
@@ -700,7 +702,7 @@ basic_multiqueue_test() ->
     % Adding a bulk based on an AAE job will be applied to the actual
     % queue regardless of filter
     Grp5A = lists:map(GenB5, lists:seq(61, 70)),
-    ok = replrtq_ttaefs(?QN2, lists:reverse(Grp5A)),
+    ok = replrtq_ttaaefs(?QN2, lists:reverse(Grp5A)),
 
     ?assertMatch({?QN1, {0, 0, 60}}, length_rtq(?QN1)),
     ?assertMatch({?QN2, {0, 10, 20}}, length_rtq(?QN2)),
@@ -750,7 +752,7 @@ basic_multiqueue_test() ->
     Grp6B = lists:map(GenB6, lists:seq(81, 90)),
     Grp6C = lists:map(GenB6, lists:seq(91, 100)),
     lists:foreach(fun(RE) -> replrtq_coordput(RE) end, Grp6B),
-    ok = replrtq_ttaefs(?QN1, lists:reverse(Grp6C)),
+    ok = replrtq_ttaaefs(?QN1, lists:reverse(Grp6C)),
     {?TB3, <<73:32/integer>>, _VC73, to_fetch} = popfrom_rtq(?QN1),
     ?assertMatch({?QN1, {0, 0, 7}}, length_rtq(?QN1)),
 
@@ -763,7 +765,7 @@ basic_multiqueue_test() ->
     {?TB3, <<74:32/integer>>, _VC74, to_fetch} = popfrom_rtq(?QN1),
     ?assertMatch({?QN1, {0, 0, 6}}, length_rtq(?QN1)),
     lists:foreach(fun replrtq_coordput/1, Grp6B),
-    ok = replrtq_ttaefs(?QN1, lists:reverse(Grp6C)),
+    ok = replrtq_ttaaefs(?QN1, lists:reverse(Grp6C)),
     {?TB3, <<75:32/integer>>, _VC75, to_fetch} = popfrom_rtq(?QN1),
     ?assertMatch({?QN1, {0, 10, 15}}, length_rtq(?QN1)),
 

--- a/src/riak_kv_ttaaefs_manager.erl
+++ b/src/riak_kv_ttaaefs_manager.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% riak_kv_ttaefs_manager: coordination of full-sync replication
+%% riak_kv_ttaaefs_manager: coordination of full-sync replication
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -700,7 +700,7 @@ generate_repairfun(ExchangeID, QueueName) ->
                     [ExchangeID, SinkDCount]),
         lager:info("AAE exchange ~w outputs ~w keys to be repaired",
                     [ExchangeID, length(ToRepair)]),
-        riak_kv_replrtq_src:replrtq_ttaefs(QueueName, ToRepair),
+        riak_kv_replrtq_src:replrtq_ttaaefs(QueueName, ToRepair),
         lager:info("AAE exchange ~w has requeue complete for ~w keys",
                     [ExchangeID, length(ToRepair)])
     end.


### PR DESCRIPTION
Be explicit that we only expect there ot be one sink queue name defiend at startup by node.  Make this the default behaviour.

This doesn't prevent multiple queue names being defined.

Also resolve inconsistent spelling of ttaaefs spotted during review.