### PR TITLE
Allow the mbox_check to be disabled

### DIFF
--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -1245,7 +1245,7 @@ get_soft_limit_option(Options) ->
     %% turn off soft-limit checking. However, by default, we should
     %% use them (if supported) - unless it is explicitly disabled by toggling the
     %% mbox_check_enabled environment flag.
-    SoftLimitedWanted = app_helper:get_env(riak_kv, mbox_check_enabled, true) andalso
+    SoftLimitedWanted = app_helper:get_env(riak_kv, mbox_check_enabled, SoftLimitSupported) andalso
                         get_option(mbox_check, Options, SoftLimitSupported),
     SoftLimitedWanted.
 

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -1243,8 +1243,10 @@ get_soft_limit_option(Options) ->
     SoftLimitSupported = riak_core_capability:get({riak_kv, put_soft_limit}, false),
     %% both the system (post forward) and the client (via options) can
     %% turn off soft-limit checking. However, by default, we should
-    %% use them (if supported)
-    SoftLimitedWanted = get_option(mbox_check, Options, SoftLimitSupported),
+    %% use them (if supported) - unless it is explicitly disabled by toggling the
+    %% mbox_check_enabled environment flag.
+    SoftLimitedWanted = app_helper:get_env(riak_kv, mbox_check_enabled, true) andalso
+                        get_option(mbox_check, Options, SoftLimitSupported),
     SoftLimitedWanted.
 
 


### PR DESCRIPTION
Where it may be necessary to disable this option, inspect boolean environment variable `mbox_check_enabled` flag to allow it to be toggled without passing additional client options.

Default behaviour leaves the option as originally intended / configured, with the explicit override disabling it, if it has been set.