### PR TITLE
Type fixes required by OTP26 dialyzer

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -52,6 +52,6 @@
     {riak_dt, {git, "https://github.com/basho/riak_dt.git", {branch, "develop"}}},
     {riak_api, {git, "https://github.com/basho/riak_api.git", {branch, "develop"}}},
     {hyper, {git, "https://github.com/basho/hyper", {tag, "1.1.0"}}},
-    {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {branch, "mas-otp26"}}},
+    {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {branch, "develop-3.1"}}},
     {rhc, {git, "https://github.com/basho/riak-erlang-http-client", {branch, "develop-3.2"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -52,6 +52,6 @@
     {riak_dt, {git, "https://github.com/basho/riak_dt.git", {branch, "develop"}}},
     {riak_api, {git, "https://github.com/basho/riak_api.git", {branch, "develop"}}},
     {hyper, {git, "https://github.com/basho/hyper", {tag, "1.1.0"}}},
-    {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {branch, "develop-3.1"}}},
+    {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree.git", {branch, "mas-otp26"}}},
     {rhc, {git, "https://github.com/basho/riak-erlang-http-client", {branch, "develop-3.2"}}}
 ]}.

--- a/src/riak_kv.app.src
+++ b/src/riak_kv.app.src
@@ -26,7 +26,8 @@
                   redbug,
                   recon,
                   riakc,
-                  rhc
+                  rhc,
+                  bitcask
                  ]},
   {registered, []},
   {mod, {riak_kv_app, []}},

--- a/src/riak_kv_clusteraae_fsm.erl
+++ b/src/riak_kv_clusteraae_fsm.erl
@@ -315,7 +315,8 @@
                         %% fetch_clocks_range | fetch_clocks_nval |
                         %% find_keys
                         list_query_result() |
-                        repl_result().
+                        repl_result() |
+                        erase_result().
 
 -type branches() :: list(branch()).
 %% level 2 of tree
@@ -329,11 +330,12 @@
 -type key_clock() :: {riak_object:bucket(), riak_object:key(), vclock:vclock()}.
 
 -type keys() :: list({riak_object:bucket(), riak_object:key(), integer()}).
--type object_stats() :: proplist:proplist().
+-type object_stats() :: proplists:proplist().
 -type repl_result() :: {list(riak_kv_replrtq_src:repl_entry()),
                         non_neg_integer(),
                         riak_kv_replrtq_src:queue_name(),
                         pos_integer()}.
+-type erase_result() :: {list(), non_neg_integer(), local|count|pid()}.
 
 -type query_state() :: #state{}.
 

