### PR TITLE
Defer reaps not prompted due to failure

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -298,6 +298,19 @@
   {commented, 2}
 ]}.
 
+%% @doc Deferred reap on failure
+%% Should one or more primaries be unavilable the reap following delete will
+%% not be triggered.  Rather than being ignored, it can be deferred by enabling
+%% defer_reap_on_failure.  This will queue the reap on the reaper untill all
+%% primaries are available.  The reaper queue will be erased on restart, so
+%% further failure may lead to the loss of deferred reaps
+{mapping, "defer_reap_on_failure", "riak_kv.defer_reap_on_failure", [
+  {datatype, flag},
+  {default, on},
+  hidden
+]}.
+
+
 %% @doc Whether to allow node to participate in coverage queries.
 %% This is used as a manual switch to stop nodes in incomplete states
 %% (E.g. doing a full partition repair, or node replace) from participating

--- a/src/riak_kv_get_core.erl
+++ b/src/riak_kv_get_core.erl
@@ -45,7 +45,7 @@
     {delete_repair,
         [{non_neg_integer(), repair_reason()}],
         riak_object:riak_object()} |
-    delete.
+    {delete, riak_object:riak_object()}.
 -type idxresult() :: {non_neg_integer(), result()}.
 -type idx_type() :: [{non_neg_integer, 'primary' | 'fallback'}].
 
@@ -379,7 +379,7 @@ final_action(GetCore = #getcore{n = N, merged = Merged0, results = Results,
     Action =
         case ReadRepairs of
             [] when ObjState == tombstone, AllResults ->
-                delete;
+                {delete, MObj};
             [] ->
                nop;
             _ when ObjState == tombstone, AllResults ->


### PR DESCRIPTION
Rather than wait for the next read (which may never happen) to repair - try and defer, as the reaper will not process until the failure has cleared.