### PR TITLE
Don't trigger node confirms failure if clock expected

### DIFF
--- a/src/riak_kv_get_core.erl
+++ b/src/riak_kv_get_core.erl
@@ -245,12 +245,15 @@ enough(_) ->
 %% Get success/fail response once enough results received
 -spec response(getcore()) -> {reply(), getcore()}.
 %% Met quorum for a standard get request/response
-response(#getcore{node_confirms = RequiredConfirms,
-                    confirmed_nodes = Nodes} = GetCore)
-            when length(Nodes) < RequiredConfirms ->
-    check_overload({error,
-                    {insufficient_nodes,
-                        length(Nodes), need, RequiredConfirms}}, GetCore);
+response(
+    #getcore{
+        node_confirms = RqdConfirms,
+        confirmed_nodes = Nodes,
+        expected_fetchclock = ExpClock} = GetCore)
+            when (length(Nodes) < RqdConfirms andalso ExpClock =/= true) ->
+    check_overload(
+        {error, {insufficient_nodes, length(Nodes), need, RqdConfirms}},
+        GetCore);
     %% Insufficient nodes confirmed
 response(#getcore{r = R, num_ok = NumOK, pr= PR, num_pok = NumPOK,
                     expected_fetchclock = ExpClock, head_merge = HM} = GetCore)


### PR DESCRIPTION
When fetching an object for replication, enough nodes are found if the expected clock is true - but that might then fail on node_confirms.  Don't generate the node_confirms response error if there has been a match on the expected clock.
