### PR TITLE
add missing function clause repair_keys_range in convert_fold

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -907,7 +907,7 @@ aae_fold(Query, {?MODULE, [Node, _ClientId]}) ->
         true ->
             riak_kv_clusteraae_fsm_sup:start_clusteraae_fsm(Node,
                                                             [{raw, ReqId, Me},
-                                                            [Query, TimeOut]]),
+                                                            [Q0, TimeOut]]),
             wait_for_fold_results(ReqId, TimeOut);
         false ->
             {error, "Invalid AAE fold definition"}

--- a/src/riak_kv_clusteraae_fsm.erl
+++ b/src/riak_kv_clusteraae_fsm.erl
@@ -891,6 +891,8 @@ convert_fold({find_tombs, B, KR, SF, MR}) ->
     {find_tombs, B, KR, SF, convert_modrange(MR)};
 convert_fold({reap_tombs, B, KR, SF, MR, CM}) ->
     {reap_tombs, B, KR, SF, convert_modrange(MR), CM};
+convert_fold({repair_keys_range, B, KR, MR, L}) ->
+    {repair_keys_range, B, KR, convert_modrange(MR), L};
 convert_fold({erase_keys, B, KR, SF, MR, CM}) ->
     {erase_keys, B, KR, SF, convert_modrange(MR), CM};
 convert_fold(Fold) ->


### PR DESCRIPTION
This is to unbreak `aae_fold` for `repair_keys_range`.

In collaboration with @pjaclark.