### PR TITLE
Mas i1788 reconcileapi

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -60,5 +60,5 @@
     {hyper, {git, "git://github.com/basho/hyper", {tag, "1.1.0"}}},
     {leveled, {git, "https://github.com/martinsumner/leveled.git", {tag, "1.0.4"}}},
     {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "0.9.18"}}},
-    {riakhttpc, {git, "git://github.com/basho/riak-erlang-http-client", {tag, "3.0.4"}}}
+    {riakhttpc, {git, "git://github.com/basho/riak-erlang-http-client", {branch, "mas-i1788-reconcileapi"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -56,7 +56,7 @@
     {sext, {git, "git://github.com/uwiger/sext.git", {tag, "1.4.1"}}},
     {riak_pipe, {git, "git://github.com/basho/riak_pipe.git", {tag, "riak_kv-3.0.5"}}},
     {riak_dt, {git, "git://github.com/basho/riak_dt.git", {tag, "riak_kv-3.0.0"}}},
-    {riak_api, {git, "git://github.com/basho/riak_api.git", {tag, "riak_kv-3.0.5"}}},
+    {riak_api, {git, "git://github.com/basho/riak_api.git", {branch, "mas-i1788-reconcileapi"}}},
     {hyper, {git, "git://github.com/basho/hyper", {tag, "1.1.0"}}},
     {leveled, {git, "https://github.com/martinsumner/leveled.git", {tag, "1.0.4"}}},
     {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "0.9.18"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -56,9 +56,9 @@
     {sext, {git, "git://github.com/uwiger/sext.git", {tag, "1.4.1"}}},
     {riak_pipe, {git, "git://github.com/basho/riak_pipe.git", {tag, "riak_kv-3.0.5"}}},
     {riak_dt, {git, "git://github.com/basho/riak_dt.git", {tag, "riak_kv-3.0.0"}}},
-    {riak_api, {git, "git://github.com/basho/riak_api.git", {branch, "mas-i1788-reconcileapi"}}},
+    {riak_api, {git, "git://github.com/basho/riak_api.git", {branch, "develop-3.0"}}},
     {hyper, {git, "git://github.com/basho/hyper", {tag, "1.1.0"}}},
     {leveled, {git, "https://github.com/martinsumner/leveled.git", {tag, "1.0.4"}}},
     {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "0.9.18"}}},
-    {riakhttpc, {git, "git://github.com/basho/riak-erlang-http-client", {branch, "mas-i1788-reconcileapi"}}}
+    {riakhttpc, {git, "git://github.com/basho/riak-erlang-http-client", {branch, "develop-3.0"}}}
        ]}.

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -38,7 +38,7 @@
                    {riak_kv_pb_counter, 50, 53}, %% counter requests
                    {riak_kv_pb_crdt, 80, 83}, %% CRDT requests
                    {riak_kv_pb_aaefold, 210, 231}, %% AAE Fold requests
-                   {riak_kv_pb_object, 202, 203} %% Object Fetch Request
+                   {riak_kv_pb_object, 202, 205} %% Object Fetch/Push Request
                   ]).
 -define(MAX_FLUSH_PUT_FSM_RETRIES, 10).
 

