### PR TITLE
Do not crash when object's contents is an empty list

### DIFF
--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -1676,6 +1676,17 @@ delete_hash(ObjOrClock) ->
 
 -ifdef(TEST).
 
+%% See https://github.com/basho/riak_kv/issues/1707
+object_with_empty_contents_test() ->
+    B = <<"buckets_are_binaries">>,
+    K = <<"keys are binaries">>,
+
+    Contents = [],
+    O = #r_object{bucket=B,key=K,
+                  contents=Contents,vclock=vclock:fresh()},
+
+    ?assertEqual(false, is_head(O)).
+
 object_test() ->
     B = <<"buckets_are_binaries">>,
     K = <<"keys are binaries">>,

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -348,6 +348,8 @@ find_bestobject(FetchedItems) ->
 
 -spec is_head({ok, riak_object()}|riak_object()) -> boolean().
 %% @private Check if an object is simply a head response
+is_head({ok, #r_object{contents=[]}}) ->
+    false;
 is_head({ok, #r_object{contents=Contents}}) ->
     C0 = lists:nth(1, Contents),
     case C0#r_content.value of


### PR DESCRIPTION
### Description

It is related to [this](https://github.com/basho/riak_kv/issues/1707) known issue.

The issue, however, is that [this](https://github.com/basho/riak_kv/blob/6ebac46bf9ead05dae716b05b2a3f5767c5288db/src/riak_kv_vnode.erl#L3124) case clause, which was introduced to be able to debug the issue, is never executed because `riak_object:is_head/1` [called in the case statement](https://github.com/basho/riak_kv/blob/6ebac46bf9ead05dae716b05b2a3f5767c5288db/src/riak_kv_vnode.erl#L3121) crashes due to the object's content being an empty list.

```
[error] <0.10284.7>@riak_core_vnode:vnode_command:376 riak_kv_vnode command failed {function_clause,[{lists,nth,[1,[]],[{file,"lists.erl"},{line,170}]},{riak_object,is_head,1,[{file,"/root/riak/rel/pkg/out/BUILD/riak-3.0.10-OTP22.3/_build/default/lib/riak_kv/src/riak_object.erl"},{line,352}]},{riak_kv_vnode,enforce_allow_mult,3,[{file,"/root/riak/rel/pkg/out/BUILD/riak-3.0.10-OTP22.3/_build/default/lib/riak_kv/src/riak_kv_vnode.erl"},{line,3123}]},{riak_kv_vnode,prepare_put_existing_object,6,[{file,"/root/riak/rel/pkg/out/BUILD/riak-3.0.10-OTP22.3/_build/default/lib/riak_kv/src/riak_kv_vnode.erl"},{line,2875}]},{riak_kv_vnode,do_put,7,[{file,"/root/riak/rel/pkg/out/BUILD/riak-3.0.10-OTP22.3/_build/default/lib/riak_kv/src/riak_kv_vnode.erl"},{line,2716}]},{riak_kv_vnode,handle_request,4,[{file,"/root/riak/rel/pkg/out/BUILD/riak-3.0.10-OTP22.3/_build/default/lib/riak_kv/src/riak_kv_vnode.erl"},{line,1489}]},{riak_core_vnode,vnode_command,3,[{file,"/root/riak/rel/pkg/out/BUILD/riak-3.0.10-OTP22.3/_build/default/lib/riak_core/src/riak_core_vnode.erl"},{line,373}]},{gen_fsm,handle_msg,8,[{file,"gen_fsm.erl"},{line,497}]}]}
```