### PR TITLE
Reset deferred queue length on change

### DIFF
--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -347,6 +347,7 @@ handle_call({worker_count, QueueN, WorkerCount, PerPeerLimit}, _From, State) ->
             SinkWork0 =
                 SinkWork#sink_work{work_queue = WorkQueue,
                                     minimum_queue_length = QueueLength,
+                                    deferred_queue_length = 0,
                                     max_worker_count = WorkerCount},
             W0 =
                 lists:keyreplace(QueueN, 1, State#state.work,


### PR DESCRIPTION
The deferred_queue_length should be reset when a new iteration of the worker queue is prompted by changing the worker count.

https://github.com/basho/riak_kv/issues/1867

https://github.com/basho/riak_test/pull/1380