### PR TITLE
queue stats logging refinements

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1411,6 +1411,19 @@
     {commented, 900}
 ]}.
 
+%% @doc Periodically log replrtq queue stats (queue size, reap/delete
+%% attempts and aborts) at this interval (seconds)
+{mapping, "queue_manager_log_frequency", "riak_kv.queue_manager_log_frequency", [
+    {datatype, integer},
+    {default, 30}
+]}.
+
+%% @doc Suppress logging of queue stats when all items are 0
+{mapping, "queue_manager_log_suppress_zero_stats", "riak_kv.queue_manager_log_suppress_zero_stats", [
+    {datatype, flag},
+    {default, off}
+]}.
+
 %% @doc Enable the `recalc` compaction strategy within the leveled backend in
 %% riak.  The default (when disabled) is `retain`, but this will leave
 %% uncollected garbage within the, journal. 

--- a/src/riak_kv_replrtq_snk.erl
+++ b/src/riak_kv_replrtq_snk.erl
@@ -415,10 +415,12 @@ handle_cast({requeue_work, WorkItem}, State) ->
 
 handle_info(timeout, State) ->
     prompt_work(),
-    erlang:send_after(?LOG_TIMER_SECONDS * 1000, self(), log_stats),
+    LogFreq = app_helper:get_env(riak_kv, queue_manager_log_frequency, ?LOG_TIMER_SECONDS),
+    erlang:send_after(LogFreq * 1000, self(), log_stats),
     {noreply, State};
 handle_info(log_stats, State) ->
-    erlang:send_after(?LOG_TIMER_SECONDS * 1000, self(), log_stats),
+    LogFreq = app_helper:get_env(riak_kv, queue_manager_log_frequency, ?LOG_TIMER_SECONDS),
+    erlang:send_after(LogFreq * 1000, self(), log_stats),
     SinkWork0 =
         case State#state.enabled of
             true ->
@@ -854,7 +856,8 @@ log_mapfun({QueueName, Iteration, SinkWork}) ->
         {replmod_time, RT},
         {modified_time, MTS, MTM, MTH, MTD, MTL}}
         = SinkWork#sink_work.queue_stats,
-    lager:info("Queue=~w success_count=~w error_count=~w" ++
+    lager:info([{queue_name, QueueName}],
+               "Queue=~w success_count=~w error_count=~w" ++
                 " mean_fetchtime_ms=~s" ++
                 " mean_pushtime_ms=~s" ++
                 " mean_repltime_ms=~s" ++
@@ -868,7 +871,8 @@ log_mapfun({QueueName, Iteration, SinkWork}) ->
         end,
     PeerDelays =
         lists:foldl(FoldPeerInfoFun, "", SinkWork#sink_work.peer_list),
-    lager:info("Queue=~w has peer delays of~s", [QueueName, PeerDelays]),
+    lager:info([{queue_name, QueueName}],
+               "Queue=~w has peer delays of~s", [QueueName, PeerDelays]),
     {QueueName, Iteration, SinkWork#sink_work{queue_stats = ?ZERO_STATS}}.
 
 -spec log_queue_addition(


### PR DESCRIPTION
This is https://github.com/basho/riak_kv/pull/1875 manually reapplied to 3.0 branch. Specifically:

* New tunable, `queue_manager_log_frequency`, setting the interval, in seconds, between logging of queue stats in replrtq_{snk,src}.

* New tunable, `queue_manager_log_suppress_zero_stats`, optionally to avoid logging of zero stats in replrtq_src and overflow_queue.

* Logging in replrtq_* is now done with `queue_name` in lager:info metadata, to allow operators to filter such entries into separate lager sinks.