### PR TITLE
Handle reap and erase in batches

### DIFF
--- a/src/riak_kv_eraser.erl
+++ b/src/riak_kv_eraser.erl
@@ -38,6 +38,8 @@
             start_job/1,
             request_delete/1,
             request_delete/2,
+            bulk_request_delete/1,
+            bulk_request_delete/2,
             delete_stats/0,
             delete_stats/1,
             override_redo/1,
@@ -83,6 +85,14 @@ request_delete(DeleteReference) ->
 -spec request_delete(pid()|module(), delete_reference()) -> ok.
 request_delete(Pid, DeleteReference) ->
     riak_kv_queue_manager:request(Pid, DeleteReference).
+
+-spec bulk_request_delete(list(delete_reference())) -> ok.
+bulk_request_delete(RefList) ->
+    bulk_request_delete(?MODULE, RefList).
+
+-spec bulk_request_delete(pid()|module(), list(delete_reference())) -> ok.
+bulk_request_delete(Pid, RefList) ->
+    riak_kv_queue_manager:bulk_request(Pid, RefList).
 
 -spec delete_stats() ->
     list({atom(), non_neg_integer()|riak_kv_overflow_queue:queue_stats()}).

--- a/src/riak_kv_reaper.erl
+++ b/src/riak_kv_reaper.erl
@@ -49,6 +49,8 @@
             start_job/1,
             request_reap/1,
             request_reap/2,
+            bulk_request_reap/1,
+            bulk_request_reap/2,
             direct_reap/1,
             reap_stats/0,
             reap_stats/1,
@@ -93,6 +95,14 @@ request_reap(ReapReference) ->
 -spec request_reap(pid()|module(), reap_reference()) -> ok.
 request_reap(Pid, ReapReference) ->
     riak_kv_queue_manager:request(Pid, ReapReference).
+
+-spec bulk_request_reap(list(reap_reference())) -> ok.
+bulk_request_reap(RefList) ->
+    bulk_request_reap(?MODULE, RefList).
+
+-spec bulk_request_reap(pid()|module(), list(reap_reference())) -> ok.
+bulk_request_reap(Pid, RefList) ->
+    riak_kv_queue_manager:bulk_request(Pid, RefList).
 
 -spec reap_stats() ->
     list({atom(), non_neg_integer()|riak_kv_overflow_queue:queue_stats()}).


### PR DESCRIPTION
Avoid overloading the eraser/reaper process mailbox by sending the requests in batches (as already happened with range_repl), and waiting for a response.

When a job is used, not local, the batching is done from the clusteraae_fsm.  This mechanism existed prior to this commit, and has not been changed, but has been extended to support the last-batch overflow