### PR TITLE
Allow nextgenrepl to real-time replicate reaps (#6)

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1337,8 +1337,15 @@
     {default, "q1_ttaaefs:block_rtq"}
 ]}.
 
-%% @doc Enable this node zlib compress objects over the wire
+%% @doc Enable this node to zlib compress objects over the wire
 {mapping, "replrtq_compressonwire", "riak_kv.replrtq_compressonwire", [
+    {datatype, {flag, enabled, disabled}},
+    {default, disabled},
+    {commented, enabled}
+]}.
+
+%% @doc Enable this node to replicate reap requests to other clusters
+{mapping, "repl_reap", "riak_kv.repl_reap", [
     {datatype, {flag, enabled, disabled}},
     {default, disabled},
     {commented, enabled}

--- a/src/riak_kv_clusteraae_fsm.erl
+++ b/src/riak_kv_clusteraae_fsm.erl
@@ -585,8 +585,8 @@ json_encode_results(find_keys, Result) ->
     Keys = {struct, [{<<"results">>, [{struct, encode_find_key(Key, Int)} || {_Bucket, Key, Int} <- Result]}
                     ]},
     mochijson2:encode(Keys);
-json_encode_results(find_tombs, Result) ->
-    json_encode_results(find_keys, Result);
+json_encode_results(find_tombs, KeysNClocks) ->
+    encode_keys_and_clocks(KeysNClocks);
 json_encode_results(reap_tombs, Count) ->
     mochijson2:encode({struct, [{<<"dispatched_count">>, Count}]});
 json_encode_results(erase_keys, Count) ->
@@ -616,7 +616,7 @@ pb_encode_results(merge_branch_nval, _QD, Branches) ->
         level_two = L2
     };
 pb_encode_results(fetch_clocks_nval, _QD, KeysNClocks) ->
-     #rpbaaefoldkeyvalueresp{
+    #rpbaaefoldkeyvalueresp{
         response_type = atom_to_binary(clock, unicode),
         keys_value = lists:map(fun pb_encode_bucketkeyclock/1, KeysNClocks)};
 pb_encode_results(merge_tree_range, QD, Tree) ->
@@ -662,8 +662,10 @@ pb_encode_results(find_keys, _QD, Results) ->
         end,
     #rpbaaefoldkeycountresp{response_type = <<"find_keys">>, 
                             keys_count = lists:map(KeyCountMap, Results)};
-pb_encode_results(find_tombs, QD, Results) ->
-    pb_encode_results(find_keys, QD, Results);
+pb_encode_results(find_tombs, _QD, KeysNClocks) ->
+    #rpbaaefoldkeyvalueresp{
+        response_type = atom_to_binary(clock, unicode),
+        keys_value = lists:map(fun pb_encode_bucketkeyclock/1, KeysNClocks)};
 pb_encode_results(reap_tombs, _QD, Count) ->
     #rpbaaefoldkeycountresp{response_type = <<"reap_tombs">>, 
                             keys_count =

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -237,6 +237,13 @@ queue_fetch(timeout, StateData) ->
             Msg = {ReqID, {ok, {deleted, ExpectedClock, Obj}}},
             Pid ! Msg,
             ok = riak_kv_stat:update(ngrfetch_prefetch),
+            {stop, normal, StateData};
+        {Bucket, Key, TombClock, {reap, LMD}} ->
+            % A reap request was queued - so there is no need to fetch
+            % A tombstone was queued - so there is no need to fetch
+            Msg = {ReqID, {ok, {reap, {Bucket, Key, TombClock, LMD}}}},
+            Pid ! Msg,
+            ok = riak_kv_stat:update(ngrfetch_prefetch),
             {stop, normal, StateData}
     end.
 

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1961,14 +1961,14 @@ handle_aaefold({find_tombs,
                     IndexNs, Filtered, ReturnFun, Cntrl, Sender,
                     State) ->
     FoldFun =
-        fun(BF, KF, EFs, TombHashAcc) ->
+        fun(BF, KF, EFs, TombClockAcc) ->
             {md, MD} = lists:keyfind(md, 1, EFs),
             case riak_object:is_aae_object_deleted(MD, false) of
                 {true, undefined} ->
                     {clock, VV} = lists:keyfind(clock, 1, EFs),
-                    [{BF, KF, riak_object:delete_hash(VV)}|TombHashAcc];
+                    [{BF, KF, VV}|TombClockAcc];
                 {false, undefined} ->
-                    TombHashAcc
+                    TombClockAcc
             end
         end,
     WrappedFoldFun = aaefold_withcoveragecheck(FoldFun, IndexNs, Filtered),
@@ -1997,25 +1997,24 @@ handle_aaefold({reap_tombs,
             case riak_object:is_aae_object_deleted(MD, false) of
                 {true, undefined} ->
                     {clock, VV} = lists:keyfind(clock, 1, EFs),
-                    DH = riak_object:delete_hash(VV),
                     case TombHashAcc of
                         {BatchList, Count, local} ->
                             NewCount = Count + 1,
                             case NewCount div ?REAPER_BATCH_SIZE of
                                 0 ->
                                     riak_kv_reaper:bulk_request_reap(
-                                        [{{BF, KF}, DH}|BatchList]
+                                        [{{BF, KF}, VV, true}|BatchList]
                                     ),
                                     {[], NewCount, local};
                                 _ ->
-                                    {[{{BF, KF}, DH}|BatchList],
+                                    {[{{BF, KF}, VV, true}|BatchList],
                                         NewCount,
                                         local}
                             end;
                         {BatchList, Count, count} ->
                             {BatchList, Count + 1, count};
                         {BatchList, Count, Job} ->
-                            {[{{BF, KF}, DH}|BatchList], Count + 1, Job}
+                            {[{{BF, KF}, VV, true}|BatchList], Count + 1, Job}
                     end;
                 {false, undefined} ->
                     TombHashAcc


### PR DESCRIPTION
* Allow nextgenrepl to real-time replicate reaps

This is to address the issue of reaping across sync'd clusters.  Without this feature it is necessary to disable full-sync whilst independently replicating on each cluster.

Now if reaping via riak_kv_reaper the reap will be replicated assuming the `riak_kv.repl_reap` flag has been enabled.  At the receiving cluster the reap will not be replicated any further.

There are some API changes to support this.  The `find_tombs` aae_fold will now return Keys/Clocks and not Keys/DeleteHash.  The ReapReference for riak_kv_repaer will now expect a clock (version vector) not a DeleteHash, and will also now expect an additional boolean to indicate if this repl is a replication candidate (it will be false for all pushed reaps).

The object encoding for nextgenrepl now has a flag to indicate a reap, with a special encoding for reap references.

* Update riak_object.erl

Clarify specs

* Take timestamp at correct point (after push)

* Updates following review

* Update rebar.config