### PR TITLE
Mas i1807 overflowqueues

### DIFF
--- a/README.org
+++ b/README.org
@@ -43,7 +43,7 @@ git push mine some-topic-branch
 # standard tests
 ./rebar3 do xref, dialyzer, eunit
 # property-based tests
-./rebar3 as test eqc
+./rebar3 as test eqc --testing_budget 600
 #+END_SRC
 
 For a more complete set of tests, update riak_kv in the full Riak application and run any appropriate [[https://github.com/basho/riak_test/tree/develop-3.0/groups][Riak riak_test groups]]

--- a/eqc/reaper_eqc.erl
+++ b/eqc/reaper_eqc.erl
@@ -18,8 +18,10 @@ start_args(_S) ->
   [].
 
 start() ->
-  {ok, Pid} = gen_server:start_link(riak_kv_reaper, [eqc_job, fun reaper/1], []),
-  Pid.
+    FilePath = riak_kv_test_util:get_test_dir("reaper_eqc"),
+    {ok, Pid} = riak_kv_reaper:start_link(FilePath),
+    ok = gen_server:call(Pid, {override_action, fun reaper/2}),
+    Pid.
 
 start_next(S, Pid, []) ->
   S#{ pid => Pid }.
@@ -78,7 +80,7 @@ stop_job(Pid) ->
   end.
 
 
-reaper(Ref) ->
+reaper(Ref, _) ->
   case ets:lookup(?MODULE, Ref) of
     [{_, 1}] ->
       ets:delete(?MODULE, Ref), true;

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -47,6 +47,18 @@
   {datatype, directory}
 ]}.
 
+%% @doc A path under which the eraser overload queue will be stored.
+{mapping, "eraser_dataroot", "riak_kv.eraser_dataroot", [
+  {default, "$(platform_data_dir)/kv_eraser"},
+  {datatype, directory}
+]}.
+
+%% @doc A path under which the reaper overload queue will be stored.
+{mapping, "reaper_dataroot", "riak_kv.reaper_dataroot", [
+  {default, "$(platform_data_dir)/kv_reaper"},
+  {datatype, directory}
+]}.
+
 %% @doc Parallel key store type
 %% When running in parallel mode, which will be the default if the backend does
 %% not support native tictac aae (i.e. is not leveled), what type of parallel 

--- a/rebar.config
+++ b/rebar.config
@@ -11,11 +11,7 @@
             {i, "./_build/default/plugins/gpb/include"},
             {d, 'TEST_FS2_BACKEND_IN_RIAK_KV'}]}.
 
