### PR TITLE
Mas i1121 reip3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -42,7 +42,7 @@
 ]}.
 
 {deps, [
-    {riak_core, {git, "https://github.com/basho/riak_core.git", {branch, "mas-i1121-passringdir"}}},
+    {riak_core, {git, "https://github.com/basho/riak_core.git", {branch, "develop-3.0"}}},
     {sidejob, {git, "https://github.com/basho/sidejob.git", {tag, "2.1.0"}}},
     {bitcask, {git, "https://github.com/basho/bitcask.git", {tag, "2.1.0"}}},
     {redbug, {git, "https://github.com/massemanet/redbug", {tag, "1.2.2"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -42,7 +42,7 @@
 ]}.
 
 {deps, [
-    {riak_core, {git, "https://github.com/basho/riak_core.git", {tag, "riak_kv-3.0.10"}}},
+    {riak_core, {git, "https://github.com/basho/riak_core.git", {branch, "mas-i1121-passringdir"}}},
     {sidejob, {git, "https://github.com/basho/sidejob.git", {tag, "2.1.0"}}},
     {bitcask, {git, "https://github.com/basho/bitcask.git", {tag, "2.1.0"}}},
     {redbug, {git, "https://github.com/massemanet/redbug", {tag, "1.2.2"}}},

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -242,6 +242,7 @@ reip_manual([OldNode, NewNode, Dir, ClusterName]) ->
         Cluster = atom_to_list(ClusterName),
         {ok, RingFile} =
             riak_core_ring_manager:find_latest_ringfile(RingDir, Cluster),
+        io:format("~nCHANGE DETAILS:~n"),
         io:format("RingFile to update ~p~n", [RingFile]),
         BackupFN =
             filename:join([RingDir, filename:basename(RingFile)++".BAK"]),
@@ -254,10 +255,12 @@ reip_manual([OldNode, NewNode, Dir, ClusterName]) ->
                 RingDir, Cluster),
         ok = riak_core_ring_manager:do_write_ringfile(NewRing, NewRingFN),
         io:format("New ring file written to ~p~n", [NewRingFN]),
+        io:format("~nATTENTION REQUIRED:~n"),
         io:format(
-            "~nUpdate required to riak.conf nodename before restarting node" ++
-            "nodename should be changed to ~p~n",
-            [NewNode])
+            "Update required to riak.conf nodename before restarting node;"
+            ++ " nodename should be changed to ~s~n",
+            [atom_to_list(NewNode)]),
+        io:format("~nok~n")
     catch
         Exception:Reason ->
             io:format("Reip failed ~p:~p", [Exception, Reason]),

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -31,7 +31,7 @@
          status/1,
          vnode_status/1,
          reip/1,
-         reip/3,
+         reip_manual/3,
          ringready/1,
          cluster_info/1,
          down/1,
@@ -233,7 +233,7 @@ reip([OldNode, NewNode]) ->
             error
     end.
 
-reip([OldNode, NewNode], RingDir, ClusterName) ->
+reip_manual([OldNode, NewNode], RingDir, ClusterName) ->
     try
         %% reip/1 requires riak_core to be loaded to learn the Ring Directory
         %% and the Cluster Name.  In reip/3 these can be passed in instead

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -236,8 +236,10 @@ reip([OldNode, NewNode]) ->
 reip_manual([OldNode, NewNode, RingDir, ClusterName]) ->
     try
         %% reip/1 requires riak_core to be loaded to learn the Ring Directory
-        %% and the Cluster Name.  In reip/3 these can be passed in instead
-        {ok, RingFile} = riak_core_ring_manager:find_latest_ringfile(RingDir),
+        %% and the Cluster Name.  In reip_manual/1 these can be passed in 
+        %% instead
+        {ok, RingFile} =
+            riak_core_ring_manager:find_latest_ringfile(RingDir, ClusterName),
         BackupFN =
             filename:join([RingDir, filename:basename(RingFile)++".BAK"]),
         {ok, _} = file:copy(RingFile, BackupFN),

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -31,7 +31,7 @@
          status/1,
          vnode_status/1,
          reip/1,
-         reip_manual/3,
+         reip_manual/1,
          ringready/1,
          cluster_info/1,
          down/1,
@@ -233,7 +233,7 @@ reip([OldNode, NewNode]) ->
             error
     end.
 
-reip_manual([OldNode, NewNode], RingDir, ClusterName) ->
+reip_manual([OldNode, NewNode, RingDir, ClusterName]) ->
     try
         %% reip/1 requires riak_core to be loaded to learn the Ring Directory
         %% and the Cluster Name.  In reip/3 these can be passed in instead

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -253,7 +253,11 @@ reip_manual([OldNode, NewNode, Dir, ClusterName]) ->
             riak_core_ring_manager:generate_ring_filename(
                 RingDir, Cluster),
         ok = riak_core_ring_manager:do_write_ringfile(NewRing, NewRingFN),
-        io:format("New ring file written to ~p~n", [NewRingFN])
+        io:format("New ring file written to ~p~n", [NewRingFN]),
+        io:format(
+            "~nUpdate required to riak.conf nodename before restarting node" ++
+            "nodename should be changed to ~p~n",
+            [NewNode])
     catch
         Exception:Reason ->
             io:format("Reip failed ~p:~p", [Exception, Reason]),


### PR DESCRIPTION
Add a `reip_manual/1` function to riak_kv_console that allows reip to be done with knowledge of ring_sir and cluster name - avoiding the need to load riak_core.

https://github.com/basho/riak_core/pull/992

https://github.com/basho/riak/issues/1121