### PR TITLE
queue stats logging refinements

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1148,7 +1148,7 @@
 
 %% @doc Periodically log replrtq queue stats (queue size, reap/delete
 %% attempts and aborts) at this interval (seconds)
-{mapping, "replrtq_logfrequency", "riak_kv.replrtq_logfrequency", [
+{mapping, "queue_manager_log_frequency", "riak_kv.queue_manager_log_frequency", [
     {datatype, integer},
     {default, 30}
 ]}.

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1153,6 +1153,12 @@
     {default, 30}
 ]}.
 
+%% @doc Suppress logging of queue stats when all items are 0
+{mapping, "queue_manager_log_suppress_zero_stats", "riak_kv.queue_manager_log_suppress_zero_stats", [
+    {datatype, flag},
+    {default, off}
+]}.
+
 %% @doc The maximume number of workers to be for any given peer may be
 %% configured - if not configured will default to the number of sinkworkers
 {mapping, "replrtq_sinkpeerlimit", "riak_kv.replrtq_sinkpeerlimit", [

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1146,6 +1146,13 @@
     {default, 24}
 ]}.
 
+%% @doc Periodically log replrtq queue stats (queue size, reap/delete
+%% attempts and aborts) at this interval (seconds)
+{mapping, "replrtq_logfrequency", "riak_kv.replrtq_logfrequency", [
+    {datatype, integer},
+    {default, 30}
+]}.
+
 %% @doc The maximume number of workers to be for any given peer may be
 %% configured - if not configured will default to the number of sinkworkers
 {mapping, "replrtq_sinkpeerlimit", "riak_kv.replrtq_sinkpeerlimit", [

--- a/src/riak_kv_reaper.erl
+++ b/src/riak_kv_reaper.erl
@@ -275,12 +275,22 @@ handle_async_message(timeout, State) ->
                             pqueue_length = {RedoQL, ReapQL - BatchSize}}}
     end;
 handle_async_message(log_queue, State) ->
