### PR TITLE
Mas i1801 2iqueryperf

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1206,3 +1206,28 @@
     {default, disabled},
     {commented, enabled}
 ]}.
+
+%% @doc Set the vnode worker pool size
+%% This is a pool of workers per-vnode, to be used for general queries, in
+%% particular secondary index queries.  This now defaults to 4 workers, prior
+%% to release 3.0.9 it was set to a default of 10.
+%% The number of concurrent index queries that can be supported in the cluster
+%% will be equal to n_val * worker_count.
+%% The statistic worker_vnode_pool_worktime_mean tracks the average time
+%% each worker is taking per query in microseconds, so the overall queries
+%% per second supported will be:
+%%  (1000000 div worker_vnode_pool_worktime) * n_val * worker_count
+%% It should normally be possible to support >> 100 queries per second with 
+%% just a single worker per vnode.
+%% The statistic workervnode_pool_queuetime_mean will track the average time
+%% a query is spending on a queue, should the vnode pool be exhausted.
+%% If using tictac_aae this should be set to at least 2, as tree rebuilds use
+%% this pool as well as queries.  Also consider that long-running legacy
+%% legacy queries (list keys and list buckets, not using aae_fold) also use
+%% this pool.  All aae_fold type queries will use the alternative
+%% node_worker_pool, unless none is used for the worker_pool_strategy, in which
+%% case the vnode pool is also used for aae_folds.
+{mapping, "worker_pool_size", "riak_kv.worker_pool_size", [
+    {datatype, integer},
+    {default, 4}
+]}.

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1173,7 +1173,7 @@
     {default, 24}
 ]}.
 