--- a/src/riak_kv_index_fsm.erl
+++ b/src/riak_kv_index_fsm.erl
@@ -62,7 +62,7 @@
 -endif.
 
 -record(timings, 
-            {start_time = os:timestamp() :: os:timestamp(),
+            {start_time = os:timestamp() :: erlang:timestamp(),
                 max = 0 :: non_neg_integer(),
                 min = infinity :: non_neg_integer()|infinity,
                 count = 0 :: non_neg_integer(),
@@ -80,7 +80,7 @@
                 max_results :: all | pos_integer(),
                 results_per_vnode = dict:new() :: riak_kv_index_fsm_dict(),
                 timings = #timings{} :: timings(),
-                bucket :: riak_object:buckey() | undefined,
+                bucket :: riak_object:bucket() | undefined,
                 results_sent = 0 :: non_neg_integer()}).
 
 

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -590,10 +590,10 @@ load_built(#state{trees=Trees}) ->
     end.
 
 %% Generate a hash value for a `riak_object'
--spec hash_object({riak_object:bucket(), riak_object:key()},
-                    riak_object_t2b() | 
-                        riak_object:riak_object() | riak_object:proxy_object(),
-                    version()) -> binary().
+-spec hash_object(
+    {riak_object:bucket(), riak_object:key()},
+    riak_object_t2b() | riak_object:riak_object() | riak_object:proxy_object(),
+    version()) -> binary().
 hash_object({Bucket, Key}, RObj, Version) ->
     riak_object:hash(Bucket, Key, RObj, Version).
 
@@ -666,8 +666,7 @@ maybe_throttle_build(RObjBin, Limit, Wait, Acc) ->
 
 -type hashtree_fold_fun() ::
     fun((
-        {riak_object:bucket(), riak_object:key()},
-        riak_object:riak_object(),
+        {riak_object:bucket(), riak_object:key()}, riak_object_t2b(),
         {non_neg_integer(), {non_neg_integer(), non_neg_integer()}}) ->
             {non_neg_integer(), {non_neg_integer(), non_neg_integer()}}).
 
@@ -719,7 +718,7 @@ handle_corrupted_object(Bucket, Key, Error, Reason) ->
 -spec object_fold_fun(pid()) ->
     fun((
         {riak_object:bucket(), riak_object:key()},
-        riak_object:object(),
+        riak_object_t2b() | riak_object:riak_object() | riak_object:proxy_object(),
         binary()) -> ok).
 object_fold_fun(HashtreePid) ->
     Version = get_version(HashtreePid),
@@ -731,7 +730,8 @@ object_fold_fun(HashtreePid) ->
     end.
 
 -spec index_fold_fun(pid()) ->
-    fun((riak_object:object(), binary()) -> ok).
+    fun((riak_object:riak_object()|riak_object:proxy_object(), binary())
+            -> ok).
 index_fold_fun(HashtreePid) ->
     fun(RObj, BinBKey) ->
             IndexData = riak_object:index_data(RObj),

--- a/src/riak_kv_mapreduce.erl
+++ b/src/riak_kv_mapreduce.erl
@@ -49,10 +49,6 @@
 
 -include_lib("kernel/include/logger.hrl").
 
-%-ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
-%-endif.
-
 %%
 %% Map Phases
 %%
@@ -279,6 +275,9 @@ is_datum(_) ->
     true.
 
 %% unit tests %%
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
 map_identity_test() ->
     O1 = riak_object:new(<<"a">>, <<"1">>, "value1"),
     [O1] = map_identity(O1, test, test).
@@ -345,3 +344,5 @@ reduce_count_inputs_test() ->
                               {"b5","k5"},{"b5","k5"}],
                              none),
                         none)).
+
+-endif.

--- a/src/riak_kv_overflow_queue.erl
+++ b/src/riak_kv_overflow_queue.erl
@@ -397,7 +397,7 @@ generate_ordered_guid() ->
         [Year, Month, Day, H, M, C band 16#0fff, D band 16#3fff bor 16#8000, E]).
 
 
--spec disklog_filename(string(), string()) -> filename:filename().
+-spec disklog_filename(string(), string()) -> filename().
 disklog_filename(RootPath, GUID) ->
     filename:join(RootPath, GUID ++ ?DISKLOG_EXT).
 

--- a/src/riak_kv_overflow_queue.erl
+++ b/src/riak_kv_overflow_queue.erl
@@ -49,7 +49,7 @@
 
 -type priority() :: pos_integer().
 -type continuation() :: start|disk_log:continuation().
--type filename() :: file:filename()|none.
+-type filename() :: file:filename_all()|none.
 -type queue_stats() :: list({pos_integer(), non_neg_integer()}).
 
 -record(overflowq,  
@@ -397,7 +397,7 @@ generate_ordered_guid() ->
         [Year, Month, Day, H, M, C band 16#0fff, D band 16#3fff bor 16#8000, E]).
 
 
--spec disklog_filename(string(), string()) -> filename().
+-spec disklog_filename(string(), string()) -> file:filename_all().
 disklog_filename(RootPath, GUID) ->
     filename:join(RootPath, GUID ++ ?DISKLOG_EXT).
 

--- a/src/riak_kv_pb_object.erl
+++ b/src/riak_kv_pb_object.erl
@@ -448,8 +448,7 @@ make_binarykey(RObj) ->
     make_binarykey(riak_object:bucket(RObj), riak_object:key(RObj)).
 
 -spec unpack_keyclock_fun(#rpbkeysvalue{}) ->
-        {riak_object:bucket(RObj), riak_object:key(RObj), vclock:vclock(),
-            to_fetch}.
+        {riak_object:bucket(), riak_object:key(), vclock:vclock(), to_fetch}.
 unpack_keyclock_fun(RpbKeysClock) ->
     Bucket =
         case RpbKeysClock#rpbkeysvalue.type of


### PR DESCRIPTION
mochijson2 types are not exported by mochijson, and so for convenience they are simply redefined.