### PR TITLE
Assume no props if no props passed

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -57,7 +57,7 @@
     {riak_dt, {git, "git://github.com/basho/riak_dt.git", {tag, "riak_kv-3.0.0"}}},
     {riak_api, {git, "git://github.com/basho/riak_api.git", {tag, "riak_kv-3.0.2"}}},
     {hyper, {git, "git://github.com/basho/hyper", {tag, "1.1.0"}}},
-    {leveled, {git, "https://github.com/martinsumner/leveled.git", {tag, "1.0.2"}}},
+    {leveled, {git, "https://github.com/martinsumner/leveled.git", {branch, "develop-3.0"}}},
     {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "0.9.18"}}},
     {riakhttpc, {git, "git://github.com/basho/riak-erlang-http-client", {tag, "riak_kv-3.0.2"}}}
        ]}.

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -496,6 +496,8 @@ bucket_type_print_activate_result(Type, {error, undefined}, _IsFirst) ->
 bucket_type_print_activate_result(Type, {error, not_ready}, _IsFirst) ->
     bucket_type_print_status(Type, created).
 
+bucket_type_create([TypeStr]) ->
+    bucket_type_create([TypeStr, ""]);
 bucket_type_create([TypeStr, ""]) ->
     Type = unicode:characters_to_binary(TypeStr, utf8, utf8),
     EmptyProps = {struct, [{<<"props">>, {struct, []}}]},


### PR DESCRIPTION
The parsing of command lines doesn't pass the emtpy string in now as the second parameter when creating bucket types - so this is done explicitly now.

Also uplift to leveled to fix perf issue.