### PR TITLE
Mas i350 selectivesync

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -13,7 +13,7 @@ riak_core_pb.erl:163: The pattern 'true' can never match the type 'false'
 riak_core_pb.erl:175: The pattern {_, _, Dict} can never match the type 'false'
 riak_core_pb.erl:193: The pattern 'true' can never match the type 'false'
 riak_core_pb.erl:202: The pattern <Binary, 'string'> can never match the type <_,'bytes'>
-riak_core_pb.erl:222: The pattern <Types, [{Fnum, Bytes} | Tail], Acc> can never match the type <_,[],[{_,_}]>
+riak_core_pb.erl:222: The pattern <Types, [{FNum, Bytes} | Tail], Acc> can never match the type <_,[],[{_,_}]>
 riak_kv_bitcask_backend.erl:24: Callback info about the riak_kv_backend behaviour is not available
 riak_kv_buckets_fsm.erl:27: Callback info about the riak_core_coverage_fsm behaviour is not available
 riak_kv_console.erl:154: The pattern {'error', 'legacy_mode'} can never match the type {'error','is_up' | 'not_member' | 'only_member'}
@@ -28,6 +28,7 @@ riak_kv_index_fsm.erl:38: Callback info about the riak_core_coverage_fsm behavio
 riak_kv_keys_fsm.erl:38: Callback info about the riak_core_coverage_fsm behaviour is not available
 riak_kv_memory_backend.erl:40: Callback info about the riak_kv_backend behaviour is not available
 riak_kv_multi_backend.erl:24: Callback info about the riak_kv_backend behaviour is not available
+riak_kv_multi_prefix_backend.erl:74: Callback info about the riak_kv_backend behaviour is not available
 riak_kv_pipe_index.erl:164: Function queue_existing_pipe/4 has no local return
 riak_kv_pipe_listkeys.erl:159: Function queue_existing_pipe/3 has no local return
 riak_kv_pncounter.erl:100: Function merge/2 has no local return
@@ -39,6 +40,8 @@ riak_kv_put_fsm.erl:828: The pattern <[COP = {'crdt_op', _Op} | T], Acc> can nev
 riak_kv_util.erl:283: The pattern 'error' can never match the type 'ok' | 'undefined'
 riak_kv_vnode.erl:839: The pattern Q = {'riak_kv_index_v3', _, _, _, _, _, _, _, _, RE, _} can never match the type 'undefined' | {_,_}
 riak_kv_vnode.erl:849: The pattern <{'riak_kv_index_v3', _, _, _, _, _, _, _, _, _, N}, DefaultSize> can never match the type <'undefined' | {_,_},'undefined' | pos_integer()>