-    lager:info("Reaper Job ~w has queue lengths ~w " ++
-                    " reap_attempts=~w reap_aborts=~w ",
-                [State#state.job_id,
-                    State#state.pqueue_length,
-                    State#state.reap_attempts,
-                    State#state.reap_aborts]),
+    LogLevel =
+        case State of
+            #state{pqueue_length = {0,0},
+                   reap_attempts = 0,
+                   reap_aborts = 0} ->
+                debug;
+            _ ->
+                info
+        end,
+    lager:log(LogLevel,
+              "Reaper Job ~w has queue lengths ~w "
+              "reap_attempts=~w reap_aborts=~w",
+              [State#state.job_id,
+                  State#state.pqueue_length,
+                  State#state.reap_attempts,
+                  State#state.reap_aborts]),
     erlang:send_after(?LOG_TICK, self(), log_queue),
     {noreply, State#state{reap_attempts = 0, reap_aborts = 0}}.
 

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -393,12 +393,12 @@ handle_cast({requeue_work, WorkItem}, State) ->
 
 handle_info(timeout, State) ->
     prompt_work(),
-    LogFreq = app_helper:get_env(riak_kv, replrtq_logfrequency,
+    LogFreq = app_helper:get_env(riak_kv, queue_manager_log_frequency,
                                  ?LOG_TIMER_SECONDS),
     erlang:send_after(LogFreq * 1000, self(), log_stats),
     {noreply, State};
 handle_info(log_stats, State) ->
-    LogFreq = app_helper:get_env(riak_kv, replrtq_logfrequency,
+    LogFreq = app_helper:get_env(riak_kv, queue_manager_log_frequency,
                                  ?LOG_TIMER_SECONDS),
     erlang:send_after(LogFreq * 1000, self(), log_stats),
     SinkWork0 =

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -786,7 +786,8 @@ log_mapfun({QueueName, Iteration, SinkWork}) ->
         {replmod_time, RT},
         {modified_time, MTS, MTM, MTH, MTD, MTL}}
         = SinkWork#sink_work.queue_stats,
-    lager:info("Queue=~w success_count=~w error_count=~w" ++
+    lager:info([{queue_name, QueueName}],
+               "Queue=~w success_count=~w error_count=~w" ++
                 " mean_fetchtime_ms=~s" ++
                 " mean_pushtime_ms=~s" ++
                 " mean_repltime_ms=~s" ++
@@ -800,7 +801,8 @@ log_mapfun({QueueName, Iteration, SinkWork}) ->
         end,
     PeerDelays =
         lists:foldl(FoldPeerInfoFun, "", SinkWork#sink_work.peer_list),
-    lager:info("Queue=~w has peer delays of~s", [QueueName, PeerDelays]),
+    lager:info([{queue_name, QueueName}],
+               "Queue=~w has peer delays of~s", [QueueName, PeerDelays]),
     {QueueName, Iteration, SinkWork#sink_work{queue_stats = ?ZERO_STATS}}.
 
 

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -393,10 +393,14 @@ handle_cast({requeue_work, WorkItem}, State) ->
 
 handle_info(timeout, State) ->
     prompt_work(),
-    erlang:send_after(?LOG_TIMER_SECONDS * 1000, self(), log_stats),
+    LogFreq = app_helper:get_env(riak_kv, replrtq_logfrequency,
+                                 ?LOG_TIMER_SECONDS),
+    erlang:send_after(LogFreq * 1000, self(), log_stats),
     {noreply, State};
 handle_info(log_stats, State) ->
-    erlang:send_after(?LOG_TIMER_SECONDS * 1000, self(), log_stats),
+    LogFreq = app_helper:get_env(riak_kv, replrtq_logfrequency,
+                                 ?LOG_TIMER_SECONDS),
+    erlang:send_after(LogFreq * 1000, self(), log_stats),
     SinkWork0 =
         case State#state.enabled of
             true ->

--- a/src/riak_kv_replrtq_src.erl
+++ b/src/riak_kv_replrtq_src.erl
@@ -288,14 +288,14 @@ init([]) ->
     QC = lists:map(MaptoQC, QFM),
     QL = app_helper:get_env(riak_kv, replrtq_srcqueuelimit, ?QUEUE_LIMIT),
     OL = app_helper:get_env(riak_kv, replrtq_srcobjectlimit, ?OBJECT_LIMIT),
-    LogFreq = app_helper:get_env(riak_kv, replrtq_logfrequency, ?LOG_TIMER_SECONDS * 1000),
+    LogFreq = app_helper:get_env(riak_kv, replrtq_logfrequency, ?LOG_TIMER_SECONDS),
     erlang:send_after(LogFreq, self(), log_queue),
     {ok, #state{queue_filtermap = QFM,
                 queue_map = QM,
                 queue_countmap = QC,
                 queue_limit = QL,
                 object_limit = OL,
-                log_frequency_in_ms = LogFreq}}.
+                log_frequency_in_ms = LogFreq * 1000}}.
 
 handle_call({rtq_ttaaefs, QueueName, ReplEntries}, _From, State) ->
     {ApproachingLimit, QueueMap, QueueCountMap} =

--- a/src/riak_kv_replrtq_src.erl
+++ b/src/riak_kv_replrtq_src.erl
@@ -410,8 +410,10 @@ handle_cast({rtq_coordput, Bucket, ReplEntry}, State) ->
 handle_info(log_queue, State) ->
     LogFun =
         fun({QueueName, {P1Q, P2Q, P3Q}}) ->
-            lager:info("QueueName=~w has queue sizes p1=~w p2=~w p3=~w",
-                        [QueueName, P1Q, P2Q, P3Q])
+            lager:info(
+              [{queue_name, QueueName}, {p1q, P1Q}, {p2q, P2Q}, {p3q, P3Q}],
+              "QueueName=~w has queue sizes p1=~w p2=~w p3=~w",
+              [QueueName, P1Q, P2Q, P3Q])
         end,
     lists:foreach(LogFun, State#state.queue_countmap),
     erlang:send_after(State#state.log_frequency_in_ms, self(), log_queue),

--- a/src/riak_kv_replrtq_src.erl
+++ b/src/riak_kv_replrtq_src.erl
@@ -408,8 +408,9 @@ handle_cast({rtq_coordput, Bucket, ReplEntry}, State) ->
                             queue_countmap = QueueCountMap}}.
 
 handle_info(log_queue, State) ->
+    Suppress = app_helper:get_env(riak_kv, queue_manager_log_suppress_zero_stats, false),
     LogFun =
-        fun({_QueueName, {0, 0, 0}}) ->
+        fun({_QueueName, {0, 0, 0}}) when Suppress == true ->
                 ok;
            ({QueueName, {P1Q, P2Q, P3Q}}) ->
                 lager:info(

--- a/src/riak_kv_replrtq_src.erl
+++ b/src/riak_kv_replrtq_src.erl
@@ -409,11 +409,13 @@ handle_cast({rtq_coordput, Bucket, ReplEntry}, State) ->
 
 handle_info(log_queue, State) ->
     LogFun =
-        fun({QueueName, {P1Q, P2Q, P3Q}}) ->
-            lager:info(
-              [{queue_name, QueueName}, {p1q, P1Q}, {p2q, P2Q}, {p3q, P3Q}],
-              "QueueName=~w has queue sizes p1=~w p2=~w p3=~w",
-              [QueueName, P1Q, P2Q, P3Q])
+        fun({_QueueName, {0, 0, 0}}) ->
+                ok;
+           ({QueueName, {P1Q, P2Q, P3Q}}) ->
+                lager:info(
+                  [{queue_name, QueueName}, {p1q, P1Q}, {p2q, P2Q}, {p3q, P3Q}],
+                  "QueueName=~w has queue sizes p1=~w p2=~w p3=~w",
+                  [QueueName, P1Q, P2Q, P3Q])
         end,
     lists:foreach(LogFun, State#state.queue_countmap),
     erlang:send_after(State#state.log_frequency_in_ms, self(), log_queue),

--- a/src/riak_kv_replrtq_src.erl
+++ b/src/riak_kv_replrtq_src.erl
@@ -288,7 +288,7 @@ init([]) ->
     QC = lists:map(MaptoQC, QFM),
     QL = app_helper:get_env(riak_kv, replrtq_srcqueuelimit, ?QUEUE_LIMIT),
     OL = app_helper:get_env(riak_kv, replrtq_srcobjectlimit, ?OBJECT_LIMIT),
-    LogFreq = app_helper:get_env(riak_kv, replrtq_logfrequency, ?LOG_TIMER_SECONDS),
+    LogFreq = app_helper:get_env(riak_kv, queue_manager_log_frequency, ?LOG_TIMER_SECONDS),
     erlang:send_after(LogFreq, self(), log_queue),
     {ok, #state{queue_filtermap = QFM,
                 queue_map = QM,


### PR DESCRIPTION
This PR has a few refinements to logging for 2.9.x users:

* Exposes `replrtq_logfrequency` in riak.conf. This tunable was already [consulted](https://github.com/basho/riak_kv/blob/develop-2.9/src/riak_kv_replrtq_src.erl#L291) but wasn't present in riak_kv.schema, resulting in `application:get_value` on that key always returning the default value of 30 sec.
* Suppresses logging of queue stats when queue sizes are 0.
* Adds a metadata item, `queue_name`, to the periodic queue stats logging, to enable selective logging into separate lager sinks.