### PR TITLE
Mas pr1757 softlimitdisable

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -448,7 +448,7 @@
     {default, on},
     {datatype, flag},
     hidden
-]}
+]}.
 
 %% @doc Controls which binary representation of a riak value is stored
 %% on disk.

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -439,6 +439,17 @@
   hidden
 ]}.
 
+%% @doc Enable or disable mbox_check on PUTs
+%% By default mbox_checks are performed so that vnodes with long queues
+%% will not be used as put coordinators.  To return to the pre-2.9 behaviour
+%% of not checking, this can be disabled.  The mbox_check may add additional
+%% latency to PUTs in some environments.
+{mapping, "mbox_check_enabled", "riak_kv.mbox_check_enabled", [
+    {default, on},
+    {datatype, flag},
+    hidden
+]}
+
 %% @doc Controls which binary representation of a riak value is stored
 %% on disk.
 %% * 0: Original erlang:term_to_binary format. Higher space overhead.

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -1269,7 +1269,10 @@ get_soft_limit_option(Options) ->
     %% both the system (post forward) and the client (via options) can
     %% turn off soft-limit checking. However, by default, we should
     %% use them (if supported)
-    SoftLimitedWanted = get_option(mbox_check, Options, SoftLimitSupported),
+    SoftLimitedWanted =
+        app_helper:get_env(riak_kv, mbox_check_enabled, true) andalso
+        SoftLimitSupported andalso
+        get_option(mbox_check, Options, SoftLimitSupported),
     SoftLimitedWanted.
 
 


### PR DESCRIPTION
This is a repeat of PR 1757 https://github.com/basho/riak_kv/pull/1757, but to pull into develop-2.9.  For consistency with other options, it is made available in riak.conf.

this does mean that mbox_check_enabled will be on by default, but SoftLimit may not be supported by every node in the cluster - and so the logic is explicit here that mbox_check_enabled must be true and soft limit is supported