### PR TITLE
Mas i1850 handoffdelete

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1493,3 +1493,10 @@
     {default, disabled},
     hidden
 ]}.
+
+%% @doc When doing handoffs, forward delete requests so that if the delete_mode
+%% is not keep, tombstones will still be reaped.
+{mapping, "handoff_deletes", "riak_kv.handoff_deletes", [
+    {datatype, {flag, enabled, disabled}},
+    {default, disabled}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -52,6 +52,6 @@
     {riak_dt, {git, "https://github.com/basho/riak_dt.git", {tag, "riak_kv-3.0.0"}}},
     {riak_api, {git, "https://github.com/basho/riak_api.git", {tag, "riak_kv-3.0.13"}}},
     {hyper, {git, "https://github.com/basho/hyper", {tag, "1.1.0"}}},
-    {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "1.0.5"}}},
+    {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {branch, "develop-3.0"}}},
     {riakhttpc, {git, "https://github.com/basho/riak-erlang-http-client", {tag, "3.0.13"}}}
        ]}.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -2326,6 +2326,16 @@ handle_handoff_request(kv_w1c_put_request, Request, Sender, State) ->
             NewState
     end,
     {forward, NewState0};
+handle_handoff_request(kv_delete_request, Request, Sender, State) ->
+    {reply, Reply, NewState} =
+        handle_request(kv_delete_request, Request, Sender, State),
+    riak_core_vnode:reply(Sender, Reply),
+    case Reply of
+        {del, _Idx, _Reason} ->
+            {forward, NewState};
+        _ ->
+            {noreply, NewState}
+    end;
 handle_handoff_request(_Other, Req, Sender, State) ->
     %% @todo: this should be based on the type of the request when the
     %%        hiding of records is complete.


### PR DESCRIPTION
Currently delete requests do not handoff.  This means that deletes which happen during handoffs do not get reaped (i.e. when delete_mode is not keep).

The option to handoff deletes is added as a non-default configuration.  It should probably be default behaviour, however, it is not clear if not making this default behaviour was at some stage a deliberate decision.

Test - https://github.com/basho/riak_test/pull/1371