### PR TITLE
Update log

### DIFF
--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -708,8 +708,10 @@ fold_fun(HashtreePid, _HasIndexTree = true) ->
 -spec handle_corrupted_object(
     riak_object:bucket(), riak_object:key(), term(), term()) -> ok.
 handle_corrupted_object(Bucket, Key, Error, Reason) ->
-    lager:warning("Unable to read B=~p K=~p", [Bucket, Key]),
-    lager:warning("Read failure due to ~w ~w", [Error, Reason]),
+    lager:warning(
+        "Unable to read B=~p K=~p due to ~p ~p during tree rebuild " ++
+        "so will prompt read_repair - ignore warning during shutdown",
+        [Bucket, Key, Error, Reason]),
     riak_kv_reader:request_read({Bucket, Key}).
 
 -spec object_fold_fun(pid()) ->


### PR DESCRIPTION
Make situation clearer in log

Rather than change behaviour, just make it clear that the warning can be ignored when shutting down.  This should avoid unnecessary concern.