--- a/src/riak_kv_pb_object.erl
+++ b/src/riak_kv_pb_object.erl
@@ -445,12 +445,14 @@ unpack_keyclock_fun(RpbKeysClock) ->
         undefined ->
             {RpbKeysClock#rpbkeysvalue.bucket,
                 RpbKeysClock#rpbkeysvalue.key,
-                riak_object:decode_vclock(RpbKeysClock#rpbkeysvalue.value)};
+                riak_object:decode_vclock(RpbKeysClock#rpbkeysvalue.value),
+                to_fetch};
         T ->
             {{T,
                 RpbKeysClock#rpbkeysvalue.bucket},
                 RpbKeysClock#rpbkeysvalue.key,
-                riak_object:decode_vclock(RpbKeysClock#rpbkeysvalue.value)}
+                riak_object:decode_vclock(RpbKeysClock#rpbkeysvalue.value),
+                to_fetch}
     end.
 
 -spec make_binarykey(riak_object:bucket(), riak_object:key()) -> binary().

--- a/src/riak_kv_pb_object.erl
+++ b/src/riak_kv_pb_object.erl
@@ -439,7 +439,8 @@ make_binarykey(RObj) ->
     make_binarykey(riak_object:bucket(RObj), riak_object:key(RObj)).
 
 -spec unpack_keyclock_fun(#rpbkeysvalue{}) ->
-        {riak_object:bucket(RObj), riak_object:key(RObj), vclock:vclock()}.
+        {riak_object:bucket(RObj), riak_object:key(RObj), vclock:vclock(),
+            to_fetch}.
 unpack_keyclock_fun(RpbKeysClock) ->
     case RpbKeysClock#rpbkeysvalue.type of
         undefined ->

--- a/src/riak_kv_pb_object.erl
+++ b/src/riak_kv_pb_object.erl
@@ -257,14 +257,14 @@ process(#rpbpushreq{queuename = QueueNameBin, keys_value = KVL}, State) ->
         {QueueName, {FL, FSL, RTL}} ->
             {reply,
                 #rpbpushresp{queue_exists = true,
-                                queuename = QueueName,
+                                queuename = QueueNameBin,
                                 foldq_length = FL,
                                 fsync_length = FSL,
                                 realt_length = RTL},
                 State};
         _ ->
             {reply,
-                #rpbpushresp{queue_exists = false, queuename = QueueName},
+                #rpbpushresp{queue_exists = false, queuename = QueueNameBin},
                 State}
     end;
 

--- a/src/riak_kv_pb_object.erl
+++ b/src/riak_kv_pb_object.erl
@@ -442,19 +442,17 @@ make_binarykey(RObj) ->
         {riak_object:bucket(RObj), riak_object:key(RObj), vclock:vclock(),
             to_fetch}.
 unpack_keyclock_fun(RpbKeysClock) ->
-    case RpbKeysClock#rpbkeysvalue.type of
-        undefined ->
-            {RpbKeysClock#rpbkeysvalue.bucket,
-                RpbKeysClock#rpbkeysvalue.key,
-                riak_object:decode_vclock(RpbKeysClock#rpbkeysvalue.value),
-                to_fetch};
-        T ->
-            {{T,
-                RpbKeysClock#rpbkeysvalue.bucket},
-                RpbKeysClock#rpbkeysvalue.key,
-                riak_object:decode_vclock(RpbKeysClock#rpbkeysvalue.value),
-                to_fetch}
-    end.
+    Bucket =
+        case RpbKeysClock#rpbkeysvalue.type of
+            undefined ->
+                RpbKeysClock#rpbkeysvalue.bucket;
+            T ->
+                {T, RpbKeysClock#rpbkeysvalue.bucket}
+        end,
+    {Bucket,
+        RpbKeysClock#rpbkeysvalue.key,
+        riak_object:decode_vclock(RpbKeysClock#rpbkeysvalue.value),
+        to_fetch}.
 
 -spec make_binarykey(riak_object:bucket(), riak_object:key()) -> binary().
 %% @doc

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -512,7 +512,7 @@ map_peer_to_wi_fun({QueueName, Iteration, PeerInfo}) ->
             pb ->
                 CaCertificateFilename =
                     app_helper:get_env(riak_kv, repl_cacert_filename),
-                CertfiicateFilename =
+                CertificateFilename =
                     app_helper:get_env(riak_kv, repl_cert_filename),
                 KeyFilename =
                     app_helper:get_env(riak_kv, repl_key_filename),
@@ -526,7 +526,7 @@ map_peer_to_wi_fun({QueueName, Iteration, PeerInfo}) ->
                             [{silence_terminate_crash, true},
                                 {credentials, SecuritySitename, ""},
                                 {cacertfile, CaCert},
-                                {certfile, CertfiicateFilename},
+                                {certfile, CertificateFilename},
                                 {keyfile, KeyFilename}]
                     end,
                 InitClientFun = client_start(pb, Host, Port, Opts),

--- a/src/riak_kv_wm_queue.erl
+++ b/src/riak_kv_wm_queue.erl
@@ -25,7 +25,7 @@
 %% ```
 %% GET /queuename/QueueName
 %%
-%% Will return an object if an object is present on the queue
+%% Will return an object if an object is present in the queue
 %%
 %% Parameters to pass:
 %% object_format - internal (return object in internal repl format)

--- a/src/riak_kv_wm_queue.erl
+++ b/src/riak_kv_wm_queue.erl
@@ -180,7 +180,7 @@ process_post(RD, Ctx) ->
             {QueueName, {FL, FSL, RTL}} ->
                 io_lib:format("Queue ~w: ~w ~w ~w", [QueueName, FL, FSL, RTL]);
             _ ->
-                io_lib:format("No queue stats", [])
+                io_lib:format("No queue ~w", [QueueName])
         end,
     {true,
         wrq:set_resp_body(

--- a/src/riak_kv_wm_queue.erl
+++ b/src/riak_kv_wm_queue.erl
@@ -25,11 +25,15 @@
 %% ```
 %% GET /queuename/QueueName
 %%
-%% Will return an object id an object present on queue
+%% Will return an object if an object is present on the queue
 %%
 %% Parameters to pass:
-%% object_format - internal (only currently supported object format)
+%% object_format - internal (return object in internal repl format)
+%%               - internal_aaehash (also return segment hash and vc hash)
 %%
+%% POST /queuename/QueueName
+%%
+%% Body should be a JSON in the format `[{Bucket:[{Key, Clock}]}]`
 %% ```
 
 -module(riak_kv_wm_queue).
@@ -40,17 +44,22 @@
          service_available/2,
          malformed_request/2,
          content_types_provided/2,
-         produce_queue_fetch/2
+         produce_queue_fetch/2,
+         produce_requeue/2
         ]).
 
 -record(ctx, {
-            client,       %% riak_client() - the store client
-            riak,         %% local | {node(), atom()} - params for riak client
-            queuename,  %% Queue Name (from uri)
-            object_format = internal :: internal %% object format to be used in response
+            client,         %% riak_client() - the store client
+            riak,           %% local | {node(), atom()} - params for riak client
+            queuename,      %% Queue Name (from uri)
+            keyclocklist = [] :: list(riak_kv_replrtq_src:repl_entry()),
+                            %% List of Bucket, Key, Clock tuples
+            object_format = internal :: internal|internal_aaehash,
+                            %% object format to be used in response
+            method :: 'GET'|'PUT'|'POST'|undefined
+
          }).
 -type context() :: #ctx{}.
-
 
 -include_lib("webmachine/include/webmachine.hrl").
 -include("riak_kv_wm_raw.hrl").
@@ -63,12 +72,12 @@ init(Props) ->
 -spec service_available(#wm_reqdata{}, context()) ->
     {boolean(), #wm_reqdata{}, context()}.
 %% @doc Determine whether or not a connection to Riak
-%%      can be established. Also, extract query params.
+%%      can be established. 
 service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
     ClientID = riak_kv_wm_utils:get_client_id(RD),
     case riak_kv_wm_utils:get_riak_client(RiakProps, ClientID) of
         {ok, C} ->
-            {true, RD, Ctx#ctx{client = C}};
+            {true, RD, Ctx#ctx{client = C, method=wrq:method(RD)}};
         Error ->
             {false,
              wrq:set_resp_body(
@@ -80,22 +89,54 @@ service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
 -spec malformed_request(#wm_reqdata{}, context()) ->
     {boolean(), #wm_reqdata{}, context()}.
 %% @doc Determine whether request is well-formed
-malformed_request(RD, Ctx) ->
-    QueueNameRaw = wrq:path_info(queuename, RD),
-    QueueName =
-        list_to_atom(riak_kv_wm_utils:maybe_decode_uri(RD, QueueNameRaw)),
+malformed_request(RD, Ctx) when Ctx#ctx.method =:= 'GET' ->
+    QueueName = malformed_queuename(RD),
     ObjectFormatRaw = wrq:get_qs_value(?Q_OBJECT_FORMAT, "internal", RD),
     ObjectFormat = list_to_atom(ObjectFormatRaw),
-    {false, RD, Ctx#ctx{queuename = QueueName, object_format = ObjectFormat}}.
+    {false, RD, Ctx#ctx{queuename = QueueName, object_format = ObjectFormat}};
+malformed_request(RD, Ctx) when Ctx#ctx.method =:= 'POST' ->
+    QueueName = malformed_queuename(RD),
+    KeyClockList = malformed_keyclocklist(wrq:req_body(RD)),
+    {false, RD, Ctx#ctx{queuename = QueueName, keyclocklist = KeyClockList}}.
+
+-spec malformed_queuename(#wm_reqdata{}) -> atom().
+malformed_queuename(RD) ->
+    QueueNameRaw = wrq:path_info(queuename, RD),
+    list_to_atom(riak_kv_wm_utils:maybe_decode_uri(RD, QueueNameRaw)).
+
+-spec malformed_keyclocklist(iolist()) -> list(riak_kv_replrtq_src:rpel_entry()).
+malformed_keyclocklist(ReqBody) ->
+    DecodeBKLFun =
+        fun({B, [{struct, KCL}]}) ->
+            ReplEntryFun = 
+                fun({K, C}) ->
+                    {B,
+                        K,
+                        riak_object:decode_vclock(base64:decode(C)),
+                        to_fetch}
+                end,
+            lists:map(ReplEntryFun, KCL)
+        end,
+    {struct, BKL} = mochijson2:decode(ReqBody),
+    lists:flatten(lists:map(DecodeBKLFun, BKL)).
 
 
 -spec content_types_provided(#wm_reqdata{}, context()) ->
     {[{ContentType::string(), Producer::atom()}], #wm_reqdata{}, context()}.
 %% @doc List the content types available for representing this resource.
 %%      "application/json" is the content-type for bucket lists.
-content_types_provided(RD, Ctx) ->
-    {[{"application/octet-stream", produce_queue_fetch}], RD, Ctx}.
+content_types_provided(RD, Ctx) when Ctx#ctx.method =:= 'GET' ->
+    {[{"application/octet-stream", produce_queue_fetch}], RD, Ctx};
+content_types_provided(RD, Ctx) when Ctx#ctx.method =:= 'POST' ->
+    {[{"application/text", produce_requeue}], RD, Ctx}.
 
+-spec produce_requeue(#wm_reqdata{}, context()) ->
+    {iolist()|{error, any()}, #wm_reqdata{}, context()}.
+produce_requeue(RD, Ctx) ->
+    QueueName = Ctx#ctx.queuename,
+    KeyClockList = Ctx#ctx.keyclocklist,
+    ok = riak_kv_replrtq_src:replrtq_ttaaefs(QueueName, KeyClockList),
+    {"ok " ++ integer_to_list(length(KeyClockList)), RD, Ctx}.
 
 -spec produce_queue_fetch(#wm_reqdata{}, context()) ->
     {binary()|{error, any()}, #wm_reqdata{}, context()}.
@@ -108,8 +149,34 @@ produce_queue_fetch(RD, Ctx) ->
                         RD,
                         Ctx).
     
-format_response(internal, {ok, queue_empty}, RD, Ctx) ->
+format_response(_, {ok, queue_empty}, RD, Ctx) ->
     {<<0:8/integer>>, RD, Ctx};
+format_response(_, {error, Reason}, RD, Ctx) ->
+    lager:warning("Fetch error ~w", [Reason]),
+    {{error, Reason}, RD, Ctx};
+format_response(internal_aaehash, {ok, {deleted, TombClock, RObj}}, RD, Ctx) ->
+    BK = make_binarykey(riak_object:bucket(RObj), riak_object:key(RObj)),
+    {SegmentID, SegmentHash} =
+        leveled_tictac:tictac_hash(BK, lists:sort(TombClock)),
+    SuccessMark = <<1:8/integer>>,
+    IsTombstone = <<1:8/integer>>,
+    ObjBin = encode_riakobject(RObj),
+    TombClockBin = term_to_binary(TombClock),
+    TCL = byte_size(TombClockBin),
+    {<<SuccessMark/binary, IsTombstone/binary,
+        SegmentID:32/integer, SegmentHash:32/integer,
+        TCL:32/integer, TombClockBin/binary,
+        ObjBin/binary>>, RD, Ctx};
+format_response(internal_aaehash, {ok, RObj}, RD, Ctx) ->
+    BK = make_binarykey(riak_object:bucket(RObj), riak_object:key(RObj)),
+    {SegmentID, SegmentHash} =
+        leveled_tictac:tictac_hash(BK, lists:sort(riak_object:vclock(RObj))),
+    SuccessMark = <<1:8/integer>>,
+    IsTombstone = <<0:8/integer>>,
+    ObjBin = encode_riakobject(RObj),
+    {<<SuccessMark/binary, IsTombstone/binary,
+        SegmentID:32/integer, SegmentHash:32/integer,
+        ObjBin/binary>>, RD, Ctx};
 format_response(internal, {ok, {deleted, TombClock, RObj}}, RD, Ctx) ->
     SuccessMark = <<1:8/integer>>,
     IsTombstone = <<1:8/integer>>,
@@ -124,13 +191,19 @@ format_response(internal, {ok, RObj}, RD, Ctx) ->
     IsTombstone = <<0:8/integer>>,
     ObjBin = encode_riakobject(RObj),
     {<<SuccessMark/binary, IsTombstone/binary,
-        ObjBin/binary>>, RD, Ctx};
-format_response(internal, {error, Reason}, RD, Ctx) ->
-    lager:warning("Fetch error ~w", [Reason]),
-    {{error, Reason}, RD, Ctx}.
+        ObjBin/binary>>, RD, Ctx}.
 
 encode_riakobject(RObj) ->
     ToCompress = app_helper:get_env(riak_kv, replrtq_compressonwire, false),
     FullObjBin = riak_object:nextgenrepl_encode(repl_v1, RObj, ToCompress),
     CRC = erlang:crc32(FullObjBin),
     <<CRC:32/integer, FullObjBin/binary>>. 
+
+-spec make_binarykey(riak_object:bucket(), riak_object:key()) -> binary().
+%% @doc
+%% Convert Bucket and Key into a single binary 
+make_binarykey({Type, Bucket}, Key)
+                    when is_binary(Type), is_binary(Bucket), is_binary(Key) ->
+    <<Type/binary, Bucket/binary, Key/binary>>;
+make_binarykey(Bucket, Key) when is_binary(Bucket), is_binary(Key) ->
+    <<Bucket/binary, Key/binary>>.

--- a/src/riak_kv_wm_queue.erl
+++ b/src/riak_kv_wm_queue.erl
@@ -120,7 +120,7 @@ malformed_queuename(RD) ->
 -spec malformed_keyclocklist(iolist()) -> list(riak_kv_replrtq_src:repl_entry()).
 malformed_keyclocklist(ReqBody) ->
     {struct, [{<<"keys-clocks">>, KCL}]} = mochijson2:decode(ReqBody),
-    lists:foldl(fun decode_bucketkeyclock/2, [], KCL).
+    lists:reverse(lists:foldl(fun decode_bucketkeyclock/2, [], KCL)).
 
 decode_bucketkeyclock({struct, BKC}, Acc) ->
     B = 

--- a/src/riak_kv_wm_queue.erl
+++ b/src/riak_kv_wm_queue.erl
@@ -42,6 +42,7 @@
 -export([
          init/1,
          service_available/2,
+         allowed_methods/2,
          malformed_request/2,
          content_types_provided/2,
          produce_queue_fetch/2,
@@ -85,6 +86,10 @@ service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx}
     end.
+
+
+allowed_methods(RD, Ctx) ->
+    {['GET', 'POST'], RD, Ctx}.
 
 -spec malformed_request(#wm_reqdata{}, context()) ->
     {boolean(), #wm_reqdata{}, context()}.


### PR DESCRIPTION
Complete fetch API for PB as well as http.  Add Push API, to allow for discovered differences to be re-queued.

The intention is that this can be used to assist when reconciling a Riak store against an external data store.  Some testing outside of riak_test has been done with dynamodb.  The reconciliation is originally intended to be one-way (e.g. assuming the  non-Riak data store is a read-only copy).

The fetch API is extended to support a different encoding of the fetched object, `internal_aaehash`.  This encoding provides the SegmentId and SegmentHash for this version of the object, to allow that to be indexed within the external db (e.g. to provide merkle trees for comparison).

Testing - https://github.com/basho/riak_test/pull/1356