### PR TITLE
Set Index hashtree sync_stop timeout to infinity

### DIFF
--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -96,6 +96,9 @@
 %% Magic Tree id for 2i data.
 -define(INDEX_2I_N, {0, 0}).
 
+% gen_server call timeout for sync stop
+-define(SYNC_STOP_TIMEOUT, 60000).
+
 %% Throttle used when folding over K/V data to build AAE trees: {Limit, Wait}.
 %% After traversing Limit bytes, the fold will sleep for Wait milliseconds.
 %% Default: 1 MB limit / 100 ms wait
@@ -244,7 +247,7 @@ stop(Tree) ->
 sync_stop(undefined) ->
     ok;
 sync_stop(Tree) ->
-    gen_server:call(Tree, stop).
+    gen_server:call(Tree, stop, ?SYNC_STOP_TIMEOUT).
 
 %% @doc Destroy the specified index_hashtree, which will destroy all
 %%      associated hashtrees and terminate.


### PR DESCRIPTION
When stopping a riak node, `riak_kv_vnode` terminates and `riak_kv_index_hashtree:sync_stop/1` called. 
This may end up in crash if it could not finish in 5 sec:

`CRASH REPORT Process <0.1193.0> with 1 neighbours exited with reason: {timeout,{gen_server,call,[<0.1248.0>,stop]}} in gen_fsm:terminate/7 line 600`

 I think this could created a situation where a normal riak stop can cause this error:

` CRASH REPORT Process <0.3158.0> with 0 neighbours exited with reason: no match of right hand value {error,{db_open,"Corruption: truncated record at end of file"}} in hashtree:new_segment_store/2 line 728 in gen_server:init_it/6 line 328`