+riak_kv_vnode.erl:970: Invalid type specification for function riak_kv_vnode:prepare_index_query/1. The success typing is ('undefined' | {_,_}) -> 'undefined' | {_,_}
+riak_kv_vnode.erl:1002: The call riak_kv_vnode:prepare_index_query(Query::'undefined' | {_,_}) breaks the contract (#riak_kv_index_v3{}) -> #riak_kv_index_v3{}
 riak_kv_vnode.erl:1270: Function do_backend_delete/3 has no local return
 riak_kv_vnode.erl:1977: Function delete_from_hashtree/3 has no local return
 riak_kv_vnode.erl:1981: The call riak_kv_index_hashtree:async_delete(Items::[{'object',{_,_}},...],Trees::'undefined' | pid()) breaks the contract ({binary(),binary()} | [{binary(),binary()}],pid()) -> 'ok'
@@ -55,6 +58,7 @@ Unknown functions:
   yz_kv:index/3
   yz_kv:is_search_enabled_for_bucket/1
   yz_kv:should_handoff/1
+  yz_kv:index_binary/5
 Unknown types:
   base64:ascii_binary/0
   calendar:t_now/0

--- a/rebar.config
+++ b/rebar.config
@@ -58,7 +58,7 @@
     {riak_dt, {git, "git://github.com/basho/riak_dt.git", {tag, "riak_kv-3.0.0"}}},
     {riak_api, {git, "git://github.com/basho/riak_api.git", {tag, "riak_kv-3.0.7"}}},
     {hyper, {git, "git://github.com/basho/hyper", {tag, "1.1.0"}}},
-    {leveled, {git, "https://github.com/martinsumner/leveled.git", {tag, "1.0.4"}}},
+    {leveled, {git, "https://github.com/martinsumner/leveled.git", {branch, "mas-i350-selectivesync"}}},
     {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "0.9.18"}}},
     {riakhttpc, {git, "git://github.com/basho/riak-erlang-http-client", {tag, "3.0.7"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -48,7 +48,7 @@
 ]}.
 
 {deps, [
-    {riak_core, {git, "git://github.com/basho/riak_core.git", {tag, "riak_kv-3.0.5"}}},
+    {riak_core, {git, "git://github.com/basho/riak_core.git", {branch, "mas-i350-selectivesync"}}},
     {sidejob, {git, "git://github.com/basho/sidejob.git", {tag, "2.1.0"}}},
     {bitcask, {git, "git://github.com/basho/bitcask.git", {tag, "2.1.0"}}},
     {redbug, {git, "https://github.com/massemanet/redbug", {tag, "1.2.1"}}},

--- a/src/riak_kv_bucket.erl
+++ b/src/riak_kv_bucket.erl
@@ -298,6 +298,13 @@ validate([{QProp, MaybeQ}=Prop | T], ValidProps, Errors) when QProp =:= dw
         false ->
             validate(T, ValidProps, [{QProp, not_valid_quorum} | Errors])
     end;
+validate([{SyncProp, MaybeSync}=Prop | T], ValidProps, Errors) when SyncProp =:= sync_on_write ->
+    case is_valid_sync_param(MaybeSync) of
+        true ->
+            validate(T, [Prop | ValidProps], Errors);
+        false ->
+            validate(T, ValidProps, [{SyncProp, not_valid_sync_param} | Errors])
+    end;
 validate([Prop|T], ValidProps, Errors) ->
     validate(T, [Prop|ValidProps], Errors).
 
@@ -314,6 +321,17 @@ is_quorum(Q)  when Q =:= quorum
     true;
 is_quorum(_) ->
     false.
+
+-spec is_valid_sync_param(term()) -> boolean().
+is_valid_sync_param(SP) when SP =:= one
+                        orelse SP =:= all
+                        orelse SP =:= backend
+                        orelse SP =:= <<"one">>
+                        orelse SP =:= <<"all">>
+                        orelse SP =:= <<"backend">> ->
+   true;
+is_valid_sync_param(_) ->
+   false.
 
 %% @private some quorum options can be zero
 -spec is_opt_quorum(term()) -> boolean().

--- a/src/riak_kv_bucket.erl
+++ b/src/riak_kv_bucket.erl
@@ -298,12 +298,12 @@ validate([{QProp, MaybeQ}=Prop | T], ValidProps, Errors) when QProp =:= dw
         false ->
             validate(T, ValidProps, [{QProp, not_valid_quorum} | Errors])
     end;
-validate([{SyncProp, MaybeSync}=Prop | T], ValidProps, Errors) when SyncProp =:= sync_on_write ->
+validate([{sync_on_write, MaybeSync}=Prop | T], ValidProps, Errors) ->
     case is_valid_sync_param(MaybeSync) of
         true ->
             validate(T, [Prop | ValidProps], Errors);
         false ->
-            validate(T, ValidProps, [{SyncProp, not_valid_sync_param} | Errors])
+            validate(T, ValidProps, [{sync_on_write, not_valid_sync_param} | Errors])
     end;
 validate([Prop|T], ValidProps, Errors) ->
     validate(T, [Prop|ValidProps], Errors).
@@ -322,6 +322,10 @@ is_quorum(Q)  when Q =:= quorum
 is_quorum(_) ->
     false.
 
+%% validation of sync parameters
+%% one = sync coordinating node only
+%% all = sync all nodes
+%% backend = take sync value for all nodes from backend config (don't override)
 -spec is_valid_sync_param(term()) -> boolean().
 is_valid_sync_param(SP) when SP =:= one
                         orelse SP =:= all

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -200,12 +200,11 @@ do_put(Bucket, PrimaryKey, IndexSpecs, Val, Sync, #state{ref=Ref,
     Updates1 = [{put, StorageKey, Val} || Val /= undefined],
 
     %% Setup write options...
-    case Sync of
+    WriteOpts2 = case Sync of
         true ->
-            WriteOpts1 = lists:keydelete(sync,1,WriteOpts),
-            WriteOpts2 = lists:append(WriteOpts1, [{sync,Sync}]);
+            lists:keyreplace(sync,1,WriteOpts, {sync,Sync});
         _ ->
-            WriteOpts2 = WriteOpts
+            WriteOpts
     end,
 
     %% Convert IndexSpecs to index updates...

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -178,14 +178,16 @@ get(Bucket, Key, #state{read_opts=ReadOpts,
                  {ok, state()} |
                  {error, term(), state()}.
 put(Bucket, PrimaryKey, IndexSpecs, Val, State) ->
-    do_put(Bucket, PrimaryKey, IndexSpecs, Val, false, State).
+    Sync = false,
+    do_put(Bucket, PrimaryKey, IndexSpecs, Val, Sync, State).
 
 %% @doc put_flush capability - do a put with a flush to disk
 -spec flush_put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
                  {ok, state()} |
                  {error, term(), state()}.
 flush_put(Bucket, PrimaryKey, IndexSpecs, Val, State) ->
-    do_put(Bucket, PrimaryKey, IndexSpecs, Val, true, State).
+    Sync = true,
+    do_put(Bucket, PrimaryKey, IndexSpecs, Val, Sync, State).
 
 %% @doc Insert an object into the eleveldb backend.
 -spec do_put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), boolean(), state()) ->

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -182,16 +182,14 @@ get(Bucket, Key, #state{read_opts=ReadOpts,
                  {ok, state()} |
                  {error, term(), state()}.
 put(Bucket, PrimaryKey, IndexSpecs, Val, State) ->
-    Sync = false,
-    do_put(Bucket, PrimaryKey, IndexSpecs, Val, Sync, State).
+    do_put(Bucket, PrimaryKey, IndexSpecs, Val, false, State).
 
 %% @doc put_flush capability - do a put with a flush to disk
 -spec flush_put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
                  {ok, state()} |
                  {error, term(), state()}.
 flush_put(Bucket, PrimaryKey, IndexSpecs, Val, State) ->
-    Sync = true,
-    do_put(Bucket, PrimaryKey, IndexSpecs, Val, Sync, State).
+    do_put(Bucket, PrimaryKey, IndexSpecs, Val, true, State).
 
 %% @doc Insert an object into the eleveldb backend.
 -spec do_put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), boolean(), state()) ->

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -65,6 +65,8 @@
         %% Request additional details about request added as extra
         %% element at the end of result tuple
         {details, detail()} |
+        %% Sync-on-write setting, backend, one(co-ordinating) or all
+        {sync_on_write, atom()} |
         %% Put the value as-is, do not increment the vclocks
         %% to make the value a frontier.
         asis |
@@ -89,6 +91,7 @@
                 w :: non_neg_integer(),
                 dw :: non_neg_integer(),
                 pw :: non_neg_integer(),
+                sync_on_write :: atom(),
                 coord_pl_entry :: {integer(), atom()},
                 preflist2 :: riak_core_apl:preflist_ann(),
                 bkey :: {riak_object:bucket(), riak_object:key()},

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -31,6 +31,7 @@
          fallback/4,
          expand_value/3,
          expand_rw_value/4,
+         expand_sync_on_write/2,
          normalize_rw_value/2,
          make_request/2,
          get_index_n/1,
@@ -142,6 +143,20 @@ expand_value(Type, default, BucketProps) ->
     get_bucket_option(Type, BucketProps);
 expand_value(_Type, Value, _BucketProps) ->
     Value.
+
+expand_sync_on_write(default, BucketProps) ->
+    normalize_value(get_bucket_option(sync_on_write, BucketProps));
+expand_sync_on_write(Value, _BucketProps) ->
+    Value.
+
+normalize_value(Val) when is_atom(Val) ->
+    Val;
+normalize_value(Val) when is_binary(Val) ->
+    try
+        binary_to_existing_atom(Val, utf8)
+    catch _:badarg ->
+        error
+    end.
 
 expand_rw_value(Type, default, BucketProps, N) ->
     normalize_rw_value(get_bucket_option(Type, BucketProps), N);

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -2976,17 +2976,20 @@ perform_put({true, {_Obj, _OldObj}=Objects},
       false ->
         MaxCheckFlag = do_max_check
     end,
-    case SyncOnWrite of
-        all ->
-           Sync = true;
-        %% 'one' does not override the backend value for the other nodes
-        %% therefore is only useful if the backend is configured to not sync-on-write
-        one ->
-           Sync = Coord;
-        _ ->
-           %% anything but all or one means do the default configured backend write
-           Sync = false
-    end,
+    Sync = 
+        case SyncOnWrite of
+            all ->
+                true;
+            %% 'one' does not override the backend value for the other nodes
+            %% therefore is only useful if the backend is configured to not 
+            %% sync-on-write
+            one ->
+                Coord;
+            _ ->
+            %% anything but all or one means do the default configured backend
+            %% write
+                false
+        end,
     {Reply, State2} =
         actual_put(BKey, Objects, IndexSpecs, RB, ReqID, MaxCheckFlag,
                     {Coord, Sync}, State),

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -2969,7 +2969,6 @@ perform_put({true, {_Obj, _OldObj}=Objects},
                      coord=Coord,
                      index_specs=IndexSpecs,
                      readrepair=ReadRepair,
-                     coord=Coord,
                      sync_on_write=SyncOnWrite}) ->
     case ReadRepair of
       true ->
@@ -2988,17 +2987,21 @@ perform_put({true, {_Obj, _OldObj}=Objects},
            %% anything but all or one means do the default configured backend write
            Sync = false
     end,
-    {Reply, State2} = actual_put(BKey, Objects, IndexSpecs, RB, ReqID, MaxCheckFlag, Sync, State),
+    {Reply, State2} =
+        actual_put(BKey, Objects, IndexSpecs, RB, ReqID, MaxCheckFlag,
+                    {Coord, Sync}, State),
     {Reply, State2}.
 
 actual_put(BKey, {Obj, OldObj}, IndexSpecs, RB, ReqID, State) ->
-    actual_put(BKey, {Obj, OldObj}, IndexSpecs, RB, ReqID, do_max_check, false, State).
+    actual_put(BKey, {Obj, OldObj}, IndexSpecs, RB, ReqID, do_max_check,
+                {false, false}, State).
 
 actual_put(BKey={Bucket, Key},
             {Obj, OldObj},
             IndexSpecs,
             RB, ReqID,
-            MaxCheckFlag, Sync,
+            MaxCheckFlag,
+            {Coord, Sync},
             State=#state{idx=Idx,
                             mod=Mod,
                             modstate=ModState,

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -447,8 +447,8 @@ malformed_rw_param({Idx, Name, Default}, {Result, RD, Ctx}) ->
              Ctx}
     end.
 
--spec malformed_custom_param({Idx::integer(), Name::string(), Default::string()},
-                             {boolean(), #wm_reqdata{}, context(), [atom()]}) ->
+-spec malformed_custom_param({Idx::integer(), Name::string(), Default::string(), AllowedValues::[atom()]},
+                             {boolean(), #wm_reqdata{}, context()}) ->
    {boolean(), #wm_reqdata{}, context()}.
 %% @doc Check that a custom parameter is one of the AllowedValues
 %% Store its result in context() if it is, or print an error message

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -408,7 +408,6 @@ malformed_timeout_param(RD, Ctx) ->
 %%      string-encoded integers.  Store the integer values
 %%      in context() if so.
 malformed_rw_params(RD, Ctx) ->
-    io:format("Checking parameters.~n"),
     Res =
     lists:foldl(fun malformed_rw_param/2,
                 {false, RD, Ctx},

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -422,7 +422,10 @@ malformed_rw_params(RD, Ctx) ->
     Res2 =
     lists:foldl(fun malformed_custom_param/2,
                  Res,
-                 [{#ctx.sync_on_write, "sync_on_write", "default", [default, backend, one, all]}]),
+                 [{#ctx.sync_on_write,
+                     "sync_on_write",
+                     "default",
+                     [default, backend, one, all]}]),
     lists:foldl(fun malformed_boolean_param/2,
                 Res2,
                 [{#ctx.basic_quorum, "basic_quorum", "default"},
@@ -449,21 +452,31 @@ malformed_rw_param({Idx, Name, Default}, {Result, RD, Ctx}) ->
              Ctx}
     end.
 
--spec malformed_custom_param({Idx::integer(), Name::string(), Default::string(), AllowedValues::[atom()]},
-                             {boolean(), #wm_reqdata{}, context()}) ->
+-spec malformed_custom_param({Idx::integer(),
+                                    Name::string(),
+                                    Default::string(),
+                                    AllowedValues::[atom()]},
+                                {boolean(), #wm_reqdata{}, context()}) ->
    {boolean(), #wm_reqdata{}, context()}.
 %% @doc Check that a custom parameter is one of the AllowedValues
 %% Store its result in context() if it is, or print an error message
 %% in #wm_reqdata{} if it is not.
 malformed_custom_param({Idx, Name, Default, AllowedValues}, {Result, RD, Ctx}) ->
     AllowedValueTuples = [{V} || V <- AllowedValues],
-    Option=lists:keyfind(list_to_atom(string:to_lower(wrq:get_qs_value(Name, Default, RD))),1, AllowedValueTuples),
+    Option=
+        lists:keyfind(
+            list_to_atom(
+                string:to_lower(
+                    wrq:get_qs_value(Name, Default, RD))),
+                1, 
+                AllowedValueTuples),
     case Option of
         false ->
+            ErrorText =
+                "~s query parameter must be one of the following words: ~p~n",
             {true,
              wrq:append_to_resp_body(
-               io:format("~s query parameter must be one of the following words: ~p~n",
-                             [Name, AllowedValues]),
+               io_lib:format(ErrorText, [Name, AllowedValues]),
                wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
              Ctx};
         _ ->

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -168,6 +168,7 @@
               basic_quorum, %% boolean() - whether to use basic_quorum
               notfound_ok,  %% boolean() - whether to treat notfounds as successes
               asis,         %% boolean() - whether to send the put without modifying the vclock
+              sync_on_write,%% string() - sync on write behaviour to pass to backend
               prefix,       %% string() - prefix for resource uris
               riak,         %% local | {node(), atom()} - params for riak client
               doc,          %% {ok, riak_object()}|{error, term()} - the object found
@@ -407,6 +408,7 @@ malformed_timeout_param(RD, Ctx) ->
 %%      string-encoded integers.  Store the integer values
 %%      in context() if so.
 malformed_rw_params(RD, Ctx) ->
+    io:format("Checking parameters.~n"),
     Res =
     lists:foldl(fun malformed_rw_param/2,
                 {false, RD, Ctx},
@@ -416,8 +418,12 @@ malformed_rw_params(RD, Ctx) ->
                  {#ctx.rw, "rw", "default"},
                  {#ctx.pw, "pw", "default"},
                  {#ctx.pr, "pr", "default"}]),
+    Res2 =
+    lists:foldl(fun malformed_custom_param/2,
+                 Res,
+                 [{#ctx.sync_on_write, "sync_on_write", "default", [default, backend, one, all]}]),
     lists:foldl(fun malformed_boolean_param/2,
-                Res,
+                Res2,
                 [{#ctx.basic_quorum, "basic_quorum", "default"},
                  {#ctx.notfound_ok, "notfound_ok", "default"},
                  {#ctx.asis, "asis", "false"}]).
@@ -442,9 +448,28 @@ malformed_rw_param({Idx, Name, Default}, {Result, RD, Ctx}) ->
              Ctx}
     end.
 
--spec malformed_boolean_param({Idx::integer(), Name::string(), Default::string()},
-                              {boolean(), #wm_reqdata{}, context()}) ->
-    {boolean(), #wm_reqdata{}, context()}.
+-spec malformed_custom_param({Idx::integer(), Name::string(), Default::string()},
+                             {boolean(), #wm_reqdata{}, context(), [atom()]}) ->
+   {boolean(), #wm_reqdata{}, context()}.
+%% @doc Check that a custom parameter is one of the AllowedValues
+%% Store its result in context() if it is, or print an error message
+%% in #wm_reqdata{} if it is not.
+malformed_custom_param({Idx, Name, Default, AllowedValues}, {Result, RD, Ctx}) ->
+    AllowedValueTuples = [{V} || V <- AllowedValues],
+    Option=lists:keyfind(list_to_atom(string:to_lower(wrq:get_qs_value(Name, Default, RD))),1, AllowedValueTuples),
+    case Option of
+        false ->
+            {true,
+             wrq:append_to_resp_body(
+               io:format("~s query parameter must be one of the following words: ~p~n",
+                             [Name, AllowedValues]),
+               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx};
+        _ ->
+            {Value} = Option,
+            {Result, RD, setelement(Idx, Ctx, Value)}
+    end.
+
 %% @doc Check that a specific query param is a
 %%      string-encoded boolean.  Store its result in context() if it
 %%      is, or print an error message in #wm_reqdata{} if it is not.
@@ -465,6 +490,7 @@ malformed_boolean_param({Idx, Name, Default}, {Result, RD, Ctx}) ->
              Ctx}
     end.
 
+normalize_rw_param("backend") -> backend;
 normalize_rw_param("default") -> default;
 normalize_rw_param("one") -> one;
 normalize_rw_param("quorum") -> quorum;
@@ -1253,6 +1279,7 @@ handle_common_error(Reason, RD, Ctx) ->
 make_options(Prev, Ctx) ->
     NewOpts0 = [{rw, Ctx#ctx.rw}, {r, Ctx#ctx.r}, {w, Ctx#ctx.w},
                 {pr, Ctx#ctx.pr}, {pw, Ctx#ctx.pw}, {dw, Ctx#ctx.dw},
+                {sync_on_write, Ctx#ctx.sync_on_write},
                 {timeout, Ctx#ctx.timeout}, {asis, Ctx#ctx.asis}],
     NewOpts = [ {Opt, Val} || {Opt, Val} <- NewOpts0,
                               Val /= undefined, Val /= default ],


### PR DESCRIPTION
Add selective sync to Riak KV.  Prior to this change either all vnodes sync'd a PUT (i.e. flushed to disk as part of accepting the PUT) or no vnodes.  With no sync the flush decision is controlled by either the database (bitcask, eleveldb) or the operating system (leveled).

This changes allows for three options:

backend - rely on backend configuration as now
all - force a sync on all vnodes regardless of backend configuration
one - force a sync only on the coordinating vnode

The sync option can be set on a per-bucket basis, and over-written on a per-write basis.  This provides much more flexibility.

Previously customer who wanted to make sure data was flushed to disk in a least one place for some buckets, had to set backend sync settings to sync, and sync to all vnodes on every write on every bucket.  Throughput between sync and non-sync configurations have been discovered to be large even with hardware acceleration (e.g. flash-backed write caches) - see https://github.com/martinsumner/leveled/issues/350