### PR TITLE
Mas i1793 repairkeysrange

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -59,5 +59,5 @@
     {hyper, {git, "git://github.com/basho/hyper", {tag, "1.1.0"}}},
     {leveled, {git, "https://github.com/martinsumner/leveled.git", {tag, "1.0.4"}}},
     {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "0.9.18"}}},
-    {riakhttpc, {git, "git://github.com/basho/riak-erlang-http-client", {tag, "3.0.7"}}}
+    {riakhttpc, {git, "git://github.com/basho/riak-erlang-http-client", {branch, "mas-i1793-repairkeysrange"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -43,7 +43,6 @@
 {profiles, [
     {test, [{deps, [meck,
                     {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {tag, "v0.5.0"}}}]}]},
-    {eqc, [{deps, [meck]}]},
     {gha, [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}
 ]}.
 
@@ -56,7 +55,7 @@
     {sext, {git, "git://github.com/uwiger/sext.git", {tag, "1.4.1"}}},
     {riak_pipe, {git, "git://github.com/basho/riak_pipe.git", {tag, "riak_kv-3.0.5"}}},
     {riak_dt, {git, "git://github.com/basho/riak_dt.git", {tag, "riak_kv-3.0.0"}}},
-    {riak_api, {git, "git://github.com/basho/riak_api.git", {tag, "riak_kv-3.0.7"}}},
+    {riak_api, {git, "git://github.com/basho/riak_api.git", {branch, "mas-i1793-repairkeysrange"}}},
     {hyper, {git, "git://github.com/basho/hyper", {tag, "1.1.0"}}},
     {leveled, {git, "https://github.com/martinsumner/leveled.git", {tag, "1.0.4"}}},
     {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "0.9.18"}}},

--- a/src/riak_kv_clusteraae_fsm.erl
+++ b/src/riak_kv_clusteraae_fsm.erl
@@ -940,6 +940,10 @@ is_valid_fold({repl_keys_range, B, KR, MR, _QN}) ->
     is_bucket(B) and
         is_keyrange(KR) and
         is_modrange(MR);
+is_valid_fold({repair_keys_range, B, KR, MR, all}) ->
+    is_bucket(B) and
+        is_keyrange(KR) and
+        is_modrange(MR);
 is_valid_fold({find_keys, B, KR, MR, {sibling_count, I}}) ->
     is_bucket(B) and
         is_keyrange(KR) and

--- a/src/riak_kv_pb_aaefold.erl
+++ b/src/riak_kv_pb_aaefold.erl
@@ -139,6 +139,18 @@ process(#rpbaaefoldreplkeysreq{type = T,
     QueueName = binary_to_atom(QN, utf8),
     Query = {repl_keys_range, maybe_bucket_type(T, B), KR, MR, QueueName},
     process_query(Query, State);
+process(#rpbaaefoldrepairkeysreq{type = T,
+                                    bucket = B, 
+                                    key_range = IsKR,
+                                    start_key = SK,
+                                    end_key = EK,
+                                    modified_range = IsModR,
+                                    last_mod_start = LMS,
+                                    last_mod_end = LME}, State) ->
+    KR = case IsKR of true -> {SK, EK}; false -> all end,
+    MR = case IsModR of true -> {date, LMS, LME}; false -> all end,
+    Query = {repair_keys_range, maybe_bucket_type(T, B), KR, MR, all},
+    process_query(Query, State);
 process(#rpbaaefoldfindkeysreq{type = T,
                                 bucket = B, 
                                 key_range = IsKR,

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1845,6 +1845,39 @@ handle_aaefold({repl_keys_range,
                                 InitAcc, 
                                 [{clock, null}]),
     {select_queue(?AF4_QUEUE, State), {fold, Folder, ReturnFun}, Sender, State};
+handle_aaefold({repair_keys_range,
+                        Bucket, KeyRange,
+                        ModifiedRange,
+                        all},
+                    InitAcc, _Nval,
+                    IndexNs, Filtered, ReturnFun, Cntrl, Sender,
+                    State) ->
+    {ok, C} = riak:local_client(),
+    FetchFun = riak_kv_clusteraae_fsm:repair_fun(C),
+    FoldFun =
+        fun(BF, KF, _EFs, Acc) ->
+            {AccL, Count, all, BatchSize} = Acc,
+            case Count rem BatchSize of
+                0 ->
+                    lists:foreach(FetchFun, AccL), 
+                    {[{BF, KF}], Count + 1, all, BatchSize};
+                _ ->
+                    {[{BF, KF}|AccL], Count + 1, all, BatchSize}
+            end
+        end,
+    WrappedFoldFun = aaefold_withcoveragecheck(FoldFun, IndexNs, Filtered),
+    RangeLimiter = aaefold_setrangelimiter(Bucket, KeyRange),
+    ModifiedLimiter = aaefold_setmodifiedlimiter(ModifiedRange),
+    {async, Folder} = 
+        aae_controller:aae_fold(Cntrl, 
+                                RangeLimiter,
+                                all,
+                                ModifiedLimiter,
+                                false,
+                                WrappedFoldFun, 
+                                InitAcc, 
+                                []),
+    {select_queue(?AF4_QUEUE, State), {fold, Folder, ReturnFun}, Sender, State};
 handle_aaefold({find_keys, 
                         Bucket, KeyRange,
                         ModifiedRange,

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1826,6 +1826,8 @@ handle_aaefold({repl_keys_range,
             {AccL, Count, QueueName, BatchSize} = Acc,
             case Count rem BatchSize of
                 0 ->
+                    % Reading in batch, then processing in batch assumed 
+                    % to be more efficient
                     riak_kv_replrtq_src:replrtq_aaefold(QueueName, AccL),
                     {[RE], Count + 1, QueueName, BatchSize};
                 _ ->
@@ -1859,6 +1861,8 @@ handle_aaefold({repair_keys_range,
             {AccL, Count, all, BatchSize} = Acc,
             case Count rem BatchSize of
                 0 ->
+                    % Reading in batch, then processing in batch assumed 
+                    % to be more efficient
                     lists:foreach(FetchFun, AccL), 
                     {[{BF, KF}], Count + 1, all, BatchSize};
                 _ ->

--- a/src/riak_kv_web.erl
+++ b/src/riak_kv_web.erl
@@ -139,6 +139,9 @@ raw_dispatch(Name) ->
      {["rangerepl"] ++ Prefix ++ ["buckets", bucket, "queuename", queuename],
       riak_kv_wm_aaefold, Props},
 
+     {["rangerepair"] ++ Prefix ++ ["buckets", bucket],
+      riak_kv_wm_aaefold, Props},
+
      {["siblings"] ++ Prefix ++ ["buckets", bucket, "counts", count],
       riak_kv_wm_aaefold, Props},
 

--- a/src/riak_kv_wm_aaefold.erl
+++ b/src/riak_kv_wm_aaefold.erl
@@ -26,8 +26,8 @@
 %% GET /cachedtrees/nvals/NVal/keysclocks?filter
 %% GET /rangetrees/[types/Type/]buckets/Bucket/trees/Size?filter
 %% GET /rangetrees/[types/Type/]buckets/Bucket/keysclocks?filter
-%% GET /rangerepl/[types/Type/]bucket/Bucket?filter
-%% GET /rangerepair/[types/Type/]bucket/Bucket?filter
+%% GET /rangerepl/[types/Type/]buckets/Bucket?filter
+%% GET /rangerepair/[types/Type/]buckets/Bucket?filter
 %% GET /siblings/[types/Type/]buckets/Bucket/counts/Cnt?filter
 %% GET /objectsizes/[types/Type/]buckets/Bucket/sizes/Size?filter
 %% GET /objectstats/[types/Type/]buckets/Bucket?filter
@@ -83,7 +83,7 @@
 %%          the merkle tree. If absent then the default hash fun is used.
 %%   </li>
 %%   <li><tt>change_method=count|local|{job, Integer}</tt><br />
-%%          Used only on reape and erase queries.  If the change_method is set
+%%          Used only on reap and erase queries.  If the change_method is set
 %%          to count, then no reaps or erases will be performed - a count will
 %%          simply be taken.  local will mean that on each node participating
 %%          in the query, that node's eraser/reaper queue will be used for that


### PR DESCRIPTION
Add fold to accelerate read repair on ranges on keys.

The fold will simply prompt a GET on every key, which will in turn prompt a read_repair if that is necessary.

Some consideration was given to making a more targeted change - e.g. only GET those keys that exist on a specific node with a known repair requirement.  However, preference is to keep the change a simple as possible, with some flexibility in the API to divert from specifying `all` to repair in a future change. 