### PR TITLE
Force clearing of Tictac AAE on vnode delete

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -37,7 +37,7 @@
         {riak_dt, ".*", {git, "git://github.com/basho/riak_dt.git", {tag, "riak_kv-2.9.1"}}},
         {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag, "0.1.2"}}},
         {leveled, ".*", {git, "https://github.com/martinsumner/leveled.git", {tag, "0.9.21"}}},
-        {kv_index_tictactree, ".*", {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "0.9.12"}}},
+        {kv_index_tictactree, ".*", {git, "https://github.com/martinsumner/kv_index_tictactree.git", {branch, "develop-2.9"}}},
         {riak_core, ".*", {git, "https://github.com/basho/riak_core.git", {tag, "riak_kv-2.9.2"}}},
         {riak_api, ".*", {git, "git://github.com/basho/riak_api.git", {tag, "riak_kv-2.9.2"}}},
         {hyper, ".*", {git, "git://github.com/basho/hyper", {tag, "1.0.1"}}},


### PR DESCRIPTION
To prevent an issue whereby state can be left if a node leaves then re-joins.  Clear tictac_aae just like standard aae

https://github.com/basho/riak_kv/issues/1759