### PR TITLE
Explicitly filter out non-primary exchanges

### DIFF
--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -956,11 +956,7 @@ add_index_exchanges(Index, State) ->
 -spec prune_exchanges([exchange()])
                      -> [exchange()].
 prune_exchanges(Exchanges) ->
-    L = [if A < B ->
-                 {A, B, IndexN};
-            true ->
-                 {B, A, IndexN}
-         end || {A, B, IndexN} <- Exchanges],
+    L = [Exchange || {A, B, _IndexN} = Exchange <- Exchanges, A < B],
     lists:usort(L).
 
 -spec already_exchanging(index() ,state()) -> boolean().


### PR DESCRIPTION
Explicitly filter out non-primary exchanges from exchange_queue as opposed to flipping indexes and allowing it to fail. Prevents logging of not_responsible messages when these errorneous exchanges are attempted.

Relates to https://github.com/basho/riak/issues/1011