### PR TITLE
Fix rpc calls from nodetool

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -48,12 +48,22 @@
 
 -export([ensemble_status/1]).
 
+-export([run_command/3]).
+
 %% Reused by Yokozuna for printing AAE status.
 -export([aae_exchange_status/1,
          aae_repair_status/1,
          aae_tree_status/1]).
 
 -include_lib("kernel/include/logger.hrl").
+
+run_command(Mod, Fun, Args) ->
+    case erlang:apply(Mod, Fun, Args) of
+        ok ->
+            rpc_ok;
+        Error ->
+            Error
+    end.
 
 join([NodeStr]) ->
     join(NodeStr, fun riak_core:join/1,


### PR DESCRIPTION
Nodetool now expects rpc_ok as the return from any rpc call, anything other than rpc_ok is echoed out to the shell.

See [basho/riak#1107](https://github.com/basho/riak/pull/1107)