-{eunit_opts, [
-     no_tty,  %% This turns off the default output, MUST HAVE
-     {report, {eunit_progress, [colored, profile]}} %% Use `profile' to see test timing information
-     %% Uses the progress formatter with ANSI-colored output
-     ]}.
+{eunit_opts, [verbose]}.
 
 {xref_checks,[undefined_function_calls,undefined_functions]}.
 
@@ -41,8 +37,7 @@
                  ]}.
 
 {profiles, [
-    {test, [{deps, [meck,
-                    {eunit_formatters, ".*", {git, "https://github.com/seancribbs/eunit_formatters", {tag, "v0.5.0"}}}]}]},
+    {test, [{deps, [meck]}]},
     {gha, [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}
 ]}.
 
@@ -57,6 +52,6 @@
     {riak_dt, {git, "https://github.com/basho/riak_dt.git", {tag, "riak_kv-3.0.0"}}},
     {riak_api, {git, "https://github.com/basho/riak_api.git", {tag, "riak_kv-3.0.9"}}},
     {hyper, {git, "https://github.com/basho/hyper", {tag, "1.1.0"}}},
-    {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {branch, "develop-3.0"}}},
+    {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {branch, "mas-i102-formatstatus"}}},
     {riakhttpc, {git, "https://github.com/basho/riak-erlang-http-client", {tag, "3.0.8"}}}
        ]}.

--- a/src/riak_kv_eraser.erl
+++ b/src/riak_kv_eraser.erl
@@ -24,6 +24,7 @@
 -module(riak_kv_eraser).
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-export([start_link/1]).
 -endif.
 
 -behaviour(riak_kv_queue_manager).

--- a/src/riak_kv_eraser.erl
+++ b/src/riak_kv_eraser.erl
@@ -38,8 +38,10 @@
             start_job/1,
             request_delete/1,
             request_delete/2,
+            delete_stats/0,
             delete_stats/1,
             override_redo/1,
+            clear_queue/0,
             clear_queue/1,
             stop_job/1]).
 
@@ -82,7 +84,11 @@ request_delete(DeleteReference) ->
 request_delete(Pid, DeleteReference) ->
     riak_kv_queue_manager:request(Pid, DeleteReference).
 
--spec delete_stats(pid()) ->
+-spec delete_stats() ->
+    list({atom(), non_neg_integer()|riak_kv_overflow_queue:queue_stats()}).
+delete_stats() -> delete_stats(?MODULE).
+
+-spec delete_stats(pid()|module()) ->
     list({atom(), non_neg_integer()|riak_kv_overflow_queue:queue_stats()}).
 delete_stats(Pid) ->
     riak_kv_queue_manager:stats(Pid).
@@ -94,7 +100,10 @@ delete_stats(Pid) ->
 override_redo(Redo) ->
     riak_kv_queue_manager:override_redo(?MODULE, Redo).
 
--spec clear_queue(pid()|riak_kv_eraser) -> ok.
+-spec clear_queue() -> ok.
+clear_queue() -> clear_queue(?MODULE).
+
+-spec clear_queue(pid()|module()) -> ok.
 clear_queue(Pid) ->
     riak_kv_queue_manager:clear_queue(Pid).
 

--- a/src/riak_kv_eraser.erl
+++ b/src/riak_kv_eraser.erl
@@ -171,7 +171,7 @@ standard_eraser_test_() ->
 
 standard_eraser_tester() ->
     NumberOfRefs = 1000,
-    {ok, Pid} = start_link(riak_kv_test_util:get_test_dir("std_eraser/")),
+    {ok, Pid} = start_link(riak_kv_test_util:get_test_dir("std_eraser")),
     ?assert(is_process_alive(Pid)),
     ok = gen_server:call(Pid, {override_action, fun test_100delete/2}),
     B = {<<"type1">>, <<"B1">>},

--- a/src/riak_kv_overflow_queue.erl
+++ b/src/riak_kv_overflow_queue.erl
@@ -1,0 +1,553 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_overflow_queue: A version of queue which overflows to disk
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc A wrap around queue so that when a queue limit is
+%% reached, the queue is kept on disk to reduce the memory overheads
+
+
+-module(riak_kv_overflow_queue).
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+-export([get_mqueue/1]).
+
+-endif.
+
+-export([new/4,
+        log/5,
+        addto_queue/3,
+        work/4,
+        stats/1,
+        format_state/1,
+        close/1,
+        clean_dir/1]).
+
+-define(QUEUE_LIMIT, 1000).
+-define(OVERFLOW_LIMIT, 1000000).
+-define(OVERFLOW_BATCH, 256).
+-define(DISKLOG_EXT, ".dlg").
+
+-type priority() :: pos_integer().
+-type continuation() :: start|disk_log:continuation().
+-type filename() :: file:filename()|none.
+-type queue_stats() :: list({pos_integer(), non_neg_integer()}).
+
+-record(overflowq,  
+    {
+        mqueues
+            :: list({priority(), queue:queue()}) | not_logged,
+        mqueue_lengths
+            :: queue_stats(),
+        overflow_lengths
+            :: queue_stats(),
+        overflow_discards
+            :: queue_stats(),
+        mqueue_limit
+            :: non_neg_integer(),
+        overflow_limit
+            :: non_neg_integer(),
+        overflow_filepath
+            :: string()|undefined,
+        overflow_files
+            :: list({priority(), {filename(), continuation()}})
+}).
+
+-type overflowq() :: #overflowq{}.
+
+-export_type([overflowq/0, queue_stats/0]).
+
+
+%%%============================================================================
+%%% Exported functions
+%%%============================================================================
+
+%% @doc Setup a new overflow queue
+%% It is important to specify the priorities correctly, a crash will be caused
+%% if an unspecified priority is used in any other functions within this
+%% module.
+-spec new(list(pos_integer()), string(), pos_integer(), pos_integer())
+                -> overflowq().
+new(Priorities, FilePath, QueueLimit, OverflowLimit) ->
+    InitCounts = lists:map(fun(P) -> {P, 0} end, Priorities),
+    InitFiles = lists:map(fun(P) -> {P, {none, start}} end, Priorities),
+    InitQueues = lists:map(fun(P) -> {P, queue:new()} end, Priorities),
+    clean_dir(FilePath),
+
+    #overflowq{mqueues = InitQueues,
+                mqueue_limit = QueueLimit,
+                overflow_limit = OverflowLimit,
+                overflow_filepath = FilePath,
+                mqueue_lengths = InitCounts,
+                overflow_lengths = InitCounts,
+                overflow_discards = InitCounts,
+                overflow_files = InitFiles}.
+
+%% @doc Log the current counters, and reset the discard counts
+-spec log(atom(), non_neg_integer(),
+            non_neg_integer(), non_neg_integer(),
+            overflowq()) -> overflowq().
+log(Type, JobID, Attempts, Aborts, Queue) ->
+    QueueLengths =
+        lists:foldl(fun({P, L}, Acc) ->
+                        Acc ++ io_lib:format("queue_p~w=~w ", [P, L])
+                    end,
+                    "Queue lengths ",
+                    Queue#overflowq.mqueue_lengths),
+    OverflowLengths =
+        lists:foldl(fun({P, L}, Acc) ->
+                        Acc ++ io_lib:format("overflow_p~w=~w ", [P, L])
+                    end,
+                    "Overflow lengths ",
+                    Queue#overflowq.overflow_lengths),
+    DiscardCounts =
+        lists:foldl(fun({P, L}, Acc) ->
+                        Acc ++ io_lib:format("discard_p~w=~w ", [P, L])
+                    end,
+                    "Discard counts ",
+                    Queue#overflowq.overflow_discards),
+
+    _ = lager:info("~p job_id=~p has queue lengths ~w " ++
+                        "delete_attempts=~w delete_aborts=~w " ++
+                        QueueLengths ++ OverflowLengths ++ DiscardCounts,
+                    [Type, JobID, Attempts, Aborts]),
+    
+    ResetDiscards =
+        lists:map(fun({P, _L}) -> {P, 0} end,
+                    Queue#overflowq.overflow_discards),
+
+    Queue#overflowq{overflow_discards = ResetDiscards}.
+
+
+-spec stats(overflowq()) -> list({atom(), queue_stats()}).
+stats(Queue) ->
+    [{mqueue_lengths, Queue#overflowq.mqueue_lengths},
+        {overflow_lengths, Queue#overflowq.overflow_lengths},
+        {overflow_discards, Queue#overflowq.overflow_discards}].
+
+%% @doc add an item to the queue, adding to the overflow file if an overflow
+%% file is in use at this priority, or if the addition will take the current
+%% queue length over the limit
+-spec addto_queue(pos_integer(), term(), overflowq()) -> overflowq().
+addto_queue(Priority, Item, FlowQ) ->
+    MQueueLimit = FlowQ#overflowq.mqueue_limit,
+    MQueueLengths = FlowQ#overflowq.mqueue_lengths,
+    {Priority, CurrentQL} = 
+        lists:keyfind(Priority, 1, MQueueLengths),
+    OverflowFiles = FlowQ#overflowq.overflow_files,
+    MQueues = FlowQ#overflowq.mqueues,
+    {Priority, {OverflowFile, OverflowC}} =
+        lists:keyfind(Priority, 1, OverflowFiles),
+    
+    case {OverflowFile, CurrentQL} of
+        {none, CurrentQL} when CurrentQL < MQueueLimit ->
+            UpdQueueLengths =
+                update_plist({Priority, CurrentQL + 1}, MQueueLengths),
+            {Priority, MQueue} =
+                lists:keyfind(Priority, 1, MQueues),
+            UpdMQueues =
+                update_plist({Priority, queue:in(Item, MQueue)}, MQueues),
+            FlowQ#overflowq{mqueue_lengths = UpdQueueLengths,
+                            mqueues = UpdMQueues};
+        {OverflowFile, CurrentQL} ->
+            {MaybeNewFile, MaybeNewCont} =
+                case OverflowFile of
+                    none ->
+                        open_overflow(FlowQ#overflowq.overflow_filepath);
+                    _ ->
+                        {OverflowFile, OverflowC}
+                end,
+            OverflowCounts = FlowQ#overflowq.overflow_lengths,
+            {Priority, OflowCount} =
+                lists:keyfind(Priority, 1, OverflowCounts),
+            case OflowCount >= FlowQ#overflowq.overflow_limit of
+                true ->
+                    OflowDiscards = FlowQ#overflowq.overflow_discards,
+                    {Priority, DiscardCount} =
+                        lists:keyfind(Priority, 1, OflowDiscards),
+                    UpdOflowDiscards =
+                        update_plist({Priority, DiscardCount + 1},
+                            OflowDiscards),
+                    FlowQ#overflowq{overflow_discards = UpdOflowDiscards};
+                false ->
+                    ok = disk_log:alog(MaybeNewFile, Item),
+                    UpdOverflowFiles =
+                        update_plist({Priority, {MaybeNewFile, MaybeNewCont}},
+                            OverflowFiles),
+                    UpdOverflowCounts =
+                        update_plist({Priority, OflowCount + 1},
+                            OverflowCounts),
+                    FlowQ#overflowq{overflow_lengths = UpdOverflowCounts,
+                                    overflow_files = UpdOverflowFiles}
+            end
+    end.
+
+
+%% @doc Look at queue by priority and batch size, and apply
+-spec work(list({pos_integer(), pos_integer()}),
+            fun((term()) -> boolean()),
+            fun((term()) -> ok),
+            overflowq()) ->
+                        {pos_integer()|none,
+                            non_neg_integer(),
+                            non_neg_integer(),
+                            overflowq()}.
+work([], _ApplyFun, _RequeueFun, FlowQ) ->
+    {none, 0, 0, FlowQ};
+work([{P, BatchSize}|Rest], ApplyFun, RequeueFun, FlowQ) ->
+    BatchFoldFun =
+        fun(DelRef, {AT, AB}) ->
+            case ApplyFun(DelRef) of
+                true ->
+                    {AT + 1, AB};
+                false ->
+                    RequeueFun(DelRef),
+                    {AT, AB + 1}
+            end
+        end,
+    {Batch, UpdFlowQ} = fetch_batch(P, BatchSize, FlowQ),
+    case Batch of
+        Batch when is_list(Batch) ->
+            {Attempts, Aborts} = lists:foldl(BatchFoldFun, {0, 0}, Batch),
+            {P, Attempts, Aborts, UpdFlowQ};
+        empty ->
+            work(Rest, ApplyFun, RequeueFun, UpdFlowQ)
+    end.
+
+-spec format_state(overflowq()) -> overflowq().
+format_state(FlowQ) ->
+    FlowQ#overflowq{mqueues = not_logged}.
+
+-spec clean_dir(string()) -> ok.
+clean_dir(DirPath) ->
+    ok = filelib:ensure_dir(DirPath),
+    {ok, Files} = file:list_dir(DirPath),
+    lists:foreach(fun(FN) ->
+                        File = filename:join(DirPath, FN),
+                        _ = file:delete(File)
+                    end,
+                    Files).
+
+-spec close(overflowq()) -> ok.
+close(FlowQ) ->
+    CloseFun = fun({_P, {DL, _DC}}) -> disk_log:close(DL) end,
+    lists:foreach(CloseFun, FlowQ#overflowq.overflow_files).
+
+%%%============================================================================
+%%% Internal functions
+%%%============================================================================
+
+%% @doc Fetch a batch of items from the queue.  If there are less than batch
+%% size items on the queue, then the queue may first be re-loaded with items
+%% from the overflow file, if such a file exists.
+%% The batch will be taken from the given priority queue with items are
+%% available.  An incomplete batch does not mean there are not items still
+%% ready to be processed.
+%% In some cases, when overflow files are not in use, items may also come from
+%% a lower priority queue
+-spec fetch_batch(pos_integer(), pos_integer(), overflowq()) ->
+                    {empty|list(term()), overflowq()}.
+fetch_batch(Priority, MaxBatchSize, FlowQ) ->
+    UpdFlowQ = maybereload_queue(Priority, MaxBatchSize, FlowQ),
+    case lists:keyfind(Priority, 1, UpdFlowQ#overflowq.mqueue_lengths) of
+        {Priority, 0} -> 
+            {empty, UpdFlowQ};
+        {Priority, MQueueL} ->
+            BatchSize = min(MQueueL, MaxBatchSize),
+            MQueues = UpdFlowQ#overflowq.mqueues,
+            {Priority, MQueue} =
+                lists:keyfind(Priority, 1, MQueues),
+            {UpdMQueue, UpdMQueueL, Batch} =
+                lists:foldl(fun(_X, {Q, QL, Acc}) ->
+                                case queue:out(Q) of
+                                    {{value, Item}, Q0} ->
+                                        {Q0, QL - 1, [Item|Acc]};
+                                    {empty, Q0} ->
+                                        {Q0, 0, Acc}
+                                end
+                            end,
+                            {MQueue, MQueueL, []},
+                            lists:seq(1, BatchSize)),
+            UpdMQueueLengths =
+                update_plist({Priority, UpdMQueueL},
+                                UpdFlowQ#overflowq.mqueue_lengths),
+            UpdMQueues =
+                update_plist({Priority, UpdMQueue}, MQueues),
+            {lists:reverse(Batch),
+                UpdFlowQ#overflowq{mqueues = UpdMQueues,
+                                    mqueue_lengths=UpdMQueueLengths}}
+    end.
+
+-spec maybereload_queue(pos_integer(), pos_integer(), overflowq()) ->
+                            overflowq().
+maybereload_queue(Priority, BatchSize, FlowQ) ->
+    MQueueLengths = FlowQ#overflowq.mqueue_lengths,
+    OverflowFiles = FlowQ#overflowq.overflow_files,
+    case {lists:keyfind(Priority, 1, MQueueLengths),
+            lists:keyfind(Priority, 1, OverflowFiles)} of
+        {{Priority, N}, _} when N > BatchSize ->
+            %% There are enough items on the queue, don't reload
+            FlowQ;
+        {{Priority, _N}, {Priority, {none, start}}} ->
+            %% There are no overflow files to reload from 
+            FlowQ;
+        {{Priority, N}, {Priority, {File, Continuation}}} ->
+            %% Attempt to refill the queue from the overflow file
+            OverflowCounts = FlowQ#overflowq.overflow_lengths,
+            {Priority, OflowCount} =
+                lists:keyfind(Priority, 1, OverflowCounts),
+            ChunkSize = max(?OVERFLOW_BATCH, BatchSize - N),
+            GetChunk = disk_log:chunk(File, Continuation, ChunkSize),
+            case GetChunk of
+                eof ->
+                    %% The overflow file has now been emptied, and so can be
+                    %% deleted
+                    FilePath = FlowQ#overflowq.overflow_filepath,
+                    ok = disk_log:close(File),
+                    ok = file:delete(disklog_filename(FilePath, File)),
+                    FlowQ#overflowq{
+                        overflow_lengths =
+                            update_plist({Priority, 0}, OverflowCounts),
+                        overflow_files =
+                            update_plist({Priority, {none, start}},
+                                OverflowFiles)
+                        };
+                {UpdContinuation, Items} when is_list(Items) ->
+                    %% There are items in the overflow fileto be added to the
+                    %% queue
+                    ItemCount = length(Items),
+                    MQueueAdditions = queue:from_list(Items),
+                    MQueues = FlowQ#overflowq.mqueues,
+                    {Priority, MQueue} =
+                        lists:keyfind(Priority, 1, MQueues),
+                    UpdMQueue = queue:join(MQueue, MQueueAdditions),
+                    UpdMQueues =
+                        update_plist({Priority, UpdMQueue}, MQueues),
+                    UpdOverflowFiles =
+                        update_plist({Priority, {File, UpdContinuation}},
+                            OverflowFiles),
+                    UpdOverflowCounts =
+                        update_plist({Priority, OflowCount - ItemCount},
+                            OverflowCounts),
+                    {Priority, MQueueCount} =
+                        lists:keyfind(Priority, 1, MQueueLengths),
+                    UpdMQueueCounts =
+                        update_plist({Priority, MQueueCount + ItemCount},
+                            MQueueLengths),
+                    FlowQ#overflowq{
+                        mqueues = UpdMQueues,
+                        mqueue_lengths = UpdMQueueCounts,
+                        overflow_lengths = UpdOverflowCounts,
+                        overflow_files = UpdOverflowFiles}     
+            end
+    end.
+
+
+-spec update_plist(
+    {pos_integer(), term()}, list({pos_integer(), term()})) ->
+        list({pos_integer(), term()}).
+update_plist(UpdateTuple, PriorityList) ->
+    lists:ukeysort(1, [UpdateTuple|PriorityList]).
+
+
+-spec open_overflow(string()) -> {filename(), start}.
+open_overflow(RootPath) ->
+    GUID = leveled_util:generate_uuid(),
+    {ok, OverflowQueue} =
+        disk_log:open([{name, GUID},
+            {file, disklog_filename(RootPath, GUID)},
+            {repair, false}]),
+    {OverflowQueue, start}.
+
+
+-spec disklog_filename(string(), string()) -> filename:filename().
+disklog_filename(RootPath, GUID) ->
+    filename:join(RootPath, GUID ++ ?DISKLOG_EXT).
+
+
+%%%============================================================================
+%%% Unit tests
+%%%============================================================================
+
+
+-ifdef(TEST).
+
+get_mqueue(OverflowQ) ->
+    OverflowQ#overflowq.mqueues.
+
+basic_inmemory_test() ->
+    RootPath = riak_kv_test_util:get_test_dir("overflow_inmem/"),
+    io:format("~p", [RootPath]),
+    FlowQ0 = new([1, 2], RootPath, 1000, 5000),
+    Refs = lists:seq(1, 100),
+    FlowQ1 =
+        lists:foldl(fun(R, FQ) -> addto_queue(1, R, FQ) end, FlowQ0, Refs),
+    {B1, FlowQ2} = fetch_batch(2, 16, FlowQ1),
+    ?assertMatch(empty, B1),
+
+    {mqueue_lengths, MQL1} = lists:keyfind(mqueue_lengths, 1, stats(FlowQ2)),
+    ?assertMatch([{1, 100}, {2, 0}], MQL1),
+
+    {B2, FlowQ3} = fetch_batch(1, 1, FlowQ2),
+    ?assertMatch([1], B2),
+    {mqueue_lengths, MQL2} = lists:keyfind(mqueue_lengths, 1, stats(FlowQ3)),
+    ?assertMatch([{1, 99}, {2, 0}], MQL2),
+    
+    {B3, FlowQ4} = fetch_batch(1, 99, FlowQ3),
+    ExpB = lists:seq(2, 100),
+    ?assertMatch(ExpB, B3),
+
+    {empty, _FlowQ5} = fetch_batch(1, 1, FlowQ4),
+    
+    ok = filelib:ensure_dir(RootPath),
+    {ok, Files} = file:list_dir(RootPath),
+    
+    ?assertMatch([], Files).
+
+basic_overflow_test() ->
+    RootPath = riak_kv_test_util:get_test_dir("overflow_disk/"),
+    FlowQ0 = new([1, 2], RootPath, 1000, 5000),
+    Refs = lists:seq(1, 2000),
+    FlowQ1 =
+        lists:foldl(fun(R, FQ) -> addto_queue(1, R, FQ) end, FlowQ0, Refs),
+    {B1, FlowQ2} = fetch_batch(2, 16, FlowQ1),
+    ?assertMatch(empty, B1),
+
+    {mqueue_lengths, MQL1} =
+        lists:keyfind(mqueue_lengths, 1, stats(FlowQ2)),
+    ?assertMatch([{1, 1000}, {2, 0}], MQL1),
+    {overflow_lengths, OQL1} =
+        lists:keyfind(overflow_lengths, 1, stats(FlowQ2)),
+    ?assertMatch([{1, 1000}, {2, 0}], OQL1),
+
+    close(FlowQ2),
+
+    ok = filelib:ensure_dir(RootPath),
+    {ok, Files1} = file:list_dir(RootPath),
+    ?assertMatch(1, length(Files1)),
+    
+    FlowQ_NEW = new([1, 2], RootPath, 1000, 5000),
+    {mqueue_lengths, MQL2} =
+        lists:keyfind(mqueue_lengths, 1, stats(FlowQ_NEW)),
+    ?assertMatch([{1, 0}, {2, 0}], MQL2),
+    
+    ok = filelib:ensure_dir(RootPath),
+    {ok, Files2} = file:list_dir(RootPath),
+    ?assertMatch(0, length(Files2)).
+
+
+underover_overflow_test() ->
+    RootPath = riak_kv_test_util:get_test_dir("underover_disk/"),
+    FlowQ0 = new([1, 2], RootPath, 1000, 5000),
+    Refs = lists:seq(1, 7000),
+    FlowQ1 =
+        lists:foldl(fun(R, FQ) -> addto_queue(1, R, FQ) end, FlowQ0, Refs),
+    {B1, FlowQ2} = fetch_batch(2, 16, FlowQ1),
+    ?assertMatch(empty, B1),
+
+    {mqueue_lengths, MQL1} =
+        lists:keyfind(mqueue_lengths, 1, stats(FlowQ2)),
+    ?assertMatch([{1, 1000}, {2, 0}], MQL1),
+    {overflow_lengths, OQL1} =
+        lists:keyfind(overflow_lengths, 1, stats(FlowQ2)),
+    ?assertMatch([{1, 5000}, {2, 0}], OQL1),
+    {overflow_discards, OQD1} =
+        lists:keyfind(overflow_discards, 1, stats(FlowQ2)),
+    ?assertMatch([{1, 1000}, {2, 0}], OQD1),
+
+    {B2, FlowQ3} = fetch_batch(1, 900, FlowQ2),
+    ExpB2 = lists:seq(1, 900),
+    ?assertMatch(ExpB2, B2),
+
+    {B3, FlowQ4} = fetch_batch(1, 200, FlowQ3),
+    ExpB3 = lists:seq(901, 1100),
+    ?assertMatch(ExpB3, B3),
+
+    {B4, FlowQ5} = fetch_batch(1, 200, FlowQ4),
+    ExpB4 = lists:seq(1101, 1300),
+    ?assertMatch(ExpB4, B4),
+
+    {B5, FlowQ6} = fetch_batch(1, 200, FlowQ5),
+    ExpB5 = lists:seq(1301, 1500),
+    ?assertMatch(ExpB5, B5),
+
+    {B6, FlowQ7} = fetch_batch(1, 300, FlowQ6),
+    ExpB6 = lists:seq(1501, 1800),
+    ?assertMatch(ExpB6, B6),
+
+    Refs2 = lists:seq(7001, 8000),
+    FlowQ8 =
+        lists:foldl(fun(R, FQ) -> addto_queue(1, R, FQ) end, FlowQ7, Refs2),
+    
+    {B7, FlowQ9} = fetch_batch(1, 1200, FlowQ8),
+    ExpB7 = lists:seq(1801, 3000),
+    ?assertMatch(ExpB7, B7),
+
+    {B8, FlowQ10} = fetch_batch(1, 2800, FlowQ9),
+    ExpB8 = lists:seq(3001, 5681),
+    %% Batch size may be limited by 64KB limit!
+    ?assertMatch(ExpB8, B8),
+
+    {B9, FlowQ11} = fetch_batch(1, 219, FlowQ10),
+    ExpB9 = lists:seq(5682, 5900),
+    ?assertMatch(ExpB9, B9),
+
+    {B10, FlowQ12} = fetch_batch(1, 200, FlowQ11),
+    ExpB10 = lists:seq(5901, 6000) ++ lists:seq(7001, 7100),
+    ?assertMatch(ExpB10, B10),
+
+    {B10, FlowQ12} = fetch_batch(1, 200, FlowQ11),
+    ExpB10 = lists:seq(5901, 6000) ++ lists:seq(7001, 7100),
+    ?assertMatch(ExpB10, B10),
+
+    {B11, FlowQ13} = fetch_batch(1, 800, FlowQ12),
+    ExpB11 = lists:seq(7101, 7800),
+    %% There were only 800 spaces on the queue last time
+    ?assertMatch(ExpB11, B11),
+
+    ok = filelib:ensure_dir(RootPath),
+    {ok, Files1} = file:list_dir(RootPath),
+    ?assertMatch(1, length(Files1)),
+
+    {B12, FlowQ14} = fetch_batch(1, 800, FlowQ13),
+    ?assertMatch(empty, B12),
+
+    {ok, Files2} = file:list_dir(RootPath),
+    %% The on disk component is empty - so the file should be removed
+    ?assertMatch(0, length(Files2)),
+
+    Refs3 = lists:seq(8001, 10000),
+    FlowQ15 =
+        lists:foldl(fun(R, FQ) -> addto_queue(1, R, FQ) end, FlowQ14, Refs3),
+    
+    {mqueue_lengths, MQL2} =
+        lists:keyfind(mqueue_lengths, 1, stats(FlowQ15)),
+    ?assertMatch([{1, 1000}, {2, 0}], MQL2),
+    {overflow_lengths, OQL2} =
+        lists:keyfind(overflow_lengths, 1, stats(FlowQ15)),
+    ?assertMatch([{1, 1000}, {2, 0}], OQL2),
+    {overflow_discards, OQD2} =
+        lists:keyfind(overflow_discards, 1, stats(FlowQ15)),
+    ?assertMatch([{1, 1200}, {2, 0}], OQD2),
+
+    close(FlowQ15).
+
+
+-endif.

--- a/src/riak_kv_overflow_queue.erl
+++ b/src/riak_kv_overflow_queue.erl
@@ -388,7 +388,7 @@ disklog_filename(RootPath, GUID) ->
 -ifdef(TEST).
 
 clean_dir(DirPath) ->
-    ok = filelib:ensure_dir(DirPath),
+    ok = filelib:ensure_dir(DirPath ++ "/"),
     {ok, Files} = file:list_dir(DirPath),
     lists:foreach(fun(FN) ->
                         File = filename:join(DirPath, FN),

--- a/src/riak_kv_overflow_queue.erl
+++ b/src/riak_kv_overflow_queue.erl
@@ -199,7 +199,11 @@ addto_queue(Priority, Item, FlowQ) ->
     end.
 
 
-%% @doc Look at queue by priority and batch size, and apply
+%% @doc Look at queue by priority and batch size, and apply the passed in
+%% function to a batch of up to batch size available on the queue for that
+%% priority.
+%% If the ApplyFun returns true to indicate an attempt has been made, count
+%% as such.  Otherwise, count as an abort and requeue.
 -spec work(list({pos_integer(), pos_integer()}),
             fun((term()) -> boolean()),
             fun((term()) -> ok),

--- a/src/riak_kv_overflow_queue.erl
+++ b/src/riak_kv_overflow_queue.erl
@@ -88,7 +88,7 @@ new(Priorities, FilePath, QueueLimit, OverflowLimit) ->
     InitCounts = lists:map(fun(P) -> {P, 0} end, Priorities),
     InitFiles = lists:map(fun(P) -> {P, {none, start}} end, Priorities),
     InitQueues = lists:map(fun(P) -> {P, queue:new()} end, Priorities),
-    ok = filelib:ensure_dir(FilePath),
+    ok = filelib:ensure_dir(FilePath ++ "/"),
 
     #overflowq{mqueues = InitQueues,
                 mqueue_limit = QueueLimit,
@@ -400,7 +400,7 @@ get_mqueue(OverflowQ) ->
     OverflowQ#overflowq.mqueues.
 
 basic_inmemory_test() ->
-    RootPath = riak_kv_test_util:get_test_dir("overflow_inmem/"),
+    RootPath = riak_kv_test_util:get_test_dir("overflow_inmem"),
     clean_dir(RootPath),
     io:format("~p", [RootPath]),
     FlowQ0 = new([1, 2], RootPath, 1000, 5000),
@@ -463,7 +463,7 @@ basic_overflow_test() ->
 
 
 underover_overflow_test() ->
-    RootPath = riak_kv_test_util:get_test_dir("underover_disk/"),
+    RootPath = riak_kv_test_util:get_test_dir("underover_disk"),
     clean_dir(RootPath),
     FlowQ0 = new([1, 2], RootPath, 1000, 5000),
     Refs = lists:seq(1, 7000),

--- a/src/riak_kv_overflow_queue.erl
+++ b/src/riak_kv_overflow_queue.erl
@@ -123,7 +123,7 @@ log(Type, JobID, Attempts, Aborts, Queue) ->
                     "Discard counts ",
                     Queue#overflowq.overflow_discards),
 
-    _ = lager:info("~p job_id=~p has queue lengths ~w " ++
+    _ = lager:info("~p job_id=~p has " ++
                         "delete_attempts=~w delete_aborts=~w " ++
                         QueueLengths ++ OverflowLengths ++ DiscardCounts,
                     [Type, JobID, Attempts, Aborts]),

--- a/src/riak_kv_overflow_queue.erl
+++ b/src/riak_kv_overflow_queue.erl
@@ -124,7 +124,7 @@ log(Type, JobID, Attempts, Aborts, Queue) ->
                     Queue#overflowq.overflow_discards),
 
     _ = lager:info("~p job_id=~p has " ++
-                        "delete_attempts=~w delete_aborts=~w " ++
+                        "attempts=~w aborts=~w " ++
                         QueueLengths ++ OverflowLengths ++ DiscardCounts,
                     [Type, JobID, Attempts, Aborts]),
     

--- a/src/riak_kv_queue_manager.erl
+++ b/src/riak_kv_queue_manager.erl
@@ -159,7 +159,7 @@ handle_call(stop_job, _From, State) ->
     {reply, ok, State#state{pending_close = true}, 0};
 handle_call({immediate_action, Reference}, _From, State) ->
     Mod = State#state.callback_mod,
-    {reply, Mod:action(Reference), State, 0}.
+    {reply, Mod:action(Reference, false), State, 0}.
 
 
 handle_cast({request, Reference, Priority}, State) ->

--- a/src/riak_kv_queue_manager.erl
+++ b/src/riak_kv_queue_manager.erl
@@ -1,0 +1,258 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_queue_manager: A behaviour for a worker managing a queue
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc A behaviour for a worker managing a queue, where the queue will
+%% overflow to disk
+
+-module(riak_kv_queue_manager).
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-behaviour(gen_server).
+
+-export([init/1,
+        handle_call/3,
+        handle_cast/2,
+        handle_info/2,
+        terminate/2,
+        code_change/3,
+        format_status/2]).
+
+-export([start_link/1,
+            start_job/2,
+            request/2,
+            stats/1,
+            immediate_action/2,
+            override_redo/2,
+            clear_queue/1,
+            stop_job/1]).
+
+-define(REDO_PRIORITY, 1).
+-define(REQUEST_PRIORITY, 2).
+-define(PRIORITY_LIST, [?REQUEST_PRIORITY, ?REDO_PRIORITY]).
+-define(LOG_TICK, 60000).
+-define(REQUEST_BATCHSIZE, 50).
+-define(REDO_BATCHSIZE, 1).
+
+-type action_fun() :: fun((term(), boolean()) -> boolean()).
+
+-callback start_link() -> {ok, pid()}.
+
+-callback start_job(pos_integer()) -> {ok, pid()}.
+
+-callback get_limits() ->
+    {non_neg_integer(), pos_integer(), pos_integer(), string()}.
+
+-callback action(term(), boolean()) -> boolean().
+
+-callback redo() -> boolean().
+
+-record(state,  {
+            callback_mod :: atom(),
+            queue = riak_kv_overflow_queue:overflowq(),
+            attempts = 0 :: non_neg_integer(),
+            aborts = 0 :: non_neg_integer(),
+            job_id :: non_neg_integer(), % can be 0 for named eraser
+            pending_close = false :: boolean(),
+            redo = true :: boolean(),
+            action_fun = none :: action_fun() | none,
+            redo_timeout :: non_neg_integer()
+}).
+
+
+%%%============================================================================
+%%% API
+%%%============================================================================
+
+
+-spec start_link(atom()) -> {ok, pid()}.
+start_link(Module) ->
+    gen_server:start_link(
+        {local, Module}, ?MODULE, [0, Module], []).
+
+%% @doc
+%% To be used when starting a reaper for a specific workload
+-spec start_job(pos_integer(), atom()) -> {ok, pid()}.
+start_job(JobID, Module) ->
+    gen_server:start_link(
+        ?MODULE, [JobID, Module], []).
+
+-spec request(pid()|module(), term()) -> ok.
+request(Pid, Reference) ->
+    gen_server:cast(Pid, {request, Reference, ?REQUEST_PRIORITY}).
+
+-spec stats(pid()|module()) ->
+    list({atom(), non_neg_integer()|riak_kv_overflow_queue:queue_stats()}).
+stats(Pid) ->
+    gen_server:call(Pid, stats, infinity).
+
+-spec immediate_action(pid()|module(), term()) -> boolean().
+immediate_action(Pid, Reference) ->
+    gen_server:call(Pid, {immediate_action, Reference}, infinity).
+
+-spec override_redo(pid()|module(), boolean()) -> ok.
+override_redo(Pid, Bool) ->
+    gen_server:call(Pid, {override_redo, Bool}, infinity).
+
+-spec clear_queue(pid()|module()) -> ok.
+clear_queue(Pid) ->
+    gen_server:call(Pid, clear_queue, infinity).
+
+-spec stop_job(pid()) -> ok.
+stop_job(Pid) ->
+    gen_server:call(Pid, stop_job, infinity).
+
+
+%%%============================================================================
+%%% gen_server callbacks
+%%%============================================================================
+
+
+init([JobID, Module]) ->
+    erlang:send_after(?LOG_TICK, self(), log_queue),
+    {OverflowQueue, RedoTimeout} = create_queue(Module),
+    {ok,
+        #state{callback_mod = Module,
+                job_id = JobID,
+                redo = Module:redo(),
+                redo_timeout = RedoTimeout,
+                queue = OverflowQueue},
+        0}.
+
+handle_call(stats, _From, State) ->
+    QStats = riak_kv_overflow_queue:stats(State#state.queue),
+    AStats = [{attempts, State#state.attempts}, {aborts, State#state.aborts}],
+    {reply, QStats ++ AStats, State, 0};
+handle_call({override_redo, Redo}, _From, State) ->
+    {reply, ok, State#state{redo = Redo}, 0};
+handle_call({override_action, ActionFun}, _From, State) ->
+    %% Used only in tests to change the action function, and hence override
+    %% the callback module's default action function
+    {reply, ok, State#state{action_fun = ActionFun}, 0};
+handle_call(clear_queue, _From, State) ->
+    ok = riak_kv_overflow_queue:close(State#state.queue),
+    {OverflowQueue, RedoTimeout} = create_queue(State#state.callback_mod),
+    S0 = State#state{queue = OverflowQueue, redo_timeout = RedoTimeout},
+    {reply, ok, S0, 0};
+handle_call(stop_job, _From, State) ->
+    {reply, ok, State#state{pending_close = true}, 0};
+handle_call({immediate_action, Reference}, _From, State) ->
+    Mod = State#state.callback_mod,
+    {reply, Mod:action(Reference), State, 0}.
+
+
+handle_cast({request, Reference, Priority}, State) ->
+    UpdOverflowQueue =
+        riak_kv_overflow_queue:addto_queue(Priority,
+                                            Reference,
+                                            State#state.queue),
+    {noreply, State#state{queue = UpdOverflowQueue}, 0}.
+
+
+handle_info(timeout, State) ->
+    Mod = State#state.callback_mod,
+    ActionFun = 
+        case State#state.action_fun of
+            none ->
+                fun(Ref) -> Mod:action(Ref, State#state.redo) end;
+            OverrideActionFun ->
+                fun(Ref) -> OverrideActionFun(Ref, State#state.redo) end
+        end,
+    RequeueFun = 
+        fun(Ref) ->
+            gen_server:cast(self(), {request, Ref, ?REDO_PRIORITY})
+        end,
+    PBL = [{?REQUEST_PRIORITY, ?REQUEST_BATCHSIZE},
+            {?REDO_PRIORITY, ?REDO_BATCHSIZE}],
+    {Priority, Attempts, Aborts, UpdQueue} =
+        riak_kv_overflow_queue:work(
+            PBL, ActionFun, RequeueFun, State#state.queue),
+    UpdState =
+        State#state{attempts = State#state.attempts + Attempts,
+                    aborts = State#state.aborts + Aborts,
+                    queue = UpdQueue},
+    case {Priority, State#state.pending_close, Aborts} of
+        {none, true, _} ->
+            {stop, normal, UpdState};
+        {none, false, _} ->
+            {noreply, UpdState};
+        {?REDO_PRIORITY, _, A} when A > 0 ->
+            {noreply, UpdState, State#state.redo_timeout};
+        _ ->
+            {noreply, UpdState, 0}
+    end;
+handle_info(log_queue, State) ->
+    UpdQueue =
+        riak_kv_overflow_queue:log(
+            State#state.callback_mod,
+            State#state.job_id,
+            State#state.attempts,
+            State#state.aborts,
+            State#state.queue),
+    erlang:send_after(?LOG_TICK, self(), log_queue),
+    {noreply, State#state{attempts = 0, aborts = 0, queue = UpdQueue}, 0}.
+
+format_status(normal, [_PDict, S]) ->
+    S;
+format_status(terminate, [_PDict, S]) ->
+    S#state{queue = riak_kv_overflow_queue:format_state(S#state.queue)}.
+
+terminate(_Reason, State) ->
+    riak_kv_overflow_queue:close(State#state.queue),
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%============================================================================
+%%% Internal Functions
+%%%============================================================================
+
+-spec create_queue(module()) ->
+    {riak_kv_overflow_queue:overflowq(), non_neg_integer()}.
+create_queue(Module)->
+    {RedoTimeout, QueueLimit, OverflowLimit, RootPath} = Module:get_limits(),
+    riak_kv_overflow_queue:clean_dir(RootPath),
+    OverflowQueue =
+        riak_kv_overflow_queue:new(
+            ?PRIORITY_LIST, RootPath, QueueLimit, OverflowLimit),
+    {OverflowQueue, RedoTimeout}.
+    
+
+%%%============================================================================
+%%% Unit tests
+%%%============================================================================
+
+
+-ifdef(TEST).
+
+format_status_test() ->
+    {ok, P} = start_job(1, riak_kv_reaper),
+    {status, P, {module, gen_server}, SItemL} = sys:get_status(P),
+    S = lists:keyfind(state, 1, lists:nth(5, SItemL)),
+    MQ = riak_kv_overflow_queue:get_mqueue(S#state.queue),
+    ?assertNotMatch(not_logged, MQ),
+    ST = format_status(terminate, [dict:new(), S]),
+    MQT = riak_kv_overflow_queue:get_mqueue(ST#state.queue),
+    ?assertMatch(not_logged, MQT),
+    ok = stop_job(P).
+
+-endif.

--- a/src/riak_kv_queue_manager.erl
+++ b/src/riak_kv_queue_manager.erl
@@ -54,16 +54,37 @@
 
 -type action_fun() :: fun((term(), boolean()) -> boolean()).
 
--callback start_link() -> {ok, pid()}.
-
--callback start_job(pos_integer()) -> {ok, pid()}.
 
 -callback get_limits() ->
     {non_neg_integer(), pos_integer(), pos_integer()}.
+%% A callback function which will be called at startup to return the default
+%% values of:
+%% - Redo Timeout
+%% - Queue Limit
+%% - Overflow Limit
+%% The redo timeout is a backoff (in ms) to be used when `redo() = true` and
+%% applying the action function to a reference has resulted in abort. No
+%% further work will be applied until the timeout has expired (i.e. wait for
+%% the fault to potentially clear).
+%% The queue limit is the limit to the size (by count of references) of the
+%% in-memory part of the queue.
+%% The overflow limit is the limit to the size of the on-disk portion of the
+%% queue.
 
 -callback action(term(), boolean()) -> boolean().
+%% The queue manager needs to define an action function to be applied to the
+%% queued references.  The action function takes as inputs the reference, and
+%% also a redo boolean().
+%% A redo value of `true` is used to indicate that the function should
+%% validate pre-requisites for successful completion before applying the
+%% action - and report an abort (i.e. responding `false`) on failure, in order
+%% for a redo of the queued item to be performed.
+%% With a redo value of `false` the action should be performed, and always
+%% respond `true`, and hence no redo will be triggered. 
 
 -callback redo() -> boolean().
+%% A callback function to return the default value of the redo boolean() to be
+%% passed into the action function.
 
 -record(state,  {
             callback_mod :: atom(),

--- a/src/riak_kv_reaper.erl
+++ b/src/riak_kv_reaper.erl
@@ -44,7 +44,9 @@
             request_reap/1,
             request_reap/2,
             direct_reap/1,
+            reap_stats/0,
             reap_stats/1,
+            clear_queue/0,
             clear_queue/1,
             stop_job/1]).
 
@@ -86,7 +88,11 @@ request_reap(ReapReference) ->
 request_reap(Pid, ReapReference) ->
     riak_kv_queue_manager:request(Pid, ReapReference).
 
--spec reap_stats(pid()) -> 
+-spec reap_stats() ->
+    list({atom(), non_neg_integer()|riak_kv_overflow_queue:queue_stats()}).
+reap_stats() -> reap_stats(?MODULE).
+
+-spec reap_stats(pid()|module()) -> 
     list({atom(), non_neg_integer()|riak_kv_overflow_queue:queue_stats()}).
 reap_stats(Pid) ->
     riak_kv_queue_manager:stats(Pid).
@@ -95,7 +101,10 @@ reap_stats(Pid) ->
 direct_reap(ReapReference) ->
     riak_kv_queue_manager:immediate_action(?MODULE, ReapReference).
 
--spec clear_queue(pid()|riak_kv_reaper) -> ok.
+-spec clear_queue() -> ok.
+clear_queue() -> clear_queue(?MODULE).
+
+-spec clear_queue(pid()|module()) -> ok.
 clear_queue(Reaper) ->
    riak_kv_queue_manager:clear_queue(Reaper).
 

--- a/src/riak_kv_reaper.erl
+++ b/src/riak_kv_reaper.erl
@@ -32,15 +32,11 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--behaviour(gen_server).
+-behaviour(riak_kv_queue_manager).
 
--export([init/1,
-        handle_call/3,
-        handle_cast/2,
-        handle_info/2,
-        terminate/2,
-        code_change/3,
-        format_status/2]).
+-define(QUEUE_LIMIT, 100000).
+-define(OVERFLOW_LIMIT, 10000000).
+-define(REDO_TIMEOUT, 2000).
 
 -export([start_link/0,
             start_job/1,
@@ -51,41 +47,13 @@
             clear_queue/1,
             stop_job/1]).
 
--define(QUEUE_LIMIT, 1000000).
--define(LOG_TICK, 60000).
--define(REDO_TIMEOUT, 2000).
--define(MAX_BATCH_SIZE, 100).
--define(STND_REAP_PRIORITY, 2).
--define(REDO_REAP_PRIORITY, 1).
+-export([action/2,
+            get_limits/0,
+            redo/0]).
 
--record(state,  {
-            reap_queue = riak_core_priority_queue:new()
-                :: pqueue()|not_logged,
-            pqueue_length = {0, 0} :: queue_length(),
-            reap_attempts = 0 :: non_neg_integer(),
-            reap_aborts = 0 :: non_neg_integer(),
-            reap_drops = 0 :: non_neg_integer(),
-            redo_drops = 0 :: non_neg_integer(),
-            job_id :: non_neg_integer(), % can be 0 for named reaper
-            pending_close = false :: boolean(),
-            last_tick_time = os:timestamp() :: erlang:timestamp(),
-            reap_fun :: reap_fun(),
-            redo_timeout :: non_neg_integer(),
-            queue_limit :: non_neg_integer()
-}).
-
--type priority() :: 1..2.
--type squeue() :: {queue, [any()], [any()]}.
--type pqueue() ::  squeue() | {pqueue, [{priority(), squeue()}]}.
--type queue_length() :: {non_neg_integer(), non_neg_integer()}.
 -type reap_reference() ::
     {{riak_object:bucket(), riak_object:key()}, non_neg_integer()}.
 -type job_id() :: pos_integer().
-
--type reap_stats() :: {non_neg_integer(), non_neg_integer(), queue_length()}.
-
--type reap_fun() :: fun((reap_reference()) -> boolean()).
--type reaper_state() :: #state{}.
 
 -export_type([reap_reference/0, job_id/0]).
 
@@ -94,251 +62,63 @@
 %%%============================================================================
 
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [0, fun reap/1], []).
+    riak_kv_queue_manager:start_link(?MODULE).
 
 -spec start_job(job_id()) -> {ok, pid()}.
 %% @doc
 %% To be used when starting a reaper for a specific workload
 start_job(JobID) ->
-    gen_server:start_link(?MODULE, [JobID, fun reap/1], []).
+   riak_kv_queue_manager:start_job(JobID, ?MODULE).
 
 -spec request_reap(reap_reference()) -> ok.
 request_reap(ReapReference) ->
-    request_reap(?MODULE, ReapReference, ?STND_REAP_PRIORITY).
+    request_reap(?MODULE, ReapReference).
 
--spec request_reap(pid(), reap_reference()) -> ok.
+-spec request_reap(pid()|module(), reap_reference()) -> ok.
 request_reap(Pid, ReapReference) ->
-    request_reap(Pid, ReapReference, ?STND_REAP_PRIORITY).
+    riak_kv_queue_manager:request(Pid, ReapReference).
 
-%% @doc
-%% Priority of Reaps is by default 2. 1 is reserved for redo of reaps
--spec request_reap(pid()|atom(), reap_reference(), priority()) -> ok.
-request_reap(Pid, ReapReference, Priority)
-                when Priority == ?REDO_REAP_PRIORITY;
-                     Priority == ?STND_REAP_PRIORITY ->
-    gen_server:cast(Pid, {request_reap, ReapReference, Priority}).
-
--spec reap_stats(pid()) -> reap_stats().
+-spec reap_stats(pid()) -> 
+    list({atom(), non_neg_integer()|riak_kv_overflow_queue:queue_stats()}).
 reap_stats(Pid) ->
-    gen_server:call(Pid, reap_stats, infinity).
+    riak_kv_queue_manager:stats(Pid).
 
 -spec direct_reap(reap_reference()) -> boolean().
 direct_reap(ReapReference) ->
-    gen_server:call(?MODULE, {direct_reap, ReapReference}).
+    riak_kv_queue_manager:immediate_action(?MODULE, ReapReference).
 
 -spec clear_queue(pid()|riak_kv_reaper) -> ok.
 clear_queue(Reaper) ->
-    gen_server:call(Reaper, clear_queue, infinity).
+   riak_kv_queue_manager:clear_queue(Reaper).
 
 %% @doc
 %% Stop the job once the queue is empty
 -spec stop_job(pid()) -> ok.
 stop_job(Pid) ->
-    gen_server:call(Pid, stop_job, 5000).
+    riak_kv_queue_manager:stop_job(Pid).
 
 %%%============================================================================
-%%% gen_server callbacks
+%%% Callback functions
 %%%============================================================================
 
-init([JobID, ReapFun]) ->
-    erlang:send_after(?LOG_TICK, self(), log_queue),
+-spec get_limits() -> {pos_integer(), pos_integer(), pos_integer(), string()}.
+get_limits() ->
     RedoTimeout =
         app_helper:get_env(riak_kv, reaper_redo_timeout, ?REDO_TIMEOUT),
     QueueLimit =
         app_helper:get_env(riak_kv, reaper_queue_limit, ?QUEUE_LIMIT),
-    {ok, #state{job_id = JobID,
-                reap_fun = ReapFun,
-                redo_timeout = RedoTimeout,
-                queue_limit = QueueLimit}, 0}.
-
-
-handle_call(Msg, _From, State) ->
-    {reply, R, S0} = handle_sync_message(Msg, State),
-    {reply, R, S0, 0}.
-
-handle_cast(Msg, State) ->
-    {noreply, S0} = handle_async_message(Msg, State),
-    {noreply, S0, 0}.
-
-handle_info(Msg, State) ->
-    case handle_async_message(Msg, State) of
-        {override_timeout, none, R} ->
-            R;
-        {override_timeout, T0, {noreply, S0}} ->
-            {noreply, S0, T0};
-        {noreply, S0} ->
-            {noreply, S0, 0}
-    end.
-
-format_status(normal, [_PDict, State]) ->
-    State;
-format_status(terminate, [_PDict, State]) ->
-    State#state{reap_queue = not_logged}.
-
-terminate(_Reason, _State) ->
-    ok.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
-
-
-%%%============================================================================
-%%% Actual Callbacks
-%%%============================================================================
-
-%% Handle a call message - with a reply.  The handle_call function will enforce
-%% the addition of an immediate timeout
--spec handle_sync_message(any(), reaper_state()) ->
-        {reply, any(), reaper_state()}.
-handle_sync_message(reap_stats, State) ->
-    Stats =
-        {State#state.reap_attempts,
-            State#state.reap_aborts,
-            State#state.pqueue_length},
-    {reply, Stats, State};
-handle_sync_message({direct_reap, ReapReference}, State) ->
-    {reply, reap(ReapReference), State};
-handle_sync_message(clear_queue, State) ->
-    {reply,
-        ok,
-        State#state{reap_queue = riak_core_priority_queue:new(),
-                    pqueue_length = {0, 0}}};
-handle_sync_message(stop_job, State) ->
-    {reply, ok, State#state{pending_close = true}}.
-
-%% Handle a cast or info message - with a reply.  The handle_cast function
-%% will expet a {noreply, State} response and will override the return with
-%% an immediate timeout.  the handle_info may also receive a reply with an
-%% overrride to the timeout.
--spec handle_async_message(any(), reaper_state()) ->
-        {noreply, reaper_state()}|
-        {override_timeout, none|pos_integer(), tuple()}.
-handle_async_message({request_reap, ReapReference, Priority}, State) ->
-    QueueLimit = State#state.queue_limit,
-    CurrentQL = element(Priority, State#state.pqueue_length),
-    if
-        CurrentQL >= QueueLimit ->
-            case Priority of
-                ?STND_REAP_PRIORITY ->
-                    {noreply,
-                        State#state{reap_drops =
-                                        State#state.reap_drops + 1}};
-                ?REDO_REAP_PRIORITY ->
-                    {noreply,
-                        State#state{redo_drops =
-                                        State#state.redo_drops + 1}}
-            end;
-        true ->
-            UpdQL =
-                setelement(Priority, State#state.pqueue_length,CurrentQL + 1),
-            UpdQ =
-                riak_core_priority_queue:in(ReapReference,
-                                            Priority,
-                                            State#state.reap_queue),
-            {noreply,
-                State#state{pqueue_length = UpdQL, reap_queue = UpdQ}}
-    end;
-handle_async_message(timeout, State) ->
-    ReapFun = State#state.reap_fun,
-    case State#state.pqueue_length of
-        {0, 0} ->
-            case State#state.pending_close of
-                true ->
-                    {override_timeout, none, {stop, normal, State}};
-                false ->
-                    %% No timeout here, as no work to do
-                    {override_timeout, none, {noreply, State}}
-            end;
-        {RedoQL, 0} ->
-            %% Work a single item on the redo queue, and no immediate timeout
-            %% if it aborts
-            case riak_core_priority_queue:out(State#state.reap_queue) of
-                {{value, ReapRef}, Q0} ->
-                    case ReapFun(ReapRef) of
-                        true ->
-                            AT0 = State#state.reap_attempts + 1,
-                            QL0 = {RedoQL - 1, 0},
-                            {noreply,
-                                State#state{reap_queue = Q0,
-                                            reap_attempts = AT0,
-                                            pqueue_length = QL0}};
-                        false ->
-                            AB0 = State#state.reap_aborts + 1,
-                            Q1 = riak_core_priority_queue:in(ReapRef, 1, Q0),
-                            {override_timeout,
-                                State#state.redo_timeout,
-                                {noreply,
-                                    State#state{reap_queue = Q1,
-                                                reap_aborts = AB0}}}
-                   end;
-                {empty, Q0} ->
-                    %% This shoudn't happen - must have miscalulated
-                    %% queue lengths
-                    {noreply,
-                        State#state{reap_queue = Q0,
-                                    pqueue_length = {0, 0}}}
-            end;
-        {RedoQL, ReapQL} ->
-            %% Work a batch of items from the reap queue before yielding
-            BatchSize = min(ReapQL, ?MAX_BATCH_SIZE),
-            BatchFun =
-                fun(_X, {Q, AT, AB}) ->
-                    case riak_core_priority_queue:out(Q) of
-                        {{value, ReapRef}, Q0} ->
-                            case ReapFun(ReapRef) of
-                                true ->
-                                    {Q0, AT + 1, AB};
-                                false ->
-                                    request_reap(self(),
-                                                    ReapRef,
-                                                    ?REDO_REAP_PRIORITY),
-                                    {Q0, AT, AB + 1}
-                            end;
-                        {empty, Q0} ->
-                            %% This shouldn't happen
-                            {Q0, AT, AB}
-                    end
-                end,
-            {UpdQ, AT0, AB0} =
-                lists:foldl(BatchFun,
-                            {State#state.reap_queue,
-                                State#state.reap_attempts,
-                                State#state.reap_aborts},
-                            lists:seq(1, BatchSize)),
-            {noreply,
-                State#state{reap_queue = UpdQ,
-                            reap_attempts = AT0,
-                            reap_aborts = AB0,
-                            pqueue_length = {RedoQL, ReapQL - BatchSize}}}
-    end;
-handle_async_message(log_queue, State) ->
-    lager:info("Reaper Job ~w has queue lengths ~w " ++
-                    " reap_attempts=~w reap_aborts=~w " ++
-                    " reap_drops=~w redo_drops=~w",
-                [State#state.job_id,
-                    State#state.pqueue_length,
-                    State#state.reap_attempts,
-                    State#state.reap_aborts,
-                    State#state.reap_drops,
-                    State#state.redo_drops]),
-    erlang:send_after(?LOG_TICK, self(), log_queue),
-    {noreply,
-        State#state{reap_attempts = 0,
-                    reap_aborts = 0,
-                    reap_drops = 0,
-                    redo_drops = 0}}.
-
-
-%%%============================================================================
-%%% Internal functions
-%%%============================================================================
+    OverflowLimit =
+        app_helper:get_env(riak_kv, reaper_overflow_limit, ?OVERFLOW_LIMIT),
+    RootPath =
+        app_helper:get_env(riak_kv, reaper_dataroot),
+    {RedoTimeout, QueueLimit, OverflowLimit, RootPath}.
 
 %% @doc
 %% If all primaries are up try and reap the tombstone.  The reap may fail, but
-%% we will not redo - redo is only to handle the failire related to unavailable
+%% we will not redo - redo is only to handle the failure related to unavailable
 %% primaries
--spec reap(reap_reference()) -> boolean().
-reap({{Bucket, Key}, DeleteHash}) ->
+-spec action(reap_reference(), boolean()) -> boolean().
+action({{Bucket, Key}, DeleteHash}, Redo) ->
     BucketProps = riak_core_bucket:get_bucket(Bucket),
     DocIdx = riak_core_util:chash_key({Bucket, Key}, BucketProps),
     {n_val, N} = lists:keyfind(n_val, 1, BucketProps),
@@ -349,9 +129,11 @@ reap({{Bucket, Key}, DeleteHash}) ->
             ok = riak_kv_vnode:reap(PL0, {Bucket, Key}, DeleteHash),
             true;
         _ ->
-            false
+            if Redo -> false; true -> true end
     end.
 
+-spec redo() -> boolean().
+redo() -> true.
 
 %%%============================================================================
 %%% Test
@@ -359,29 +141,18 @@ reap({{Bucket, Key}, DeleteHash}) ->
 
 -ifdef(TEST).
 
-start_test(JobID, ReapFun) ->
-    gen_server:start_link(?MODULE, [JobID, ReapFun], []).
-
 
 test_1inNreapfun(N) ->
-    fun(ReapRef) ->
+    fun(ReapRef, _Bool) ->
         case erlang:phash2({ReapRef, os:timestamp()}) rem N of
             0 -> false;
             _ -> true
         end
     end.
 
-test_100reap(_ReapRef) ->
+test_100reap(_ReapRef, _Bool) ->
     true.
 
-format_status_test() ->
-    {ok, P} = start_test(1, fun test_100reap/1),
-    {status, P, {module, gen_server}, SItemL} = sys:get_status(P),
-    S = lists:keyfind(state, 1, lists:nth(5, SItemL)),
-    ?assert(S#state.reap_queue == riak_core_priority_queue:new()),
-    ST = format_status(terminate, [dict:new(), S]),
-    ?assertMatch(not_logged, ST#state.reap_queue),
-    ok = stop_job(P).
 
 standard_reaper_test_() ->
     {timeout, 30, fun standard_reaper_tester/0}.
@@ -391,24 +162,29 @@ failure_reaper_test_() ->
 
 standard_reaper_tester() ->
     NumberOfRefs = 1000,
-    {ok, P} = start_test(1, fun test_100reap/1),
+    {ok, P} = start_job(1),
+    ok = gen_server:call(P, {override_action, fun test_100reap/2}),
     B = {<<"type1">>, <<"B1">>},
     RefList =
         lists:map(fun(X) -> {{B, term_to_binary(X)}, erlang:phash2(X)} end,
                     lists:seq(1, NumberOfRefs)),
     spawn(fun() ->
-                lists:foreach(fun(R) -> request_reap(P, R, 2) end, RefList)
+                lists:foreach(fun(R) -> request_reap(P, R) end, RefList)
             end),
     WaitFun =
         fun(Sleep, Done) ->
             case Done of
                 false ->
                     timer:sleep(Sleep),
-                    {AT, AB, L} = reap_stats(P),
+                    [{mqueue_lengths,[{1,RedoQL},{2,ReapQL}]},
+                        {overflow_lengths,[{2,0},{1,0}]},
+                        {overflow_discards,[{2,0},{1,0}]},
+                        {attempts,AT},
+                        {aborts,AB}] = reap_stats(P),
                     case AT of
                         NumberOfRefs ->
                             ?assertMatch(0, AB),
-                            ?assertMatch({0, 0}, L),
+                            ?assertMatch({0, 0}, {RedoQL, ReapQL}),
                             true;
                         _ ->
                             false
@@ -430,20 +206,25 @@ somefail_reaper_tester() ->
 
 somefail_reaper_tester(N) ->
     NumberOfRefs = 1000,
-    {ok, P} = start_test(1, test_1inNreapfun(N)),
+    {ok, P} = start_job(1),
+    ok = gen_server:call(P, {override_action, test_1inNreapfun(N)}),
     B = {<<"type1">>, <<"B1">>},
     RefList =
         lists:map(fun(X) -> {{B, term_to_binary(X)}, erlang:phash2(X)} end,
                     lists:seq(1, NumberOfRefs)),
     spawn(fun() ->
-                lists:foreach(fun(R) -> request_reap(P, R, 2) end, RefList)
+                lists:foreach(fun(R) -> request_reap(P, R) end, RefList)
             end),
     WaitFun =
         fun(Sleep, Done) ->
             case Done of
                 false ->
                     timer:sleep(Sleep),
-                    {AT, AB, {RedoQL, ReapQL}} = reap_stats(P),
+                    [{mqueue_lengths,[{1,RedoQL},{2,ReapQL}]},
+                        {overflow_lengths,[{2,0},{1,0}]},
+                        {overflow_discards,[{2,0},{1,0}]},
+                        {attempts,AT},
+                        {aborts,AB}] = reap_stats(P),
                     case (AT + AB >= NumberOfRefs) of
                         true ->
                             ?assertMatch(true, AB > 0),

--- a/src/riak_kv_reaper.erl
+++ b/src/riak_kv_reaper.erl
@@ -30,6 +30,7 @@
 -module(riak_kv_reaper).
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-export([start_link/1]).
 -endif.
 
 -behaviour(riak_kv_queue_manager).

--- a/src/riak_kv_test_util.erl
+++ b/src/riak_kv_test_util.erl
@@ -291,7 +291,13 @@ dep_apps(Test, Extra) ->
                                                         5}]}]),
                 application:set_env(lager,
                                     crash_log,
-                                    get_test_dir(Test) ++ "/log/crash.log");
+                                    get_test_dir(Test) ++ "/log/crash.log"),
+                application:set_env(riak_kv,
+                                    eraser_dataroot,
+                                    get_test_dir(Test) ++ "/kv_eraser"),
+                application:set_env(riak_kv,
+                                    reaper_dataroot,
+                                    get_test_dir(Test) ++ "/kv_reaper");
            (stop) -> ok;
            (_) -> ok
         end,


### PR DESCRIPTION
Expand on use of riak_kv_overflow_queue so that it is used by the riak_kv_replrtq_src, as well as riak_kv_reaper and riak_kv_eraser.

This means that larger queue sizes can be supported for riak_kv_replrtq_src without having to worry about compromising the memory of the node. This should allow for repl_keys_range AAE folds to generate very large replication sets, without clogging the node worker pool by pausing so that real-time replication can keep up.

The overflow queues are deleted on shutdown (if there is a queue on disk). The feature is to allow for larger queues without memory exhaustion, persistence is not used to persist queues across restarts.