### PR TITLE
Log Fragmentation

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -42,16 +42,16 @@
 ]}.
 
 {deps, [
-    {riak_core, {git, "https://github.com/basho/riak_core.git", {tag, "riak_kv-3.0.14"}}},
+    {riak_core, {git, "https://github.com/basho/riak_core.git", {branch, "develop-3.0"}}},
     {sidejob, {git, "https://github.com/basho/sidejob.git", {tag, "2.1.0"}}},
     {bitcask, {git, "https://github.com/basho/bitcask.git", {tag, "2.1.0"}}},
     {redbug, {git, "https://github.com/massemanet/redbug", {tag, "1.2.2"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.2"}}},
     {sext, {git, "https://github.com/uwiger/sext.git", {tag, "1.4.1"}}},
-    {riak_pipe, {git, "https://github.com/basho/riak_pipe.git", {tag, "riak_kv-3.0.14"}}},
+    {riak_pipe, {git, "https://github.com/basho/riak_pipe.git", {branch, "develop-3.0"}}},
     {riak_dt, {git, "https://github.com/basho/riak_dt.git", {tag, "riak_kv-3.0.0"}}},
-    {riak_api, {git, "https://github.com/basho/riak_api.git", {tag, "riak_kv-3.0.14"}}},
+    {riak_api, {git, "https://github.com/basho/riak_api.git", {branch, "develop-3.0"}}},
     {hyper, {git, "https://github.com/basho/hyper", {tag, "1.1.0"}}},
-    {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {tag, "1.0.6"}}},
+    {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {branch, "develop-3.0"}}},
     {riakhttpc, {git, "https://github.com/basho/riak-erlang-http-client", {tag, "3.0.13"}}}
        ]}.

--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -659,7 +659,7 @@ log_fragmentation(Allocator) ->
     lager:info(
         "Memory for allocator=~p "
         "mbcs_block_size=~w mbcs_carrier_size=~w "
-        "sbcs_block_size=~w sbcs_carrier_size=~W",
+        "sbcs_block_size=~w sbcs_carrier_size=~w",
         [Allocator, MB_BS, MB_CS, SB_BS, SB_CS]).
 
 %% @private

--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -616,8 +616,8 @@ data_size(_State) ->
 %% @doc Register an asynchronous callback
 -spec callback(reference(), any(), state()) -> {ok, state()}.
 callback(Ref, compact_journal, State) ->
-    log_fragmentation(eheap_alloc),
-    log_fragmentation(binary_alloc),
+    _ = spawn(fun() -> log_fragmentation(eheap_alloc) end),
+    _ = spawn(fun() -> log_fragmentation(binary_alloc) end),
     case is_reference(Ref) of
         true ->
              prompt_journalcompaction(State#state.bookie,

--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -281,7 +281,7 @@ delete(Bucket, Key, IndexSpecs, #state{bookie=Bookie}=State) ->
 -spec fold_buckets(riak_kv_backend:fold_buckets_fun(),
                    any(),
                    [],
-                   state()) -> {ok, any()} | {async, fun()}.
+                   state()) -> {ok, any()} | {async, fun(() -> any())}.
 fold_buckets(FoldBucketsFun, Acc, Opts, #state{bookie=Bookie}) ->
     {async, Folder} = 
         leveled_bookie:book_bucketlist(Bookie, 
@@ -299,7 +299,7 @@ fold_buckets(FoldBucketsFun, Acc, Opts, #state{bookie=Bookie}) ->
 -spec fold_keys(riak_kv_backend:fold_keys_fun(),
                 any(),
                 [{atom(), term()}],
-                state()) -> {ok, term()} | {async, fun()}.
+                state()) -> {ok, term()} | {async, fun(() -> any())}.
 fold_keys(FoldKeysFun, Acc, Opts, #state{bookie=Bookie}) ->
     %% Figure out how we should limit the fold: by bucket, by
     %% secondary index, or neither (fold across everything.)
@@ -391,7 +391,7 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{bookie=Bookie}) ->
 -spec fold_objects(riak_kv_backend:fold_objects_fun(),
                    any(),
                    [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()}.
+                   state()) -> {ok, any()} | {async, fun(() -> any())}.
 fold_objects(FoldObjectsFun, Acc, Opts, #state{bookie=Bookie}) ->
 
     {async, ObjectFolder} =
@@ -503,7 +503,7 @@ fold_objects(FoldObjectsFun, Acc, Opts, #state{bookie=Bookie}) ->
 -spec fold_heads(riak_kv_backend:fold_objects_fun(),
                    any(),
                    [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()}.
+                   state()) -> {ok, any()} | {async, fun(() -> any())}.
 fold_heads(FoldHeadsFun, Acc, Opts, #state{bookie=Bookie}) ->
     CheckPresence =
         case proplists:get_value(check_presence, Opts) of
@@ -581,7 +581,7 @@ is_empty(#state{bookie=Bookie}) ->
     leveled_bookie:book_isempty(Bookie, ?RIAK_TAG).
 
 %% @doc Prompt a snapshot function from which a hot backup can be called
--spec hot_backup(state(), string()) -> {queue, fun()}|{error, term()}.
+-spec hot_backup(state(), string()) -> {queue, fun(() -> any())}|{error, term()}.
 hot_backup(#state{bookie=Bookie, partition=Partition, db_path=DBP}, BackupRoot) ->
     {ok, BackupDir} = get_data_dir(BackupRoot, integer_to_list(Partition)),
     case BackupDir == DBP of
@@ -640,22 +640,25 @@ callback(Ref, UnexpectedCallback, State) ->
 
 -spec log_fragmentation(eheap_alloc|binary_alloc) -> ok.
 log_fragmentation(Allocator) ->
-    FragStats =
-        lists:filter(
-            fun(MemStuff) ->
-                element(1, element(1, MemStuff)) == Allocator
-            end,
-            recon_alloc:fragmentation(current)),
     {MB_BS, MB_CS, SB_BS, SB_CS} =
         lists:foldl(
-            fun({{_A, _I}, Stats}, {MBAcc, MCAcc, SBAcc, SCAcc}) ->
-                {MBAcc + proplists:get_value(mbcs_block_size, Stats),
-                    MCAcc + proplists:get_value(mbcs_carriers_size, Stats),
-                    SBAcc + proplists:get_value(sbcs_block_size, Stats),
-                    SCAcc + proplists:get_value(sbcs_carriers_size, Stats)}
+            fun({{A, I}, Stats}, {MBAcc, MCAcc, SBAcc, SCAcc}) ->
+                case {{A, I}, Stats} of
+                    {{Allocator, I}, Stats} when I > 0 ->
+                        {MBAcc + proplists:get_value(
+                                    mbcs_block_size, Stats, 0),
+                            MCAcc + proplists:get_value(
+                                    mbcs_carriers_size, Stats, 0),
+                            SBAcc + proplists:get_value(
+                                    sbcs_block_size, Stats, 0),
+                            SCAcc + proplists:get_value(
+                                    sbcs_carriers_size, Stats, 0)};
+                    _ ->
+                        {MBAcc, MCAcc, SBAcc, SCAcc}
+                end
             end,
             {0, 0, 0, 0},
-            FragStats),
+            recon_alloc:fragmentation(current)),
     lager:info(
         "Memory for allocator=~p "
         "mbcs_block_size=~w mbcs_carrier_size=~w "

--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -660,7 +660,7 @@ log_fragmentation(Allocator) ->
         "Memory for allocator=~p "
         "mbcs_block_size=~w mbcs_carrier_size=~w "
         "sbcs_block_size=~w sbcs_carrier_size=~W",
-        [MB_BS, MB_CS, SB_BS, SB_CS]).
+        [Allocator, MB_BS, MB_CS, SB_BS, SB_CS]).
 
 %% @private
 %% Complete a PUT, with the sync option true/false depending on whether 

--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -642,9 +642,9 @@ callback(Ref, UnexpectedCallback, State) ->
 log_fragmentation(Allocator) ->
     {MB_BS, MB_CS, SB_BS, SB_CS} =
         lists:foldl(
-            fun({{A, I}, Stats}, {MBAcc, MCAcc, SBAcc, SCAcc}) ->
-                case {{A, I}, Stats} of
-                    {{Allocator, I}, Stats} when I > 0 ->
+            fun(ReconAllocOutputLine, {MBAcc, MCAcc, SBAcc, SCAcc}) ->
+                case ReconAllocOutputLine of
+                    {{Allocator, I}, Stats} when I > 0, is_list(Stats) ->
                         {MBAcc + proplists:get_value(
                                     mbcs_block_size, Stats, 0),
                             MCAcc + proplists:get_value(


### PR DESCRIPTION
With the leveled backend, memory fragmentation is an ongoing concern.  So, here the regular compaction callback is used to log information about carrier sizes and carrier block sizes for key allocators.