-%% @doc The maximume number of workers to be for any given peer may be
+%% @doc The maximum number of workers to be for any given peer may be
 %% configured - if not configured will default to the number of sinkworkers
 {mapping, "replrtq_sinkpeerlimit", "riak_kv.replrtq_sinkpeerlimit", [
     {datatype, integer},
@@ -1195,6 +1195,13 @@
 %% journal, whereas the `recalc` strategy discards that history, but will redo
 %% a diff_index_specs calculation when reloading each object.
 {mapping, "leveled_reload_recalc", "riak_kv.leveled_reload_recalc", [
+    {datatype, {flag, enabled, disabled}},
+    {default, disabled},
+    {commented, enabled}
+]}.
+
+%% @doc Enable logging of query timings in the index_fsm
+{mapping, "log_index_fsm", "riak_kv.log_index_fsm", [
     {datatype, {flag, enabled, disabled}},
     {default, disabled},
     {commented, enabled}

--- a/rebar.config
+++ b/rebar.config
@@ -47,7 +47,7 @@
 ]}.
 
 {deps, [
-    {riak_core, {git, "https://github.com/basho/riak_core.git", {branch, "develop-3.0"}}},
+    {riak_core, {git, "https://github.com/basho/riak_core.git", {branch, "mas-i1801-monitorworkerq"}}},
     {sidejob, {git, "https://github.com/basho/sidejob.git", {tag, "2.1.0"}}},
     {bitcask, {git, "https://github.com/basho/bitcask.git", {tag, "2.1.0"}}},
     {redbug, {git, "https://github.com/massemanet/redbug", {tag, "1.2.2"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -47,15 +47,15 @@
 ]}.
 
 {deps, [
-    {riak_core, {git, "https://github.com/basho/riak_core.git", {tag, "riak_kv-3.0.8"}}},
+    {riak_core, {git, "https://github.com/basho/riak_core.git", {branch, "mas-i1801-coverageplan"}}},
     {sidejob, {git, "https://github.com/basho/sidejob.git", {tag, "2.1.0"}}},
     {bitcask, {git, "https://github.com/basho/bitcask.git", {tag, "2.1.0"}}},
     {redbug, {git, "https://github.com/massemanet/redbug", {tag, "1.2.2"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.2"}}},
     {sext, {git, "https://github.com/uwiger/sext.git", {tag, "1.4.1"}}},
-    {riak_pipe, {git, "https://github.com/basho/riak_pipe.git", {tag, "riak_kv-3.0.5"}}},
+    {riak_pipe, {git, "https://github.com/basho/riak_pipe.git", {branch, "mas-i1801-coverageplan"}}},
     {riak_dt, {git, "https://github.com/basho/riak_dt.git", {tag, "riak_kv-3.0.0"}}},
-    {riak_api, {git, "https://github.com/basho/riak_api.git", {tag, "3.0.8"}}},
+    {riak_api, {git, "https://github.com/basho/riak_api.git", {branch, "mas-i1801-coverageplan"}}},
     {hyper, {git, "https://github.com/basho/hyper", {tag, "1.1.0"}}},
     {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {branch, "develop-3.0"}}},
     {riakhttpc, {git, "https://github.com/basho/riak-erlang-http-client", {tag, "3.0.8"}}}

--- a/rebar.config
+++ b/rebar.config
@@ -57,6 +57,6 @@
     {riak_dt, {git, "https://github.com/basho/riak_dt.git", {tag, "riak_kv-3.0.0"}}},
     {riak_api, {git, "https://github.com/basho/riak_api.git", {tag, "3.0.8"}}},
     {hyper, {git, "https://github.com/basho/hyper", {tag, "1.1.0"}}},
-    {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "1.0.0"}}},
+    {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {branch, "develop-3.0"}}},
     {riakhttpc, {git, "https://github.com/basho/riak-erlang-http-client", {tag, "3.0.8"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -47,7 +47,7 @@
 ]}.
 
 {deps, [
-    {riak_core, {git, "https://github.com/basho/riak_core.git", {branch, "mas-i1801-monitorworkerq"}}},
+    {riak_core, {git, "https://github.com/basho/riak_core.git", {branch, "develop-3.0"}}},
     {sidejob, {git, "https://github.com/basho/sidejob.git", {tag, "2.1.0"}}},
     {bitcask, {git, "https://github.com/basho/bitcask.git", {tag, "2.1.0"}}},
     {redbug, {git, "https://github.com/massemanet/redbug", {tag, "1.2.2"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -47,15 +47,15 @@
 ]}.
 
 {deps, [
-    {riak_core, {git, "https://github.com/basho/riak_core.git", {branch, "mas-i1801-coverageplan"}}},
+    {riak_core, {git, "https://github.com/basho/riak_core.git", {branch, "develop-3.0"}}},
     {sidejob, {git, "https://github.com/basho/sidejob.git", {tag, "2.1.0"}}},
     {bitcask, {git, "https://github.com/basho/bitcask.git", {tag, "2.1.0"}}},
     {redbug, {git, "https://github.com/massemanet/redbug", {tag, "1.2.2"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.2"}}},
     {sext, {git, "https://github.com/uwiger/sext.git", {tag, "1.4.1"}}},
-    {riak_pipe, {git, "https://github.com/basho/riak_pipe.git", {branch, "mas-i1801-coverageplan"}}},
+    {riak_pipe, {git, "https://github.com/basho/riak_pipe.git", {branch, "develop-3.0"}}},
     {riak_dt, {git, "https://github.com/basho/riak_dt.git", {tag, "riak_kv-3.0.0"}}},
-    {riak_api, {git, "https://github.com/basho/riak_api.git", {branch, "mas-i1801-coverageplan"}}},
+    {riak_api, {git, "https://github.com/basho/riak_api.git", {branch, "develop-3.0"}}},
     {hyper, {git, "https://github.com/basho/hyper", {tag, "1.1.0"}}},
     {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {branch, "develop-3.0"}}},
     {riakhttpc, {git, "https://github.com/basho/riak-erlang-http-client", {tag, "3.0.8"}}}

--- a/src/riak_kv_index_fsm.erl
+++ b/src/riak_kv_index_fsm.erl
@@ -288,7 +288,7 @@ log_timings(Timings, Bucket) ->
 log_timings(_Timings, _Bucket, false) ->
     ok;
 log_timings(Timings, Bucket, true) ->
-    lager:info("Index query on bucket=~p" ++
+    lager:info("Index query on bucket=~p " ++
                 "max_vnodeq=~w min_vnodeq=~w sum_vnodeq=~w count_vnodeq=~w " ++
                 "slow_count_vnodeq=~w fast_count_vnodeq=~w",
                 [Bucket,

--- a/src/riak_kv_index_fsm.erl
+++ b/src/riak_kv_index_fsm.erl
@@ -180,8 +180,9 @@ process_results(VNode, done, State = #state{pagination_sort=true}) ->
 process_results(_VNode, {_Bucket, Results}, State) ->
     #state{from={raw, ReqId, ClientPid}} = State,
     send_results(ClientPid, ReqId, Results),
+    ResultsSent = length(Results) + State#state.results_sent,
     UpdTimings = update_timings(State#state.timings),
-    {ok, State#state{timings = UpdTimings}};
+    {ok, State#state{timings = UpdTimings, results_sent = ResultsSent}};
 process_results(_VNode, done, State) ->
     {done, State}.
 

--- a/src/riak_kv_index_fsm.erl
+++ b/src/riak_kv_index_fsm.erl
@@ -39,6 +39,9 @@
 
 -include_lib("riak_kv_vnode.hrl").
 
+-define(SLOW_TIME, application:get_env(riak_kv, index_fsm_slow_timems, 200)).
+-define(FAST_TIME, application:get_env(riak_kv, index_fsm_fast_timems, 10)).
+
 -export([init/2,
          plan/2,
          process_results/3,
@@ -56,12 +59,28 @@
 -type riak_kv_index_fsm_dict() :: dict().
 -endif.
 
+-record(timings, 
+            {start_time = os:timestamp() :: os:timestamp(),
+                max = 0 :: non_neg_integer(),
+                min = infinity :: non_neg_integer()|infinity,
+                count = 0 :: non_neg_integer(),
+                sum = 0 :: non_neg_integer(),
+                slow_count = 0 :: non_neg_integer(),
+                fast_count = 0 :: non_neg_integer(),
+                slow_time = ?SLOW_TIME,
+                fast_time = ?FAST_TIME}).
+-type index_timings() :: #timings{}.
+
+
 -record(state, {from :: from(),
                 pagination_sort :: boolean(),
                 merge_sort_buffer = undefined :: sms:sms() | undefined,
                 max_results :: all | pos_integer(),
                 results_per_vnode = dict:new() :: riak_kv_index_fsm_dict(),
+                timings = #timings{} :: index_timings(),
+                bucket :: riak_object:buckey() | undefined,
                 results_sent = 0 :: non_neg_integer()}).
+
 
 %% @doc Returns `true' if the new ack-based backpressure index
 %% protocol should be used.  This decision is based on the
@@ -102,7 +121,10 @@ init(From={_, _, _}, [Bucket, ItemFilter, Query, Timeout, MaxResults, PgSort0]) 
     %% Construct the key listing request
     Req = req(Bucket, ItemFilter, Query),
     {Req, all, NVal, 1, riak_kv, riak_kv_vnode_master, Timeout,
-     #state{from=From, max_results=MaxResults, pagination_sort=PgSort}}.
+     #state{from=From,
+            max_results=MaxResults,
+            pagination_sort=PgSort,
+            bucket=Bucket}}.
 
 plan(CoverageVNodes, State = #state{pagination_sort=true}) ->
     {ok, State#state{merge_sort_buffer=sms:new(CoverageVNodes)}};
@@ -151,11 +173,15 @@ process_results(VNode, done, State = #state{pagination_sort=true}) ->
     %% tell the sms buffer about the done vnode
     #state{merge_sort_buffer=MergeSortBuffer} = State,
     BufferWithNewResults = sms:add_results(VNode, done, MergeSortBuffer),
-    {done, State#state{merge_sort_buffer=BufferWithNewResults}};
+    UpdTimings = update_timings(State#state.timings),
+    {done,
+        State#state{merge_sort_buffer=BufferWithNewResults,
+                    timings=UpdTimings}};
 process_results(_VNode, {_Bucket, Results}, State) ->
     #state{from={raw, ReqId, ClientPid}} = State,
     send_results(ClientPid, ReqId, Results),
-    {ok, State};
+    UpdTimings = update_timings(State#state.timings),
+    {ok, State#state{timings = UpdTimings}};
 process_results(_VNode, done, State) ->
     {done, State}.
 
@@ -194,16 +220,17 @@ process_results({Bucket, Results},
 process_results(done, StateData) ->
     {done, StateData}.
 
-finish({error, Error},
-       StateData=#state{from={raw, ReqId, ClientPid}}) ->
+finish({error, Error}, State=#state{from={raw, ReqId, ClientPid}}) ->
     %% Notify the requesting client that an error
     %% occurred or the timeout has elapsed.
     ClientPid ! {ReqId, {error, Error}},
-    {stop, normal, StateData};
+    {stop, normal, State};
 finish(clean,
-       StateData=#state{from={raw, ReqId, ClientPid}, merge_sort_buffer=undefined}) ->
+       State=#state{from={raw, ReqId, ClientPid},
+                    merge_sort_buffer=undefined}) ->
     ClientPid ! {ReqId, done},
-    {stop, normal, StateData};
+    log_timings(State#state.timings, State#state.bucket),
+    {stop, normal, State};
 finish(clean,
        State=#state{from={raw, ReqId, ClientPid},
                     merge_sort_buffer=MergeSortBuffer,
@@ -218,6 +245,7 @@ finish(clean,
                   end,
     ClientPid ! {ReqId, {results, DownTheWire}},
     ClientPid ! {ReqId, done},
+    log_timings(State#state.timings, State#state.bucket),
     {stop, normal, State}.
 
 %% ===================================================================
@@ -226,3 +254,44 @@ finish(clean,
 
 process_query_results(_Bucket, Results, ReqId, ClientPid) ->
     ClientPid ! {ReqId, {results, Results}}.
+
+update_timings(Timings) ->
+    MS = timer:now_diff(os:timestamp(), Timings#timings.start_time) div 1000,
+    SlowCount =
+        case MS > Timings#timings.slow_time of
+            true ->
+                Timings#timings.slow_count + 1;
+            false ->
+                Timings#timings.slow_count
+        end,
+    FastCount = 
+        case MS < Timings#timings.fast_time of
+            true ->
+                Timings#timings.fast_count + 1;
+            false ->
+                Timings#timings.fast_count
+        end,
+    Timings#timings{
+        max = max(Timings#timings.max, MS),
+        min = min(Timings#timings.min, MS),
+        count = Timings#timings.count + 1,
+        sum = Timings#timings.sum + MS,
+        slow_count = SlowCount,
+        fast_count = FastCount 
+    }.
+
+log_timings(Timings, Bucket) ->
+    log_timings(Timings,
+                Bucket,
+                application:get_env(riak_kv, log_index_fsm, false)).
+
+log_timings(_Timings, _Bucket, false) ->
+    ok;
+log_timings(Timings, Bucket, true) ->
+    lager:info("Index query on bucket=~p" ++
+                "max_vnodeq=~w min_vnodeq=~w sum_vnodeq=~w count_vnodeq=~w " ++
+                "slow_count_vnodeq=~w fast_count_vnodeq=~w",
+                [Bucket,
+                    Timings#timings.max, Timings#timings.min,
+                    Timings#timings.sum, Timings#timings.count,
+                    Timings#timings.slow_count, Timings#timings.fast_count]).

--- a/src/riak_kv_index_fsm.erl
+++ b/src/riak_kv_index_fsm.erl
@@ -240,19 +240,13 @@ finish(clean,
                     results_sent=ResultsSent,
                     max_results=MaxResults}) ->
     LastResults = sms:done(MergeSortBuffer),
-    TotalResults = length(LastResults) + ResultsSent,
     DownTheWire =
-        case TotalResults > MaxResults of
-            true ->
-                lists:sublist(LastResults, MaxResults - ResultsSent);
-            false ->
-                LastResults
-        end,
+        lists:sublist(LastResults, MaxResults - ResultsSent),
     ClientPid ! {ReqId, {results, DownTheWire}},
     ClientPid ! {ReqId, done},
     log_timings(State#state.timings,
                 State#state.bucket,
-                min(MaxResults, TotalResults)),
+                ResultsSent + length(DownTheWire)),
     {stop, normal, State}.
 
 %% ===================================================================

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -206,6 +206,8 @@ do_update({vnode_index_delete, Postings}) ->
     P = riak_core_stat:prefix(),
     ok = exometer:update([P, ?APP, vnode, index, deletes], Postings),
     exometer:update([P, ?APP, vnode, index, deletes, postings], Postings);
+do_update({vnode_workerfold, _Idx, USecs}) ->
+    ok = create_or_update([?PFX, ?APP, vnode, worker_folds, time], USecs, histogram);
 do_update({vnode_dt_update, Mod, Micros}) ->
     P = ?PFX,
     Type = riak_kv_crdt:from_mod(Mod),
@@ -533,6 +535,11 @@ stats() ->
                                             {count, vnode_index_deletes_total}]},
      {[vnode, index, deletes, postings], spiral, [], [{one  , vnode_index_deletes_postings},
                                                       {count, vnode_index_deletes_postings_total}]},
+     {[vnode, worker_folds, time], histogram, [], [{mean, vnode_workerfold_time_mean},
+                                                    {median, vnode_workerfold_time_median},
+                                                    {95    , vnode_workerfold_time_95},
+                                                    {99    , vnode_workerfold_time_99},
+                                                    {max   , vnode_workerfold_time_100}]},
      {[vnode, counter, update], spiral, [], [{one  , vnode_counter_update},
                                              {count, vnode_counter_update_total}]},
      {[vnode, counter, update, time], histogram, [], [{mean  , vnode_counter_update_time_mean},

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -265,6 +265,11 @@ do_update({put_fsm_time, Bucket,  Microsecs, Stages, PerBucket, CRDTMod}) ->
     ok = create_or_update([P, ?APP, node, puts, Type, time], Microsecs, histogram),
     ok = do_stages([P, ?APP, node, puts, Type, time], Stages),
     do_put_bucket(PerBucket, {Bucket, Microsecs, Stages, Type});
+do_update({index_fsm_time, Microsecs, ResultCount}) ->
+    P = ?PFX,
+    ok = exometer:update([P, ?APP, index, fsm, complete], 1),
+    ok = exometer:update([P, ?APP, index, fsm, results], ResultCount),
+    ok = exometer:update([P, ?APP, index, fsm, time], Microsecs);
 do_update({read_repairs, Indices, Preflist}) ->
     ok = exometer:update([?PFX, ?APP, node, gets, read_repairs], 1),
     do_repairs(Indices, Preflist);
@@ -736,6 +741,18 @@ stats() ->
      {[index, fsm, create], spiral, [], [{one, index_fsm_create}]},
      {[index, fsm, create, error], spiral, [], [{one, index_fsm_create_error}]},
      {[index, fsm, active], counter, [], [{value, index_fsm_active}]},
+     {[index, fsm, complete], spiral, [], [{one, index_fsm_complete}]},
+     {[index, fsm, results], histogram, [], [{mean, index_fsm_results_mean},
+                                                {median, index_fsm_results_median},
+                                                {95    , index_fsm_results_95},
+                                                {99    , index_fsm_results_99},
+                                                {max   , index_fsm_results_100}]},
+     {[index, fsm, time], histogram, [], [{mean , index_fsm_time_mean},
+                                               {median, index_fsm_time_median},
+                                               {95    , index_fsm_time_95},
+                                               {99    , index_fsm_time_99},
+                                               {max   , index_fsm_time_100}]},
+
      {[list, fsm, create], spiral, [], [{one  , list_fsm_create},
 					{count, list_fsm_create_total}]},
      {[list, fsm, create, error], spiral, [], [{one  , list_fsm_create_error},

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -206,8 +206,6 @@ do_update({vnode_index_delete, Postings}) ->
     P = riak_core_stat:prefix(),
     ok = exometer:update([P, ?APP, vnode, index, deletes], Postings),
     exometer:update([P, ?APP, vnode, index, deletes, postings], Postings);
-do_update({vnode_workerfold, _Idx, USecs}) ->
-    ok = create_or_update([?PFX, ?APP, vnode, worker_folds, time], USecs, histogram);
 do_update({vnode_dt_update, Mod, Micros}) ->
     P = ?PFX,
     Type = riak_kv_crdt:from_mod(Mod),
@@ -540,11 +538,6 @@ stats() ->
                                             {count, vnode_index_deletes_total}]},
      {[vnode, index, deletes, postings], spiral, [], [{one  , vnode_index_deletes_postings},
                                                       {count, vnode_index_deletes_postings_total}]},
-     {[vnode, worker_folds, time], histogram, [], [{mean, vnode_workerfold_time_mean},
-                                                    {median, vnode_workerfold_time_median},
-                                                    {95    , vnode_workerfold_time_95},
-                                                    {99    , vnode_workerfold_time_99},
-                                                    {max   , vnode_workerfold_time_100}]},
      {[vnode, counter, update], spiral, [], [{one  , vnode_counter_update},
                                              {count, vnode_counter_update_total}]},
      {[vnode, counter, update, time], histogram, [], [{mean  , vnode_counter_update_time_mean},

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -2247,8 +2247,7 @@ handle_coverage_fold(FoldType, Bucket, ItemFilter, ResultFun,
     case list(FoldFun, FinishFun, Mod, FoldType, ModState, Opts, Buffer) of
         {async, AsyncWork} ->
             % This work should be sent to the vnode_worker_pool
-            TimingFun = timing_finish_fun(FinishFun, Index),
-            {async, {fold, AsyncWork, TimingFun}, Sender, State};
+            {async, {fold, AsyncWork, FinishFun}, Sender, State};
         {queue, DeferrableWork} ->
             % This work should be sent to the core node_worker_pool
             {select_queue(?AF2_QUEUE, State), 
@@ -3454,16 +3453,6 @@ finish_fun(BufferMod, Sender) ->
             finish_fold(BufferMod, Buffer, Sender)
     end.
 
-%% @doc
-%% Time the finishing of a fold, and update the associated riak_kv_stat
-timing_finish_fun(FinishFun, Idx) ->
-    ST = os:timestamp(),
-    fun(Buffer) ->
-        update_vnode_stats(vnode_workerfold, Idx, ST),
-        FinishFun(Buffer)
-    end.
-
-
 %% @private
 finish_fold(BufferMod, Buffer, Sender) ->
     BufferMod:flush(Buffer),
@@ -3943,7 +3932,7 @@ wait_for_vnode_status_results(PrefLists, ReqId, Acc) ->
     end.
 
 %% @private
--spec update_vnode_stats(vnode_get|vnode_put|vnode_head|vnode_workerfold,
+-spec update_vnode_stats(vnode_get|vnode_put|vnode_head,
                             partition(),
                             erlang:timestamp()) ->
                                 ok.


### PR DESCRIPTION
Adds stats to secondary index queries.  Adds to riak stats for each vnode fold, and adds an optional log to the `riak_kv_index_fsm`.

The optional log can be enabled by setting `riak_kv.log_index_fsm` to true (or enabling this via riak.conf).

Dependencies are updated to included the revised `riak_core_coverage_plan:initiate_plan/5` function which offers significant performance advantages for larger ring_sizes.