### PR TITLE
Mas i1656 defaultobjecthashversion

### DIFF
--- a/src/riak_kv.app.src
+++ b/src/riak_kv.app.src
@@ -73,8 +73,9 @@
          {max_siblings, 100},
 
          %% Object hash version should be 0 by default.  Without the
-         %% environment variable being set at stratup - it could by default
-         %% revert to being considered as legacy - Github Issue 1656
+         %% environment variable being set at startup, it could by default
+         %% revert to being considered as legacy even when the whole cluster
+         %% has support for version 0 - Github Issue 1656
          {object_hash_version, 0},
 
          %% @doc http_url_encoding determines how Riak treats URL encoded

--- a/src/riak_kv.app.src
+++ b/src/riak_kv.app.src
@@ -72,6 +72,10 @@
          % generate a warning in the logs
          {max_siblings, 100},
 
+         %% Object hash version should be 0 by default.  Without the
+         %% environment variable being set at stratup - it could by default
+         %% revert to being considered as legacy - Github Issue 1656
+         {object_hash_version, 0},
 
          %% @doc http_url_encoding determines how Riak treats URL encoded
          %% buckets, keys, and links over the REST API. When set to 'on' Riak


### PR DESCRIPTION
Default object_hash_version to 0.  Part of the capability check, if a node has registered and gossiped any capability, but not this one, it will fall back to RPC check to environment variable.  If this succeeds (node is up) but returns undefined - it will incorrectly default to legacy.

Should `legacy` be required, it can still be set in advanced.config.