### PR TITLE
Use 'RR' when a prunable vclock is replicated

### DIFF
--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -241,19 +241,8 @@ push(RObjMaybeBin, IsDeleted, _Opts, {?MODULE, [Node, _ClientId]}) ->
     Me = self(),
     ReqId = mk_reqid(),
     W = application:get_env(riak_kv, replrtq_vnodecheck, 1),
-    BucketProps = riak_kv_put_fsm:get_bucket_props(Bucket),
-    Clock = riak_object:vclock(RObj),
-    MaybePrunedClock =
-        vclock:prune(Clock, riak_core_util:moment(), BucketProps),
-    RR =
-        case {length(MaybePrunedClock), length(Clock)} of
-            {PVL, UPVL} when PVL < UPVL ->
-                true;
-            _ ->
-                false
-        end,
     Options = [asis, disable_hooks, {update_last_modified, false},
-                {w, W}, {pw, 1}, {dw, 0}, {node_confirms, 1}, {rr, RR}],
+                {w, W}, {pw, 1}, {dw, 0}, {node_confirms, 1}],
         % asis - stops the PUT from being re-coordinated
         % disable_hooks - this makes this compatible with previous repl,
         % although this may no longer be necessary (no repl hook to disable)

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -50,6 +50,7 @@
          waiting_local_vnode/2,
          waiting_remote_vnode/2,
          postcommit/2, finish/2]).
+-export([get_bucket_props/1]).
 
 -type detail_info() :: timing.
 -type detail() :: true |
@@ -777,6 +778,8 @@ handle_options([{K, _V} = Opt|T], Acc)
   when K == sloppy_quorum; K == n_val ->
     %% Take these options as-is
     handle_options(T, [Opt|Acc]);
+handle_options([{rr, true}|T], Acc) ->
+    handle_options(T, [{rr, true}|Acc]);
 handle_options([{_,_}|T], Acc) -> handle_options(T, Acc).
 
 %% Invokes the hook and returns a tuple of

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -397,9 +397,8 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                         end
                 end,
             RObj = apply_updates(RObj0, Options),
-            Asis = get_option(asis, Options),
             RR =
-                case Asis of
+                case get_option(asis, Options) of
                     true ->
                         Clock = riak_object:vclock(RObj),
                         MaybePrunedClock =


### PR DESCRIPTION
There may be some situations whereby a vector clock grows beyond the prescribed limits on the source cluster - in particular following read repair.

In these cases the new object needs to be replicated but with the same resulting vector clock (assuming no siblings).  If the same vector clock does not result on the sink - any full-sync operation may continuously detect the  delta, but not be able to resolve it (as the sink vnodes prune each time).

The 'rr' option will, on riak_kv_vnode, ensure pruning is bypassed so that we avoid pruning on a sink, if we have not pruned on a source.  The 'rr' option is only used when the clock is prunable (as otherwise the delta could occur in the reverse direction).

The 'rr' option also blocks some sibling constraint checks (e.g. maximum number of siblings.  However, as the most likely cause of it being applied is 'rr' on the src side - this is still generally a win for replication consistency).

https://github.com/basho/riak_kv/issues/1864