### PR TITLE
Mas i1847 putapi

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -53,5 +53,5 @@
     {riak_api, {git, "https://github.com/basho/riak_api.git", {branch, "develop-3.0"}}},
     {hyper, {git, "https://github.com/basho/hyper", {tag, "1.1.0"}}},
     {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {branch, "develop-3.0"}}},
-    {riakhttpc, {git, "https://github.com/basho/riak-erlang-http-client", {tag, "3.0.10"}}}
+    {riakhttpc, {git, "https://github.com/basho/riak-erlang-http-client", {branch, "develop-3.0"}}}
        ]}.

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -531,7 +531,7 @@ delete(Bucket,Key,{?MODULE, [_Node, _ClientId]}=THIS) -> delete(Bucket,Key,[],?D
 %%      nodes have responded with a value or error.
 %% @equiv delete(Bucket, Key, RW, default_timeout())
 delete(Bucket,Key,Options,{?MODULE, [_Node, _ClientId]}=THIS) when is_list(Options) ->
-    delete(Bucket,Key,Options,?DEFAULT_TIMEOUT,THIS);
+    delete(Bucket,Key,Options,recv_timeout(Options),THIS);
 delete(Bucket,Key,RW,{?MODULE, [_Node, _ClientId]}=THIS) ->
     delete(Bucket,Key,[{rw, RW}],?DEFAULT_TIMEOUT,THIS).
 
@@ -622,7 +622,7 @@ delete_vclock(Bucket,Key,VClock,{?MODULE, [_Node, _ClientId]}=THIS) ->
 %%      nodes have responded with a value or error.
 %% @equiv delete(Bucket, Key, RW, default_timeout())
 delete_vclock(Bucket,Key,VClock,Options,{?MODULE, [_Node, _ClientId]}=THIS) when is_list(Options) ->
-    delete_vclock(Bucket,Key,VClock,Options,?DEFAULT_TIMEOUT,THIS);
+    delete_vclock(Bucket,Key,VClock,Options,recv_timeout(Options),THIS);
 delete_vclock(Bucket,Key,VClock,RW,{?MODULE, [_Node, _ClientId]}=THIS) ->
     delete_vclock(Bucket,Key,VClock,[{rw, RW}],?DEFAULT_TIMEOUT,THIS).
 

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -1196,8 +1196,6 @@ delete_resource(RD, Ctx=#ctx{bucket_type=T, bucket=B, key=K, client=C}) ->
     case Result of
         ok ->
             {true, RD, Ctx};
-        {error, notfound} ->
-            {true, RD, Ctx};
         {error, Reason} ->
             handle_common_error(Reason, RD, Ctx)
     end.

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -37,6 +37,7 @@
 -define(HEAD_DELETED,         "X-Riak-Deleted").
 -define(HEAD_TIMEOUT,         "X-Riak-Timeout").
 -define(HEAD_CRDT_CONTEXT,    "X-Riak-CRDT-Ctx").
+-define(HEAD_IF_NOT_MODIFIED, "X-Riak_If_Not_Modified").
 
 %% Names of JSON fields in bucket properties
 -define(JSON_PROPS,   <<"props">>).

--- a/src/riak_kv_wm_raw.hrl
+++ b/src/riak_kv_wm_raw.hrl
@@ -37,7 +37,7 @@
 -define(HEAD_DELETED,         "X-Riak-Deleted").
 -define(HEAD_TIMEOUT,         "X-Riak-Timeout").
 -define(HEAD_CRDT_CONTEXT,    "X-Riak-CRDT-Ctx").
--define(HEAD_IF_NOT_MODIFIED, "X-Riak_If_Not_Modified").
+-define(HEAD_IF_NOT_MODIFIED, "X-Riak-If-Not-Modified").
 
 %% Names of JSON fields in bucket properties
 -define(JSON_PROPS,   <<"props">>).


### PR DESCRIPTION
For both PUT and DELETE the behaviour of the HTTP API should be consistent with that of the PB API, in particular it should not do a fetch of the object, unless such a fetch is required to support conditional request headers (e.g. 'if-None-Match').